### PR TITLE
FLB#57 | add last-error logging and Warning load/save diagnostics

### DIFF
--- a/src/FishingLogBook.Api/Program.cs
+++ b/src/FishingLogBook.Api/Program.cs
@@ -39,13 +39,14 @@ app.Logger.LogInformation(
     "FishingLogBook API starting in {HostingEnvironment} environment.",
     app.Environment.EnvironmentName);
 
+app.MapOpenApi();
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("/openapi/v1.json", "FishingLogBook API");
+});
+
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
-    app.UseSwaggerUI(options =>
-    {
-        options.SwaggerEndpoint("/openapi/v1.json", "FishingLogBook API");
-    });
     app.UseHttpsRedirection();
 }
 

--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
@@ -28,6 +28,9 @@ public static class DiagnosticEventNames
     public const string CatchOfflineSaveCompleted = "CatchOfflineSaveCompleted";
     public const string CatchOfflineSaveFailed = "CatchOfflineSaveFailed";
 
+    public const string CatchOfflineLoadStarted = "CatchOfflineLoadStarted";
+    public const string CatchOfflineLoadCompleted = "CatchOfflineLoadCompleted";
+
     public const string PhotoOfflineSaveStarted = "PhotoOfflineSaveStarted";
     public const string PhotoOfflineSaveCompleted = "PhotoOfflineSaveCompleted";
     public const string PhotoOfflineSaveFailed = "PhotoOfflineSaveFailed";

--- a/src/FishingLogBook.Web/Diagnostics/DiagnosticLogger.cs
+++ b/src/FishingLogBook.Web/Diagnostics/DiagnosticLogger.cs
@@ -18,6 +18,7 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
     private readonly INetworkStatus _networkStatus;
     private readonly NavigationManager _navigationManager;
     private readonly IJSRuntime _jsRuntime;
+    private readonly ILoggingService _logging;
     private readonly DiagnosticLevel _minimumPersistLevel;
     private readonly string _appVersion;
     private Guid? _anonymousSessionId;
@@ -29,7 +30,8 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
         CorrelationContext correlationContext,
         INetworkStatus networkStatus,
         NavigationManager navigationManager,
-        IJSRuntime jsRuntime)
+        IJSRuntime jsRuntime,
+        ILoggingService logging)
     {
         _store = store;
         _status = status;
@@ -38,6 +40,7 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
         _networkStatus = networkStatus;
         _navigationManager = navigationManager;
         _jsRuntime = jsRuntime;
+        _logging = logging;
         _minimumPersistLevel = Enum.TryParse(config.MinimumPersistLevel, true, out DiagnosticLevel level)
             ? level
             : DiagnosticLevel.Warning;
@@ -69,15 +72,26 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
             IsWriting.Value = true;
             try
             {
-                var diagnosticEvent = await CreateEventAsync(
+                var persistTask = PersistQueuedEventAsync(
                     level,
                     eventName,
                     message,
                     metadata,
                     exception,
                     cancellationToken);
-                await _store.EnqueueAsync(diagnosticEvent, cancellationToken);
-                _status.QueuedCount = await _store.GetCountAsync(cancellationToken);
+                var completed = await Task.WhenAny(persistTask, Task.Delay(_config.OperationTimeout, CancellationToken.None));
+                if (completed != persistTask)
+                {
+                    await RecordFailureAsync(new TimeoutException("Diagnostic persistence timed out."), eventName, cancellationToken);
+                    await WriteConsoleAsync(
+                        DiagnosticLevel.Error,
+                        eventName,
+                        "Diagnostic persistence timed out.",
+                        cancellationToken);
+                    return;
+                }
+
+                await persistTask;
             }
             finally
             {
@@ -86,9 +100,34 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
         }
         catch (Exception exceptionWhileLogging)
         {
-            _status.LastError = exceptionWhileLogging.GetType().Name;
+            await RecordFailureAsync(exceptionWhileLogging, eventName, cancellationToken);
             await WriteConsoleAsync(DiagnosticLevel.Error, eventName, "Diagnostic persistence failed.", cancellationToken);
         }
+    }
+
+    private async Task PersistQueuedEventAsync(
+        DiagnosticLevel level,
+        string eventName,
+        string message,
+        IReadOnlyDictionary<string, string>? metadata,
+        Exception? exception,
+        CancellationToken cancellationToken)
+    {
+        var diagnosticEvent = await CreateEventAsync(
+            level,
+            eventName,
+            message,
+            metadata,
+            exception,
+            cancellationToken);
+        await _store.EnqueueAsync(diagnosticEvent, cancellationToken);
+        _status.QueuedCount = await _store.GetCountAsync(cancellationToken);
+    }
+
+    private async Task RecordFailureAsync(Exception exception, string eventName, CancellationToken cancellationToken)
+    {
+        _status.LastError = exception.GetType().Name;
+        await _logging.LogErrorAsync(eventName, exception, cancellationToken);
     }
 
     private async Task<DiagnosticEvent> CreateEventAsync(
@@ -104,9 +143,9 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
         {
             isOnline = await _networkStatus.IsOnlineAsync(cancellationToken);
         }
-        catch
+        catch (Exception onlineCheckException)
         {
-            // Online state is optional on the diagnostic event.
+            await _logging.LogErrorAsync("diagnostic online check", onlineCheckException, cancellationToken);
         }
 
         return new DiagnosticEvent
@@ -145,9 +184,9 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
                 return parsed;
             }
         }
