### PR TITLE
FLB#7 | synchronise TestCatch without creating duplicate server records

### DIFF
--- a/src/FishingLogBook.Api/Endpoints/TestCatchEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/TestCatchEndpoints.cs
@@ -1,0 +1,45 @@
+using FishingLogBook.Application.TestCatches;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Api.Endpoints;
+
+public static class TestCatchEndpoints
+{
+    public static IEndpointRouteBuilder MapTestCatchEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/api/test-catches", UpsertAsync)
+            .WithName("UpsertTestCatch")
+            .WithTags("TestCatch")
+            .Produces<TestCatchDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest);
+
+        endpoints.MapGet("/api/test-catches", ListAsync)
+            .WithName("ListTestCatches")
+            .WithTags("TestCatch")
+            .Produces<IReadOnlyList<TestCatchDto>>(StatusCodes.Status200OK);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> UpsertAsync(
+        TestCatchDto testCatch,
+        TestCatchService testCatchService,
+        CancellationToken cancellationToken)
+    {
+        if (testCatch.Id == Guid.Empty || string.IsNullOrWhiteSpace(testCatch.SpeciesName))
+        {
+            return Results.BadRequest();
+        }
+
+        var saved = await testCatchService.UpsertAsync(testCatch, cancellationToken);
+        return Results.Ok(saved);
+    }
+
+    private static async Task<IResult> ListAsync(
+        TestCatchService testCatchService,
+        CancellationToken cancellationToken)
+    {
+        var catches = await testCatchService.ListAsync(cancellationToken);
+        return Results.Ok(catches);
+    }
+}

--- a/src/FishingLogBook.Api/Program.cs
+++ b/src/FishingLogBook.Api/Program.cs
@@ -46,6 +46,7 @@ if (app.Environment.IsDevelopment())
 app.UseCors(webClientCorsPolicy);
 
 app.MapSystemEndpoints();
+app.MapTestCatchEndpoints();
 
 app.Run();
 

--- a/src/FishingLogBook.Application/Contracts/ITestCatchRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/ITestCatchRepository.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Domain.TestCatches;
+
+namespace FishingLogBook.Application.Contracts;
+
+public interface ITestCatchRepository
+{
+    Task<TestCatchRecord> UpsertAsync(TestCatchRecord record, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TestCatchRecord>> GetAllAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/TestCatches/TestCatchService.cs
+++ b/src/FishingLogBook.Application/TestCatches/TestCatchService.cs
@@ -1,0 +1,40 @@
+using FishingLogBook.Application.Contracts;
+using FishingLogBook.Domain.TestCatches;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.TestCatches;
+
+public sealed class TestCatchService
+{
+    private readonly ITestCatchRepository _testCatchRepository;
+
+    public TestCatchService(ITestCatchRepository testCatchRepository)
+    {
+        _testCatchRepository = testCatchRepository;
+    }
+
+    public async Task<TestCatchDto> UpsertAsync(TestCatchDto testCatch, CancellationToken cancellationToken)
+    {
+        var record = new TestCatchRecord
+        {
+            Id = testCatch.Id,
+            SpeciesName = testCatch.SpeciesName,
+            CaughtOn = testCatch.CaughtOn,
+            Notes = testCatch.Notes
+        };
+
+        var saved = await _testCatchRepository.UpsertAsync(record, cancellationToken);
+        return ToDto(saved);
+    }
+
+    public async Task<IReadOnlyList<TestCatchDto>> ListAsync(CancellationToken cancellationToken)
+    {
+        var records = await _testCatchRepository.GetAllAsync(cancellationToken);
+        return records.Select(ToDto).ToArray();
+    }
+
+    private static TestCatchDto ToDto(TestCatchRecord record)
+    {
+        return new TestCatchDto(record.Id, record.SpeciesName, record.CaughtOn, record.Notes);
+    }
+}

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608141400_7_CreateTestCatch.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608141400_7_CreateTestCatch.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS "TestCatch"
+(
+    "Id"          uuid        NOT NULL,
+    "SpeciesName" text        NOT NULL,
+    "CaughtOn"    timestamptz NOT NULL,
+    "Notes"       text        NULL,
+    CONSTRAINT "PkTestCatch" PRIMARY KEY ("Id")
+);

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using FishingLogBook.Application.Contracts;
 using FishingLogBook.Application.SystemStatus;
+using FishingLogBook.Application.TestCatches;
 using FishingLogBook.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +22,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddFishingLogBookApplication(this IServiceCollection services)
     {
         services.AddScoped<SystemStatusService>();
+        services.AddScoped<TestCatchService>();
 
         return services;
     }
@@ -34,6 +36,7 @@ public static class ServiceCollectionExtensions
             return new NpgsqlConnectionFactory(connectionString);
         });
         services.AddScoped<ISystemRepository, SystemRepository>();
