### PR TITLE
FLB#57 | stop location and diagnostics hanging iOS offline Catch load/save

### DIFF
--- a/src/FishingLogBook.Web/Diagnostics/DiagnosticLogger.cs
+++ b/src/FishingLogBook.Web/Diagnostics/DiagnosticLogger.cs
@@ -226,9 +226,14 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
         }
         catch (Exception exception)
         {
-            _ = _logging.LogErrorAsync("diagnostic route read", exception);
+            TryToLogError("diagnostic route read", exception);
             return string.Empty;
         }
+    }
+
+    private void TryToLogError(string source, Exception exception)
+    {
+        _ = _logging.LogErrorAsync(source, exception);
     }
 
     private async Task WriteConsoleAsync(

--- a/src/FishingLogBook.Web/Diagnostics/OfflineOperation.cs
+++ b/src/FishingLogBook.Web/Diagnostics/OfflineOperation.cs
@@ -50,7 +50,7 @@ public static class OfflineOperation
         ILoggingService? logging = null)
     {
         var metadata = StartingMetadata(operation, storeName, timeout);
-        await SafeLogAsync(diagnostics, logging, DiagnosticLevel.Debug, startedEvent, $"{operation} started.", metadata, null, cancellationToken);
+        TryToLog(diagnostics, logging, DiagnosticLevel.Debug, startedEvent, $"{operation} started.", metadata, null, cancellationToken);
         var stopwatch = Stopwatch.StartNew();
 
         try
@@ -59,7 +59,7 @@ public static class OfflineOperation
             timeoutSource.CancelAfter(timeout);
             var result = await action(timeoutSource.Token);
             stopwatch.Stop();
-            await SafeLogAsync(
+            TryToLog(
                 diagnostics,
                 logging,
                 DiagnosticLevel.Debug,
@@ -73,7 +73,7 @@ public static class OfflineOperation
         catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
         {
             stopwatch.Stop();
-            await SafeLogAsync(
+            TryToLog(
                 diagnostics,
                 logging,
                 DiagnosticLevel.Warning,
@@ -88,7 +88,7 @@ public static class OfflineOperation
         {
             stopwatch.Stop();
             var timedOut = IsTimeout(exception);
-            await SafeLogAsync(
+            TryToLog(
                 diagnostics,
                 logging,
                 timedOut ? DiagnosticLevel.Warning : DiagnosticLevel.Error,
@@ -145,6 +145,19 @@ public static class OfflineOperation
     {
         return exception is TimeoutException ||
                exception.Message.Contains("timed out", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void TryToLog(
+        IDiagnosticLogger diagnostics,
+        ILoggingService? logging,
+        DiagnosticLevel level,
+        string eventName,
+        string message,
+        IReadOnlyDictionary<string, string> metadata,
+        Exception? exception,
+        CancellationToken cancellationToken)
+    {
+        _ = SafeLogAsync(diagnostics, logging, level, eventName, message, metadata, exception, cancellationToken);
     }
 
     private static async Task SafeLogAsync(

--- a/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
+++ b/src/FishingLogBook.Web/Pages/TestCatchLog/TestCatchLog.razor.cs
@@ -65,10 +65,10 @@ public partial class TestCatchLog : ComponentBase, IDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        await RefreshLocationPromptAsync();
         await LoadAsync();
+        TryToRefreshLocationPrompt();
         await TestCatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
-        await SafeDiagnosticSyncAsync();
+        TryToSynchroniseDiagnostics();
         await LoadAsync();
     }
 
@@ -87,7 +87,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
     public async Task OnBrowserOnline()
     {
         await TestCatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
-        await SafeDiagnosticSyncAsync();
+        TryToSynchroniseDiagnostics();
         await LoadAsync();
         await InvokeAsync(StateHasChanged);
     }
@@ -118,7 +118,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         var saved = false;
         try
         {
-            await SafeLogAsync(
+            TryToLog(
                 DiagnosticLevel.Warning,
                 DiagnosticEventNames.CatchOfflineSaveStarted,
                 "Catch offline save started.");
@@ -155,7 +155,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
                         _cancellationTokenSource.Token);
                 }
 
-                await SafeLogAsync(
+                TryToLog(
                     DiagnosticLevel.Warning,
                     DiagnosticEventNames.CatchOfflineSaveCompleted,
                     "Catch offline save completed.");
@@ -168,7 +168,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
             }
             catch (Exception exception)
             {
-                await SafeLogAsync(
+                TryToLog(
                     DiagnosticLevel.Error,
                     DiagnosticEventNames.CatchOfflineSaveFailed,
                     "Catch offline save failed.",
@@ -186,7 +186,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         }
 
         await TestCatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
-        await SafeDiagnosticSyncAsync();
+        TryToSynchroniseDiagnostics();
         await LoadAsync();
     }
 
@@ -194,11 +194,15 @@ public partial class TestCatchLog : ComponentBase, IDisposable
     {
         try
         {
-            await LocationService.TryCaptureAsync(true, _cancellationTokenSource.Token);
+            await LocationService
+                .TryCaptureAsync(true, _cancellationTokenSource.Token)
+                .WaitAsync(
+                    TimeSpan.FromMilliseconds(BrowserLocationService.CaptureTimeoutMilliseconds),
+                    _cancellationTokenSource.Token);
         }
         catch (Exception exception)
         {
-            await SafeLogAsync(
+            TryToLog(
                 DiagnosticLevel.Warning,
                 DiagnosticEventNames.LocationCaptureFailed,
                 "Location capture failed.",
@@ -216,7 +220,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         }
         catch (Exception exception)
         {
-            await Logging.LogErrorAsync("location prompt", exception, _cancellationTokenSource.Token);
+            TryToLogError("location prompt", exception);
         }
 
         await RefreshLocationPromptAsync();
@@ -241,24 +245,33 @@ public partial class TestCatchLog : ComponentBase, IDisposable
     {
         try
         {
-            _locationPrompt = await LocationService.GetPromptStatusAsync(_cancellationTokenSource.Token);
+            _locationPrompt = await LocationService.GetPromptStatusAsync(_cancellationTokenSource.Token)
+                .WaitAsync(
+                    TimeSpan.FromMilliseconds(BrowserLocationService.PermissionQueryTimeoutMilliseconds),
+                    _cancellationTokenSource.Token);
         }
         catch (Exception exception)
         {
             _locationPrompt = new LocationPromptStatus(false, true, false);
-            await Logging.LogErrorAsync("location prompt", exception, _cancellationTokenSource.Token);
+            TryToLogError("location prompt", exception);
         }
+
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task<TestCatchLocation?> TryCaptureLocationAsync()
     {
         try
         {
-            return await LocationService.TryCaptureAsync(false, _cancellationTokenSource.Token);
+            return await LocationService
+                .TryCaptureAsync(false, _cancellationTokenSource.Token)
+                .WaitAsync(
+                    TimeSpan.FromMilliseconds(BrowserLocationService.CaptureTimeoutMilliseconds),
+                    _cancellationTokenSource.Token);
         }
         catch (Exception exception)
         {
-            await SafeLogAsync(
+            TryToLog(
                 DiagnosticLevel.Warning,
                 DiagnosticEventNames.LocationCaptureFailed,
                 "Location capture failed.",
@@ -289,7 +302,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         _isLoading = true;
         try
         {
-            await SafeLogAsync(
+            TryToLog(
                 DiagnosticLevel.Warning,
                 DiagnosticEventNames.CatchOfflineLoadStarted,
                 "Catch offline load started.");
@@ -304,7 +317,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
             catch (Exception exception)
             {
                 _loadFailed = true;
-                await SafeLogAsync(
+                TryToLog(
                     DiagnosticLevel.Error,
                     DiagnosticEventNames.OfflineDbReadFailed,
                     "Loading local catches failed.",
@@ -313,7 +326,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
             }
 
             await LoadPhotographsAsync();
-            await SafeLogAsync(
+            TryToLog(
                 DiagnosticLevel.Warning,
                 DiagnosticEventNames.CatchOfflineLoadCompleted,
                 "Catch offline load completed.");
@@ -358,7 +371,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         }
         catch (Exception exception)
         {
-            await SafeLogAsync(
+            TryToLog(
                 DiagnosticLevel.Error,
                 DiagnosticEventNames.OfflineDbReadFailed,
                 "Loading local photograph failed.",
@@ -376,6 +389,16 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         }
     }
 
+    private void TryToRefreshLocationPrompt()
+    {
+        _ = RefreshLocationPromptAsync();
+    }
+
+    private void TryToSynchroniseDiagnostics()
+    {
+        _ = SafeDiagnosticSyncAsync();
+    }
+
     private async Task SafeDiagnosticSyncAsync()
     {
         try
@@ -384,8 +407,22 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         }
         catch (Exception exception)
         {
-            await Logging.LogErrorAsync("diagnostic upload", exception, _cancellationTokenSource.Token);
+            TryToLogError("diagnostic upload", exception);
         }
+    }
+
+    private void TryToLog(
+        DiagnosticLevel level,
+        string eventName,
+        string message,
+        Exception? exception = null)
+    {
+        _ = SafeLogAsync(level, eventName, message, exception);
+    }
+
+    private void TryToLogError(string source, Exception exception)
+    {
+        _ = Logging.LogErrorAsync(source, exception, _cancellationTokenSource.Token);
     }
 
     private async Task SafeLogAsync(
@@ -405,7 +442,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         }
         catch (Exception loggingException)
         {
-            await Logging.LogErrorAsync("diagnostic log", loggingException, _cancellationTokenSource.Token);
+            TryToLogError("diagnostic log", loggingException);
         }
     }
 

--- a/src/FishingLogBook.Web/Services/BrowserLocationService.cs
+++ b/src/FishingLogBook.Web/Services/BrowserLocationService.cs
@@ -8,8 +8,12 @@ namespace FishingLogBook.Web.Services;
 
 public sealed class BrowserLocationService : ILocationService
 {
+    public const int CaptureTimeoutMilliseconds = 8000;
+    public const int PermissionQueryTimeoutMilliseconds = 2000;
+
     private const string ModulePath = "./js/location.js";
-    private const int CaptureTimeoutMilliseconds = 8000;
+
+    private static readonly LocationPromptStatus UnavailablePrompt = new(false, true, false);
 
     private readonly IJSRuntime _jsRuntime;
     private readonly IDiagnosticLogger _diagnostics;
@@ -24,18 +28,18 @@ public sealed class BrowserLocationService : ILocationService
 
     public async Task<LocationPromptStatus> GetPromptStatusAsync(CancellationToken cancellationToken)
     {
-        var permission = await QueryPermissionAsync(cancellationToken);
-        var dismissed = await IsDismissedAsync(cancellationToken);
-
-        return permission switch
+        try
         {
-            "granted" => new LocationPromptStatus(false, false, true),
-            "denied" => new LocationPromptStatus(false, true, false),
-            "unavailable" => new LocationPromptStatus(false, true, false),
-            _ => dismissed
-                ? new LocationPromptStatus(false, true, false)
-                : new LocationPromptStatus(true, false, false)
-        };
+            using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutSource.CancelAfter(PermissionQueryTimeoutMilliseconds);
+            var permission = await QueryPermissionAsync(timeoutSource.Token);
+            var dismissed = await IsDismissedAsync(timeoutSource.Token);
+            return ToPromptStatus(permission, dismissed);
+        }
+        catch (Exception exception) when (IsBoundedFailure(exception, cancellationToken))
+        {
+            return UnavailablePrompt;
+        }
     }
 
     public async Task DismissPromptAsync(CancellationToken cancellationToken)
@@ -46,44 +50,16 @@ public sealed class BrowserLocationService : ILocationService
 
     public async Task<TestCatchLocation?> TryCaptureAsync(bool userRequested, CancellationToken cancellationToken)
     {
-        var status = await GetPromptStatusAsync(cancellationToken);
-        if (!userRequested && !status.WillCaptureOnSave)
-        {
-            return null;
-        }
-
         try
         {
-            var module = await GetModuleAsync(cancellationToken);
-            var result = await module.InvokeAsync<LocationJsResult>(
-                "getCurrent",
-                cancellationToken,
-                CaptureTimeoutMilliseconds);
-
-            if (result is null || !string.IsNullOrWhiteSpace(result.Error))
-            {
-                await LogCaptureOutcomeAsync(result?.Error, cancellationToken);
-                if (string.Equals(result?.Error, "denied", StringComparison.OrdinalIgnoreCase))
-                {
-                    await DismissPromptAsync(cancellationToken);
-                }
-
-                return null;
-            }
-
-            if (!DateTimeOffset.TryParse(result.Timestamp, out var capturedOn))
-            {
-                capturedOn = DateTimeOffset.UtcNow;
-            }
-
-            return new TestCatchLocation(
-                result.Latitude,
-                result.Longitude,
-                result.Accuracy,
-                capturedOn,
-                LocationDefaults.DeviceGps,
-                LocationDefaults.Private,
-                LocationDefaults.ConsentVersion);
+            using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutSource.CancelAfter(CaptureTimeoutMilliseconds);
+            return await CaptureAsync(userRequested, timeoutSource.Token);
+        }
+        catch (Exception exception) when (IsBoundedFailure(exception, cancellationToken))
+        {
+            await LogCaptureOutcomeAsync("timeout", cancellationToken);
+            return null;
         }
         catch (JSException exception)
         {
@@ -95,6 +71,66 @@ public sealed class BrowserLocationService : ILocationService
                 cancellationToken: cancellationToken);
             return null;
         }
+    }
+
+    private async Task<TestCatchLocation?> CaptureAsync(bool userRequested, CancellationToken cancellationToken)
+    {
+        var status = await GetPromptStatusAsync(cancellationToken);
+        if (!userRequested && !status.WillCaptureOnSave)
+        {
+            return null;
+        }
+
+        var module = await GetModuleAsync(cancellationToken);
+        var result = await module.InvokeAsync<LocationJsResult>(
+            "getCurrent",
+            cancellationToken,
+            CaptureTimeoutMilliseconds);
+
+        if (result is null || !string.IsNullOrWhiteSpace(result.Error))
+        {
+            await LogCaptureOutcomeAsync(result?.Error, cancellationToken);
+            if (string.Equals(result?.Error, "denied", StringComparison.OrdinalIgnoreCase))
+            {
+                await DismissPromptAsync(cancellationToken);
+            }
+
+            return null;
+        }
+
+        if (!DateTimeOffset.TryParse(result.Timestamp, out var capturedOn))
+        {
+            capturedOn = DateTimeOffset.UtcNow;
+        }
+
+        return new TestCatchLocation(
+            result.Latitude,
+            result.Longitude,
+            result.Accuracy,
+            capturedOn,
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+    }
+
+    private static LocationPromptStatus ToPromptStatus(string permission, bool dismissed)
+    {
+        return permission switch
+        {
+            "granted" => new LocationPromptStatus(false, false, true),
+            "denied" => UnavailablePrompt,
+            "unavailable" => UnavailablePrompt,
+            _ => dismissed
+                ? UnavailablePrompt
+                : new LocationPromptStatus(true, false, false)
+        };
+    }
+
+    private static bool IsBoundedFailure(Exception exception, CancellationToken cancellationToken)
+    {
+        return exception is TimeoutException ||
+               (exception is OperationCanceledException && !cancellationToken.IsCancellationRequested) ||
+               exception.Message.Contains("timed out", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task LogCaptureOutcomeAsync(string? error, CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/wwwroot/js/location.js
+++ b/src/FishingLogBook.Web/wwwroot/js/location.js
@@ -1,14 +1,41 @@
 const dismissedKey = 'flb-location-prompt-dismissed';
+const permissionTimeoutMs = 2000;
+
+function withTimeout(promise, milliseconds, operationName) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`${operationName} timed out`)), milliseconds);
+        promise.then(
+            (value) => {
+                clearTimeout(timer);
+                resolve(value);
+            },
+            (error) => {
+                clearTimeout(timer);
+                reject(error);
+            });
+    });
+}
 
 export async function queryPermission() {
     if (!navigator.geolocation) {
         return 'unavailable';
     }
 
+    if (!navigator.permissions || typeof navigator.permissions.query !== 'function') {
+        return 'unavailable';
+    }
+
     try {
-        const status = await navigator.permissions.query({ name: 'geolocation' });
+        const status = await withTimeout(
+            navigator.permissions.query({ name: 'geolocation' }),
+            permissionTimeoutMs,
+            'location permission');
         return status.state;
-    } catch {
+    } catch (error) {
+        if (error && String(error.message || '').includes('timed out')) {
+            return 'unavailable';
+        }
+
         return 'prompt';
     }
 }
@@ -29,40 +56,44 @@ export function setPromptDismissed() {
     }
 }
 
-export function getCurrent(timeoutMs) {
-    return new Promise((resolve) => {
-        if (!navigator.geolocation) {
-            resolve({ error: 'unavailable' });
-            return;
-        }
-
-        navigator.geolocation.getCurrentPosition(
-            (position) => {
-                resolve({
-                    latitude: position.coords.latitude,
-                    longitude: position.coords.longitude,
-                    accuracy: position.coords.accuracy,
-                    timestamp: new Date(position.timestamp).toISOString()
-                });
-            },
-            (error) => {
-                if (error.code === 1) {
-                    resolve({ error: 'denied' });
-                    return;
-                }
-
-                if (error.code === 3) {
-                    resolve({ error: 'timeout' });
-                    return;
-                }
-
+export async function getCurrent(timeoutMs) {
+    try {
+        return await withTimeout(new Promise((resolve) => {
+            if (!navigator.geolocation) {
                 resolve({ error: 'unavailable' });
-            },
-            {
-                enableHighAccuracy: true,
-                timeout: timeoutMs,
-                maximumAge: 0
+                return;
             }
-        );
-    });
+
+            navigator.geolocation.getCurrentPosition(
+                (position) => {
+                    resolve({
+                        latitude: position.coords.latitude,
+                        longitude: position.coords.longitude,
+                        accuracy: position.coords.accuracy,
+                        timestamp: new Date(position.timestamp).toISOString()
+                    });
+                },
+                (error) => {
+                    if (error.code === 1) {
+                        resolve({ error: 'denied' });
+                        return;
+                    }
+
+                    if (error.code === 3) {
+                        resolve({ error: 'timeout' });
+                        return;
+                    }
+
+                    resolve({ error: 'unavailable' });
+                },
+                {
+                    enableHighAccuracy: true,
+                    timeout: timeoutMs,
+                    maximumAge: 0
+                }
+            );
+        }), timeoutMs, 'location');
+    } catch {
+        return { error: 'timeout' };
+    }
 }

--- a/tests/FishingLogBook.Web.Tests/BrowserLocationServiceTests/WhenTestingTimeout.cs
+++ b/tests/FishingLogBook.Web.Tests/BrowserLocationServiceTests/WhenTestingTimeout.cs
@@ -1,0 +1,117 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Diagnostics;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Services;
+using Microsoft.JSInterop;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.BrowserLocationServiceTests;
+
+public class WhenTestingTimeout
+{
+    [Fact]
+    public async Task ItShouldReturnASafeStatus_WhenPermissionQueryNeverCompletes()
+    {
+        // Arrange
+        var js = new FakeLocationJsRuntime { HangPermission = true };
+        var sut = new BrowserLocationService(js, Substitute.For<IDiagnosticLogger>());
+
+        // Act
+        var status = await sut.GetPromptStatusAsync(CancellationToken.None);
+
+        // Assert
+        status.ShowExplainer.Should().BeFalse();
+        status.WillCaptureOnSave.Should().BeFalse();
+        status.ShowEnableLater.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNull_WhenGetCurrentNeverCompletes()
+    {
+        // Arrange
+        var diagnostics = Substitute.For<IDiagnosticLogger>();
+        var js = new FakeLocationJsRuntime
+        {
+            Permission = "granted",
+            HangCapture = true
+        };
+        var sut = new BrowserLocationService(js, diagnostics);
+
+        // Act
+        var location = await sut.TryCaptureAsync(false, CancellationToken.None);
+
+        // Assert
+        location.Should().BeNull();
+        await diagnostics.Received().LogAsync(
+            Arg.Any<FishingLogBook.Shared.Diagnostics.DiagnosticLevel>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, string>?>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+    }
+}
+
+internal sealed class FakeLocationJsRuntime : IJSRuntime, IJSObjectReference
+{
+    public bool HangPermission { get; init; }
+
+    public bool HangCapture { get; init; }
+
+    public string Permission { get; init; } = "prompt";
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+        return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+    {
+        return new ValueTask<TValue>(InvokeCore<TValue>(identifier, cancellationToken));
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    private async Task<TValue> InvokeCore<TValue>(string identifier, CancellationToken cancellationToken)
+    {
+        if (identifier == "import")
+        {
+            return (TValue)(object)this;
+        }
+
+        if (identifier == "queryPermission")
+        {
+            if (HangPermission)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return (TValue)(object)Permission;
+        }
+
+        if (identifier == "isPromptDismissed")
+        {
+            return (TValue)(object)false;
+        }
+
+        if (identifier == "getCurrent")
+        {
+            if (HangCapture)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+            }
+
+            return default!;
+        }
+
+        if (identifier == "setPromptDismissed")
+        {
+            return default!;
+        }
+
+        throw new InvalidOperationException(identifier);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/OfflineOperationTests/WhenTestingTimeout.cs
+++ b/tests/FishingLogBook.Web.Tests/OfflineOperationTests/WhenTestingTimeout.cs
@@ -30,8 +30,8 @@ public class WhenTestingTimeout
 
         // Assert
         await act.Should().ThrowAsync<TimeoutException>();
-        logger.Events.Should().Contain(item => item.EventName == DiagnosticEventNames.OfflineDbReadTimedOut);
-        logger.Events.Should().Contain(item => item.EventName == DiagnosticEventNames.OfflineDbReadStarted);
+        await WaitForEventAsync(logger, DiagnosticEventNames.OfflineDbReadTimedOut);
+        await WaitForEventAsync(logger, DiagnosticEventNames.OfflineDbReadStarted);
     }
 
     [Fact]
@@ -60,9 +60,68 @@ public class WhenTestingTimeout
 
         // Assert
         completed.Should().BeTrue();
+        await WaitForEventAsync(logger, DiagnosticEventNames.OfflineDbWriteCompleted);
+        await WaitForEventAsync(logger, DiagnosticEventNames.OfflineDbWriteStarted);
         var completedIndex = logger.Events.FindIndex(item => item.EventName == DiagnosticEventNames.OfflineDbWriteCompleted);
         completedIndex.Should().BeGreaterThan(0);
         logger.Events[completedIndex - 1].EventName.Should().Be(DiagnosticEventNames.OfflineDbWriteStarted);
+    }
+
+    [Fact]
+    public async Task ItShouldCompleteTheAction_WhenDiagnosticLoggingNeverCompletes()
+    {
+        // Arrange
+        var logger = new HangingDiagnosticLogger();
+        var completed = false;
+
+        // Act
+        await OfflineOperation.ExecuteAsync(
+            "write",
+            "testCatches",
+            DiagnosticEventNames.OfflineDbWriteStarted,
+            DiagnosticEventNames.OfflineDbWriteCompleted,
+            DiagnosticEventNames.OfflineDbWriteFailed,
+            DiagnosticEventNames.OfflineDbWriteTimedOut,
+            TimeSpan.FromSeconds(2),
+            logger,
+            _ =>
+            {
+                completed = true;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        // Assert
+        completed.Should().BeTrue();
+    }
+
+    private static async Task WaitForEventAsync(RecordingDiagnosticLogger logger, string eventName)
+    {
+        for (var attempt = 0; attempt < 50; attempt++)
+        {
+            if (logger.Events.Exists(item => item.EventName == eventName))
+            {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+
+        logger.Events.Should().Contain(item => item.EventName == eventName);
+    }
+
+    private sealed class HangingDiagnosticLogger : IDiagnosticLogger
+    {
+        public Task LogAsync(
+            DiagnosticLevel level,
+            string eventName,
+            string message,
+            IReadOnlyDictionary<string, string>? metadata = null,
+            Exception? exception = null,
+            CancellationToken cancellationToken = default)
+        {
+            return new TaskCompletionSource().Task;
+        }
     }
 
     private sealed class RecordingDiagnosticLogger : IDiagnosticLogger

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/BaseTestCatchLogTest.cs
@@ -46,6 +46,40 @@ public class BaseTestCatchLogTest
         return context;
     }
 
+    protected static Task Hang()
+    {
+        return new TaskCompletionSource().Task;
+    }
+
+    protected static Task<T> Hang<T>()
+    {
+        return new TaskCompletionSource<T>().Task;
+    }
+
+    protected static ILocationService HangingLocation()
+    {
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Hang<LocationPromptStatus>());
+        location.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Hang<TestCatchLocation?>());
+        return location;
+    }
+
+    protected static IDiagnosticLogger HangingDiagnostics()
+    {
+        var diagnostics = Substitute.For<IDiagnosticLogger>();
+        diagnostics.LogAsync(
+                Arg.Any<FishingLogBook.Shared.Diagnostics.DiagnosticLevel>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IReadOnlyDictionary<string, string>?>(),
+                Arg.Any<Exception?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Hang());
+        return diagnostics;
+    }
+
     protected static ILocationService DeniedLocation()
     {
         var location = Substitute.For<ILocationService>();

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingDiagnosticLoggerHang.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingDiagnosticLoggerHang.cs
@@ -1,0 +1,88 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Pages.TestCatchLog;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class WhenTestingDiagnosticLoggerHang : BaseTestCatchLogTest
+{
+    [Fact]
+    public async Task ItShouldLoadExistingCatches_WhenDiagnosticLoggingNeverCompletes()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("8c0e91a2-4d77-4b18-a6f1-0c3d5e7a9b21"),
+            "Roach",
+            DateTimeOffset.Parse("2026-08-15T18:10:00Z"),
+            null,
+            SyncStatus.SavedLocally);
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        await using var context = CreateContext(
+            store,
+            Substitute.For<ITestCatchSynchroniser>(),
+            Substitute.For<ITestCatchPhotoStore>(),
+            HangingDiagnostics());
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#test-catch-item-{existing.Id}").Should().NotBeNull();
+            cut.Find($"#test-catch-species-{existing.Id}").TextContent.Should().Contain("Roach");
+        });
+        await store.Received().GetAllAsync(Arg.Any<CancellationToken>());
+        await store.DidNotReceive().SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSaveTheCatch_WhenDiagnosticLoggingNeverCompletes()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var saved = new List<TestCatch>();
+        var store = Substitute.For<ITestCatchStore>();
+        store.SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                saved.Add(callInfo.Arg<TestCatch>());
+                return Task.CompletedTask;
+            });
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<TestCatch>>(saved.ToArray()));
+        await using var context = CreateContext(
+            store,
+            Substitute.For<ITestCatchSynchroniser>(),
+            Substitute.For<ITestCatchPhotoStore>(),
+            HangingDiagnostics());
+        var cut = context.Render<TestCatchLog>();
+        cut.WaitForAssertion(() => cut.Find("#test-catch-species").Should().NotBeNull());
+
+        // Act
+        cut.Find("#test-catch-species").Input("Bream");
+        await cut.Find("#save-test-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            saved.Should().ContainSingle();
+            saved[0].SpeciesName.Should().Be("Bream");
+            cut.Find($"#test-catch-species-{saved[0].Id}").TextContent.Should().Contain("Bream");
+            cut.FindAll("#save-test-catch-spinner").Should().BeEmpty();
+            cut.Find("#save-test-catch-button").TextContent.Should().Contain("Save catch");
+        });
+        await store.Received(1).SaveAsync(
+            Arg.Is<TestCatch>(testCatch =>
+                testCatch.SpeciesName == "Bream" &&
+                testCatch.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingLocationCaptureHang.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingLocationCaptureHang.cs
@@ -1,0 +1,60 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Pages.TestCatchLog;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class WhenTestingLocationCaptureHang : BaseTestCatchLogTest
+{
+    [Fact]
+    public async Task ItShouldSaveCatchWithoutLocation_WhenCaptureNeverCompletes()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var saved = new List<TestCatch>();
+        var store = Substitute.For<ITestCatchStore>();
+        store.SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                saved.Add(callInfo.Arg<TestCatch>());
+                return Task.CompletedTask;
+            });
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<TestCatch>>(saved.ToArray()));
+        var synchroniser = Substitute.For<ITestCatchSynchroniser>();
+        await using var context = CreateContext(
+            store,
+            synchroniser,
+            Substitute.For<ITestCatchPhotoStore>(),
+            location: HangingLocation());
+        var cut = context.Render<TestCatchLog>();
+        cut.WaitForAssertion(() => cut.Find("#test-catch-species").Should().NotBeNull());
+
+        // Act
+        cut.Find("#test-catch-species").Input("Pike");
+        await cut.Find("#save-test-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            saved.Should().ContainSingle();
+            saved[0].Location.Should().BeNull();
+            saved[0].SpeciesName.Should().Be("Pike");
+            saved[0].SyncStatus.Should().Be(SyncStatus.SavedLocally);
+            cut.Find($"#test-catch-species-{saved[0].Id}").TextContent.Should().Contain("Pike");
+            cut.FindAll("#save-test-catch-spinner").Should().BeEmpty();
+            cut.Find("#save-test-catch-button").TextContent.Should().Contain("Save catch");
+        });
+        await store.Received(1).SaveAsync(
+            Arg.Is<TestCatch>(testCatch =>
+                testCatch.SpeciesName == "Pike" &&
+                testCatch.Location == null &&
+                testCatch.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+        await synchroniser.Received().SynchronisePendingAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingLocationStatusHang.cs
+++ b/tests/FishingLogBook.Web.Tests/TestCatchLogTests/WhenTestingLocationStatusHang.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Models;
+using FishingLogBook.Web.Offline;
+using FishingLogBook.Web.Pages.TestCatchLog;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.TestCatchLogTests;
+
+public class WhenTestingLocationStatusHang : BaseTestCatchLogTest
+{
+    [Fact]
+    public async Task ItShouldLoadExistingCatches_WhenLocationStatusNeverCompletes()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var existing = new TestCatch(
+            Guid.Parse("3a1f2c8e-7b44-4d1a-9c3e-2f8a6b0d1e55"),
+            "Perch",
+            DateTimeOffset.Parse("2026-08-15T18:00:00Z"),
+            null,
+            SyncStatus.SavedLocally);
+        var store = Substitute.For<ITestCatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatch>>([existing]));
+        await using var context = CreateContext(
+            store,
+            Substitute.For<ITestCatchSynchroniser>(),
+            Substitute.For<ITestCatchPhotoStore>(),
+            location: HangingLocation());
+
+        // Act
+        var cut = context.Render<TestCatchLog>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#test-catch-item-{existing.Id}").Should().NotBeNull();
+            cut.Find($"#test-catch-species-{existing.Id}").TextContent.Should().Contain("Perch");
+        });
+        await store.Received().GetAllAsync(Arg.Any<CancellationToken>());
+        await store.DidNotReceive().SaveAsync(Arg.Any<TestCatch>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- Load local catches before location permission/status, and never let geolocation hang block the Catch page.
- Bound location capture so Save persists without location if GPS/permission fails or times out, then always clears busy state.
- Keep diagnostic logging best-effort so a slow or failed diagnostics IndexedDB cannot delay Catch load, save, photo, or sync.

Addresses #57

## Test plan
- [ ] Offline on iPhone 16 Pro Home Screen PWA: existing IndexedDB catches still show when location APIs hang or fail.
- [ ] Offline save with location unavailable/denied/timeout: Catch is stored locally, Save is not left busy.
- [ ] Diagnostics IndexedDB cannot open: Catch load/save still works.
- [ ] When location is available within timeout, it is still stored with the Catch.
- [ ] Reconnect syncs the pending Catch without creating a duplicate.