-        catch
+        catch (Exception exception)
         {
-            // Fall through and create a session locally.
+            await _logging.LogErrorAsync("diagnostic session read", exception, cancellationToken);
         }
 
         var created = Guid.NewGuid();
@@ -156,9 +195,9 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
         {
             await _jsRuntime.InvokeVoidAsync("fishingLogBookDiagnostics.setSessionId", cancellationToken, created.ToString("D"));
         }
-        catch
+        catch (Exception exception)
         {
-            // Session id still works for this in-memory lifetime.
+            await _logging.LogErrorAsync("diagnostic session write", exception, cancellationToken);
         }
 
         return created;
@@ -172,8 +211,9 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
                 await _jsRuntime.InvokeAsync<string>("fishingLogBookDiagnostics.getPlatform", cancellationToken),
                 120);
         }
-        catch
+        catch (Exception exception)
         {
+            await _logging.LogErrorAsync("diagnostic platform read", exception, cancellationToken);
             return null;
         }
     }
@@ -184,8 +224,9 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
         {
             return DiagnosticMetadata.Truncate(new Uri(_navigationManager.Uri).AbsolutePath, 80);
         }
-        catch
+        catch (Exception exception)
         {
+            _ = _logging.LogErrorAsync("diagnostic route read", exception);
             return string.Empty;
         }
     }
@@ -205,9 +246,9 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
                 eventName,
                 message);
         }
-        catch
+        catch (Exception exception)
         {
-            // Console fallback must never throw.
+            await _logging.LogErrorAsync("diagnostic console", exception, cancellationToken);
         }
     }
 }

