### PR TITLE
FLB#11 | store TestCatch photographs offline and upload to R2 without duplicates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
+    <PackageVersion Include="AWSSDK.S3" Version="3.7.501.18" />
     <PackageVersion Include="bunit" Version="2.9.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Dapper" Version="2.1.79" />
@@ -24,6 +25,8 @@
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MudBlazor" Version="9.8.0" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -137,7 +137,10 @@ These are **not** the Terraform state bucket. Photo storage is `fishing-logbook-
 (private). State stays in a separate, manually created bucket (`backend.hcl`).
 
 **R2** is S3-compatible object storage for catch photos. The bucket is private; the PWA
-must never get R2 keys. Uploads will use short-lived API-issued URLs later.
+must never get R2 keys. Uploads use short-lived API-issued URLs. Browser PUT requires
+CORS on the bucket for `https://fishing-logbook-dev.pages.dev` and local HTTPS
+(`https://localhost:7005`). Set CORS in the Cloudflare dashboard; do not run
+`terraform apply` from application work.
 
 **Pages** hosts the Blazor WASM PWA as static files. Terraform creates a **direct-upload**
 project (no Git build). GitHub Actions (`.github/workflows/deploy-web.yml`) publishes and

--- a/infrastructure/fly/README.md
+++ b/infrastructure/fly/README.md
@@ -20,6 +20,7 @@ root** so the Docker context includes `src/`.
 fly auth login
 fly apps create fishing-logbook-dev-api --org personal
 fly secrets set ConnectionStrings__Postgres="<neon npgsql string>" --app fishing-logbook-dev-api
