### PR TITLE
FLB#8 | persist TestCatch offline through close and reopen

### DIFF
--- a/src/FishingLogBook.Web/Layouts/MainLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/MainLayout.razor
@@ -9,6 +9,11 @@
     <MudAppBar Elevation="1">
         <MudText Typo="Typo.h6">@Loc["App_Name"]</MudText>
         <MudSpacer />
+        <MudIconButton Href="/test-catch"
+                       Icon="@Icons.Material.Filled.Phishing"
+                       Color="Color.Inherit"
+                       aria-label="@Loc["TestCatch_Nav"]"
+                       id="test-catch-nav-button" />
         <LanguageSwitcher />
         <MudIconButton Icon="@ThemeToggleIcon"
                        Color="Color.Inherit"

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -72,4 +72,43 @@
   <data name="Language_French" xml:space="preserve">
     <value>Français</value>
   </data>
+  <data name="TestCatch_Nav" xml:space="preserve">
+    <value>Prise de test</value>
+  </data>
+  <data name="TestCatch_PageTitle" xml:space="preserve">
+    <value>FishingLogBook - Prise de test</value>
+  </data>
+  <data name="TestCatch_Title" xml:space="preserve">
+    <value>Prise de test</value>
+  </data>
+  <data name="TestCatch_Subtitle" xml:space="preserve">
+    <value>Enregistrée sur cet appareil jusqu'à la synchronisation</value>
+  </data>
+  <data name="TestCatch_Species" xml:space="preserve">
+    <value>Espèce</value>
+  </data>
+  <data name="TestCatch_Notes" xml:space="preserve">
+    <value>Notes</value>
+  </data>
+  <data name="TestCatch_Save" xml:space="preserve">
+    <value>Enregistrer la prise</value>
+  </data>
+  <data name="TestCatch_Empty" xml:space="preserve">
+    <value>Aucune prise enregistrée</value>
+  </data>
+  <data name="SyncStatus_SavedLocally" xml:space="preserve">
+    <value>Enregistrée localement — pas encore synchronisée</value>
+  </data>
+  <data name="SyncStatus_WaitingToSynchronise" xml:space="preserve">
+    <value>En attente de synchronisation</value>
+  </data>
+  <data name="SyncStatus_Synchronising" xml:space="preserve">
+    <value>Synchronisation en cours</value>
+  </data>
+  <data name="SyncStatus_Synchronised" xml:space="preserve">
+    <value>Synchronisée</value>
+  </data>
+  <data name="SyncStatus_FailedToSynchronise" xml:space="preserve">
+    <value>Échec de la synchronisation</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -72,4 +72,43 @@
   <data name="Language_French" xml:space="preserve">
     <value>Français</value>
   </data>
+  <data name="TestCatch_Nav" xml:space="preserve">
+    <value>Test catch</value>
+  </data>
+  <data name="TestCatch_PageTitle" xml:space="preserve">
+    <value>FishingLogBook - Test catch</value>
+  </data>
+  <data name="TestCatch_Title" xml:space="preserve">
+    <value>Test catch</value>
+  </data>
+  <data name="TestCatch_Subtitle" xml:space="preserve">
+    <value>Saved on this device until synchronisation</value>
+  </data>
+  <data name="TestCatch_Species" xml:space="preserve">
+    <value>Species</value>
+  </data>
+  <data name="TestCatch_Notes" xml:space="preserve">
+    <value>Notes</value>
+  </data>
+  <data name="TestCatch_Save" xml:space="preserve">
+    <value>Save catch</value>
+  </data>
+  <data name="TestCatch_Empty" xml:space="preserve">
+    <value>No catches saved yet</value>
+  </data>
+  <data name="SyncStatus_SavedLocally" xml:space="preserve">
+    <value>Saved locally — not synchronised</value>
+  </data>
+  <data name="SyncStatus_WaitingToSynchronise" xml:space="preserve">
+    <value>Waiting to synchronise</value>
+  </data>
+  <data name="SyncStatus_Synchronising" xml:space="preserve">
+    <value>Synchronising</value>
+  </data>
+  <data name="SyncStatus_Synchronised" xml:space="preserve">
+    <value>Synchronised</value>
+  </data>
+  <data name="SyncStatus_FailedToSynchronise" xml:space="preserve">
+    <value>Failed to synchronise</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Models/SyncStatus.cs
+++ b/src/FishingLogBook.Web/Models/SyncStatus.cs
@@ -1,0 +1,10 @@
+namespace FishingLogBook.Web.Models;
+
+public enum SyncStatus
+{
+    SavedLocally,
+    WaitingToSynchronise,
+    Synchronising,
+    Synchronised,
+    FailedToSynchronise
+}