--- a/src/FishingLogBook.Web/Diagnostics/ILoggingService.cs
+++ b/src/FishingLogBook.Web/Diagnostics/ILoggingService.cs
@@ -1,0 +1,23 @@
+using FishingLogBook.Shared.Diagnostics;
+
+namespace FishingLogBook.Web.Diagnostics;
+
+public interface ILoggingService
+{
+    Task LogErrorAsync(string source, Exception exception, CancellationToken cancellationToken = default);
+
+    Task LogErrorAsync(string source, string message, CancellationToken cancellationToken = default);
+
+    Task<LastErrorLog?> GetLastErrorAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class LastErrorLog
+{
+    public DateTimeOffset TimestampUtc { get; set; }
+
+    public string Source { get; set; } = string.Empty;
+
+    public string? ErrorType { get; set; }
+
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/FishingLogBook.Web/Diagnostics/LoggingService.cs
+++ b/src/FishingLogBook.Web/Diagnostics/LoggingService.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using FishingLogBook.Shared.Diagnostics;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Diagnostics;
+
+public sealed class LoggingService : ILoggingService
+{
+    private const string SetLastError = "fishingLogBookDiagnostics.setLastError";
+    private const string GetLastError = "fishingLogBookDiagnostics.getLastError";
+    private const int MaxMessageLength = 500;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly IJSRuntime _jsRuntime;
+
+    public LoggingService(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public Task LogErrorAsync(string source, Exception exception, CancellationToken cancellationToken = default)
+    {
+        return LogErrorAsync(source, exception.GetType().Name, exception.Message, cancellationToken);
+    }
+
+    public Task LogErrorAsync(string source, string message, CancellationToken cancellationToken = default)
+    {
+        return LogErrorAsync(source, null, message, cancellationToken);
+    }
+
+    public async Task<LastErrorLog?> GetLastErrorAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var json = await _jsRuntime.InvokeAsync<string?>(GetLastError, cancellationToken);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
+            return JsonSerializer.Deserialize<LastErrorLog>(json, JsonOptions);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task LogErrorAsync(
+        string source,
+        string? errorType,
+        string message,
+        CancellationToken cancellationToken)
+    {
+        var lastError = new LastErrorLog
+        {
+            TimestampUtc = DateTimeOffset.UtcNow,
+            Source = DiagnosticMetadata.Truncate(source, 80),
+            ErrorType = errorType,
+            Message = DiagnosticMetadata.Truncate(message, MaxMessageLength)
+        };
+
+        Console.Error.WriteLine($"[FLB] {lastError.Source}: {lastError.ErrorType}: {lastError.Message}");
+
+        try
+        {
+            await _jsRuntime.InvokeVoidAsync(
+                SetLastError,
+                cancellationToken,
+                JsonSerializer.Serialize(lastError, JsonOptions));
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Diagnostics/OfflineOperation.cs
+++ b/src/FishingLogBook.Web/Diagnostics/OfflineOperation.cs
@@ -15,7 +15,8 @@ public static class OfflineOperation
         TimeSpan timeout,
         IDiagnosticLogger diagnostics,
         Func<CancellationToken, Task> action,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        ILoggingService? logging = null)
     {
         await ExecuteAsync(
             operation,
@@ -31,7 +32,8 @@ public static class OfflineOperation
                 await action(token);
                 return 0;
             },
-            cancellationToken);
+            cancellationToken,
+            logging);
     }
 
     public static async Task<T> ExecuteAsync<T>(
@@ -44,10 +46,11 @@ public static class OfflineOperation
         TimeSpan timeout,
         IDiagnosticLogger diagnostics,
         Func<CancellationToken, Task<T>> action,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        ILoggingService? logging = null)
     {
         var metadata = StartingMetadata(operation, storeName, timeout);
-        await SafeLogAsync(diagnostics, DiagnosticLevel.Debug, startedEvent, $"{operation} started.", metadata, null, cancellationToken);
+        await SafeLogAsync(diagnostics, logging, DiagnosticLevel.Debug, startedEvent, $"{operation} started.", metadata, null, cancellationToken);
         var stopwatch = Stopwatch.StartNew();
 
         try
@@ -58,6 +61,7 @@ public static class OfflineOperation
             stopwatch.Stop();
             await SafeLogAsync(
                 diagnostics,
+                logging,
                 DiagnosticLevel.Debug,
                 completedEvent,
                 $"{operation} completed.",
@@ -71,6 +75,7 @@ public static class OfflineOperation
             stopwatch.Stop();
             await SafeLogAsync(
                 diagnostics,
+                logging,
                 DiagnosticLevel.Warning,
                 timedOutEvent,
                 $"{operation} timed out.",
@@ -85,6 +90,7 @@ public static class OfflineOperation
             var timedOut = IsTimeout(exception);
             await SafeLogAsync(
                 diagnostics,
+                logging,
                 timedOut ? DiagnosticLevel.Warning : DiagnosticLevel.Error,
                 timedOut ? timedOutEvent : failedEvent,
                 timedOut ? $"{operation} timed out." : $"{operation} failed.",
@@ -143,6 +149,7 @@ public static class OfflineOperation
 
     private static async Task SafeLogAsync(
         IDiagnosticLogger diagnostics,
+        ILoggingService? logging,
         DiagnosticLevel level,
         string eventName,
         string message,
@@ -154,9 +161,12 @@ public static class OfflineOperation
         {
             await diagnostics.LogAsync(level, eventName, message, metadata, exception, cancellationToken);
         }
-        catch
+        catch (Exception loggingException)
         {
-            // Diagnostic failure must not change the original operation outcome.
+            if (logging is not null)
+            {
+                await logging.LogErrorAsync("diagnostic log", loggingException, cancellationToken);
+            }
         }
     }
 }

--- a/src/FishingLogBook.Web/Localization/CultureService.cs
+++ b/src/FishingLogBook.Web/Localization/CultureService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using FishingLogBook.Web.Diagnostics;
 using Microsoft.JSInterop;
 
 namespace FishingLogBook.Web.Localization;
@@ -6,10 +7,12 @@ namespace FishingLogBook.Web.Localization;
 public sealed class CultureService : ICultureService
 {
     private readonly IJSRuntime _jsRuntime;
+    private readonly ILoggingService _logging;
 
-    public CultureService(IJSRuntime jsRuntime)
+    public CultureService(IJSRuntime jsRuntime, ILoggingService logging)
     {
         _jsRuntime = jsRuntime;
+        _logging = logging;
     }
 
     public string CurrentCulture => CultureInfo.CurrentUICulture.Name;
@@ -23,8 +26,9 @@ public sealed class CultureService : ICultureService
             stored = await _jsRuntime.InvokeAsync<string?>("fishingLogBookCulture.get");
             browser = await _jsRuntime.InvokeAsync<string?>("fishingLogBookCulture.browser");
         }
-        catch (JSException)
+        catch (JSException exception)
         {
+            await _logging.LogErrorAsync("culture read", exception);
         }
 
         Apply(CultureMatcher.Resolve(stored, browser));

--- a/src/FishingLogBook.Web/Offline/IndexedDbTestCatchJsonStore.cs
+++ b/src/FishingLogBook.Web/Offline/IndexedDbTestCatchJsonStore.cs
@@ -12,6 +12,7 @@ public sealed class IndexedDbTestCatchJsonStore : ITestCatchJsonStore
 
     private readonly IJSRuntime _jsRuntime;
     private readonly IDiagnosticLogger _diagnostics;
+    private readonly ILoggingService _logging;
     private readonly DiagnosticsClientConfig _config;
     private readonly SemaphoreSlim _moduleLock = new(1, 1);
     private IJSObjectReference? _module;
@@ -19,10 +20,12 @@ public sealed class IndexedDbTestCatchJsonStore : ITestCatchJsonStore
     public IndexedDbTestCatchJsonStore(
         IJSRuntime jsRuntime,
         IDiagnosticLogger diagnostics,
+        ILoggingService logging,
         DiagnosticsClientConfig config)
     {
         _jsRuntime = jsRuntime;
         _diagnostics = diagnostics;
+        _logging = logging;
         _config = config;
     }
 
@@ -42,7 +45,8 @@ public sealed class IndexedDbTestCatchJsonStore : ITestCatchJsonStore
                 var module = await GetModuleAsync(token);
                 await module.InvokeVoidAsync("putTestCatch", token, json);
             },
-            cancellationToken);
+            cancellationToken,
+            _logging);
     }
 
     public async Task<IReadOnlyList<string>> GetAllAsync(CancellationToken cancellationToken)
@@ -62,7 +66,8 @@ public sealed class IndexedDbTestCatchJsonStore : ITestCatchJsonStore
                 var items = await module.InvokeAsync<string[]>("getAllTestCatches", token);
                 return (IReadOnlyList<string>)(items ?? []);
             },
-            cancellationToken);
+            cancellationToken,
+            _logging);
     }
 
     private async Task<IJSObjectReference> GetModuleAsync(CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/Offline/IndexedDbTestCatchPhotoStore.cs
+++ b/src/FishingLogBook.Web/Offline/IndexedDbTestCatchPhotoStore.cs
@@ -12,6 +12,7 @@ public sealed class IndexedDbTestCatchPhotoStore : ITestCatchPhotoStore
 
     private readonly IJSRuntime _jsRuntime;
     private readonly IDiagnosticLogger _diagnostics;
+    private readonly ILoggingService _logging;
     private readonly DiagnosticsClientConfig _config;
     private readonly SemaphoreSlim _moduleLock = new(1, 1);
     private IJSObjectReference? _module;
@@ -19,10 +20,12 @@ public sealed class IndexedDbTestCatchPhotoStore : ITestCatchPhotoStore
     public IndexedDbTestCatchPhotoStore(
         IJSRuntime jsRuntime,
         IDiagnosticLogger diagnostics,
+        ILoggingService logging,
         DiagnosticsClientConfig config)
     {
         _jsRuntime = jsRuntime;
         _diagnostics = diagnostics;
+        _logging = logging;
         _config = config;
     }
 
@@ -42,7 +45,8 @@ public sealed class IndexedDbTestCatchPhotoStore : ITestCatchPhotoStore
                 var module = await GetModuleAsync(token);
                 await module.InvokeVoidAsync("putTestCatchPhotograph", token, testCatchId.ToString(), bytes, contentType);
             },
