### PR TITLE
FLB#8 | serve navigations from cache without redirected responses

### DIFF
--- a/src/FishingLogBook.Web/Properties/launchSettings.json
+++ b/src/FishingLogBook.Web/Properties/launchSettings.json
@@ -16,7 +16,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:7005;http://localhost:5019",
+      "applicationUrl": "https://localhost:7005;http://0.0.0.0:5019",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -59,7 +59,7 @@
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script>
         (async () => {
-            const epoch = '20260814-sw-navigation-fix';
+            const epoch = '20260814-cache-first-unredirected';
             try {
                 if (localStorage.getItem('flb-sw-epoch') !== epoch) {
                     const registrations = await navigator.serviceWorker.getRegistrations();

--- a/src/FishingLogBook.Web/wwwroot/service-worker.published.js
+++ b/src/FishingLogBook.Web/wwwroot/service-worker.published.js
@@ -1,5 +1,8 @@
 // Caution! Be sure you understand the caveats before publishing an application with
 // offline support. See https://aka.ms/blazor-offline-considerations
+//
+// Cloudflare Pages 308s /index.html to /. Chrome rejects redirected responses for
+// navigations. Cache-first, then rebuild redirected responses (dotnet/aspnetcore#33872).
 
 self.importScripts('./service-worker-assets.js');
 self.addEventListener('install', event => event.waitUntil(onInstall(event)));
@@ -9,7 +12,11 @@ self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
 const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.woff2$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.svg$/, /\.blat$/, /\.dat$/, /\.webmanifest$/ ];
-const offlineAssetsExclude = [ /^service-worker\.js$/ ];
+const offlineAssetsExclude = [ /^service-worker\.js$/, /\/_redirects$/, /\/_headers$/ ];
+
+const base = '/';
+const baseUrl = new URL(base, self.origin);
+const manifestUrlList = self.assetsManifest.assets.map(asset => new URL(asset.url, baseUrl).href);
 
 async function onInstall(event) {
     console.info('Service worker: Install');
@@ -20,8 +27,8 @@ async function onInstall(event) {
         .filter(asset => !offlineAssetsExclude.some(pattern => pattern.test(asset.url)))
         .map(asset => new Request(asset.url, { cache: 'no-cache' }));
 
-    await Promise.all(assetsRequests.map(request => cache.add(request).catch(() => undefined)));
-    await cacheNavigationShell(cache);
+    await Promise.all(assetsRequests.map(request => cacheUnredirected(cache, request).catch(() => undefined)));
+    await cacheAppShell(cache);
     await self.skipWaiting();
 }
 
@@ -45,45 +52,52 @@ async function onFetch(event) {
         return fetch(event.request);
     }
 
+    const shouldServeIndexHtml = event.request.mode === 'navigate'
+        && !manifestUrlList.some(manifestUrl => manifestUrl === event.request.url);
+
+    const request = shouldServeIndexHtml ? 'index.html' : event.request;
     const cache = await caches.open(cacheName);
+    let cachedResponse = await cache.match(request, { ignoreSearch: true });
 
-    if (event.request.mode === 'navigate') {
-        try {
-            const networkResponse = await fetch(event.request);
-            if (networkResponse.ok) {
-                return networkResponse;
-            }
-        } catch {
-            // Offline or unreachable: use the cached shell below.
-        }
-
-        const cachedIndex = await asNavigationResponse(await matchIndexHtml(cache));
-        if (cachedIndex) {
-            return cachedIndex;
-        }
-
-        return Response.error();
+    if (!cachedResponse && shouldServeIndexHtml) {
+        cachedResponse = await matchIndexHtml(cache);
     }
 
-    const cachedResponse = await cache.match(event.request, { ignoreSearch: true });
-    if (cachedResponse && cachedResponse.ok && !cachedResponse.redirected) {
-        return cachedResponse;
+    if (cachedResponse) {
+        cachedResponse = await withoutRedirect(cachedResponse);
     }
 
-    return fetch(event.request);
+    return cachedResponse || fetch(event.request);
 }
 
-async function cacheNavigationShell(cache) {
-    const response = await fetch(new Request('index.html', { cache: 'no-cache' }));
+async function cacheAppShell(cache) {
+    const response = await fetch(new Request('./', { cache: 'no-cache' }));
     if (!response.ok) {
         return;
     }
 
-    await cache.put('index.html', await asNavigationResponse(response));
+    const shell = await withoutRedirect(response);
+    if (!shell) {
+        return;
+    }
+
+    await cache.put('index.html', shell);
+}
+
+async function cacheUnredirected(cache, request) {
+    const response = await fetch(request);
+    if (!response.ok) {
+        return;
+    }
+
+    const stored = await withoutRedirect(response);
+    if (stored) {
+        await cache.put(request, stored);
+    }
 }
 
 async function matchIndexHtml(cache) {
-    const candidates = ['index.html', './index.html', '/index.html'];
+    const candidates = ['index.html', './index.html', '/index.html', './', '/'];
     for (const candidate of candidates) {
         const matched = await cache.match(candidate, { ignoreSearch: true });
         if (matched) {
@@ -100,14 +114,19 @@ async function matchIndexHtml(cache) {
     return indexKey ? cache.match(indexKey) : undefined;
 }
 
-async function asNavigationResponse(response) {
-    if (!response || !response.ok) {
+async function withoutRedirect(response) {
+    if (!response) {
         return undefined;
     }
 
-    return new Response(await response.blob(), {
-        status: 200,
-        statusText: 'OK',
-        headers: response.headers
+    if (!response.redirected) {
+        return response;
+    }
+
+    const clonedResponse = response.clone();
+    return new Response(clonedResponse.body, {
+        headers: clonedResponse.headers,
+        status: clonedResponse.status,
+        statusText: clonedResponse.statusText
     });
 }

--- a/tests/FishingLogBook.Web.Tests/ServiceWorkerTests/WhenTestingPublishedWorker.cs
+++ b/tests/FishingLogBook.Web.Tests/ServiceWorkerTests/WhenTestingPublishedWorker.cs
@@ -5,22 +5,34 @@ namespace FishingLogBook.Web.Tests.ServiceWorkerTests;
 public class WhenTestingPublishedWorker : BaseServiceWorkerTest
 {
     [Fact]
-    public void ItShouldServeCachedIndexHtmlForNavigations()
+    public void ItShouldServeCachedIndexHtmlForNavigationsWithoutWaitingOnTheNetwork()
     {
         // Arrange
         var script = ReadWwwRootFile("service-worker.published.js");
-        var navigateIndex = script.IndexOf("event.request.mode === 'navigate'", StringComparison.Ordinal);
 
         // Act
-        var navigateHandler = navigateIndex >= 0 ? script[navigateIndex..] : string.Empty;
-
         // Assert
-        navigateIndex.Should().BeGreaterThanOrEqualTo(0);
-        navigateHandler.Should().Contain("fetch(event.request)");
-        navigateHandler.Should().Contain("asNavigationResponse");
-        navigateHandler.Should().Contain("matchIndexHtml");
-        navigateHandler.IndexOf("fetch(event.request)", StringComparison.Ordinal)
-            .Should().BeLessThan(navigateHandler.IndexOf("asNavigationResponse", StringComparison.Ordinal));
+        script.Should().Contain("event.request.mode === 'navigate'");
+        script.Should().Contain("shouldServeIndexHtml");
+        script.Should().Contain("? 'index.html'");
+        script.Should().Contain("cachedResponse || fetch(event.request)");
+        script.IndexOf("cache.match", StringComparison.Ordinal)
+            .Should().BeLessThan(script.IndexOf("cachedResponse || fetch(event.request)", StringComparison.Ordinal));
+        script.Should().NotContain("const networkResponse = await fetch(event.request)");
+    }
+
+    [Fact]
+    public void ItShouldRebuildRedirectedCachedResponsesBeforeServingThem()
+    {
+        // Arrange
+        var script = ReadWwwRootFile("service-worker.published.js");
+
+        // Act
+        // Assert
+        script.Should().Contain("response.redirected");
+        script.Should().Contain("new Response(clonedResponse.body");
+        script.Should().Contain("cacheAppShell");
+        script.Should().Contain("cache.put('index.html'");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Serve navigations from the cached app shell (cache-first), and rebuild redirected cached responses so Chrome accepts them.
- Cloudflare Pages 308s `/index.html` to `/`; serving that redirected response was the live `ERR_FAILED` and the reason network-first then failed offline.
- Bind local HTTP to `0.0.0.0:5019` so a phone on Wi-Fi can open `dotnet run` (not an offline proof).

Follows the Blazor template approach for [dotnet/aspnetcore#33872](https://github.com/dotnet/aspnetcore/issues/33872). Related to #8. Supersedes the network-first change in #53.

## Test plan
- [x] `dotnet test tests/FishingLogBook.Web.Tests` (25 passed)
- [ ] After deploy: open https://fishing-logbook-dev.pages.dev/ on Wi-Fi and wait until it has loaded
- [ ] Airplane mode, close and reopen — app shell should load
- [ ] If a device is still stuck on the old worker, uninstall the PWA or unregister the service worker once
