### PR TITLE
FLB#57 | allow camera and gallery photograph pickers on mobile

### DIFF
--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -120,6 +120,12 @@
   <data name="TestCatch_RetryPhotograph" xml:space="preserve">
     <value>Réessayer le téléversement de la photo</value>
   </data>
+  <data name="TestCatch_TakePhoto" xml:space="preserve">
+    <value>Prendre une photo</value>
+  </data>
+  <data name="TestCatch_ChoosePhoto" xml:space="preserve">
+    <value>Choisir une photo existante</value>
+  </data>
   <data name="TestCatch_PhotographAlt" xml:space="preserve">
     <value>Photo de la prise</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -120,6 +120,12 @@
   <data name="TestCatch_RetryPhotograph" xml:space="preserve">
     <value>Retry photograph upload</value>
   </data>
+  <data name="TestCatch_TakePhoto" xml:space="preserve">
+    <value>Take photo</value>
+  </data>
+  <data name="TestCatch_ChoosePhoto" xml:space="preserve">
+    <value>Choose existing photo</value>
+  </data>
   <data name="TestCatch_PhotographAlt" xml:space="preserve">
     <value>Catch photograph</value>
   </data>

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor
@@ -22,10 +22,27 @@
                               Variant="Variant.Outlined"
                               Lines="3"
                               id="test-catch-notes" />
-                <InputFile OnChange="OnPhotographSelected"
-                           accept="image/*"
-                           capture="environment"
-                           id="test-catch-photo" />
+                <div class="test-catch-photo-actions">
+                    <label for="test-catch-photo-camera"
+                           class="test-catch-photo-picker"
+                           id="test-catch-take-photo">
+                        @Loc["TestCatch_TakePhoto"]
+                    </label>
+                    <label for="test-catch-photo-gallery"
+                           class="test-catch-photo-picker"
+                           id="test-catch-choose-photo">
+                        @Loc["TestCatch_ChoosePhoto"]
+                    </label>
+                    <InputFile OnChange="OnPhotographSelected"
+                               accept="image/*"
+                               capture="environment"
+                               class="test-catch-photo-input"
+                               id="test-catch-photo-camera" />
+                    <InputFile OnChange="OnPhotographSelected"
+                               accept="image/*"
+                               class="test-catch-photo-input"
+                               id="test-catch-photo-gallery" />
+                </div>
                 @if (_pendingPhotographUrl is not null)
                 {
                     <img src="@_pendingPhotographUrl"

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.css
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.css
@@ -10,3 +10,35 @@
     border-radius: 0.5rem;
 }
 
+.test-catch-photo-actions {
+    display: flex;
+    position: relative;
+    gap: 0.75rem;
+}
+
+.test-catch-photo-picker {
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.5rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    cursor: pointer;
+    text-align: center;
+    font-weight: 500;
+}
+
+::deep .test-catch-photo-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+


### PR DESCRIPTION
## Summary
- Keep Take photo opening the camera (`capture="environment"`).
- Add Choose existing photo so the gallery/library picker is available on mobile.
- Hide the native file inputs so only the two labelled actions show.

## Test plan
- [ ] Mobile: Take photo opens the camera.
- [ ] Mobile: Choose existing photo opens the gallery, not the camera.
- [ ] Native Choose File controls are not visible.
- [ ] Selected photo still previews and saves with the catch.