-            cancellationToken);
+            cancellationToken,
+            _logging);
     }
 
     public async Task<TestCatchPhotoBytes?> GetAsync(Guid testCatchId, CancellationToken cancellationToken)
@@ -71,7 +75,8 @@ public sealed class IndexedDbTestCatchPhotoStore : ITestCatchPhotoStore
 
                 return new TestCatchPhotoBytes(Convert.FromBase64String(stored.BytesBase64), stored.ContentType);
             },
-            cancellationToken);
+            cancellationToken,
+            _logging);
     }
 
     private async Task<IJSObjectReference> GetModuleAsync(CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/Offline/TestCatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Offline/TestCatchSynchroniser.cs
@@ -13,19 +13,22 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
     private readonly ITestCatchClient _client;
     private readonly INetworkStatus _networkStatus;
     private readonly IDiagnosticLogger? _diagnostics;
+    private readonly ILoggingService? _logging;
 
     public TestCatchSynchroniser(
         ITestCatchStore store,
         ITestCatchPhotoStore photoStore,
         ITestCatchClient client,
         INetworkStatus networkStatus,
-        IDiagnosticLogger? diagnostics = null)
+        IDiagnosticLogger? diagnostics = null,
+        ILoggingService? logging = null)
     {
         _store = store;
         _photoStore = photoStore;
         _client = client;
         _networkStatus = networkStatus;
         _diagnostics = diagnostics;
+        _logging = logging;
     }
 
     public async Task SynchronisePendingAsync(CancellationToken cancellationToken)
@@ -284,9 +287,12 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
         {
             await _diagnostics.LogAsync(level, eventName, message, exception: exception, cancellationToken: cancellationToken);
         }
-        catch
+        catch (Exception loggingException)
         {
-            // Diagnostic failure must not affect catch synchronisation.
+            if (_logging is not null)
+            {
+                await _logging.LogErrorAsync("diagnostic log", loggingException, cancellationToken);
+            }
         }
     }
 }

--- a/src/FishingLogBook.Web/Pages/Diagnostics/DiagnosticsInspector.razor.cs
+++ b/src/FishingLogBook.Web/Pages/Diagnostics/DiagnosticsInspector.razor.cs
@@ -25,6 +25,9 @@ public partial class DiagnosticsInspector : ComponentBase
     private INetworkStatus NetworkStatus { get; set; } = default!;
 
     [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     private IReadOnlyList<DiagnosticEvent> _events = [];
@@ -55,7 +58,7 @@ public partial class DiagnosticsInspector : ComponentBase
             await SafeSynchroniseAsync();
             _queuedCount = await Store.GetCountAsync(CancellationToken.None);
             _events = await Store.GetPendingAsync(Config.MaxQueueSize, CancellationToken.None);
-            _lastError = Status.LastError;
+            _lastError = await ReadLastErrorAsync();
             _isOnline = await NetworkStatus.IsOnlineAsync(CancellationToken.None);
             var estimate = await Store.GetStorageEstimateAsync(CancellationToken.None);
             _usageLabel = estimate.Usage?.ToString() ?? Loc["Diagnostics_UnavailableValue"];
@@ -65,9 +68,11 @@ public partial class DiagnosticsInspector : ComponentBase
             Status.StorageUsageBytes = estimate.Usage;
             Status.StorageQuotaBytes = estimate.Quota;
         }
