### PR TITLE
FLB#8 | serve the PWA shell from cache so it reopens offline

### DIFF
--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -7,7 +7,6 @@
     <title>FishingLogBook</title>
     <base href="/" />
     <link rel="preload" id="webassembly" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
@@ -60,7 +59,7 @@
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script>
         (async () => {
-            const epoch = '20260814-testcatch-offline';
+            const epoch = '20260814-offline-shell';
             try {
                 if (localStorage.getItem('flb-sw-epoch') !== epoch) {
                     const registrations = await navigator.serviceWorker.getRegistrations();

--- a/src/FishingLogBook.Web/wwwroot/service-worker.published.js
+++ b/src/FishingLogBook.Web/wwwroot/service-worker.published.js
@@ -8,18 +8,24 @@ self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
-const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.blat$/, /\.dat$/, /\.webmanifest$/ ];
+const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.woff2$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.svg$/, /\.blat$/, /\.dat$/, /\.webmanifest$/ ];
 const offlineAssetsExclude = [ /^service-worker\.js$/ ];
 
 async function onInstall(event) {
     console.info('Service worker: Install');
     self.skipWaiting();
 
+    const cache = await caches.open(cacheName);
     const assetsRequests = self.assetsManifest.assets
         .filter(asset => offlineAssetsInclude.some(pattern => pattern.test(asset.url)))
         .filter(asset => !offlineAssetsExclude.some(pattern => pattern.test(asset.url)))
         .map(asset => new Request(asset.url, { cache: 'no-cache' }));
-    await caches.open(cacheName).then(cache => cache.addAll(assetsRequests));
+
+    await Promise.all(assetsRequests.map(request => cache.add(request).catch(() => undefined)));
+
+    if (!await matchIndexHtml(cache)) {
+        throw new Error('Service worker: index.html was not cached');
+    }
 }
 
 async function onActivate(event) {
@@ -37,18 +43,35 @@ async function onFetch(event) {
         return fetch(event.request);
     }
 
-    // Navigations always hit the network so a language switch / new deploy is not
-    // stuck behind a stale cached index.html (local dotnet run has no published SW).
+    const cache = await caches.open(cacheName);
+
     if (event.request.mode === 'navigate') {
-        try {
-            return await fetch(event.request);
-        } catch {
-            const cache = await caches.open(cacheName);
-            return await cache.match('index.html') || Response.error();
+        const cachedIndex = await matchIndexHtml(cache);
+        if (cachedIndex) {
+            return cachedIndex;
+        }
+
+        return fetch(event.request);
+    }
+
+    const cachedResponse = await cache.match(event.request, { ignoreSearch: true });
+    return cachedResponse || fetch(event.request);
+}
+
+async function matchIndexHtml(cache) {
+    const candidates = ['index.html', './index.html', '/index.html'];
+    for (const candidate of candidates) {
+        const matched = await cache.match(candidate, { ignoreSearch: true });
+        if (matched) {
+            return matched;
         }
     }
 
-    const cache = await caches.open(cacheName);
-    const cachedResponse = await cache.match(event.request);
-    return cachedResponse || fetch(event.request);
+    const keys = await cache.keys();
+    const indexKey = keys.find(key => {
+        const path = new URL(key.url).pathname;
+        return path.endsWith('/index.html') || path === '/';
+    });
+
+    return indexKey ? cache.match(indexKey) : undefined;
 }

--- a/tests/FishingLogBook.Web.Tests/ServiceWorkerTests/BaseServiceWorkerTest.cs
+++ b/tests/FishingLogBook.Web.Tests/ServiceWorkerTests/BaseServiceWorkerTest.cs
@@ -1,0 +1,23 @@
+using AwesomeAssertions;
+
+namespace FishingLogBook.Web.Tests.ServiceWorkerTests;
+
+public class BaseServiceWorkerTest
+{
+    protected static string ReadWwwRootFile(string fileName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "src", "FishingLogBook.Web", "wwwroot", fileName);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find wwwroot file '{fileName}'.");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/ServiceWorkerTests/WhenTestingPublishedWorker.cs
+++ b/tests/FishingLogBook.Web.Tests/ServiceWorkerTests/WhenTestingPublishedWorker.cs
@@ -1,0 +1,35 @@
+using AwesomeAssertions;
+
+namespace FishingLogBook.Web.Tests.ServiceWorkerTests;
+
+public class WhenTestingPublishedWorker : BaseServiceWorkerTest
+{
+    [Fact]
+    public void ItShouldServeCachedIndexHtmlForNavigations()
+    {
+        // Arrange
+        var script = ReadWwwRootFile("service-worker.published.js");
+        var navigateIndex = script.IndexOf("event.request.mode === 'navigate'", StringComparison.Ordinal);
+
+        // Act
+        var navigateHandler = navigateIndex >= 0 ? script[navigateIndex..] : string.Empty;
+
+        // Assert
+        navigateIndex.Should().BeGreaterThanOrEqualTo(0);
+        navigateHandler.Should().Contain("matchIndexHtml");
+        navigateHandler.IndexOf("cachedIndex", StringComparison.Ordinal)
+            .Should().BeLessThan(navigateHandler.IndexOf("return fetch(event.request)", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ItShouldNotDependOnExternalFontsInTheAppShell()
+    {
+        // Arrange
+        var indexHtml = ReadWwwRootFile("index.html");
+
+        // Act
+        // Assert
+        indexHtml.Should().NotContain("fonts.googleapis.com");
+        indexHtml.Should().Contain("service-worker.js");
+    }
+}


### PR DESCRIPTION
Fixes the #8 reopen gap: a TestCatch could be saved while the page was already open offline, but closing and reopening the PWA with no network failed because the app shell was not served from cache.

## Summary
- Serve `index.html` from the service worker cache for navigations so the PWA can start with no network.
- Stop loading Google Fonts from the network (that stylesheet blocked the shell offline).
- Bump the service worker epoch so phones pick up the new worker after deploy.

## Test plan
- [x] Automated checks that the published worker caches the shell for navigations and that `index.html` has no Google Fonts URL
- [ ] After deploy: open the app online once (so the new service worker installs)
- [ ] Add a test catch, turn off Wi-Fi and mobile data, close the PWA, reopen it, confirm the app loads and the catch is still listed