--- a/src/FishingLogBook.Web/Offline/ITestCatchJsonStore.cs
+++ b/src/FishingLogBook.Web/Offline/ITestCatchJsonStore.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Web.Offline;
+
+public interface ITestCatchJsonStore
+{
+    Task PutAsync(string json, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<string>> GetAllAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Offline/ITestCatchStore.cs
+++ b/src/FishingLogBook.Web/Offline/ITestCatchStore.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Web.Offline;
+
+public interface ITestCatchStore
+{
+    Task SaveAsync(TestCatch testCatch, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TestCatch>> GetAllAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Offline/IndexedDbTestCatchJsonStore.cs
+++ b/src/FishingLogBook.Web/Offline/IndexedDbTestCatchJsonStore.cs
@@ -1,0 +1,49 @@
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Offline;
+
+public sealed class IndexedDbTestCatchJsonStore : ITestCatchJsonStore
+{
+    private const string ModulePath = "./js/offline-store.js";
+
+    private readonly IJSRuntime _jsRuntime;
+    private readonly SemaphoreSlim _moduleLock = new(1, 1);
+    private IJSObjectReference? _module;
+
+    public IndexedDbTestCatchJsonStore(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task PutAsync(string json, CancellationToken cancellationToken)
+    {
+        var module = await GetModuleAsync(cancellationToken);
+        await module.InvokeVoidAsync("putTestCatch", cancellationToken, json);
+    }
+
+    public async Task<IReadOnlyList<string>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        var module = await GetModuleAsync(cancellationToken);
+        var items = await module.InvokeAsync<string[]>("getAllTestCatches", cancellationToken);
+        return items ?? [];
+    }
+
+    private async Task<IJSObjectReference> GetModuleAsync(CancellationToken cancellationToken)
+    {
+        if (_module is not null)
+        {
+            return _module;
+        }
+
+        await _moduleLock.WaitAsync(cancellationToken);
+        try
+        {
+            _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+            return _module;
+        }
+        finally
+        {
+            _moduleLock.Release();
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Offline/TestCatch.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatch.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Web.Models;
+
+namespace FishingLogBook.Web.Offline;
+
+public sealed record TestCatch(
+    Guid Id,
+    string SpeciesName,
+    DateTimeOffset CaughtOn,
+    string? Notes,
+    SyncStatus SyncStatus);

--- a/src/FishingLogBook.Web/Offline/TestCatchJson.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatchJson.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FishingLogBook.Web.Offline;
+
+internal static class TestCatchJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+}

--- a/src/FishingLogBook.Web/Offline/TestCatchStore.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatchStore.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+
+namespace FishingLogBook.Web.Offline;
+
+public sealed class TestCatchStore : ITestCatchStore
+{
+    private readonly ITestCatchJsonStore _jsonStore;
+
+    public TestCatchStore(ITestCatchJsonStore jsonStore)
+    {
+        _jsonStore = jsonStore;
+    }
+
+    public Task SaveAsync(TestCatch testCatch, CancellationToken cancellationToken)
+    {
+        var json = JsonSerializer.Serialize(testCatch, TestCatchJson.Options);
+        return _jsonStore.PutAsync(json, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<TestCatch>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        var items = await _jsonStore.GetAllAsync(cancellationToken);
+        return items
+            .Select(json => JsonSerializer.Deserialize<TestCatch>(json, TestCatchJson.Options))
+            .Where(testCatch => testCatch is not null)
+            .Cast<TestCatch>()
+            .ToArray();
+    }
+}

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor
@@ -1,0 +1,61 @@
+@page "/test-catch"
+
+<PageTitle>@Loc["TestCatch_PageTitle"]</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="test-catch-container pa-4">
+    <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
+        <MudStack Spacing="1" AlignItems="AlignItems.Center">
+            <MudText Typo="Typo.h4" Align="Align.Center">@Loc["TestCatch_Title"]</MudText>
+            <MudText Typo="Typo.subtitle1" Align="Align.Center" Class="mud-text-secondary">@Loc["TestCatch_Subtitle"]</MudText>
+        </MudStack>
+
+        <MudPaper Class="pa-4" Elevation="2">
+            <MudStack Spacing="3">
+                <MudTextField @bind-Value="_speciesName"
+                              Label="@Loc["TestCatch_Species"]"
+                              Variant="Variant.Outlined"
+                              Immediate="true"
+                              id="test-catch-species" />
+                <MudTextField @bind-Value="_notes"
+                              Label="@Loc["TestCatch_Notes"]"
+                              Variant="Variant.Outlined"
+                              Lines="3"
+                              id="test-catch-notes" />
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           FullWidth="true"
+                           Disabled="@(!CanSave)"
+                           OnClick="SaveAsync"
+                           id="save-test-catch-button">
+                    @Loc["TestCatch_Save"]
+                </MudButton>
+            </MudStack>
+        </MudPaper>
+
+        <MudPaper Class="pa-4" Elevation="2" id="test-catch-list">
+            @if (_catches.Count == 0)
+            {
+                <MudText Typo="Typo.body2" Class="mud-text-secondary" Align="Align.Center" id="test-catch-empty">
+                    @Loc["TestCatch_Empty"]
+                </MudText>
+            }
+            else
+            {
+                <MudStack Spacing="2">
+                    @foreach (var testCatch in _catches)
+                    {
+                        <MudPaper Class="pa-3" Outlined="true" id="@($"test-catch-item-{testCatch.Id}")">
+                            <MudStack Spacing="1">
+                                <MudText Typo="Typo.subtitle1" id="@($"test-catch-species-{testCatch.Id}")">@testCatch.SpeciesName</MudText>
+                                <MudText Typo="Typo.caption" Class="mud-text-secondary" id="@($"test-catch-caught-on-{testCatch.Id}")">@testCatch.CaughtOn.ToLocalTime().ToString("g")</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Warning" id="@($"test-catch-sync-status-{testCatch.Id}")">
+                                    @Loc[SyncStatusKey(testCatch.SyncStatus)]
+                                </MudText>
+                            </MudStack>
+                        </MudPaper>
+                    }
+                </MudStack>
+            }
+        </MudPaper>
+    </MudStack>
+</MudContainer>

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
@@ -1,0 +1,77 @@
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Pages.TestCatchLog;
+
+public partial class TestCatchLog : ComponentBase, IDisposable
+{
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    private string _speciesName = string.Empty;
+    private string _notes = string.Empty;
+    private IReadOnlyList<TestCatch> _catches = [];
+    private bool _isSaving;
+
+    [Inject]
+    private ITestCatchStore TestCatchStore { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool CanSave => !_isSaving && !string.IsNullOrWhiteSpace(_speciesName);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task SaveAsync()
+    {
+        if (!CanSave)
+        {
+            return;
+        }
+
+        _isSaving = true;
+
+        var testCatch = new TestCatch(
+            Guid.NewGuid(),
+            _speciesName.Trim(),
+            DateTimeOffset.UtcNow,
+            string.IsNullOrWhiteSpace(_notes) ? null : _notes.Trim(),
+            SyncStatus.SavedLocally);
+
+        await TestCatchStore.SaveAsync(testCatch, _cancellationTokenSource.Token);
+        _speciesName = string.Empty;
+        _notes = string.Empty;
+        await LoadAsync();
+        _isSaving = false;
+    }
+
+    private async Task LoadAsync()
+    {
+        _catches = await TestCatchStore.GetAllAsync(_cancellationTokenSource.Token);
+    }
+
+    private static string SyncStatusKey(SyncStatus syncStatus)
+    {
+        return syncStatus switch
+        {
+            SyncStatus.SavedLocally => "SyncStatus_SavedLocally",
+            SyncStatus.WaitingToSynchronise => "SyncStatus_WaitingToSynchronise",
+            SyncStatus.Synchronising => "SyncStatus_Synchronising",
+            SyncStatus.Synchronised => "SyncStatus_Synchronised",
+            SyncStatus.FailedToSynchronise => "SyncStatus_FailedToSynchronise",
+            _ => "SyncStatus_SavedLocally"
+        };
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.css
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.css
@@ -1,0 +1,3 @@
+.test-catch-container {
+    padding-top: 2rem;
+}

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Offline;
 using FishingLogBook.Web.Services;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
@@ -17,6 +18,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(apiConfig);
         services.AddScoped(_ => new HttpClient { BaseAddress = apiBaseAddress });
         services.AddScoped<ISystemStatusClient, SystemStatusClient>();
+        services.AddScoped<ITestCatchJsonStore, IndexedDbTestCatchJsonStore>();
+        services.AddScoped<ITestCatchStore, TestCatchStore>();
         services.AddLocalization();
         services.AddScoped<ICultureService, CultureService>();
         services.AddMudServices();

--- a/src/FishingLogBook.Web/_Imports.razor
+++ b/src/FishingLogBook.Web/_Imports.razor
@@ -13,5 +13,6 @@
 @using FishingLogBook.Web.Layouts
 @using FishingLogBook.Web.Localization
 @using FishingLogBook.Web.Models
+@using FishingLogBook.Web.Offline
 @using FishingLogBook.Web.Services
 @using FishingLogBook.Shared.Dtos

--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -60,7 +60,7 @@
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script>
         (async () => {
-            const epoch = '20260813-loc-reload';
+            const epoch = '20260814-testcatch-offline';
             try {
                 if (localStorage.getItem('flb-sw-epoch') !== epoch) {
                     const registrations = await navigator.serviceWorker.getRegistrations();

--- a/src/FishingLogBook.Web/wwwroot/js/offline-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/offline-store.js
@@ -1,0 +1,50 @@
+const databaseName = 'FishingLogBook';
+const storeName = 'testCatches';
+const version = 1;
+
+function openDatabase() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(databaseName, version);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(storeName)) {
+                db.createObjectStore(storeName, { keyPath: 'id' });
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+export async function putTestCatch(json) {
+    const catchRecord = JSON.parse(json);
+    const db = await openDatabase();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(storeName, 'readwrite');
+        transaction.oncomplete = () => {
+            db.close();
+            resolve();
+        };
+        transaction.onerror = () => {
+            db.close();
+            reject(transaction.error);
+        };
+        transaction.objectStore(storeName).put(catchRecord);
+    });
+}
+
+export async function getAllTestCatches() {
+    const db = await openDatabase();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(storeName, 'readonly');
+        const request = transaction.objectStore(storeName).getAll();
+        request.onsuccess = () => {
+            db.close();
+            resolve(request.result.map((item) => JSON.stringify(item)));
+        };
+        request.onerror = () => {
+            db.close();
+            reject(request.error);
+        };
+    });
+}

--- a/tests/FishingLogBook.Web.Tests/DependencyInjectionTests/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjectionTests/WhenTestingContainer.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Offline;
 using FishingLogBook.Web.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
@@ -41,6 +42,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
 
         // Assert
         injectedTypes.Should().Contain(typeof(ISystemStatusClient));
+        injectedTypes.Should().Contain(typeof(ITestCatchStore));
         injectedTypes.Should().Contain(typeof(ICultureService));
         injectedTypes.Should().Contain(typeof(IStringLocalizer<UiStrings>));
         resolve.Should().NotThrow();

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
@@ -1,0 +1,24 @@
+using Bunit;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Offline;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class BaseTestCatchLogTest
+{
+    protected static BunitContext CreateContext(ITestCatchStore store)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(store);
+        context.Services.AddSingleton(Substitute.For<ICultureService>());
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingReopen.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingReopen.cs
@@ -1,0 +1,71 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Pages.TestCatchLog;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class WhenTestingReopen : BaseTestCatchLogTest
+{
+    [Fact]
+    public async Task ItShouldShowSavedCatch_WhenPageIsCreatedAgain()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("3a1f2c8e-7b44-4d1a-9c3e-2f8a6b0d1e55"),
+            "Perch",
+            DateTimeOffset.Parse("2026-08-14T10:30:00Z"),
+            "Reed margin",
+            SyncStatus.SavedLocally);
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#test-catch-item-{existing.Id}").Should().NotBeNull();
+            cut.Find($"#test-catch-species-{existing.Id}").TextContent.Should().Contain("Perch");
+            cut.Find($"#test-catch-sync-status-{existing.Id}").TextContent.Should()
+                .Contain("Saved locally — not synchronised");
+        });
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.DidNotReceive().SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchLocalStatus_WhenUiCultureIsFrench()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var existing = new TestCatch(
+            Guid.Parse("8c0e91a2-4d77-4b18-a6f1-0c3d5e7a9b21"),
+            "Brochet",
+            DateTimeOffset.Parse("2026-08-14T11:00:00Z"),
+            null,
+            SyncStatus.SavedLocally);
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#test-catch-sync-status-{existing.Id}").TextContent.Should()
+                .Contain("Enregistrée localement — pas encore synchronisée");
+        });
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingSave.cs
@@ -1,0 +1,67 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Pages.TestCatchLog;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class WhenTestingSave : BaseTestCatchLogTest
+{
+    [Fact]
+    public async Task ItShouldStoreAndListCatchImmediately_WhenSaved()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var saved = new List<TestCatch>();
+        var store = Substitute.For<ITestCatchStore>();
+        store.SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                saved.Add(callInfo.Arg<TestCatch>());
+                return Task.CompletedTask;
+            });
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<TestCatch>>(saved.ToArray()));
+        await using var context = CreateContext(store);
+        var cut = context.Render<TestCatchLog>();
+
+        // Act
+        cut.Find("#test-catch-species").Input("Pike");
+        await cut.Find("#save-test-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            saved.Should().ContainSingle();
+            cut.Find($"#test-catch-species-{saved[0].Id}").TextContent.Should().Contain("Pike");
+            cut.Find($"#test-catch-sync-status-{saved[0].Id}").TextContent.Should()
+                .Contain("Saved locally — not synchronised");
+        });
+        await store.Received(1).SaveAsync(
+            Arg.Is<TestCatch>(testCatch =>
+                testCatch.SpeciesName == "Pike" &&
+                testCatch.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotSave_WhenSpeciesIsMissing()
+    {
+        // Arrange
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([]));
+        await using var context = CreateContext(store);
+        var cut = context.Render<TestCatchLog>();
+
+        // Act
+        await cut.Find("#save-test-catch-button").ClickAsync();
+
+        // Assert
+        await store.DidNotReceive().SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>());
+        cut.Find("#test-catch-empty").TextContent.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchStoreTests/BaseTestCatchStoreTest.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchStoreTests/BaseTestCatchStoreTest.cs
@@ -1,0 +1,14 @@
+using FishingLogBook.Web.Offline;
+
+namespace FishingLogBook.Web.Tests.TestCatchStoreTests;
+
+public class BaseTestCatchStoreTest
+{
+    protected readonly List<string> BackingStore = [];
+    protected readonly TestCatchStore Sut;
+
+    protected BaseTestCatchStoreTest()
+    {
+        Sut = new TestCatchStore(new MemoryTestCatchJsonStore(BackingStore));
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchStoreTests/MemoryTestCatchJsonStore.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchStoreTests/MemoryTestCatchJsonStore.cs
@@ -1,0 +1,24 @@
+using FishingLogBook.Web.Offline;
+
+namespace FishingLogBook.Web.Tests.TestCatchStoreTests;
+
+internal sealed class MemoryTestCatchJsonStore : ITestCatchJsonStore
+{
+    private readonly List<string> _items;
+
+    public MemoryTestCatchJsonStore(List<string> items)
+    {
+        _items = items;
+    }
+
+    public Task PutAsync(string json, CancellationToken cancellationToken)
+    {
+        _items.Add(json);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<string>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyList<string>>(_items.ToArray());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchStoreTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchStoreTests/WhenTestingSave.cs
@@ -1,0 +1,49 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+
+namespace FishingLogBook.Web.Tests.TestCatchStoreTests;
+
+public class WhenTestingSave : BaseTestCatchStoreTest
+{
+    [Fact]
+    public async Task ItShouldListCatchImmediately_WhenSaved()
+    {
+        // Arrange
+        var testCatch = new TestCatch(
+            Guid.NewGuid(),
+            "Pike",
+            DateTimeOffset.Parse("2026-08-14T08:00:00Z"),
+            "Weed bed",
+            SyncStatus.SavedLocally);
+
+        // Act
+        await Sut.SaveAsync(testCatch, CancellationToken.None);
+        var saved = await Sut.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle()
+            .Which.Should().Be(testCatch);
+    }
+
+    [Fact]
+    public async Task ItShouldStillContainCatch_WhenNewStoreReadsSamePersistence()
+    {
+        // Arrange
+        var testCatch = new TestCatch(
+            Guid.NewGuid(),
+            "Brown trout",
+            DateTimeOffset.Parse("2026-08-14T09:15:00Z"),
+            null,
+            SyncStatus.SavedLocally);
+        await Sut.SaveAsync(testCatch, CancellationToken.None);
+        var reopened = new TestCatchStore(new MemoryTestCatchJsonStore(BackingStore));
+
+        // Act
+        var saved = await reopened.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle()
+            .Which.Should().Be(testCatch);
+    }
+}


### PR DESCRIPTION
Closes #8

## Summary
- Add a minimal TestCatch (id, species, caught on, notes, sync status) stored in IndexedDB.
- Saving a catch lists it immediately as saved locally and not synchronised.
- A new store/page instance still loads the same locally saved catch (close and reopen).

## Test plan
- [x] Automated tests for save, list, reopen and local sync status (EN/FR)
- [x] Existing tests remain passing (47 total in Release)
- [ ] On a device/browser: open `/test-catch`, go offline, save a catch, close the PWA, reopen still offline, confirm it is still listed as saved locally