-        catch
+        catch (Exception exception)
         {
-            _lastError = Status.LastError ?? Loc["Diagnostics_Unknown"];
+            await Logging.LogErrorAsync("diagnostics refresh", exception);
+            _lastError = await ReadLastErrorAsync() ?? exception.GetType().Name;
+            Status.LastError = exception.GetType().Name;
         }
         finally
         {
@@ -81,9 +86,26 @@ public partial class DiagnosticsInspector : ComponentBase
         {
             await Synchroniser.SynchronisePendingAsync(CancellationToken.None);
         }
-        catch
+        catch (Exception exception)
         {
-            // Upload failure must not hide the remaining local queue.
+            await Logging.LogErrorAsync("diagnostic upload", exception);
+            Status.LastError = exception.GetType().Name;
         }
+    }
+
+    private async Task<string?> ReadLastErrorAsync()
+    {
+        var lastError = await Logging.GetLastErrorAsync();
+        if (lastError is null)
+        {
+            return Status.LastError;
+        }
+
+        if (string.IsNullOrWhiteSpace(lastError.ErrorType))
+        {
+            return lastError.Message;
+        }
+
+        return $"{lastError.ErrorType}: {lastError.Message}";
     }
 }

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
@@ -42,6 +42,9 @@ public partial class TestCatchLog : ComponentBase, IDisposable
     private IDiagnosticLogger Diagnostics { get; set; } = default!;
 
     [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
     private IDiagnosticSynchroniser DiagnosticSynchroniser { get; set; } = default!;
 
     [Inject]
@@ -110,7 +113,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         try
         {
             await SafeLogAsync(
-                DiagnosticLevel.Information,
+                DiagnosticLevel.Warning,
                 DiagnosticEventNames.CatchOfflineSaveStarted,
                 "Catch offline save started.");
 
@@ -144,7 +147,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
                 }
 
                 await SafeLogAsync(
-                    DiagnosticLevel.Information,
+                    DiagnosticLevel.Warning,
                     DiagnosticEventNames.CatchOfflineSaveCompleted,
                     "Catch offline save completed.");
                 _speciesName = string.Empty;
@@ -200,6 +203,11 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         _isLoading = true;
         try
         {
+            await SafeLogAsync(
+                DiagnosticLevel.Warning,
+                DiagnosticEventNames.CatchOfflineLoadStarted,
+                "Catch offline load started.");
+
             try
             {
                 _catches = (await TestCatchStore.GetAllAsync(_cancellationTokenSource.Token))
@@ -219,6 +227,10 @@ public partial class TestCatchLog : ComponentBase, IDisposable
             }
 
             await LoadPhotographsAsync();
+            await SafeLogAsync(
+                DiagnosticLevel.Warning,
+                DiagnosticEventNames.CatchOfflineLoadCompleted,
+                "Catch offline load completed.");
         }
         finally
         {
@@ -284,9 +296,9 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         {
             await DiagnosticSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
         }
-        catch
+        catch (Exception exception)
         {
-            // Diagnostic upload must never block catch use.
+            await Logging.LogErrorAsync("diagnostic upload", exception, _cancellationTokenSource.Token);
         }
     }
 
@@ -305,9 +317,9 @@ public partial class TestCatchLog : ComponentBase, IDisposable
                 exception: exception,
                 cancellationToken: _cancellationTokenSource.Token);
         }
-        catch
+        catch (Exception loggingException)
         {
-            // Diagnostic failure must never prevent catch save or load.
+            await Logging.LogErrorAsync("diagnostic log", loggingException, _cancellationTokenSource.Token);
         }
     }
 

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITestCatchPhotoStore, IndexedDbTestCatchPhotoStore>();
         services.AddScoped<ITestCatchSynchroniser, TestCatchSynchroniser>();
         services.AddSingleton<DiagnosticStatus>();
+        services.AddScoped<ILoggingService, LoggingService>();
         services.AddScoped<IDiagnosticEventStore, IndexedDbDiagnosticEventStore>();
         services.AddScoped<IDiagnosticLogger, DiagnosticLogger>();
         services.AddScoped<IDiagnosticSynchroniser, DiagnosticSynchroniser>();

--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -64,6 +64,12 @@
                 } else {
                     console.debug(line);
                 }
+            },
+            setLastError: (json) => {
+                try { localStorage.setItem('flb-last-error', json); } catch { }
+            },
+            getLastError: () => {
+                try { return localStorage.getItem('flb-last-error'); } catch { return null; }
             }
         };
         navigator.serviceWorker?.addEventListener('message', (event) => {

--- a/src/FishingLogBook.Web/wwwroot/js/offline-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/offline-store.js
@@ -177,6 +177,19 @@ function runTransaction(objectStoreName, mode, operationName, execute) {
                     operation: operationName,
                     elapsedMilliseconds: elapsedSince(started)
                 });
+            }, (error) => {
+                emit('OfflineDbTransactionError', {
+                    storeName: objectStoreName,
+                    operation: operationName,
+                    elapsedMilliseconds: elapsedSince(started),
+                    errorType: error?.name
+                });
+                try {
+                    transaction.abort();
+                } catch {
+                    // Already aborted.
+                }
+                reject(error || new Error('IndexedDB request failed'));
             });
         });
 