+fly secrets set ObjectStorage__ServiceUrl="https://<account-id>.r2.cloudflarestorage.com" ObjectStorage__BucketName="fishing-logbook-dev" ObjectStorage__AccessKeyId="<r2-access-key>" ObjectStorage__SecretAccessKey="<r2-secret>" --app fishing-logbook-dev-api
 ```
 
 ## Deploy

--- a/src/FishingLogBook.Api/Endpoints/TestCatchEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/TestCatchEndpoints.cs
@@ -18,6 +18,21 @@ public static class TestCatchEndpoints
             .WithTags("TestCatch")
             .Produces<IReadOnlyList<TestCatchDto>>(StatusCodes.Status200OK);
 
+        endpoints.MapPost("/api/test-catches/{id:guid}/photographs/upload-url", CreatePhotographUploadAsync)
+            .WithName("CreateTestCatchPhotographUpload")
+            .WithTags("TestCatch")
+            .Produces<PhotographUploadDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        endpoints.MapPost("/api/test-catches/{id:guid}/photographs", RecordPhotographAsync)
+            .WithName("RecordTestCatchPhotograph")
+            .WithTags("TestCatch")
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
+
         return endpoints;
     }
 
@@ -41,5 +56,60 @@ public static class TestCatchEndpoints
     {
         var catches = await testCatchService.ListAsync(cancellationToken);
         return Results.Ok(catches);
+    }
+
+    private static async Task<IResult> CreatePhotographUploadAsync(
+        Guid id,
+        PhotographUploadRequestDto request,
+        TestCatchService testCatchService,
+        CancellationToken cancellationToken)
+    {
+        if (!testCatchService.IsObjectStorageConfigured)
+        {
+            return Results.Problem(
+                title: "Object storage is not configured.",
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (id == Guid.Empty ||
+            request.PhotographId == Guid.Empty ||
+            !IsImageContentType(request.ContentType))
+        {
+            return Results.BadRequest();
+        }
+
+        var upload = await testCatchService.CreatePhotographUploadAsync(id, request, cancellationToken);
+        return upload is null ? Results.NotFound() : Results.Ok(upload);
+    }
+
+    private static async Task<IResult> RecordPhotographAsync(
+        Guid id,
+        RecordPhotographDto request,
+        TestCatchService testCatchService,
+        CancellationToken cancellationToken)
+    {
+        if (id == Guid.Empty ||
+            request.PhotographId == Guid.Empty ||
+            string.IsNullOrWhiteSpace(request.ObjectKey) ||
+            !IsImageContentType(request.ContentType))
+        {
+            return Results.BadRequest();
+        }
+
+        try
+        {
+            var recorded = await testCatchService.RecordPhotographAsync(id, request, cancellationToken);
+            return recorded ? Results.NoContent() : Results.NotFound();
+        }
+        catch (ArgumentException)
+        {
+            return Results.BadRequest();
+        }
+    }
+
+    private static bool IsImageContentType(string? contentType)
+    {
+        return !string.IsNullOrWhiteSpace(contentType) &&
+               contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/FishingLogBook.Api/appsettings.Development.json
+++ b/src/FishingLogBook.Api/appsettings.Development.json
@@ -10,5 +10,11 @@
       "https://localhost:7005",
       "http://localhost:5019"
     ]
+  },
+  "ObjectStorage": {
+    "BucketName": "fishing-logbook-dev",
+    "ServiceUrl": "set in user secrets fishinglogbook-api",
+    "AccessKeyId": "set in user secrets fishinglogbook-api",
+    "SecretAccessKey": "set in user secrets fishinglogbook-api"
   }
 }

--- a/src/FishingLogBook.Api/appsettings.json
+++ b/src/FishingLogBook.Api/appsettings.json
@@ -11,5 +11,11 @@
   },
   "Cors": {
     "AllowedOrigins": []
+  },
+  "ObjectStorage": {
+    "ServiceUrl": "set in user secrets fishinglogbook-api",
+    "BucketName": "fishing-logbook-dev",
+    "AccessKeyId": "set in user secrets fishinglogbook-api",
+    "SecretAccessKey": "set in user secrets fishinglogbook-api"
   }
 }

--- a/src/FishingLogBook.Application/Contracts/IObjectStorage.cs
+++ b/src/FishingLogBook.Application/Contracts/IObjectStorage.cs
@@ -1,0 +1,14 @@
+namespace FishingLogBook.Application.Contracts;
+
+public interface IObjectStorage
+{
+    bool IsConfigured { get; }
+
+    Task<Uri> CreateUploadUrlAsync(
+        string objectKey,
+        string contentType,
+        TimeSpan lifetime,
+        CancellationToken cancellationToken);
+
+    Task<Uri> CreateDownloadUrlAsync(string objectKey, TimeSpan lifetime, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Contracts/ITestCatchRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/ITestCatchRepository.cs
@@ -6,5 +6,14 @@ public interface ITestCatchRepository
 {
     Task<TestCatchRecord> UpsertAsync(TestCatchRecord record, CancellationToken cancellationToken);
 
+    Task<TestCatchRecord?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
     Task<IReadOnlyList<TestCatchRecord>> GetAllAsync(CancellationToken cancellationToken);
+
+    Task UpsertPhotographAsync(
+        Guid testCatchId,
+        Guid photographId,
+        string objectKey,
+        string contentType,
+        CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Application/TestCatches/TestCatchService.cs
+++ b/src/FishingLogBook.Application/TestCatches/TestCatchService.cs
@@ -6,12 +6,19 @@ namespace FishingLogBook.Application.TestCatches;
 
 public sealed class TestCatchService
 {
-    private readonly ITestCatchRepository _testCatchRepository;
+    private static readonly TimeSpan UploadLifetime = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan DownloadLifetime = TimeSpan.FromHours(1);
 
-    public TestCatchService(ITestCatchRepository testCatchRepository)
+    private readonly ITestCatchRepository _testCatchRepository;
+    private readonly IObjectStorage _objectStorage;
+
+    public TestCatchService(ITestCatchRepository testCatchRepository, IObjectStorage objectStorage)
     {
         _testCatchRepository = testCatchRepository;
+        _objectStorage = objectStorage;
     }
+
+    public bool IsObjectStorageConfigured => _objectStorage.IsConfigured;
 
     public async Task<TestCatchDto> UpsertAsync(TestCatchDto testCatch, CancellationToken cancellationToken)
     {
@@ -24,17 +31,92 @@ public sealed class TestCatchService
         };
 
         var saved = await _testCatchRepository.UpsertAsync(record, cancellationToken);
-        return ToDto(saved);
+        return await ToDtoAsync(saved, cancellationToken);
     }
 
     public async Task<IReadOnlyList<TestCatchDto>> ListAsync(CancellationToken cancellationToken)
     {
         var records = await _testCatchRepository.GetAllAsync(cancellationToken);
-        return records.Select(ToDto).ToArray();
+        var dtos = new List<TestCatchDto>(records.Count);
+        foreach (var record in records)
+        {
+            dtos.Add(await ToDtoAsync(record, cancellationToken));
+        }
+
+        return dtos;
     }
 
-    private static TestCatchDto ToDto(TestCatchRecord record)
+    public async Task<PhotographUploadDto?> CreatePhotographUploadAsync(
+        Guid testCatchId,
+        PhotographUploadRequestDto request,
+        CancellationToken cancellationToken)
     {
-        return new TestCatchDto(record.Id, record.SpeciesName, record.CaughtOn, record.Notes);
+        var existing = await _testCatchRepository.GetByIdAsync(testCatchId, cancellationToken);
+        if (existing is null)
+        {
+            return null;
+        }
+
+        var objectKey = ObjectKey(testCatchId, request.PhotographId);
+        var uploadUrl = await _objectStorage.CreateUploadUrlAsync(
+            objectKey,
+            request.ContentType,
+            UploadLifetime,
+            cancellationToken);
+
+        return new PhotographUploadDto(objectKey, uploadUrl.ToString());
+    }
+
+    public async Task<bool> RecordPhotographAsync(
+        Guid testCatchId,
+        RecordPhotographDto request,
+        CancellationToken cancellationToken)
+    {
+        var existing = await _testCatchRepository.GetByIdAsync(testCatchId, cancellationToken);
+        if (existing is null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(request.ObjectKey, ObjectKey(testCatchId, request.PhotographId), StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Photograph object key does not match the catch.", nameof(request));
+        }
+
+        await _testCatchRepository.UpsertPhotographAsync(
+            testCatchId,
+            request.PhotographId,
+            request.ObjectKey,
+            request.ContentType,
+            cancellationToken);
+
+        return true;
+    }
+
+    private async Task<TestCatchDto> ToDtoAsync(TestCatchRecord record, CancellationToken cancellationToken)
+    {
+        string? photographUrl = null;
+        if (!string.IsNullOrWhiteSpace(record.PhotographObjectKey) && _objectStorage.IsConfigured)
+        {
+            var url = await _objectStorage.CreateDownloadUrlAsync(
+                record.PhotographObjectKey,
+                DownloadLifetime,
+                cancellationToken);
+            photographUrl = url.ToString();
+        }
+
+        return new TestCatchDto(
+            record.Id,
+            record.SpeciesName,
+            record.CaughtOn,
+            record.Notes,
+            record.PhotographId,
+            record.PhotographContentType,
+            photographUrl);
+    }
+
+    private static string ObjectKey(Guid testCatchId, Guid photographId)
+    {
+        return $"test-catches/{testCatchId:D}/{photographId:D}";
     }
 }

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608141500_11_CreateTestCatchPhotograph.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608141500_11_CreateTestCatchPhotograph.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS "TestCatchPhotograph"
+(
+    "TestCatchId"  uuid NOT NULL,
+    "PhotographId" uuid NOT NULL,
+    "ObjectKey"    text NOT NULL,
+    "ContentType"  text NOT NULL,
+    CONSTRAINT "PkTestCatchPhotograph" PRIMARY KEY ("TestCatchId"),
+    CONSTRAINT "FkTestCatchPhotographTestCatch" FOREIGN KEY ("TestCatchId") REFERENCES "TestCatch" ("Id")
+);

--- a/src/FishingLogBook.DependencyInjection/FishingLogBook.DependencyInjection.csproj
+++ b/src/FishingLogBook.DependencyInjection/FishingLogBook.DependencyInjection.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 
 </Project>

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 using FishingLogBook.Application.Contracts;
 using FishingLogBook.Application.SystemStatus;
 using FishingLogBook.Application.TestCatches;
+using FishingLogBook.Domain.Config;
 using FishingLogBook.Infrastructure.Persistence;
+using FishingLogBook.Infrastructure.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -37,6 +39,8 @@ public static class ServiceCollectionExtensions
         });
         services.AddScoped<ISystemRepository, SystemRepository>();
         services.AddScoped<ITestCatchRepository, TestCatchRepository>();
+        services.Configure<ObjectStorageConfig>(configuration.GetSection(ObjectStorageConfig.SectionName));
+        services.AddSingleton<IObjectStorage, S3CompatibleObjectStorage>();
 
         return services;
     }

--- a/src/FishingLogBook.Domain/Config/ObjectStorageConfig.cs
+++ b/src/FishingLogBook.Domain/Config/ObjectStorageConfig.cs
@@ -1,0 +1,26 @@
+namespace FishingLogBook.Domain.Config;
+
+public sealed class ObjectStorageConfig
+{
+    public const string SectionName = "ObjectStorage";
+
+    public string ServiceUrl { get; set; } = string.Empty;
+
+    public string BucketName { get; set; } = string.Empty;
+
+    public string AccessKeyId { get; set; } = string.Empty;
+
+    public string SecretAccessKey { get; set; } = string.Empty;
+
+    public bool IsConfigured =>
+        IsProvided(ServiceUrl) &&
+        IsProvided(BucketName) &&
+        IsProvided(AccessKeyId) &&
+        IsProvided(SecretAccessKey);
+
+    private static bool IsProvided(string value)
+    {
+        return !string.IsNullOrWhiteSpace(value) &&
+               !value.Contains("user secrets", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/FishingLogBook.Domain/TestCatches/TestCatchRecord.cs
+++ b/src/FishingLogBook.Domain/TestCatches/TestCatchRecord.cs
@@ -9,4 +9,10 @@ public sealed class TestCatchRecord
     public DateTimeOffset CaughtOn { get; init; }
 
     public string? Notes { get; init; }
+
+    public Guid? PhotographId { get; init; }
+
+    public string? PhotographObjectKey { get; init; }
+
+    public string? PhotographContentType { get; init; }
 }

--- a/src/FishingLogBook.Infrastructure/FishingLogBook.Infrastructure.csproj
+++ b/src/FishingLogBook.Infrastructure/FishingLogBook.Infrastructure.csproj
@@ -6,7 +6,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="Dapper" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Npgsql" />
   </ItemGroup>
 

--- a/src/FishingLogBook.Infrastructure/Persistence/TestCatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/TestCatchRepository.cs
@@ -6,6 +6,13 @@ namespace FishingLogBook.Infrastructure.Persistence;
 
 public sealed class TestCatchRepository : ITestCatchRepository
 {
+    private const string SelectSql = """
+        SELECT t."Id", t."SpeciesName", t."CaughtOn", t."Notes",
+               p."PhotographId", p."ObjectKey" AS "PhotographObjectKey", p."ContentType" AS "PhotographContentType"
+        FROM "TestCatch" t
+        LEFT JOIN "TestCatchPhotograph" p ON p."TestCatchId" = t."Id"
+        """;
+
     private readonly IDbConnectionFactory _connectionFactory;
 
     public TestCatchRepository(IDbConnectionFactory connectionFactory)
@@ -21,29 +28,65 @@ public sealed class TestCatchRepository : ITestCatchRepository
             ON CONFLICT ("Id") DO NOTHING;
             """;
 
-        const string selectSql = """
-            SELECT "Id", "SpeciesName", "CaughtOn", "Notes"
-            FROM "TestCatch"
-            WHERE "Id" = @Id;
-            """;
-
         await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
         await connection.ExecuteAsync(new CommandDefinition(insertSql, record, cancellationToken: cancellationToken));
-        return await connection.QuerySingleAsync<TestCatchRecord>(
-            new CommandDefinition(selectSql, new { record.Id }, cancellationToken: cancellationToken));
+        return await QueryByIdAsync(connection, record.Id, cancellationToken)
+            ?? throw new InvalidOperationException($"TestCatch {record.Id} was not found after upsert.");
+    }
+
+    public async Task<TestCatchRecord?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+        return await QueryByIdAsync(connection, id, cancellationToken);
     }
 
     public async Task<IReadOnlyList<TestCatchRecord>> GetAllAsync(CancellationToken cancellationToken)
     {
-        const string sql = """
-            SELECT "Id", "SpeciesName", "CaughtOn", "Notes"
-            FROM "TestCatch"
-            ORDER BY "CaughtOn" DESC;
+        const string sql = $"""
+            {SelectSql}
+            ORDER BY t."CaughtOn" DESC;
             """;
 
         await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
         var command = new CommandDefinition(sql, cancellationToken: cancellationToken);
         var records = await connection.QueryAsync<TestCatchRecord>(command);
         return records.ToArray();
+    }
+
+    public async Task UpsertPhotographAsync(
+        Guid testCatchId,
+        Guid photographId,
+        string objectKey,
+        string contentType,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            INSERT INTO "TestCatchPhotograph" ("TestCatchId", "PhotographId", "ObjectKey", "ContentType")
+            VALUES (@TestCatchId, @PhotographId, @ObjectKey, @ContentType)
+            ON CONFLICT ("TestCatchId") DO UPDATE
+            SET "PhotographId" = EXCLUDED."PhotographId",
+                "ObjectKey" = EXCLUDED."ObjectKey",
+                "ContentType" = EXCLUDED."ContentType";
+            """;
+
+        await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+        await connection.ExecuteAsync(new CommandDefinition(
+            sql,
+            new { TestCatchId = testCatchId, PhotographId = photographId, ObjectKey = objectKey, ContentType = contentType },
+            cancellationToken: cancellationToken));
+    }
+
+    private static Task<TestCatchRecord?> QueryByIdAsync(
+        Npgsql.NpgsqlConnection connection,
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        const string sql = $"""
+            {SelectSql}
+            WHERE t."Id" = @Id;
+            """;
+
+        return connection.QuerySingleOrDefaultAsync<TestCatchRecord>(
+            new CommandDefinition(sql, new { Id = id }, cancellationToken: cancellationToken));
     }
 }

--- a/src/FishingLogBook.Infrastructure/Storage/S3CompatibleObjectStorage.cs
+++ b/src/FishingLogBook.Infrastructure/Storage/S3CompatibleObjectStorage.cs
@@ -1,0 +1,73 @@
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using FishingLogBook.Application.Contracts;
+using FishingLogBook.Domain.Config;
+using Microsoft.Extensions.Options;
+
+namespace FishingLogBook.Infrastructure.Storage;
+
+public sealed class S3CompatibleObjectStorage : IObjectStorage, IDisposable
+{
+    private readonly ObjectStorageConfig _config;
+    private readonly AmazonS3Client? _client;
+
+    public S3CompatibleObjectStorage(IOptions<ObjectStorageConfig> configOptions)
+    {
+        _config = configOptions.Value;
+        if (!_config.IsConfigured)
+        {
+            return;
+        }
+
+        var credentials = new BasicAWSCredentials(_config.AccessKeyId, _config.SecretAccessKey);
+        var amazonS3Config = new AmazonS3Config
+        {
+            ServiceURL = _config.ServiceUrl.TrimEnd('/'),
+            ForcePathStyle = true,
+            AuthenticationRegion = "auto"
+        };
+        _client = new AmazonS3Client(credentials, amazonS3Config);
+    }
+
+    public bool IsConfigured => _config.IsConfigured && _client is not null;
+
+    public Task<Uri> CreateUploadUrlAsync(
+        string objectKey,
+        string contentType,
+        TimeSpan lifetime,
+        CancellationToken cancellationToken)
+    {
+        var request = new GetPreSignedUrlRequest
+        {
+            BucketName = _config.BucketName,
+            Key = objectKey,
+            Verb = HttpVerb.PUT,
+            Expires = DateTime.UtcNow.Add(lifetime),
+            ContentType = contentType
+        };
+
+        return Task.FromResult(new Uri(Client.GetPreSignedURL(request)));
+    }
+
+    public Task<Uri> CreateDownloadUrlAsync(string objectKey, TimeSpan lifetime, CancellationToken cancellationToken)
+    {
+        var request = new GetPreSignedUrlRequest
+        {
+            BucketName = _config.BucketName,
+            Key = objectKey,
+            Verb = HttpVerb.GET,
+            Expires = DateTime.UtcNow.Add(lifetime)
+        };
+
+        return Task.FromResult(new Uri(Client.GetPreSignedURL(request)));
+    }
+
+    public void Dispose()
+    {
+        _client?.Dispose();
+    }
+
+    private AmazonS3Client Client =>
+        _client ?? throw new InvalidOperationException("Object storage is not configured.");
+}

--- a/src/FishingLogBook.Shared/Dtos/PhotographUploadDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/PhotographUploadDto.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record PhotographUploadDto(string ObjectKey, string UploadUrl);

--- a/src/FishingLogBook.Shared/Dtos/PhotographUploadRequestDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/PhotographUploadRequestDto.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record PhotographUploadRequestDto(Guid PhotographId, string ContentType);

--- a/src/FishingLogBook.Shared/Dtos/RecordPhotographDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/RecordPhotographDto.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record RecordPhotographDto(Guid PhotographId, string ObjectKey, string ContentType);

--- a/src/FishingLogBook.Shared/Dtos/TestCatchDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/TestCatchDto.cs
@@ -4,4 +4,7 @@ public sealed record TestCatchDto(
     Guid Id,
     string SpeciesName,
     DateTimeOffset CaughtOn,
-    string? Notes);
+    string? Notes,
+    Guid? PhotographId = null,
+    string? PhotographContentType = null,
+    string? PhotographUrl = null);

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -114,4 +114,25 @@
   <data name="TestCatch_Retry" xml:space="preserve">
     <value>Réessayer la synchronisation</value>
   </data>
+  <data name="TestCatch_RetryPhotograph" xml:space="preserve">
+    <value>Réessayer le téléversement de la photo</value>
+  </data>
+  <data name="TestCatch_PhotographAlt" xml:space="preserve">
+    <value>Photo de la prise</value>
+  </data>
+  <data name="TestCatch_PhotoSavedLocally" xml:space="preserve">
+    <value>Photo enregistrée localement — pas encore téléversée</value>
+  </data>
+  <data name="TestCatch_PhotoWaiting" xml:space="preserve">
+    <value>Photo en attente de téléversement</value>
+  </data>
+  <data name="TestCatch_PhotoUploading" xml:space="preserve">
+    <value>Téléversement de la photo</value>
+  </data>
+  <data name="TestCatch_PhotoUploaded" xml:space="preserve">
+    <value>Photo téléversée</value>
+  </data>
+  <data name="TestCatch_PhotoFailed" xml:space="preserve">
+    <value>Échec du téléversement de la photo</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -114,4 +114,25 @@
   <data name="TestCatch_Retry" xml:space="preserve">
     <value>Retry synchronisation</value>
   </data>
+  <data name="TestCatch_RetryPhotograph" xml:space="preserve">
+    <value>Retry photograph upload</value>
+  </data>
+  <data name="TestCatch_PhotographAlt" xml:space="preserve">
+    <value>Catch photograph</value>
+  </data>
+  <data name="TestCatch_PhotoSavedLocally" xml:space="preserve">
+    <value>Photograph saved locally — not uploaded</value>
+  </data>
+  <data name="TestCatch_PhotoWaiting" xml:space="preserve">
+    <value>Photograph waiting to upload</value>
+  </data>
+  <data name="TestCatch_PhotoUploading" xml:space="preserve">
+    <value>Uploading photograph</value>
+  </data>
+  <data name="TestCatch_PhotoUploaded" xml:space="preserve">
+    <value>Photograph uploaded</value>
+  </data>
+  <data name="TestCatch_PhotoFailed" xml:space="preserve">
+    <value>Photograph upload failed</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Offline/ITestCatchPhotoStore.cs
+++ b/src/FishingLogBook.Web/Offline/ITestCatchPhotoStore.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Web.Offline;
+
+public interface ITestCatchPhotoStore
+{
+    Task PutAsync(Guid testCatchId, byte[] bytes, string contentType, CancellationToken cancellationToken);
+
+    Task<TestCatchPhotoBytes?> GetAsync(Guid testCatchId, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Offline/ITestCatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Offline/ITestCatchSynchroniser.cs
@@ -5,4 +5,6 @@ public interface ITestCatchSynchroniser
     Task SynchronisePendingAsync(CancellationToken cancellationToken);
 
     Task RetryAsync(Guid id, CancellationToken cancellationToken);
+
+    Task RetryPhotographAsync(Guid id, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Offline/IndexedDbTestCatchPhotoStore.cs
+++ b/src/FishingLogBook.Web/Offline/IndexedDbTestCatchPhotoStore.cs
@@ -1,0 +1,65 @@
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Offline;
+
+public sealed class IndexedDbTestCatchPhotoStore : ITestCatchPhotoStore
+{
+    private const string ModulePath = "./js/offline-store.js";
+
+    private readonly IJSRuntime _jsRuntime;
+    private readonly SemaphoreSlim _moduleLock = new(1, 1);
+    private IJSObjectReference? _module;
+
+    public IndexedDbTestCatchPhotoStore(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task PutAsync(Guid testCatchId, byte[] bytes, string contentType, CancellationToken cancellationToken)
+    {
+        var module = await GetModuleAsync(cancellationToken);
+        await module.InvokeVoidAsync("putTestCatchPhotograph", cancellationToken, testCatchId.ToString(), bytes, contentType);
+    }
+
+    public async Task<TestCatchPhotoBytes?> GetAsync(Guid testCatchId, CancellationToken cancellationToken)
+    {
+        var module = await GetModuleAsync(cancellationToken);
+        var stored = await module.InvokeAsync<PhotographJsDto?>(
+            "getTestCatchPhotograph",
+            cancellationToken,
+            testCatchId.ToString());
+
+        if (string.IsNullOrWhiteSpace(stored?.BytesBase64) || string.IsNullOrWhiteSpace(stored.ContentType))
+        {
+            return null;
+        }
+
+        return new TestCatchPhotoBytes(Convert.FromBase64String(stored.BytesBase64), stored.ContentType);
+    }
+
+    private async Task<IJSObjectReference> GetModuleAsync(CancellationToken cancellationToken)
+    {
+        if (_module is not null)
+        {
+            return _module;
+        }
+
+        await _moduleLock.WaitAsync(cancellationToken);
+        try
+        {
+            _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+            return _module;
+        }
+        finally
+        {
+            _moduleLock.Release();
+        }
+    }
+
+    private sealed class PhotographJsDto
+    {
+        public string? BytesBase64 { get; set; }
+
+        public string? ContentType { get; set; }
+    }
+}

--- a/src/FishingLogBook.Web/Offline/TestCatch.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatch.cs
@@ -7,4 +7,5 @@ public sealed record TestCatch(
     string SpeciesName,
     DateTimeOffset CaughtOn,
     string? Notes,
-    SyncStatus SyncStatus);
+    SyncStatus SyncStatus,
+    TestCatchPhotograph? Photograph = null);

--- a/src/FishingLogBook.Web/Offline/TestCatchPhotoBytes.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatchPhotoBytes.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Web.Offline;
+
+public sealed record TestCatchPhotoBytes(byte[] Bytes, string ContentType);

--- a/src/FishingLogBook.Web/Offline/TestCatchPhotograph.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatchPhotograph.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Web.Models;
+
+namespace FishingLogBook.Web.Offline;
+
+public sealed record TestCatchPhotograph(
+    Guid Id,
+    string ContentType,
+    SyncStatus SyncStatus,
+    string? ObjectKey = null,
+    string? RemoteUrl = null);

--- a/src/FishingLogBook.Web/Offline/TestCatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatchSynchroniser.cs
@@ -7,15 +7,18 @@ namespace FishingLogBook.Web.Offline;
 public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
 {
     private readonly ITestCatchStore _store;
+    private readonly ITestCatchPhotoStore _photoStore;
     private readonly ITestCatchClient _client;
     private readonly INetworkStatus _networkStatus;
 
     public TestCatchSynchroniser(
         ITestCatchStore store,
+        ITestCatchPhotoStore photoStore,
         ITestCatchClient client,
         INetworkStatus networkStatus)
     {
         _store = store;
+        _photoStore = photoStore;
         _client = client;
         _networkStatus = networkStatus;
     }
@@ -30,15 +33,21 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
         await MergeFromServerAsync(cancellationToken);
 
         var local = await _store.GetAllAsync(cancellationToken);
-        foreach (var testCatch in local.Where(NeedsSync))
+        foreach (var testCatch in local.Where(NeedsCatchSync))
         {
             await _store.SaveAsync(testCatch with { SyncStatus = SyncStatus.WaitingToSynchronise }, cancellationToken);
         }
 
         local = await _store.GetAllAsync(cancellationToken);
-        foreach (var testCatch in local.Where(NeedsSync))
+        foreach (var testCatch in local.Where(NeedsCatchSync))
         {
-            await SynchroniseOneAsync(testCatch, cancellationToken);
+            await SynchroniseCatchAsync(testCatch, cancellationToken);
+        }
+
+        local = await _store.GetAllAsync(cancellationToken);
+        foreach (var testCatch in local.Where(catchItem => catchItem.SyncStatus == SyncStatus.Synchronised && NeedsPhotoSync(catchItem)))
+        {
+            await SynchronisePhotographAsync(testCatch, cancellationToken);
         }
     }
 
@@ -46,7 +55,7 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
     {
         var local = await _store.GetAllAsync(cancellationToken);
         var testCatch = local.SingleOrDefault(item => item.Id == id);
-        if (testCatch is null || !NeedsSync(testCatch))
+        if (testCatch is null || !NeedsCatchSync(testCatch))
         {
             return;
         }
@@ -57,7 +66,36 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
             return;
         }
 
-        await SynchroniseOneAsync(testCatch, cancellationToken);
+        await SynchroniseCatchAsync(testCatch, cancellationToken);
+        local = await _store.GetAllAsync(cancellationToken);
+        testCatch = local.SingleOrDefault(item => item.Id == id);
+        if (testCatch is not null && testCatch.SyncStatus == SyncStatus.Synchronised && NeedsPhotoSync(testCatch))
+        {
+            await SynchronisePhotographAsync(testCatch, cancellationToken);
+        }
+    }
+
+    public async Task RetryPhotographAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var local = await _store.GetAllAsync(cancellationToken);
+        var testCatch = local.SingleOrDefault(item => item.Id == id);
+        if (testCatch is null || !NeedsPhotoSync(testCatch))
+        {
+            return;
+        }
+
+        if (!await _networkStatus.IsOnlineAsync(cancellationToken))
+        {
+            await SavePhotographStatusAsync(testCatch, SyncStatus.WaitingToSynchronise, cancellationToken);
+            return;
+        }
+
+        if (NeedsCatchSync(testCatch))
+        {
+            return;
+        }
+
+        await SynchronisePhotographAsync(testCatch, cancellationToken);
     }
 
     private async Task MergeFromServerAsync(CancellationToken cancellationToken)
@@ -81,18 +119,29 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
 
         foreach (var dto in remote)
         {
-            if (localById.TryGetValue(dto.Id, out var existing) && NeedsSync(existing))
+            localById.TryGetValue(dto.Id, out var existing);
+            if (existing is not null && NeedsCatchSync(existing))
             {
                 continue;
             }
 
+            var photograph = existing is not null && NeedsPhotoSync(existing)
+                ? existing.Photograph
+                : FromRemotePhotograph(dto);
+
             await _store.SaveAsync(
-                new TestCatch(dto.Id, dto.SpeciesName, dto.CaughtOn, dto.Notes, SyncStatus.Synchronised),
+                new TestCatch(
+                    dto.Id,
+                    dto.SpeciesName,
+                    dto.CaughtOn,
+                    dto.Notes,
+                    SyncStatus.Synchronised,
+                    photograph),
                 cancellationToken);
         }
     }
 
-    private async Task SynchroniseOneAsync(TestCatch testCatch, CancellationToken cancellationToken)
+    private async Task SynchroniseCatchAsync(TestCatch testCatch, CancellationToken cancellationToken)
     {
         await _store.SaveAsync(testCatch with { SyncStatus = SyncStatus.Synchronising }, cancellationToken);
 
@@ -113,9 +162,91 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
         }
     }
 
-    private static bool NeedsSync(TestCatch testCatch)
+    private async Task SynchronisePhotographAsync(TestCatch testCatch, CancellationToken cancellationToken)
+    {
+        var photograph = testCatch.Photograph;
+        if (photograph is null)
+        {
+            return;
+        }
+
+        var bytes = await _photoStore.GetAsync(testCatch.Id, cancellationToken);
+        if (bytes is null)
+        {
+            return;
+        }
+
+        await SavePhotographStatusAsync(testCatch, SyncStatus.Synchronising, cancellationToken);
+
+        try
+        {
+            var upload = await _client.CreatePhotographUploadAsync(
+                testCatch.Id,
+                new PhotographUploadRequestDto(photograph.Id, photograph.ContentType),
+                cancellationToken);
+            await _client.UploadPhotographAsync(upload.UploadUrl, bytes.Bytes, photograph.ContentType, cancellationToken);
+            await _client.RecordPhotographAsync(
+                testCatch.Id,
+                new RecordPhotographDto(photograph.Id, upload.ObjectKey, photograph.ContentType),
+                cancellationToken);
+            await _store.SaveAsync(
+                testCatch with
+                {
+                    SyncStatus = SyncStatus.Synchronised,
+                    Photograph = photograph with
+                    {
+                        SyncStatus = SyncStatus.Synchronised,
+                        ObjectKey = upload.ObjectKey
+                    }
+                },
+                cancellationToken);
+        }
+        catch (HttpRequestException)
+        {
+            await SavePhotographStatusAsync(testCatch with { SyncStatus = SyncStatus.Synchronised }, SyncStatus.FailedToSynchronise, cancellationToken);
+        }
+        catch (TaskCanceledException)
+        {
+            await SavePhotographStatusAsync(testCatch with { SyncStatus = SyncStatus.Synchronised }, SyncStatus.FailedToSynchronise, cancellationToken);
+        }
+    }
+
+    private Task SavePhotographStatusAsync(TestCatch testCatch, SyncStatus photoStatus, CancellationToken cancellationToken)
+    {
+        if (testCatch.Photograph is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        return _store.SaveAsync(
+            testCatch with { Photograph = testCatch.Photograph with { SyncStatus = photoStatus } },
+            cancellationToken);
+    }
+
+    private static TestCatchPhotograph? FromRemotePhotograph(TestCatchDto dto)
+    {
+        if (dto.PhotographId is null || string.IsNullOrWhiteSpace(dto.PhotographUrl))
+        {
+            return null;
+        }
+
+        return new TestCatchPhotograph(
+            dto.PhotographId.Value,
+            dto.PhotographContentType ?? "image/jpeg",
+            SyncStatus.Synchronised,
+            RemoteUrl: dto.PhotographUrl);
+    }
+
+    private static bool NeedsCatchSync(TestCatch testCatch)
     {
         return testCatch.SyncStatus is SyncStatus.SavedLocally
+            or SyncStatus.WaitingToSynchronise
+            or SyncStatus.FailedToSynchronise;
+    }
+
+    private static bool NeedsPhotoSync(TestCatch testCatch)
+    {
+        return testCatch.Photograph?.SyncStatus is SyncStatus.SavedLocally
             or SyncStatus.WaitingToSynchronise
             or SyncStatus.FailedToSynchronise;
     }

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor
@@ -1,4 +1,5 @@
 @page "/test-catch"
+@using Microsoft.AspNetCore.Components.Forms
 
 <PageTitle>@Loc["TestCatch_PageTitle"]</PageTitle>
 
@@ -21,6 +22,17 @@
                               Variant="Variant.Outlined"
                               Lines="3"
                               id="test-catch-notes" />
+                <InputFile OnChange="OnPhotographSelected"
+                           accept="image/*"
+                           capture="environment"
+                           id="test-catch-photo" />
+                @if (_pendingPhotographUrl is not null)
+                {
+                    <img src="@_pendingPhotographUrl"
+                         alt="@Loc["TestCatch_PhotographAlt"]"
+                         class="test-catch-photo-preview"
+                         id="test-catch-photo-preview" />
+                }
                 <MudButton Variant="Variant.Filled"
                            Color="Color.Primary"
                            FullWidth="true"
@@ -51,6 +63,19 @@
                                 <MudText Typo="Typo.caption" Color="@SyncStatusColor(testCatch.SyncStatus)" id="@($"test-catch-sync-status-{testCatch.Id}")">
                                     @Loc[SyncStatusKey(testCatch.SyncStatus)]
                                 </MudText>
+                                @if (_photographUrls.TryGetValue(testCatch.Id, out var photographUrl))
+                                {
+                                    <img src="@photographUrl"
+                                         alt="@Loc["TestCatch_PhotographAlt"]"
+                                         class="test-catch-photo-preview"
+                                         id="@($"test-catch-photo-{testCatch.Id}")" />
+                                }
+                                @if (testCatch.Photograph is not null)
+                                {
+                                    <MudText Typo="Typo.caption" Color="@SyncStatusColor(testCatch.Photograph.SyncStatus)" id="@($"test-catch-photo-status-{testCatch.Id}")">
+                                        @Loc[PhotoStatusKey(testCatch.Photograph.SyncStatus)]
+                                    </MudText>
+                                }
                                 @if (testCatch.SyncStatus == SyncStatus.FailedToSynchronise)
                                 {
                                     <MudButton Variant="Variant.Text"
@@ -59,6 +84,16 @@
                                                OnClick="@(() => RetryAsync(testCatch.Id))"
                                                id="@($"retry-test-catch-{testCatch.Id}")">
                                         @Loc["TestCatch_Retry"]
+                                    </MudButton>
+                                }
+                                @if (testCatch.Photograph?.SyncStatus == SyncStatus.FailedToSynchronise)
+                                {
+                                    <MudButton Variant="Variant.Text"
+                                               Color="Color.Primary"
+                                               Size="Size.Small"
+                                               OnClick="@(() => RetryPhotographAsync(testCatch.Id))"
+                                               id="@($"retry-test-catch-photo-{testCatch.Id}")">
+                                        @Loc["TestCatch_RetryPhotograph"]
                                     </MudButton>
                                 }
                             </MudStack>

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
@@ -2,6 +2,7 @@ using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Models;
 using FishingLogBook.Web.Offline;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
 using MudBlazor;
@@ -10,16 +11,25 @@ namespace FishingLogBook.Web.Pages.TestCatchLog;
 
 public partial class TestCatchLog : ComponentBase, IDisposable
 {
+    private const long MaxPhotographBytes = 10 * 1024 * 1024;
+
     private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly Dictionary<Guid, string> _photographUrls = [];
     private DotNetObjectReference<TestCatchLog>? _dotNetReference;
 
     private string _speciesName = string.Empty;
     private string _notes = string.Empty;
     private IReadOnlyList<TestCatch> _catches = [];
     private bool _isSaving;
+    private byte[]? _pendingPhotographBytes;
+    private string? _pendingPhotographContentType;
+    private string? _pendingPhotographUrl;
 
     [Inject]
     private ITestCatchStore TestCatchStore { get; set; } = default!;
+
+    [Inject]
+    private ITestCatchPhotoStore TestCatchPhotoStore { get; set; } = default!;
 
     [Inject]
     private ITestCatchSynchroniser TestCatchSynchroniser { get; set; } = default!;
@@ -58,6 +68,19 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         await InvokeAsync(StateHasChanged);
     }
 
+    private async Task OnPhotographSelected(InputFileChangeEventArgs args)
+    {
+        var file = args.File;
+        await using var stream = file.OpenReadStream(MaxPhotographBytes);
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, _cancellationTokenSource.Token);
+        _pendingPhotographBytes = buffer.ToArray();
+        _pendingPhotographContentType = string.IsNullOrWhiteSpace(file.ContentType)
+            ? "image/jpeg"
+            : file.ContentType;
+        _pendingPhotographUrl = $"data:{_pendingPhotographContentType};base64,{Convert.ToBase64String(_pendingPhotographBytes)}";
+    }
+
     private async Task SaveAsync()
     {
         if (!CanSave)
@@ -67,16 +90,38 @@ public partial class TestCatchLog : ComponentBase, IDisposable
 
         _isSaving = true;
 
+        TestCatchPhotograph? photograph = null;
+        if (_pendingPhotographBytes is { Length: > 0 } && _pendingPhotographContentType is not null)
+        {
+            photograph = new TestCatchPhotograph(
+                Guid.NewGuid(),
+                _pendingPhotographContentType,
+                SyncStatus.SavedLocally);
+        }
+
         var testCatch = new TestCatch(
             Guid.NewGuid(),
             _speciesName.Trim(),
             DateTimeOffset.UtcNow,
             string.IsNullOrWhiteSpace(_notes) ? null : _notes.Trim(),
-            SyncStatus.SavedLocally);
+            SyncStatus.SavedLocally,
+            photograph);
 
         await TestCatchStore.SaveAsync(testCatch, _cancellationTokenSource.Token);
+        if (photograph is not null && _pendingPhotographBytes is not null)
+        {
+            await TestCatchPhotoStore.PutAsync(
+                testCatch.Id,
+                _pendingPhotographBytes,
+                photograph.ContentType,
+                _cancellationTokenSource.Token);
+        }
+
         _speciesName = string.Empty;
         _notes = string.Empty;
+        _pendingPhotographBytes = null;
+        _pendingPhotographContentType = null;
+        _pendingPhotographUrl = null;
         await TestCatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
         await LoadAsync();
         _isSaving = false;
@@ -88,9 +133,28 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         await LoadAsync();
     }
 
+    private async Task RetryPhotographAsync(Guid id)
+    {
+        await TestCatchSynchroniser.RetryPhotographAsync(id, _cancellationTokenSource.Token);
+        await LoadAsync();
+    }
+
     private async Task LoadAsync()
     {
         _catches = await TestCatchStore.GetAllAsync(_cancellationTokenSource.Token);
+        _photographUrls.Clear();
+        foreach (var testCatch in _catches)
+        {
+            var local = await TestCatchPhotoStore.GetAsync(testCatch.Id, _cancellationTokenSource.Token);
+            if (local is not null)
+            {
+                _photographUrls[testCatch.Id] = $"data:{local.ContentType};base64,{Convert.ToBase64String(local.Bytes)}";
+            }
+            else if (!string.IsNullOrWhiteSpace(testCatch.Photograph?.RemoteUrl))
+            {
+                _photographUrls[testCatch.Id] = testCatch.Photograph.RemoteUrl;
+            }
+        }
     }
 
     private static string SyncStatusKey(SyncStatus syncStatus)
@@ -103,6 +167,19 @@ public partial class TestCatchLog : ComponentBase, IDisposable
             SyncStatus.Synchronised => "SyncStatus_Synchronised",
             SyncStatus.FailedToSynchronise => "SyncStatus_FailedToSynchronise",
             _ => "SyncStatus_SavedLocally"
+        };
+    }
+
+    private static string PhotoStatusKey(SyncStatus syncStatus)
+    {
+        return syncStatus switch
+        {
+            SyncStatus.SavedLocally => "TestCatch_PhotoSavedLocally",
+            SyncStatus.WaitingToSynchronise => "TestCatch_PhotoWaiting",
+            SyncStatus.Synchronising => "TestCatch_PhotoUploading",
+            SyncStatus.Synchronised => "TestCatch_PhotoUploaded",
+            SyncStatus.FailedToSynchronise => "TestCatch_PhotoFailed",
+            _ => "TestCatch_PhotoSavedLocally"
         };
     }
 

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.css
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.css
@@ -1,3 +1,12 @@
 .test-catch-container {
     padding-top: 2rem;
 }
+
+.test-catch-photo-preview {
+    display: block;
+    width: 100%;
+    max-height: 12rem;
+    object-fit: cover;
+    border-radius: 0.5rem;
+}
+

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<INetworkStatus, BrowserNetworkStatus>();
         services.AddScoped<ITestCatchJsonStore, IndexedDbTestCatchJsonStore>();
         services.AddScoped<ITestCatchStore, TestCatchStore>();
+        services.AddScoped<ITestCatchPhotoStore, IndexedDbTestCatchPhotoStore>();
         services.AddScoped<ITestCatchSynchroniser, TestCatchSynchroniser>();
         services.AddLocalization();
         services.AddScoped<ICultureService, CultureService>();

--- a/src/FishingLogBook.Web/Services/ITestCatchClient.cs
+++ b/src/FishingLogBook.Web/Services/ITestCatchClient.cs
@@ -7,4 +7,13 @@ public interface ITestCatchClient
     Task UpsertAsync(TestCatchDto testCatch, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<TestCatchDto>> GetAllAsync(CancellationToken cancellationToken);
+
+    Task<PhotographUploadDto> CreatePhotographUploadAsync(
+        Guid testCatchId,
+        PhotographUploadRequestDto request,
+        CancellationToken cancellationToken);
+
+    Task UploadPhotographAsync(string uploadUrl, byte[] bytes, string contentType, CancellationToken cancellationToken);
+
+    Task RecordPhotographAsync(Guid testCatchId, RecordPhotographDto request, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Services/TestCatchClient.cs
+++ b/src/FishingLogBook.Web/Services/TestCatchClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FishingLogBook.Shared.Dtos;
 
@@ -25,5 +26,43 @@ public sealed class TestCatchClient : ITestCatchClient
             cancellationToken);
 
         return catches ?? [];
+    }
+
+    public async Task<PhotographUploadDto> CreatePhotographUploadAsync(
+        Guid testCatchId,
+        PhotographUploadRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.PostAsJsonAsync(
+            $"api/test-catches/{testCatchId:D}/photographs/upload-url",
+            request,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var upload = await response.Content.ReadFromJsonAsync<PhotographUploadDto>(cancellationToken);
+        return upload ?? throw new HttpRequestException("Photograph upload URL was missing.");
+    }
+
+    public async Task UploadPhotographAsync(
+        string uploadUrl,
+        byte[] bytes,
+        string contentType,
+        CancellationToken cancellationToken)
+    {
+        using var content = new ByteArrayContent(bytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        using var response = await _httpClient.PutAsync(uploadUrl, content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task RecordPhotographAsync(
+        Guid testCatchId,
+        RecordPhotographDto request,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.PostAsJsonAsync(
+            $"api/test-catches/{testCatchId:D}/photographs",
+            request,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
     }
 }

--- a/src/FishingLogBook.Web/wwwroot/js/offline-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/offline-store.js
@@ -1,6 +1,7 @@
 const databaseName = 'FishingLogBook';
 const storeName = 'testCatches';
-const version = 1;
+const photographStoreName = 'testCatchPhotographs';
+const version = 2;
 
 function openDatabase() {
     return new Promise((resolve, reject) => {
@@ -9,6 +10,9 @@ function openDatabase() {
             const db = request.result;
             if (!db.objectStoreNames.contains(storeName)) {
                 db.createObjectStore(storeName, { keyPath: 'id' });
+            }
+            if (!db.objectStoreNames.contains(photographStoreName)) {
+                db.createObjectStore(photographStoreName, { keyPath: 'id' });
             }
         };
         request.onsuccess = () => resolve(request.result);
@@ -47,4 +51,61 @@ export async function getAllTestCatches() {
             reject(request.error);
         };
     });
+}
+
+export async function putTestCatchPhotograph(id, bytes, contentType) {
+    const db = await openDatabase();
+    const blob = new Blob([toUint8Array(bytes)], { type: contentType });
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(photographStoreName, 'readwrite');
+        transaction.oncomplete = () => {
+            db.close();
+            resolve();
+        };
+        transaction.onerror = () => {
+            db.close();
+            reject(transaction.error);
+        };
+        transaction.objectStore(photographStoreName).put({ id, blob, contentType });
+    });
+}
+
+export async function getTestCatchPhotograph(id) {
+    const db = await openDatabase();
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(photographStoreName, 'readonly');
+        const request = transaction.objectStore(photographStoreName).get(id);
+        request.onsuccess = async () => {
+            db.close();
+            const item = request.result;
+            if (!item) {
+                resolve(null);
+                return;
+            }
+            const buffer = await item.blob.arrayBuffer();
+            resolve({ contentType: item.contentType, bytesBase64: uint8ToBase64(new Uint8Array(buffer)) });
+        };
+        request.onerror = () => {
+            db.close();
+            reject(request.error);
+        };
+    });
+}
+
+function toUint8Array(bytes) {
+    if (bytes instanceof Uint8Array) {
+        return bytes;
+    }
+
+    return new Uint8Array(bytes);
+}
+
+function uint8ToBase64(bytes) {
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+        binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+    }
+
+    return btoa(binary);
 }

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -15,6 +15,8 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
 
     public ITestCatchRepository TestCatchRepository { get; } = Substitute.For<ITestCatchRepository>();
 
+    public IObjectStorage ObjectStorage { get; } = Substitute.For<IObjectStorage>();
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Production");
@@ -33,6 +35,8 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
             services.AddScoped(_ => SystemRepository);
             services.RemoveAll<ITestCatchRepository>();
             services.AddScoped(_ => TestCatchRepository);
+            services.RemoveAll<IObjectStorage>();
+            services.AddSingleton(_ => ObjectStorage);
         });
     }
 }

--- a/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingPhotograph.cs
+++ b/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingPhotograph.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Domain.TestCatches;
+using FishingLogBook.Shared.Dtos;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.TestCatchEndpointsTests;
+
+public class WhenTestingPhotograph : IClassFixture<SystemApiFactory>
+{
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingPhotograph(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectUploadUrl_WhenObjectStorageIsNotConfigured()
+    {
+        // Arrange
+        _factory.ObjectStorage.ClearReceivedCalls();
+        _factory.ObjectStorage.IsConfigured.Returns(false);
+        var client = _factory.CreateClient();
+        var catchId = Guid.Parse("1a2b3c4d-5e6f-7081-92a3-b4c5d6e7f809");
+        var request = new PhotographUploadRequestDto(Guid.NewGuid(), "image/jpeg");
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/test-catches/{catchId:D}/photographs/upload-url",
+            request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        await _factory.ObjectStorage.DidNotReceive().CreateUploadUrlAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnUploadUrl_WhenObjectStorageIsConfigured()
+    {
+        // Arrange
+        var catchId = Guid.Parse("9f8e7d6c-5b4a-3928-1706-54e3d2c1b0a9");
+        var photographId = Guid.Parse("0a1b2c3d-4e5f-6789-abcd-ef0123456789");
+        var record = new TestCatchRecord
+        {
+            Id = catchId,
+            SpeciesName = "Bream",
+            CaughtOn = DateTimeOffset.Parse("2026-08-14T17:00:00Z")
+        };
+        _factory.ObjectStorage.ClearReceivedCalls();
+        _factory.ObjectStorage.IsConfigured.Returns(true);
+        _factory.TestCatchRepository
+            .GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(record);
+        _factory.ObjectStorage
+            .CreateUploadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(new Uri("https://storage.test/upload"));
+        var client = _factory.CreateClient();
+        var request = new PhotographUploadRequestDto(photographId, "image/jpeg");
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/test-catches/{catchId:D}/photographs/upload-url",
+            request);
+        var body = await response.Content.ReadFromJsonAsync<PhotographUploadDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().NotBeNull();
+        body!.ObjectKey.Should().Be($"test-catches/{catchId:D}/{photographId:D}");
+        body.UploadUrl.Should().Be("https://storage.test/upload");
+    }
+
+    [Fact]
+    public async Task ItShouldKeepASinglePhotograph_WhenMetadataIsPostedTwice()
+    {
+        // Arrange
+        var catchId = Guid.Parse("11223344-5566-7788-99aa-bbccddeeff00");
+        var photographId = Guid.Parse("ffeeddcc-bbaa-9988-7766-554433221100");
+        var objectKey = $"test-catches/{catchId:D}/{photographId:D}";
+        var record = new TestCatchRecord
+        {
+            Id = catchId,
+            SpeciesName = "Rudd",
+            CaughtOn = DateTimeOffset.Parse("2026-08-14T18:00:00Z")
+        };
+        _factory.TestCatchRepository
+            .GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(record);
+        _factory.TestCatchRepository.ClearReceivedCalls();
+        var client = _factory.CreateClient();
+        var request = new RecordPhotographDto(photographId, objectKey, "image/jpeg");
+
+        // Act
+        var first = await client.PostAsJsonAsync($"/api/test-catches/{catchId:D}/photographs", request);
+        var second = await client.PostAsJsonAsync($"/api/test-catches/{catchId:D}/photographs", request);
+
+        // Assert
+        first.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        second.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await _factory.TestCatchRepository.Received(2).UpsertPhotographAsync(
+            catchId,
+            photographId,
+            objectKey,
+            "image/jpeg",
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/MemoryObjectStorage.cs
+++ b/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/MemoryObjectStorage.cs
@@ -1,0 +1,22 @@
+using FishingLogBook.Application.Contracts;
+
+namespace FishingLogBook.Application.Tests.TestCatchServiceTests;
+
+internal sealed class MemoryObjectStorage : IObjectStorage
+{
+    public bool IsConfigured { get; init; } = true;
+
+    public Task<Uri> CreateUploadUrlAsync(
+        string objectKey,
+        string contentType,
+        TimeSpan lifetime,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new Uri($"https://storage.test/upload/{objectKey}"));
+    }
+
+    public Task<Uri> CreateDownloadUrlAsync(string objectKey, TimeSpan lifetime, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(new Uri($"https://storage.test/download/{objectKey}"));
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/MemoryTestCatchRepository.cs
+++ b/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/MemoryTestCatchRepository.cs
@@ -13,8 +13,36 @@ internal sealed class MemoryTestCatchRepository : ITestCatchRepository
         return Task.FromResult(_records[record.Id]);
     }
 
+    public Task<TestCatchRecord?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        _records.TryGetValue(id, out var record);
+        return Task.FromResult(record);
+    }
+
     public Task<IReadOnlyList<TestCatchRecord>> GetAllAsync(CancellationToken cancellationToken)
     {
         return Task.FromResult<IReadOnlyList<TestCatchRecord>>(_records.Values.ToArray());
+    }
+
+    public Task UpsertPhotographAsync(
+        Guid testCatchId,
+        Guid photographId,
+        string objectKey,
+        string contentType,
+        CancellationToken cancellationToken)
+    {
+        var existing = _records[testCatchId];
+        _records[testCatchId] = new TestCatchRecord
+        {
+            Id = existing.Id,
+            SpeciesName = existing.SpeciesName,
+            CaughtOn = existing.CaughtOn,
+            Notes = existing.Notes,
+            PhotographId = photographId,
+            PhotographObjectKey = objectKey,
+            PhotographContentType = contentType
+        };
+
+        return Task.CompletedTask;
     }
 }

--- a/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/WhenTestingPhotograph.cs
+++ b/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/WhenTestingPhotograph.cs
@@ -1,0 +1,85 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.TestCatches;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Tests.TestCatchServiceTests;
+
+public class WhenTestingPhotograph
+{
+    [Fact]
+    public async Task ItShouldKeepASinglePhotograph_WhenTheSameCatchPhotographIsRecordedTwice()
+    {
+        // Arrange
+        var repository = new MemoryTestCatchRepository();
+        var sut = new TestCatchService(repository, new MemoryObjectStorage());
+        var catchId = Guid.Parse("7a1c3e90-2b44-4d18-9f05-6c8e0a2d1b77");
+        var photographId = Guid.Parse("b2d8f014-5c31-4a90-8e26-1f7c4b9a0d55");
+        await sut.UpsertAsync(
+            new TestCatchDto(catchId, "Carp", DateTimeOffset.Parse("2026-08-14T14:00:00Z"), null),
+            CancellationToken.None);
+        var request = new RecordPhotographDto(
+            photographId,
+            $"test-catches/{catchId:D}/{photographId:D}",
+            "image/jpeg");
+
+        // Act
+        await sut.RecordPhotographAsync(catchId, request, CancellationToken.None);
+        await sut.RecordPhotographAsync(catchId, request, CancellationToken.None);
+        var listed = await sut.ListAsync(CancellationToken.None);
+
+        // Assert
+        listed.Should().ContainSingle();
+        listed[0].PhotographId.Should().Be(photographId);
+        listed[0].PhotographContentType.Should().Be("image/jpeg");
+        listed[0].PhotographUrl.Should().Contain(photographId.ToString("D"));
+    }
+
+    [Fact]
+    public async Task ItShouldCreateAnUploadUrl_WhenTheCatchExists()
+    {
+        // Arrange
+        var sut = new TestCatchService(new MemoryTestCatchRepository(), new MemoryObjectStorage());
+        var catchId = Guid.Parse("0c9e4a12-8d70-4b31-a5c3-7e1f2d8b6a40");
+        var photographId = Guid.Parse("5e8b1c24-9a03-4f67-b2d1-0c4e8a7f3519");
+        await sut.UpsertAsync(
+            new TestCatchDto(catchId, "Tench", DateTimeOffset.Parse("2026-08-14T15:00:00Z"), null),
+            CancellationToken.None);
+
+        // Act
+        var upload = await sut.CreatePhotographUploadAsync(
+            catchId,
+            new PhotographUploadRequestDto(photographId, "image/jpeg"),
+            CancellationToken.None);
+
+        // Assert
+        upload.Should().NotBeNull();
+        upload!.ObjectKey.Should().Be($"test-catches/{catchId:D}/{photographId:D}");
+        upload.UploadUrl.Should().Contain(upload.ObjectKey);
+    }
+
+    [Fact]
+    public async Task ItShouldOmitPhotographUrl_WhenObjectStorageIsNotConfigured()
+    {
+        // Arrange
+        var repository = new MemoryTestCatchRepository();
+        var configured = new TestCatchService(repository, new MemoryObjectStorage());
+        var catchId = Guid.Parse("3f6a9c81-4d20-4e15-b8a7-2c1d0e9f5648");
+        var photographId = Guid.Parse("9d2e7b50-1c84-4a36-9f0d-8b5c3a1e7260");
+        await configured.UpsertAsync(
+            new TestCatchDto(catchId, "Roach", DateTimeOffset.Parse("2026-08-14T16:00:00Z"), null),
+            CancellationToken.None);
+        await configured.RecordPhotographAsync(
+            catchId,
+            new RecordPhotographDto(photographId, $"test-catches/{catchId:D}/{photographId:D}", "image/jpeg"),
+            CancellationToken.None);
+        var sut = new TestCatchService(repository, new MemoryObjectStorage { IsConfigured = false });
+
+        // Act
+        var listed = await sut.ListAsync(CancellationToken.None);
+
+        // Assert
+        listed.Should().ContainSingle();
+        listed[0].PhotographId.Should().Be(photographId);
+        listed[0].PhotographUrl.Should().BeNull();
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Application.Tests/TestCatchServiceTests/WhenTestingUpsert.cs
@@ -11,7 +11,7 @@ public class WhenTestingUpsert
     {
         // Arrange
         var repository = new MemoryTestCatchRepository();
-        var sut = new TestCatchService(repository);
+        var sut = new TestCatchService(repository, new MemoryObjectStorage());
         var testCatch = new TestCatchDto(
             Guid.Parse("4e2a1c90-8b33-4f6d-9a17-5c0e8d2b1a44"),
             "Pike",
@@ -34,7 +34,7 @@ public class WhenTestingUpsert
     public async Task ItShouldReturnTheCatch_WhenUpserted()
     {
         // Arrange
-        var sut = new TestCatchService(new MemoryTestCatchRepository());
+        var sut = new TestCatchService(new MemoryTestCatchRepository(), new MemoryObjectStorage());
         var testCatch = new TestCatchDto(
             Guid.NewGuid(),
             "Perch",

--- a/tests/FishingLogBook.Infrastructure.Tests/ObjectStorageConfigTests/WhenTestingIsConfigured.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/ObjectStorageConfigTests/WhenTestingIsConfigured.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using FishingLogBook.Domain.Config;
+
+namespace FishingLogBook.Infrastructure.Tests.ObjectStorageConfigTests;
+
+public class WhenTestingIsConfigured
+{
+    [Fact]
+    public void ItShouldBeUnconfigured_WhenSecretsAreUserSecretPlaceholders()
+    {
+        // Arrange
+        var config = new ObjectStorageConfig
+        {
+            ServiceUrl = "set in user secrets fishinglogbook-api",
+            BucketName = "fishing-logbook-dev",
+            AccessKeyId = "set in user secrets fishinglogbook-api",
+            SecretAccessKey = "set in user secrets fishinglogbook-api"
+        };
+
+        // Act
+        var configured = config.IsConfigured;
+
+        // Assert
+        configured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItShouldBeConfigured_WhenAllValuesAreProvided()
+    {
+        // Arrange
+        var config = new ObjectStorageConfig
+        {
+            ServiceUrl = "https://example.r2.cloudflarestorage.com",
+            BucketName = "fishing-logbook-dev",
+            AccessKeyId = "access-key",
+            SecretAccessKey = "secret-key"
+        };
+
+        // Act
+        var configured = config.IsConfigured;
+
+        // Assert
+        configured.Should().BeTrue();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DependencyInjectionTests/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjectionTests/WhenTestingContainer.cs
@@ -43,6 +43,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         // Assert
         injectedTypes.Should().Contain(typeof(ISystemStatusClient));
         injectedTypes.Should().Contain(typeof(ITestCatchStore));
+        injectedTypes.Should().Contain(typeof(ITestCatchPhotoStore));
         injectedTypes.Should().Contain(typeof(ITestCatchSynchroniser));
         injectedTypes.Should().Contain(typeof(ICultureService));
         injectedTypes.Should().Contain(typeof(IStringLocalizer<UiStrings>));

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
@@ -11,10 +11,18 @@ public class BaseTestCatchLogTest
 {
     protected static BunitContext CreateContext(ITestCatchStore store)
     {
-        return CreateContext(store, Substitute.For<ITestCatchSynchroniser>());
+        return CreateContext(store, Substitute.For<ITestCatchSynchroniser>(), Substitute.For<ITestCatchPhotoStore>());
     }
 
     protected static BunitContext CreateContext(ITestCatchStore store, ITestCatchSynchroniser synchroniser)
+    {
+        return CreateContext(store, synchroniser, Substitute.For<ITestCatchPhotoStore>());
+    }
+
+    protected static BunitContext CreateContext(
+        ITestCatchStore store,
+        ITestCatchSynchroniser synchroniser,
+        ITestCatchPhotoStore photoStore)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -22,6 +30,7 @@ public class BaseTestCatchLogTest
         context.Services.AddLocalization();
         context.Services.AddSingleton(store);
         context.Services.AddSingleton(synchroniser);
+        context.Services.AddSingleton(photoStore);
         context.Services.AddSingleton(Substitute.For<ICultureService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
 

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingPhotograph.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingPhotograph.cs
@@ -1,0 +1,122 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Pages.TestCatchLog;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class WhenTestingPhotograph : BaseTestCatchLogTest
+{
+    [Fact]
+    public async Task ItShouldShowPhotograph_WhenReopened()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("5a2c8e14-9d70-4b31-8f6a-1c3e7b90d246"),
+            "Carp",
+            DateTimeOffset.Parse("2026-08-14T17:00:00Z"),
+            null,
+            SyncStatus.SavedLocally,
+            new TestCatchPhotograph(
+                Guid.Parse("aa11bb22-cc33-dd44-ee55-ff6677889900"),
+                "image/jpeg",
+                SyncStatus.SavedLocally));
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        var photos = Substitute.For<ITestCatchPhotoStore>();
+        photos.GetAsync(existing.Id, Arg.Any<CancellationToken>())
+            .Returns(new TestCatchPhotoBytes([0xFF, 0xD8, 0xFF], "image/jpeg"));
+        await using var context = CreateContext(store, Substitute.For<ITestCatchSynchroniser>(), photos);
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#test-catch-photo-{existing.Id}").Should().NotBeNull();
+            cut.Find($"#test-catch-photo-{existing.Id}").GetAttribute("src").Should().StartWith("data:image/jpeg;base64,");
+            cut.Find($"#test-catch-photo-status-{existing.Id}").TextContent.Should()
+                .Contain("Photograph saved locally — not uploaded");
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldShowPhotographRetry_WhenUploadFailed()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("0e7b3c91-5a24-4d86-b1f0-8c2d9e4a6b17"),
+            "Tench",
+            DateTimeOffset.Parse("2026-08-14T18:00:00Z"),
+            null,
+            SyncStatus.Synchronised,
+            new TestCatchPhotograph(
+                Guid.Parse("bb22cc33-dd44-ee55-ff66-77889900aa11"),
+                "image/jpeg",
+                SyncStatus.FailedToSynchronise,
+                RemoteUrl: null));
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        var photos = Substitute.For<ITestCatchPhotoStore>();
+        photos.GetAsync(existing.Id, Arg.Any<CancellationToken>())
+            .Returns(new TestCatchPhotoBytes([0xFF, 0xD8, 0xFF], "image/jpeg"));
+        var synchroniser = Substitute.For<ITestCatchSynchroniser>();
+        await using var context = CreateContext(store, synchroniser, photos);
+        var cut = context.Render<TestCatchLog>();
+
+        // Act
+        cut.WaitForAssertion(() => cut.Find($"#retry-test-catch-photo-{existing.Id}").Should().NotBeNull());
+        await cut.Find($"#retry-test-catch-photo-{existing.Id}").ClickAsync();
+
+        // Assert
+        cut.Find($"#test-catch-photo-status-{existing.Id}").TextContent.Should()
+            .Contain("Photograph upload failed");
+        cut.FindAll($"#retry-test-catch-{existing.Id}").Should().BeEmpty();
+        await synchroniser.Received(1).RetryPhotographAsync(existing.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowRemotePhotograph_WhenOpenedOnAnotherSession()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("8c1d4a70-2e59-4b16-9f83-6a0c7d5e1b42"),
+            "Rudd",
+            DateTimeOffset.Parse("2026-08-14T19:00:00Z"),
+            null,
+            SyncStatus.Synchronised,
+            new TestCatchPhotograph(
+                Guid.Parse("cc33dd44-ee55-ff66-7788-9900aabb1122"),
+                "image/jpeg",
+                SyncStatus.Synchronised,
+                RemoteUrl: "https://storage.test/download/photo"));
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        var photos = Substitute.For<ITestCatchPhotoStore>();
+        photos.GetAsync(existing.Id, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TestCatchPhotoBytes?>(null));
+        await using var context = CreateContext(store, Substitute.For<ITestCatchSynchroniser>(), photos);
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#test-catch-photo-{existing.Id}").GetAttribute("src")
+                .Should().Be("https://storage.test/download/photo");
+            cut.Find($"#test-catch-photo-status-{existing.Id}").TextContent.Should()
+                .Contain("Photograph uploaded");
+        });
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchPhotoStoreTests/MemoryTestCatchPhotoStore.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchPhotoStoreTests/MemoryTestCatchPhotoStore.cs
@@ -1,0 +1,25 @@
+using FishingLogBook.Web.Offline;
+
+namespace FishingLogBook.Web.Tests.TestCatchPhotoStoreTests;
+
+internal sealed class MemoryTestCatchPhotoStore : ITestCatchPhotoStore
+{
+    private readonly Dictionary<Guid, TestCatchPhotoBytes> _items;
+
+    public MemoryTestCatchPhotoStore(Dictionary<Guid, TestCatchPhotoBytes> items)
+    {
+        _items = items;
+    }
+
+    public Task PutAsync(Guid testCatchId, byte[] bytes, string contentType, CancellationToken cancellationToken)
+    {
+        _items[testCatchId] = new TestCatchPhotoBytes(bytes, contentType);
+        return Task.CompletedTask;
+    }
+
+    public Task<TestCatchPhotoBytes?> GetAsync(Guid testCatchId, CancellationToken cancellationToken)
+    {
+        _items.TryGetValue(testCatchId, out var stored);
+        return Task.FromResult(stored);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchPhotoStoreTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchPhotoStoreTests/WhenTestingSave.cs
@@ -1,0 +1,27 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Offline;
+
+namespace FishingLogBook.Web.Tests.TestCatchPhotoStoreTests;
+
+public class WhenTestingSave
+{
+    [Fact]
+    public async Task ItShouldStillContainPhotograph_WhenNewStoreReadsSamePersistence()
+    {
+        // Arrange
+        var backing = new Dictionary<Guid, TestCatchPhotoBytes>();
+        var sut = new MemoryTestCatchPhotoStore(backing);
+        var catchId = Guid.Parse("3a1f2c8e-7b44-4d1a-9c3e-2f8a6b0d1e55");
+        var bytes = new byte[] { 0xFF, 0xD8, 0xFF };
+        await sut.PutAsync(catchId, bytes, "image/jpeg", CancellationToken.None);
+        var reopened = new MemoryTestCatchPhotoStore(backing);
+
+        // Act
+        var saved = await reopened.GetAsync(catchId, CancellationToken.None);
+
+        // Assert
+        saved.Should().NotBeNull();
+        saved!.ContentType.Should().Be("image/jpeg");
+        saved.Bytes.Should().Equal(bytes);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchSynchroniserTests/WhenTestingSynchronise.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchSynchroniserTests/WhenTestingSynchronise.cs
@@ -18,7 +18,7 @@ public class WhenTestingSynchronise
         var store = CreateStore([testCatch]);
         var client = Substitute.For<ITestCatchClient>();
         client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
-        var sut = new TestCatchSynchroniser(store, client, Online());
+        var sut = new TestCatchSynchroniser(store, EmptyPhotos(), client, Online());
 
         // Act
         await sut.SynchronisePendingAsync(CancellationToken.None);
@@ -42,7 +42,7 @@ public class WhenTestingSynchronise
         client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
         client.UpsertAsync(Arg.Any<TestCatchDto>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("network"));
-        var sut = new TestCatchSynchroniser(store, client, Online());
+        var sut = new TestCatchSynchroniser(store, EmptyPhotos(), client, Online());
 
         // Act
         await sut.SynchronisePendingAsync(CancellationToken.None);
@@ -63,7 +63,7 @@ public class WhenTestingSynchronise
         var client = Substitute.For<ITestCatchClient>();
         var network = Substitute.For<INetworkStatus>();
         network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
-        var sut = new TestCatchSynchroniser(store, client, network);
+        var sut = new TestCatchSynchroniser(store, EmptyPhotos(), client, network);
 
         // Act
         await sut.SynchronisePendingAsync(CancellationToken.None);
@@ -83,7 +83,7 @@ public class WhenTestingSynchronise
         var store = CreateStore([testCatch]);
         var client = Substitute.For<ITestCatchClient>();
         client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
-        var sut = new TestCatchSynchroniser(store, client, Online());
+        var sut = new TestCatchSynchroniser(store, EmptyPhotos(), client, Online());
 
         // Act
         await sut.SynchronisePendingAsync(CancellationToken.None);
@@ -111,7 +111,7 @@ public class WhenTestingSynchronise
             null);
         var client = Substitute.For<ITestCatchClient>();
         client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([remote]);
-        var sut = new TestCatchSynchroniser(store, client, Online());
+        var sut = new TestCatchSynchroniser(store, EmptyPhotos(), client, Online());
 
         // Act
         await sut.SynchronisePendingAsync(CancellationToken.None);
@@ -123,6 +123,108 @@ public class WhenTestingSynchronise
         saved[0].SpeciesName.Should().Be("Bream");
         saved[0].SyncStatus.Should().Be(SyncStatus.Synchronised);
         await client.DidNotReceive().UpsertAsync(Arg.Any<TestCatchDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepCatchSynchronised_WhenPhotographUploadFails()
+    {
+        // Arrange
+        var photograph = new TestCatchPhotograph(
+            Guid.Parse("aa11bb22-cc33-dd44-ee55-ff6677889900"),
+            "image/jpeg",
+            SyncStatus.SavedLocally);
+        var testCatch = CreateCatch(SyncStatus.SavedLocally) with { Photograph = photograph };
+        var store = CreateStore([testCatch]);
+        var photos = CreatePhotoStore(testCatch.Id, [1, 2, 3], "image/jpeg");
+        var client = Substitute.For<ITestCatchClient>();
+        client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
+        client.CreatePhotographUploadAsync(Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("storage unavailable"));
+        var sut = new TestCatchSynchroniser(store, photos, client, Online());
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle();
+        saved[0].Id.Should().Be(testCatch.Id);
+        saved[0].SyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved[0].Photograph!.SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        await client.Received(1).UpsertAsync(
+            Arg.Is<TestCatchDto>(dto => dto.Id == testCatch.Id),
+            Arg.Any<CancellationToken>());
+        await client.DidNotReceive().RecordPhotographAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordPhotographDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRetryTheSamePhotograph_WhenUploadIsRetried()
+    {
+        // Arrange
+        var photograph = new TestCatchPhotograph(
+            Guid.Parse("aa11bb22-cc33-dd44-ee55-ff6677889900"),
+            "image/jpeg",
+            SyncStatus.FailedToSynchronise);
+        var testCatch = CreateCatch(SyncStatus.Synchronised) with { Photograph = photograph };
+        var store = CreateStore([testCatch]);
+        var photos = CreatePhotoStore(testCatch.Id, [1, 2, 3], "image/jpeg");
+        var client = Substitute.For<ITestCatchClient>();
+        client.CreatePhotographUploadAsync(Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("storage unavailable"));
+        var sut = new TestCatchSynchroniser(store, photos, client, Online());
+
+        // Act
+        await sut.RetryPhotographAsync(testCatch.Id, CancellationToken.None);
+        await sut.RetryPhotographAsync(testCatch.Id, CancellationToken.None);
+        var saved = await store.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle();
+        saved[0].SyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved[0].Photograph!.Id.Should().Be(photograph.Id);
+        saved[0].Photograph!.SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        await client.DidNotReceive().UpsertAsync(Arg.Any<TestCatchDto>(), Arg.Any<CancellationToken>());
+        await client.Received(2).CreatePhotographUploadAsync(
+            testCatch.Id,
+            Arg.Is<PhotographUploadRequestDto>(request => request.PhotographId == photograph.Id),
+            Arg.Any<CancellationToken>());
+        await client.DidNotReceive().RecordPhotographAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordPhotographDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowRemotePhotograph_WhenMergedFromApi()
+    {
+        // Arrange
+        var store = CreateStore([]);
+        var photographId = Guid.Parse("c0ffee00-1111-2222-3333-444455556666");
+        var remote = new TestCatchDto(
+            Guid.Parse("6f4c8a12-3e90-4b7d-a1c5-9d2e8f0b6a33"),
+            "Bream",
+            DateTimeOffset.Parse("2026-08-14T16:00:00Z"),
+            null,
+            photographId,
+            "image/jpeg",
+            "https://storage.test/download/photo");
+        var client = Substitute.For<ITestCatchClient>();
+        client.GetAllAsync(Arg.Any<CancellationToken>()).Returns([remote]);
+        var sut = new TestCatchSynchroniser(store, EmptyPhotos(), client, Online());
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle();
+        saved[0].Photograph.Should().NotBeNull();
+        saved[0].Photograph!.Id.Should().Be(photographId);
+        saved[0].Photograph!.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved[0].Photograph!.RemoteUrl.Should().Be("https://storage.test/download/photo");
     }
 
     private static INetworkStatus Online()
@@ -140,6 +242,22 @@ public class WhenTestingSynchronise
             DateTimeOffset.Parse("2026-08-14T12:00:00Z"),
             "First attempt",
             status);
+    }
+
+    private static ITestCatchPhotoStore EmptyPhotos()
+    {
+        var photos = Substitute.For<ITestCatchPhotoStore>();
+        photos.GetAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<TestCatchPhotoBytes?>(null));
+        return photos;
+    }
+
+    private static ITestCatchPhotoStore CreatePhotoStore(Guid testCatchId, byte[] bytes, string contentType)
+    {
+        var photos = Substitute.For<ITestCatchPhotoStore>();
+        photos.GetAsync(testCatchId, Arg.Any<CancellationToken>())
+            .Returns(new TestCatchPhotoBytes(bytes, contentType));
+        return photos;
     }
 
     private static ITestCatchStore CreateStore(IReadOnlyList<TestCatch> seed)


### PR DESCRIPTION
## Summary
- Persists one TestCatch photograph in IndexedDB so it survives close and reopen, then uploads bytes to R2 independently of catch metadata.
- Retrying a photograph does not lose catch metadata; catch stays synchronised if the photo is still uploading or has failed. Photograph retries reuse the same photograph id.
- After a successful upload, another session can view the photo via a presigned GET URL. If R2 is not configured, the API returns 503 instead of pretending the upload succeeded.
- Closes #11.

Deploy notes:
- CI deploys the API but does not run DbUp. After merge, apply `202608141500_11_CreateTestCatchPhotograph.sql` against Neon (and local Postgres) with:

```
dotnet run --project src/FishingLogBook.Db.Migrations.App -- --run
```

- Fly `ObjectStorage__*` secrets are already set on `fishing-logbook-dev-api`.
- R2 CORS is already configured for localhost and `https://fishing-logbook-dev.pages.dev`.

## Test plan
- [ ] Apply the photograph migration, save a TestCatch photo offline, close and reopen — the photo is still there.
- [ ] Fail the photo upload while catch metadata succeeds — catch stays synchronised; retry photo does not create a second catch.
- [ ] After a successful photo upload, open another browser/session and view the photograph.
- [ ] Confirm an unconfigured R2 setup returns 503 rather than a fake success.
- [ ] CI tests stay green.