+        services.AddScoped<ITestCatchRepository, TestCatchRepository>();
 
         return services;
     }

--- a/src/FishingLogBook.Domain/TestCatches/TestCatchRecord.cs
+++ b/src/FishingLogBook.Domain/TestCatches/TestCatchRecord.cs
@@ -1,0 +1,12 @@
+namespace FishingLogBook.Domain.TestCatches;
+
+public sealed class TestCatchRecord
+{
+    public Guid Id { get; init; }
+
+    public string SpeciesName { get; init; } = string.Empty;
+
+    public DateTimeOffset CaughtOn { get; init; }
+
+    public string? Notes { get; init; }
+}

--- a/src/FishingLogBook.Infrastructure/Persistence/TestCatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/TestCatchRepository.cs
@@ -1,0 +1,49 @@
+using Dapper;
+using FishingLogBook.Application.Contracts;
+using FishingLogBook.Domain.TestCatches;
+
+namespace FishingLogBook.Infrastructure.Persistence;
+
+public sealed class TestCatchRepository : ITestCatchRepository
+{
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public TestCatchRepository(IDbConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+    }
+
+    public async Task<TestCatchRecord> UpsertAsync(TestCatchRecord record, CancellationToken cancellationToken)
+    {
+        const string insertSql = """
+            INSERT INTO "TestCatch" ("Id", "SpeciesName", "CaughtOn", "Notes")
+            VALUES (@Id, @SpeciesName, @CaughtOn, @Notes)
+            ON CONFLICT ("Id") DO NOTHING;
+            """;
+
+        const string selectSql = """
+            SELECT "Id", "SpeciesName", "CaughtOn", "Notes"
+            FROM "TestCatch"
+            WHERE "Id" = @Id;
+            """;
+
+        await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+        await connection.ExecuteAsync(new CommandDefinition(insertSql, record, cancellationToken: cancellationToken));
+        return await connection.QuerySingleAsync<TestCatchRecord>(
+            new CommandDefinition(selectSql, new { record.Id }, cancellationToken: cancellationToken));
+    }
+
+    public async Task<IReadOnlyList<TestCatchRecord>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT "Id", "SpeciesName", "CaughtOn", "Notes"
+            FROM "TestCatch"
+            ORDER BY "CaughtOn" DESC;
+            """;
+
+        await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+        var command = new CommandDefinition(sql, cancellationToken: cancellationToken);
+        var records = await connection.QueryAsync<TestCatchRecord>(command);
+        return records.ToArray();
+    }
+}

--- a/src/FishingLogBook.Shared/Dtos/TestCatchDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/TestCatchDto.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record TestCatchDto(
+    Guid Id,
+    string SpeciesName,
+    DateTimeOffset CaughtOn,
+    string? Notes);

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -111,4 +111,7 @@
   <data name="SyncStatus_FailedToSynchronise" xml:space="preserve">
     <value>Échec de la synchronisation</value>
   </data>
+  <data name="TestCatch_Retry" xml:space="preserve">
+    <value>Réessayer la synchronisation</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -111,4 +111,7 @@
   <data name="SyncStatus_FailedToSynchronise" xml:space="preserve">
     <value>Failed to synchronise</value>
   </data>
+  <data name="TestCatch_Retry" xml:space="preserve">
+    <value>Retry synchronisation</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Offline/ITestCatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Offline/ITestCatchSynchroniser.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Web.Offline;
+
+public interface ITestCatchSynchroniser
+{
+    Task SynchronisePendingAsync(CancellationToken cancellationToken);
+
+    Task RetryAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Offline/TestCatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatchSynchroniser.cs
@@ -1,0 +1,122 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Services;
+
+namespace FishingLogBook.Web.Offline;
+
+public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
+{
+    private readonly ITestCatchStore _store;
+    private readonly ITestCatchClient _client;
+    private readonly INetworkStatus _networkStatus;
+
+    public TestCatchSynchroniser(
+        ITestCatchStore store,
+        ITestCatchClient client,
+        INetworkStatus networkStatus)
+    {
+        _store = store;
+        _client = client;
+        _networkStatus = networkStatus;
+    }
+
+    public async Task SynchronisePendingAsync(CancellationToken cancellationToken)
+    {
+        if (!await _networkStatus.IsOnlineAsync(cancellationToken))
+        {
+            return;
+        }
+
+        await MergeFromServerAsync(cancellationToken);
+
+        var local = await _store.GetAllAsync(cancellationToken);
+        foreach (var testCatch in local.Where(NeedsSync))
+        {
+            await _store.SaveAsync(testCatch with { SyncStatus = SyncStatus.WaitingToSynchronise }, cancellationToken);
+        }
+
+        local = await _store.GetAllAsync(cancellationToken);
+        foreach (var testCatch in local.Where(NeedsSync))
+        {
+            await SynchroniseOneAsync(testCatch, cancellationToken);
+        }
+    }
+
+    public async Task RetryAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var local = await _store.GetAllAsync(cancellationToken);
+        var testCatch = local.SingleOrDefault(item => item.Id == id);
+        if (testCatch is null || !NeedsSync(testCatch))
+        {
+            return;
+        }
+
+        if (!await _networkStatus.IsOnlineAsync(cancellationToken))
+        {
+            await _store.SaveAsync(testCatch with { SyncStatus = SyncStatus.WaitingToSynchronise }, cancellationToken);
+            return;
+        }
+
+        await SynchroniseOneAsync(testCatch, cancellationToken);
+    }
+
+    private async Task MergeFromServerAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<TestCatchDto> remote;
+        try
+        {
+            remote = await _client.GetAllAsync(cancellationToken);
+        }
+        catch (HttpRequestException)
+        {
+            return;
+        }
+        catch (TaskCanceledException)
+        {
+            return;
+        }
+
+        var local = await _store.GetAllAsync(cancellationToken);
+        var localById = local.ToDictionary(item => item.Id);
+
+        foreach (var dto in remote)
+        {
+            if (localById.TryGetValue(dto.Id, out var existing) && NeedsSync(existing))
+            {
+                continue;
+            }
+
+            await _store.SaveAsync(
+                new TestCatch(dto.Id, dto.SpeciesName, dto.CaughtOn, dto.Notes, SyncStatus.Synchronised),
+                cancellationToken);
+        }
+    }
+
+    private async Task SynchroniseOneAsync(TestCatch testCatch, CancellationToken cancellationToken)
+    {
+        await _store.SaveAsync(testCatch with { SyncStatus = SyncStatus.Synchronising }, cancellationToken);
+
+        try
+        {
+            await _client.UpsertAsync(
+                new TestCatchDto(testCatch.Id, testCatch.SpeciesName, testCatch.CaughtOn, testCatch.Notes),
+                cancellationToken);
+            await _store.SaveAsync(testCatch with { SyncStatus = SyncStatus.Synchronised }, cancellationToken);
+        }
+        catch (HttpRequestException)
+        {
+            await _store.SaveAsync(testCatch with { SyncStatus = SyncStatus.FailedToSynchronise }, cancellationToken);
+        }
+        catch (TaskCanceledException)
+        {
+            await _store.SaveAsync(testCatch with { SyncStatus = SyncStatus.FailedToSynchronise }, cancellationToken);
+        }
+    }
+
+    private static bool NeedsSync(TestCatch testCatch)
+    {
+        return testCatch.SyncStatus is SyncStatus.SavedLocally
+            or SyncStatus.WaitingToSynchronise
+            or SyncStatus.FailedToSynchronise;
+    }
+}

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor
@@ -48,9 +48,19 @@
                             <MudStack Spacing="1">
                                 <MudText Typo="Typo.subtitle1" id="@($"test-catch-species-{testCatch.Id}")">@testCatch.SpeciesName</MudText>
                                 <MudText Typo="Typo.caption" Class="mud-text-secondary" id="@($"test-catch-caught-on-{testCatch.Id}")">@testCatch.CaughtOn.ToLocalTime().ToString("g")</MudText>
-                                <MudText Typo="Typo.caption" Color="Color.Warning" id="@($"test-catch-sync-status-{testCatch.Id}")">
+                                <MudText Typo="Typo.caption" Color="@SyncStatusColor(testCatch.SyncStatus)" id="@($"test-catch-sync-status-{testCatch.Id}")">
                                     @Loc[SyncStatusKey(testCatch.SyncStatus)]
                                 </MudText>
+                                @if (testCatch.SyncStatus == SyncStatus.FailedToSynchronise)
+                                {
+                                    <MudButton Variant="Variant.Text"
+                                               Color="Color.Primary"
+                                               Size="Size.Small"
+                                               OnClick="@(() => RetryAsync(testCatch.Id))"
+                                               id="@($"retry-test-catch-{testCatch.Id}")">
+                                        @Loc["TestCatch_Retry"]
+                                    </MudButton>
+                                }
                             </MudStack>
                         </MudPaper>
                     }

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
@@ -3,12 +3,15 @@ using FishingLogBook.Web.Models;
 using FishingLogBook.Web.Offline;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
+using Microsoft.JSInterop;
+using MudBlazor;
 
 namespace FishingLogBook.Web.Pages.TestCatchLog;
 
 public partial class TestCatchLog : ComponentBase, IDisposable
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private DotNetObjectReference<TestCatchLog>? _dotNetReference;
 
     private string _speciesName = string.Empty;
     private string _notes = string.Empty;
@@ -19,6 +22,12 @@ public partial class TestCatchLog : ComponentBase, IDisposable
     private ITestCatchStore TestCatchStore { get; set; } = default!;
 
     [Inject]
+    private ITestCatchSynchroniser TestCatchSynchroniser { get; set; } = default!;
+
+    [Inject]
+    private IJSRuntime JsRuntime { get; set; } = default!;
+
+    [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     private bool CanSave => !_isSaving && !string.IsNullOrWhiteSpace(_speciesName);
@@ -26,6 +35,27 @@ public partial class TestCatchLog : ComponentBase, IDisposable
     protected override async Task OnInitializedAsync()
     {
         await LoadAsync();
+        await TestCatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
+        await LoadAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        _dotNetReference = DotNetObjectReference.Create(this);
+        await JsRuntime.InvokeVoidAsync("fishingLogBookNetwork.onOnline", _dotNetReference);
+    }
+
+    [JSInvokable]
+    public async Task OnBrowserOnline()
+    {
+        await TestCatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
+        await LoadAsync();
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task SaveAsync()
@@ -47,8 +77,15 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         await TestCatchStore.SaveAsync(testCatch, _cancellationTokenSource.Token);
         _speciesName = string.Empty;
         _notes = string.Empty;
+        await TestCatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
         await LoadAsync();
         _isSaving = false;
+    }
+
+    private async Task RetryAsync(Guid id)
+    {
+        await TestCatchSynchroniser.RetryAsync(id, _cancellationTokenSource.Token);
+        await LoadAsync();
     }
 
     private async Task LoadAsync()
@@ -69,9 +106,21 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         };
     }
 
+    private static Color SyncStatusColor(SyncStatus syncStatus)
+    {
+        return syncStatus switch
+        {
+            SyncStatus.Synchronised => Color.Success,
+            SyncStatus.FailedToSynchronise => Color.Error,
+            SyncStatus.WaitingToSynchronise or SyncStatus.Synchronising => Color.Info,
+            _ => Color.Warning
+        };
+    }
+
     public void Dispose()
     {
         _cancellationTokenSource.Cancel();
+        _dotNetReference?.Dispose();
         _cancellationTokenSource.Dispose();
     }
 }

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -18,8 +18,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(apiConfig);
         services.AddScoped(_ => new HttpClient { BaseAddress = apiBaseAddress });
         services.AddScoped<ISystemStatusClient, SystemStatusClient>();
+        services.AddScoped<ITestCatchClient, TestCatchClient>();
+        services.AddScoped<INetworkStatus, BrowserNetworkStatus>();
         services.AddScoped<ITestCatchJsonStore, IndexedDbTestCatchJsonStore>();
         services.AddScoped<ITestCatchStore, TestCatchStore>();
+        services.AddScoped<ITestCatchSynchroniser, TestCatchSynchroniser>();
         services.AddLocalization();
         services.AddScoped<ICultureService, CultureService>();
         services.AddMudServices();

--- a/src/FishingLogBook.Web/Services/BrowserNetworkStatus.cs
+++ b/src/FishingLogBook.Web/Services/BrowserNetworkStatus.cs
@@ -1,0 +1,18 @@
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Services;
+
+public sealed class BrowserNetworkStatus : INetworkStatus
+{
+    private readonly IJSRuntime _jsRuntime;
+
+    public BrowserNetworkStatus(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task<bool> IsOnlineAsync(CancellationToken cancellationToken)
+    {
+        return await _jsRuntime.InvokeAsync<bool>("fishingLogBookNetwork.isOnline", cancellationToken);
+    }
+}

--- a/src/FishingLogBook.Web/Services/INetworkStatus.cs
+++ b/src/FishingLogBook.Web/Services/INetworkStatus.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Web.Services;
+
+public interface INetworkStatus
+{
+    Task<bool> IsOnlineAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Services/ITestCatchClient.cs
+++ b/src/FishingLogBook.Web/Services/ITestCatchClient.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Services;
+
+public interface ITestCatchClient
+{
+    Task UpsertAsync(TestCatchDto testCatch, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TestCatchDto>> GetAllAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Services/TestCatchClient.cs
+++ b/src/FishingLogBook.Web/Services/TestCatchClient.cs
@@ -1,0 +1,29 @@
+using System.Net.Http.Json;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Services;
+
+public sealed class TestCatchClient : ITestCatchClient
+{
+    private readonly HttpClient _httpClient;
+
+    public TestCatchClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task UpsertAsync(TestCatchDto testCatch, CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.PostAsJsonAsync("api/test-catches", testCatch, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<IReadOnlyList<TestCatchDto>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        var catches = await _httpClient.GetFromJsonAsync<IReadOnlyList<TestCatchDto>>(
+            "api/test-catches",
+            cancellationToken);
+
+        return catches ?? [];
+    }
+}

--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -34,6 +34,14 @@
                 location.replace(`${location.origin}${location.pathname || '/'}`);
             }
         };
+        window.fishingLogBookNetwork = {
+            isOnline: () => navigator.onLine,
+            onOnline: (helper) => {
+                window.addEventListener('online', () => {
+                    helper.invokeMethodAsync('OnBrowserOnline');
+                });
+            }
+        };
         const storedCulture = window.fishingLogBookCulture.get();
         if (storedCulture) {
             document.documentElement.lang = storedCulture;

--- a/tests/FishingLogBook.Api.Tests/DependencyInjectionTests/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Api.Tests/DependencyInjectionTests/WhenTestingContainer.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using FishingLogBook.Application.Contracts;
 using FishingLogBook.Application.SystemStatus;
+using FishingLogBook.Application.TestCatches;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FishingLogBook.Api.Tests.DependencyInjectionTests;
@@ -41,6 +42,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
 
         // Assert
         injectedTypes.Should().Contain(typeof(SystemStatusService));
+        injectedTypes.Should().Contain(typeof(TestCatchService));
         resolve.Should().NotThrow();
     }
 

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -13,6 +13,8 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
 {
     public ISystemRepository SystemRepository { get; } = Substitute.For<ISystemRepository>();
 
+    public ITestCatchRepository TestCatchRepository { get; } = Substitute.For<ITestCatchRepository>();
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Production");
@@ -29,6 +31,8 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
         {
             services.RemoveAll<ISystemRepository>();
             services.AddScoped(_ => SystemRepository);
+            services.RemoveAll<ITestCatchRepository>();
+            services.AddScoped(_ => TestCatchRepository);
         });
     }
 }

--- a/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingUpsert.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Domain.TestCatches;
+using FishingLogBook.Shared.Dtos;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.TestCatchEndpointsTests;
+
+public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
+{
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingUpsert(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheSameRecord_WhenPostedTwiceWithTheSameId()
+    {
+        // Arrange
+        var record = new TestCatchRecord
+        {
+            Id = Guid.Parse("9b7e2d14-0c58-4a91-8e26-3f1d0a7c4b85"),
+            SpeciesName = "Trout",
+            CaughtOn = DateTimeOffset.Parse("2026-08-14T14:00:00Z"),
+            Notes = "Weir pool"
+        };
+        _factory.TestCatchRepository
+            .UpsertAsync(Arg.Any<TestCatchRecord>(), Arg.Any<CancellationToken>())
+            .Returns(record);
+        var client = _factory.CreateClient();
+        var dto = new TestCatchDto(record.Id, record.SpeciesName, record.CaughtOn, record.Notes);
+
+        // Act
+        var first = await client.PostAsJsonAsync("/api/test-catches", dto);
+        var second = await client.PostAsJsonAsync("/api/test-catches", dto);
+        var firstBody = await first.Content.ReadFromJsonAsync<TestCatchDto>();
+        var secondBody = await second.Content.ReadFromJsonAsync<TestCatchDto>();
+
+        // Assert
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        firstBody.Should().Be(dto);
+        secondBody.Should().Be(dto);
+        await _factory.TestCatchRepository.Received(2).UpsertAsync(
+            Arg.Is<TestCatchRecord>(item => item.Id == record.Id),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheCatch_WhenSpeciesIsMissing()
+    {
+        // Arrange
+        _factory.TestCatchRepository.ClearReceivedCalls();
+        var client = _factory.CreateClient();
+        var dto = new TestCatchDto(Guid.NewGuid(), "  ", DateTimeOffset.UtcNow, null);
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/test-catches", dto);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TestCatchRepository.DidNotReceive()
+            .UpsertAsync(Arg.Any<TestCatchRecord>(), Arg.Any<CancellationToken>());
+    }
+}
+
+public class WhenTestingList : IClassFixture<SystemApiFactory>
+{
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingList(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldReturnStoredCatches()
+    {
+        // Arrange
+        var record = new TestCatchRecord
+        {
+            Id = Guid.Parse("1c9a4e70-6d2b-4f18-a5c3-8e0b9d47f012"),
+            SpeciesName = "Roach",
+            CaughtOn = DateTimeOffset.Parse("2026-08-14T15:00:00Z"),
+            Notes = null
+        };
+        _factory.TestCatchRepository
+            .GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatchRecord>>([record]));
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+        var body = await response.Content.ReadFromJsonAsync<IReadOnlyList<TestCatchDto>>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().ContainSingle()
+            .Which.Should().Be(new TestCatchDto(record.Id, record.SpeciesName, record.CaughtOn, record.Notes));
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/MemoryTestCatchRepository.cs
+++ b/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/MemoryTestCatchRepository.cs
@@ -1,0 +1,20 @@
+using FishingLogBook.Application.Contracts;
+using FishingLogBook.Domain.TestCatches;
+
+namespace FishingLogBook.Application.Tests.TestCatchServiceTests;
+
+internal sealed class MemoryTestCatchRepository : ITestCatchRepository
+{
+    private readonly Dictionary<Guid, TestCatchRecord> _records = new();
+
+    public Task<TestCatchRecord> UpsertAsync(TestCatchRecord record, CancellationToken cancellationToken)
+    {
+        _records.TryAdd(record.Id, record);
+        return Task.FromResult(_records[record.Id]);
+    }
+
+    public Task<IReadOnlyList<TestCatchRecord>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IReadOnlyList<TestCatchRecord>>(_records.Values.ToArray());
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/WhenTestingUpsert.cs
@@ -1,0 +1,50 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.TestCatches;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Tests.TestCatchServiceTests;
+
+public class WhenTestingUpsert
+{
+    [Fact]
+    public async Task ItShouldKeepASingleRecord_WhenTheSameCatchIsUpsertedTwice()
+    {
+        // Arrange
+        var repository = new MemoryTestCatchRepository();
+        var sut = new TestCatchService(repository);
+        var testCatch = new TestCatchDto(
+            Guid.Parse("4e2a1c90-8b33-4f6d-9a17-5c0e8d2b1a44"),
+            "Pike",
+            DateTimeOffset.Parse("2026-08-14T12:00:00Z"),
+            "First attempt");
+
+        // Act
+        await sut.UpsertAsync(testCatch, CancellationToken.None);
+        var retried = testCatch with { Notes = "Retry after timeout" };
+        await sut.UpsertAsync(retried, CancellationToken.None);
+        var listed = await sut.ListAsync(CancellationToken.None);
+
+        // Assert
+        listed.Should().ContainSingle()
+            .Which.Id.Should().Be(testCatch.Id);
+        listed[0].Notes.Should().Be("First attempt");
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheCatch_WhenUpserted()
+    {
+        // Arrange
+        var sut = new TestCatchService(new MemoryTestCatchRepository());
+        var testCatch = new TestCatchDto(
+            Guid.NewGuid(),
+            "Perch",
+            DateTimeOffset.Parse("2026-08-14T13:00:00Z"),
+            null);
+
+        // Act
+        var saved = await sut.UpsertAsync(testCatch, CancellationToken.None);
+
+        // Assert
+        saved.Should().Be(testCatch);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DependencyInjectionTests/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjectionTests/WhenTestingContainer.cs
@@ -43,6 +43,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         // Assert
         injectedTypes.Should().Contain(typeof(ISystemStatusClient));
         injectedTypes.Should().Contain(typeof(ITestCatchStore));
+        injectedTypes.Should().Contain(typeof(ITestCatchSynchroniser));
         injectedTypes.Should().Contain(typeof(ICultureService));
         injectedTypes.Should().Contain(typeof(IStringLocalizer<UiStrings>));
         resolve.Should().NotThrow();

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
@@ -11,11 +11,17 @@ public class BaseTestCatchLogTest
 {
     protected static BunitContext CreateContext(ITestCatchStore store)
     {
+        return CreateContext(store, Substitute.For<ITestCatchSynchroniser>());
+    }
+
+    protected static BunitContext CreateContext(ITestCatchStore store, ITestCatchSynchroniser synchroniser)
+    {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
         context.Services.AddSingleton(store);
+        context.Services.AddSingleton(synchroniser);
         context.Services.AddSingleton(Substitute.For<ICultureService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
 

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingReopen.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingReopen.cs
@@ -37,7 +37,7 @@ public class WhenTestingReopen : BaseTestCatchLogTest
             cut.Find($"#test-catch-sync-status-{existing.Id}").TextContent.Should()
                 .Contain("Saved locally — not synchronised");
         });
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received().GetAllAsync(Arg.Any<CancellationToken>());
         await store.DidNotReceive().SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>());
     }
 
@@ -66,6 +66,6 @@ public class WhenTestingReopen : BaseTestCatchLogTest
             cut.Find($"#test-catch-sync-status-{existing.Id}").TextContent.Should()
                 .Contain("Enregistrée localement — pas encore synchronisée");
         });
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received().GetAllAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingSyncStatus.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingSyncStatus.cs
@@ -1,0 +1,99 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Pages.TestCatchLog;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class WhenTestingSyncStatus : BaseTestCatchLogTest
+{
+    [Fact]
+    public async Task ItShouldShowRetry_WhenSynchronisationFailed()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("5a2c8e14-9d70-4b31-8f6a-1c3e7b90d246"),
+            "Carp",
+            DateTimeOffset.Parse("2026-08-14T17:00:00Z"),
+            null,
+            SyncStatus.FailedToSynchronise);
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        var synchroniser = Substitute.For<ITestCatchSynchroniser>();
+        await using var context = CreateContext(store, synchroniser);
+        var cut = context.Render<TestCatchLog>();
+
+        // Act
+        cut.WaitForAssertion(() => cut.Find($"#retry-test-catch-{existing.Id}").Should().NotBeNull());
+        await cut.Find($"#retry-test-catch-{existing.Id}").ClickAsync();
+
+        // Assert
+        cut.Find($"#test-catch-sync-status-{existing.Id}").TextContent.Should()
+            .Contain("Failed to synchronise");
+        await synchroniser.Received(1).RetryAsync(existing.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowSynchronisedStatus()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("0e7b3c91-5a24-4d86-b1f0-8c2d9e4a6b17"),
+            "Tench",
+            DateTimeOffset.Parse("2026-08-14T18:00:00Z"),
+            null,
+            SyncStatus.Synchronised);
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#test-catch-sync-status-{existing.Id}").TextContent.Should()
+                .Contain("Synchronised");
+        });
+        cut.FindAll($"#retry-test-catch-{existing.Id}").Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(SyncStatus.WaitingToSynchronise, "Waiting to synchronise")]
+    [InlineData(SyncStatus.Synchronising, "Synchronising")]
+    [InlineData(SyncStatus.SavedLocally, "Saved locally — not synchronised")]
+    public async Task ItShouldShowTheSyncState(SyncStatus status, string expected)
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("8c1d4a70-2e59-4b16-9f83-6a0c7d5e1b42"),
+            "Rudd",
+            DateTimeOffset.Parse("2026-08-14T19:00:00Z"),
+            null,
+            status);
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#test-catch-sync-status-{existing.Id}").TextContent.Should()
+                .Contain(expected);
+        });
+        cut.FindAll($"#retry-test-catch-{existing.Id}").Should().BeEmpty();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchSynchroniserTests/WhenTestingSynchronise.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchSynchroniserTests/WhenTestingSynchronise.cs
@@ -1,0 +1,169 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Services;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.TestCatchSynchroniserTests;
+
+public class WhenTestingSynchronise
+{
+    [Fact]
+    public async Task ItShouldMarkCatchSynchronised_WhenApiAcceptsIt()
+    {
+        // Arrange
+        var testCatch = CreateCatch(SyncStatus.SavedLocally);
+        var store = CreateStore([testCatch]);
+        var client = Substitute.For<ITestCatchClient>();
+        client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
+        var sut = new TestCatchSynchroniser(store, client, Online());
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle()
+            .Which.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        await client.Received(1).UpsertAsync(
+            Arg.Is<TestCatchDto>(dto => dto.Id == testCatch.Id),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheLocalCatchAndMarkFailed_WhenApiCallFails()
+    {
+        // Arrange
+        var testCatch = CreateCatch(SyncStatus.SavedLocally);
+        var store = CreateStore([testCatch]);
+        var client = Substitute.For<ITestCatchClient>();
+        client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
+        client.UpsertAsync(Arg.Any<TestCatchDto>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("network"));
+        var sut = new TestCatchSynchroniser(store, client, Online());
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle();
+        saved[0].Id.Should().Be(testCatch.Id);
+        saved[0].SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+    }
+
+    [Fact]
+    public async Task ItShouldLeaveCatchSavedLocally_WhenOffline()
+    {
+        // Arrange
+        var testCatch = CreateCatch(SyncStatus.SavedLocally);
+        var store = CreateStore([testCatch]);
+        var client = Substitute.For<ITestCatchClient>();
+        var network = Substitute.For<INetworkStatus>();
+        network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var sut = new TestCatchSynchroniser(store, client, network);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle()
+            .Which.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        await client.DidNotReceive().UpsertAsync(Arg.Any<TestCatchDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotCreateASecondServerRecord_WhenFailedCatchIsRetried()
+    {
+        // Arrange
+        var testCatch = CreateCatch(SyncStatus.SavedLocally);
+        var store = CreateStore([testCatch]);
+        var client = Substitute.For<ITestCatchClient>();
+        client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
+        var sut = new TestCatchSynchroniser(store, client, Online());
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var afterFirst = (await store.GetAllAsync(CancellationToken.None))[0];
+        await store.SaveAsync(afterFirst with { SyncStatus = SyncStatus.FailedToSynchronise }, CancellationToken.None);
+        await sut.RetryAsync(testCatch.Id, CancellationToken.None);
+        var saved = await store.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle().Which.Id.Should().Be(testCatch.Id);
+        await client.Received(2).UpsertAsync(
+            Arg.Is<TestCatchDto>(dto => dto.Id == testCatch.Id),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowServerCatchesAsSynchronised_WhenMergedFromApi()
+    {
+        // Arrange
+        var store = CreateStore([]);
+        var remote = new TestCatchDto(
+            Guid.Parse("6f4c8a12-3e90-4b7d-a1c5-9d2e8f0b6a33"),
+            "Bream",
+            DateTimeOffset.Parse("2026-08-14T16:00:00Z"),
+            null);
+        var client = Substitute.For<ITestCatchClient>();
+        client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([remote]);
+        var sut = new TestCatchSynchroniser(store, client, Online());
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle();
+        saved[0].Id.Should().Be(remote.Id);
+        saved[0].SpeciesName.Should().Be("Bream");
+        saved[0].SyncStatus.Should().Be(SyncStatus.Synchronised);
+        await client.DidNotReceive().UpsertAsync(Arg.Any<TestCatchDto>(), Arg.Any<CancellationToken>());
+    }
+
+    private static INetworkStatus Online()
+    {
+        var network = Substitute.For<INetworkStatus>();
+        network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(true);
+        return network;
+    }
+
+    private static TestCatch CreateCatch(SyncStatus status)
+    {
+        return new TestCatch(
+            Guid.Parse("2d8b6e40-1a57-4c3f-9e12-7b0c5d8a4f21"),
+            "Pike",
+            DateTimeOffset.Parse("2026-08-14T12:00:00Z"),
+            "First attempt",
+            status);
+    }
+
+    private static ITestCatchStore CreateStore(IReadOnlyList<TestCatch> seed)
+    {
+        var items = seed.ToList();
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<TestCatch>>(items.ToArray()));
+        store.SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var saved = callInfo.Arg<TestCatch>();
+                var index = items.FindIndex(item => item.Id == saved.Id);
+                if (index >= 0)
+                {
+                    items[index] = saved;
+                }
+                else
+                {
+                    items.Add(saved);
+                }
+
+                return Task.CompletedTask;
+            });
+        return store;
+    }
+}


### PR DESCRIPTION
## Summary
- Uploads unsynchronised TestCatch records when connectivity returns, using the device-generated `Id` so a retry cannot create a second PostgreSQL row.
- Shows local / waiting / synchronising / synchronised / failed state, with a manual retry on failure, and merges already-synced catches onto another device via `GET /api/test-catches`.
- Closes #7.

Deploy note: CI deploys the API but does not run DbUp. After merge, apply `202608141400_7_CreateTestCatch.sql` against Neon (and local Postgres) with:

```
dotnet run --project src/FishingLogBook.Db.Migrations.App -- --run
```

Otherwise `POST /api/test-catches` will fail until the `TestCatch` table exists.

## Test plan
- [ ] Apply the TestCatch migration locally, then save a catch offline and restore connectivity — one row appears in PostgreSQL.
- [ ] Force a failed sync and retry — still one server record for that Id.
- [ ] Confirm the list shows saved locally, waiting, synchronising, synchronised, and failed, with retry only when failed.
- [ ] After a successful sync, refresh another browser/device and see the catch.
- [ ] CI tests stay green.