@@ -194,15 +207,15 @@ function runTransaction(objectStoreName, mode, operationName, execute) {
 
 export async function putTestCatch(json) {
     const catchRecord = JSON.parse(json);
-    await runTransaction(storeName, 'readwrite', 'write', (store, succeed) => {
+    await runTransaction(storeName, 'readwrite', 'write', (store, succeed, fail) => {
         const request = store.put(catchRecord);
         request.onsuccess = () => succeed();
-        request.onerror = () => { };
+        request.onerror = () => fail(request.error);
     });
 }
 
 export async function getAllTestCatches() {
-    return runTransaction(storeName, 'readonly', 'read', (store, succeed) => {
+    return runTransaction(storeName, 'readonly', 'read', (store, succeed, fail) => {
         const items = [];
         const request = store.openCursor();
         request.onsuccess = () => {
@@ -215,16 +228,16 @@ export async function getAllTestCatches() {
             items.push(cursor.value);
             cursor.continue();
         };
-        request.onerror = () => { };
+        request.onerror = () => fail(request.error);
     });
 }
 
 export async function putTestCatchPhotograph(id, bytes, contentType) {
     const storedBytes = toStoredBytes(bytes);
-    await runTransaction(photographStoreName, 'readwrite', 'write', (store, succeed) => {
+    await runTransaction(photographStoreName, 'readwrite', 'write', (store, succeed, fail) => {
         const request = store.put({ id, bytes: storedBytes, contentType });
         request.onsuccess = () => succeed();
-        request.onerror = () => { };
+        request.onerror = () => fail(request.error);
     });
 }
 
@@ -287,7 +300,7 @@ function readPhotograph(db, id, started) {
             });
             item = photographFromRecord(request.result);
         };
-        request.onerror = () => { };
+        request.onerror = () => reject(request.error);
     }).then((record) => completePhotograph(record));
 }
 

--- a/tests/FishingLogBook.Api.Tests/SwaggerTests/WhenTestingProduction.cs
+++ b/tests/FishingLogBook.Api.Tests/SwaggerTests/WhenTestingProduction.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests;
+
+namespace FishingLogBook.Api.Tests.SwaggerTests;
+
+public class WhenTestingProduction : IClassFixture<SystemApiFactory>
+{
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingProduction(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldServeTheOpenApiDocument()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/openapi/v1.json");
+        var body = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Contain("FishingLogBook");
+    }
+
+    [Fact]
+    public async Task ItShouldServeSwaggerUi()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/swagger/index.html");
+        var body = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Contain("swagger");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DependencyInjectionTests/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjectionTests/WhenTestingContainer.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using FishingLogBook.Web.Diagnostics;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Offline;
 using FishingLogBook.Web.Services;
@@ -46,6 +47,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         injectedTypes.Should().Contain(typeof(ITestCatchPhotoStore));
         injectedTypes.Should().Contain(typeof(ITestCatchSynchroniser));
         injectedTypes.Should().Contain(typeof(ICultureService));
+        injectedTypes.Should().Contain(typeof(ILoggingService));
         injectedTypes.Should().Contain(typeof(IStringLocalizer<UiStrings>));
         resolve.Should().NotThrow();
     }

--- a/tests/FishingLogBook.Web.Tests/DiagnosticLoggerTests/MemoryDiagnosticEventStore.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticLoggerTests/MemoryDiagnosticEventStore.cs
@@ -13,12 +13,19 @@ public sealed class MemoryDiagnosticEventStore : IDiagnosticEventStore
 
     public Exception? ThrowOnEnqueue { get; set; }
 
+    public TaskCompletionSource<bool>? HangOnEnqueue { get; set; }
+
     public Task EnqueueAsync(DiagnosticEvent diagnosticEvent, CancellationToken cancellationToken)
     {
         EnqueueCalls++;
         if (ThrowOnEnqueue is not null)
         {
             throw ThrowOnEnqueue;
+        }
+
+        if (HangOnEnqueue is not null)
+        {
+            return HangOnEnqueue.Task;
         }
 
         var index = Items.FindIndex(item => item.Id == diagnosticEvent.Id);

--- a/tests/FishingLogBook.Web.Tests/DiagnosticLoggerTests/WhenTestingLog.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticLoggerTests/WhenTestingLog.cs
@@ -97,20 +97,51 @@ public class WhenTestingLog
         store.Items[0].Metadata.Should().NotContainKey("notes");
     }
 
+    [Fact]
+    public async Task ItShouldReturnAndRecordTimeout_WhenPersistenceDoesNotComplete()
+    {
+        // Arrange
+        var store = new MemoryDiagnosticEventStore
+        {
+            HangOnEnqueue = new TaskCompletionSource<bool>()
+        };
+        var status = new DiagnosticStatus();
+        var sut = CreateLogger(
+            store,
+            new DiagnosticsClientConfig
+            {
+                MinimumPersistLevel = "Information",
+                OperationTimeoutMilliseconds = 250
+            },
+            status);
+
+        // Act
+        await sut.LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchOfflineSaveStarted,
+            "started");
+
+        // Assert
+        store.Items.Should().BeEmpty();
+        status.LastError.Should().Be(nameof(TimeoutException));
+    }
+
     private static DiagnosticLogger CreateLogger(
         MemoryDiagnosticEventStore store,
-        DiagnosticsClientConfig? config = null)
+        DiagnosticsClientConfig? config = null,
+        DiagnosticStatus? status = null)
     {
         var network = Substitute.For<INetworkStatus>();
         network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
         return new DiagnosticLogger(
             store,
-            new DiagnosticStatus(),
+            status ?? new DiagnosticStatus(),
             config ?? new DiagnosticsClientConfig { MinimumPersistLevel = "Information" },
             new CorrelationContext(),
             network,
             new TestNavigation(),
-            Substitute.For<IJSRuntime>());
+            Substitute.For<IJSRuntime>(),
+            Substitute.For<ILoggingService>());
     }
 
     private sealed class TestNavigation : NavigationManager

--- a/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/BaseDiagnosticsInspectorTest.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/BaseDiagnosticsInspectorTest.cs
@@ -15,7 +15,8 @@ public class BaseDiagnosticsInspectorTest
         IDiagnosticEventStore store,
         IDiagnosticSynchroniser? synchroniser = null,
         INetworkStatus? network = null,
-        DiagnosticsClientConfig? config = null)
+        DiagnosticsClientConfig? config = null,
+        ILoggingService? logging = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -26,6 +27,7 @@ public class BaseDiagnosticsInspectorTest
         context.Services.AddSingleton(new DiagnosticStatus());
         context.Services.AddSingleton(config ?? new DiagnosticsClientConfig { MaxQueueSize = 500 });
         context.Services.AddSingleton(network ?? OnlineNetwork());
+        context.Services.AddSingleton(logging ?? SilentLogging());
         context.Services.AddSingleton(Substitute.For<ICultureService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
@@ -47,5 +49,16 @@ public class BaseDiagnosticsInspectorTest
         store.GetStorageEstimateAsync(Arg.Any<CancellationToken>())
             .Returns(new StorageEstimate { Quota = 1000, Usage = 10 });
         return store;
+    }
+
+    protected static ILoggingService SilentLogging()
+    {
+        var logging = Substitute.For<ILoggingService>();
+        logging.GetLastErrorAsync(Arg.Any<CancellationToken>()).Returns((LastErrorLog?)null);
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return logging;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/WhenTestingQueuedEvents.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/WhenTestingQueuedEvents.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Web.Diagnostics;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Pages.Diagnostics;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace FishingLogBook.Web.Tests.DiagnosticsInspectorTests;
 
@@ -131,5 +132,52 @@ public class WhenTestingQueuedEvents : BaseDiagnosticsInspectorTest
         await synchroniser.Received(2).SynchronisePendingAsync(Arg.Any<CancellationToken>());
         await store.Received(2).GetPendingAsync(500, Arg.Any<CancellationToken>());
         await store.Received(2).GetCountAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheErrorType_WhenQueueReadFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = CreateStore();
+        store.GetPendingAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("queue read timed out"));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<DiagnosticsInspector>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#diagnostics-last-error").TextContent.Should().Contain(nameof(TimeoutException));
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldShowLastErrorFromLoggingService()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = CreateStore();
+        var logging = SilentLogging();
+        logging.GetLastErrorAsync(Arg.Any<CancellationToken>()).Returns(new LastErrorLog
+        {
+            TimestampUtc = DateTimeOffset.Parse("2026-08-15T08:00:00Z"),
+            Source = "diagnostics refresh",
+            ErrorType = nameof(TimeoutException),
+            Message = "queue read timed out"
+        });
+        await using var context = CreateContext(store, logging: logging);
+
+        // Act
+        var cut = context.Render<DiagnosticsInspector>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#diagnostics-last-error").TextContent.Should().Contain(nameof(TimeoutException));
+            cut.Find("#diagnostics-last-error").TextContent.Should().Contain("queue read timed out");
+        });
     }
 }

--- a/tests/FishingLogBook.Web.Tests/LoggingServiceTests/WhenTestingLogError.cs
+++ b/tests/FishingLogBook.Web.Tests/LoggingServiceTests/WhenTestingLogError.cs
@@ -1,0 +1,95 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Diagnostics;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Tests.LoggingServiceTests;
+
+public class WhenTestingLogError
+{
+    [Fact]
+    public async Task ItShouldOverwriteTheStoredLastError()
+    {
+        // Arrange
+        var js = new LastErrorJsRuntime();
+        var sut = new LoggingService(js);
+
+        // Act
+        await sut.LogErrorAsync("first", new InvalidOperationException("one"));
+        await sut.LogErrorAsync("diagnostics refresh", new TimeoutException("queue read timed out"));
+        var lastError = await sut.GetLastErrorAsync();
+
+        // Assert
+        lastError.Should().NotBeNull();
+        lastError!.Source.Should().Be("diagnostics refresh");
+        lastError.ErrorType.Should().Be(nameof(TimeoutException));
+        lastError.Message.Should().Be("queue read timed out");
+        js.SetCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNull_WhenNothingIsStored()
+    {
+        // Arrange
+        var sut = new LoggingService(new LastErrorJsRuntime());
+
+        // Act
+        var lastError = await sut.GetLastErrorAsync();
+
+        // Assert
+        lastError.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldNotThrow_WhenLocalStorageFails()
+    {
+        // Arrange
+        var sut = new LoggingService(new LastErrorJsRuntime { ThrowOnSet = true });
+
+        // Act
+        var act = async () => await sut.LogErrorAsync("diagnostic log", new InvalidOperationException("failed"));
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    private sealed class LastErrorJsRuntime : IJSRuntime
+    {
+        public int SetCalls { get; private set; }
+
+        public bool ThrowOnSet { get; init; }
+
+        private string? _json;
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            if (identifier == "fishingLogBookDiagnostics.setLastError")
+            {
+                if (ThrowOnSet)
+                {
+                    throw new JSException("localStorage");
+                }
+
+                SetCalls++;
+                _json = args?[0] as string;
+                return default!;
+            }
+
+            if (identifier == "fishingLogBookDiagnostics.getLastError")
+            {
+                if (_json is null)
+                {
+                    return ValueTask.FromResult(default(TValue)!);
+                }
+
+                return ValueTask.FromResult((TValue)(object)_json);
+            }
+
+            throw new NotSupportedException(identifier);
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/OfflineStoreTests/WhenTestingTransactionCompletion.cs
+++ b/tests/FishingLogBook.Web.Tests/OfflineStoreTests/WhenTestingTransactionCompletion.cs
@@ -17,10 +17,8 @@ public class WhenTestingTransactionCompletion : BaseOfflineStoreTest
         // Assert
         completeIndex.Should().BeGreaterThan(0);
         resolveIndex.Should().BeGreaterThan(completeIndex);
-        script.Should().Contain("transaction.oncomplete");
-        script.Should().Contain("transaction.onabort");
-        script.Should().Contain("transaction.onerror");
-        script.Should().Contain("db.onversionchange");
+        script.Should().Contain("request.onerror = () => fail(request.error)");
+        script.Should().NotContain("request.onerror = () => { };");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
@@ -34,6 +34,7 @@ public class BaseTestCatchLogTest
         context.Services.AddSingleton(synchroniser);
         context.Services.AddSingleton(photoStore);
         context.Services.AddSingleton(diagnostics ?? Substitute.For<IDiagnosticLogger>());
+        context.Services.AddSingleton(Substitute.For<ILoggingService>());
         context.Services.AddSingleton(Substitute.For<IDiagnosticSynchroniser>());
         context.Services.AddSingleton(new CorrelationContext());
         context.Services.AddSingleton(Substitute.For<ICultureService>());

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingLoadDiagnostics.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingLoadDiagnostics.cs
@@ -1,0 +1,84 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Web.Diagnostics;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Pages.TestCatchLog;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class WhenTestingLoadDiagnostics : BaseTestCatchLogTest
+{
+    [Fact]
+    public async Task ItShouldLogWarningLoadStartedAndCompleted_WhenPageLoads()
+    {
+        // Arrange
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([]));
+        var diagnostics = Substitute.For<IDiagnosticLogger>();
+        await using var context = CreateContext(
+            store,
+            Substitute.For<ITestCatchSynchroniser>(),
+            Substitute.For<ITestCatchPhotoStore>(),
+            diagnostics);
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+        cut.WaitForAssertion(() => cut.Find("#test-catch-empty").Should().NotBeNull());
+
+        // Assert
+        await diagnostics.Received().LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchOfflineLoadStarted,
+            "Catch offline load started.",
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+        await diagnostics.Received().LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchOfflineLoadCompleted,
+            "Catch offline load completed.",
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotLogLoadCompleted_WhenLocalReadFails()
+    {
+        // Arrange
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("read timed out"));
+        var diagnostics = Substitute.For<IDiagnosticLogger>();
+        await using var context = CreateContext(
+            store,
+            Substitute.For<ITestCatchSynchroniser>(),
+            Substitute.For<ITestCatchPhotoStore>(),
+            diagnostics);
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+        cut.WaitForAssertion(() => cut.Find("#test-catch-load-error").Should().NotBeNull());
+
+        // Assert
+        await diagnostics.Received().LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchOfflineLoadStarted,
+            "Catch offline load started.",
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+        await diagnostics.DidNotReceive().LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchOfflineLoadCompleted,
+            "Catch offline load completed.",
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingSave.cs
@@ -1,5 +1,7 @@
 using AwesomeAssertions;
 using Bunit;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Web.Diagnostics;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Models;
 using FishingLogBook.Web.Offline;
@@ -46,6 +48,50 @@ public class WhenTestingSave : BaseTestCatchLogTest
             Arg.Is<TestCatch>(testCatch =>
                 testCatch.SpeciesName == "Pike" &&
                 testCatch.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLogWarningSaveStartedAndCompleted_WhenSaved()
+    {
+        // Arrange
+        var saved = new List<TestCatch>();
+        var store = Substitute.For<ITestCatchStore>();
+        store.SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                saved.Add(callInfo.Arg<TestCatch>());
+                return Task.CompletedTask;
+            });
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<TestCatch>>(saved.ToArray()));
+        var diagnostics = Substitute.For<IDiagnosticLogger>();
+        await using var context = CreateContext(
+            store,
+            Substitute.For<ITestCatchSynchroniser>(),
+            Substitute.For<ITestCatchPhotoStore>(),
+            diagnostics);
+        var cut = context.Render<TestCatchLog>();
+
+        // Act
+        cut.Find("#test-catch-species").Input("Pike");
+        await cut.Find("#save-test-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => saved.Should().ContainSingle());
+        await diagnostics.Received().LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchOfflineSaveStarted,
+            "Catch offline save started.",
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+        await diagnostics.Received().LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchOfflineSaveCompleted,
+            "Catch offline save completed.",
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<Exception?>(),
             Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## Summary
- Add last-error logging (console + localStorage) and raise Test Catch load/save diagnostic events to Warning so they persist on the phone and show on Diagnostics.
- Enable Swagger in Production so Fly API availability can be checked independently of the PWA.
- Follow-up to #60, which merged the IndexedDB hang change and LF enforcement.

Related to #57

## Test plan
- [ ] Desktop: run Api:https and Web:https separately, save a Test Catch with a photo, refresh, confirm the list and photo still load.
- [ ] Diagnostics: Last error is empty after a successful save; load/save Warning events appear in the queue.
- [ ] iPhone Home Screen PWA, offline: save a Test Catch with a photo, refresh, confirm Save does not hang and the catch is still there.
- [ ] After coming online, queued Warning events upload and appear in Grafana.
- [ ] https://fishing-logbook-dev-api.fly.dev/swagger loads after API deploy.