### PR TITLE
FLB#57 | stop location and diagnostics hanging iOS offline Catch load/save

### DIFF
--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticMetadata.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticMetadata.cs
@@ -94,6 +94,24 @@ public static class DiagnosticMetadata
         return true;
     }
 
+    public static string SafeErrorMessage(string? message, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return string.Empty;
+        }
+
+        foreach (var fragment in ForbiddenFragments)
+        {
+            if (message.Contains(fragment, StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+        }
+
+        return Truncate(message, maxLength);
+    }
+
     public static string Truncate(string value, int maxLength)
     {
         if (string.IsNullOrEmpty(value) || value.Length <= maxLength)

--- a/src/FishingLogBook.Web/Diagnostics/BrowserDiagnosticIndexedDbProbe.cs
+++ b/src/FishingLogBook.Web/Diagnostics/BrowserDiagnosticIndexedDbProbe.cs
@@ -1,0 +1,88 @@
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Web.Configuration;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Diagnostics;
+
+public sealed class BrowserDiagnosticIndexedDbProbe : IDiagnosticIndexedDbProbe
+{
+    public const string IsolatedDatabaseName = "FishingLogBookDiagnosticsTest";
+    public const string IsolatedStoreName = "probeEvents";
+    public const string ProductionDatabaseName = "FishingLogBookDiagnostics";
+    public const string ProductionStoreName = "diagnosticEvents";
+
+    public const string StageStartingImport = "DIAG-01 starting module import";
+    public const string StageModuleImported = "DIAG-02 module imported";
+    public const string StageOpeningDatabase = "DIAG-03 opening diagnostic IndexedDB";
+    public const string StageDatabaseOpened = "DIAG-04 database opened";
+    public const string StageWriting = "DIAG-05 writing test diagnostic";
+    public const string StageWriteCompleted = "DIAG-06 write transaction completed";
+    public const string StageReadingCount = "DIAG-07 reading diagnostic count";
+    public const string StageCountReturned = "DIAG-08 count returned";
+
+    private const string ModulePath = "./js/diagnostic-probe.js";
+
+    private readonly IJSRuntime _jsRuntime;
+    private readonly DiagnosticsClientConfig _config;
+
+    public BrowserDiagnosticIndexedDbProbe(IJSRuntime jsRuntime, DiagnosticsClientConfig config)
+    {
+        _jsRuntime = jsRuntime;
+        _config = config;
+    }
+
+    public async Task<DiagnosticProbeResult> RunAsync(
+        string databaseName,
+        bool writeTestRecord,
+        CancellationToken cancellationToken)
+    {
+        var result = new DiagnosticProbeResult { DatabaseName = databaseName };
+        var storeName = StoreNameFor(databaseName);
+        var timeoutMs = (int)_config.OperationTimeout.TotalMilliseconds;
+        var inProgress = StageStartingImport;
+        try
+        {
+            using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutSource.CancelAfter(_config.OperationTimeout);
+            var token = timeoutSource.Token;
+
+            var module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", token, ModulePath);
+            result.LastCompletedStage = StageModuleImported;
+
+            inProgress = StageOpeningDatabase;
+            await module.InvokeVoidAsync("openProbeDatabase", token, databaseName, storeName, timeoutMs);
+            result.LastCompletedStage = StageDatabaseOpened;
+
+            if (writeTestRecord)
+            {
+                inProgress = StageWriting;
+                await module.InvokeVoidAsync("writeProbeRecord", token, databaseName, storeName, timeoutMs);
+                result.LastCompletedStage = StageWriteCompleted;
+            }
+
+            inProgress = StageReadingCount;
+            result.Count = await module.InvokeAsync<int>("countProbeRecords", token, databaseName, storeName, timeoutMs);
+            result.LastCompletedStage = StageCountReturned;
+            return result;
+        }
+        catch (Exception exception)
+        {
+            result.FailedStage = inProgress;
+            result.Error = FormatError(exception);
+            return result;
+        }
+    }
+
+    private static string StoreNameFor(string databaseName)
+    {
+        return databaseName == ProductionDatabaseName ? ProductionStoreName : IsolatedStoreName;
+    }
+
+    private static string FormatError(Exception exception)
+    {
+        var message = DiagnosticMetadata.SafeErrorMessage(exception.Message, 120);
+        return string.IsNullOrWhiteSpace(message)
+            ? exception.GetType().Name
+            : $"{exception.GetType().Name}: {message}";
+    }
+}

--- a/src/FishingLogBook.Web/Diagnostics/DiagnosticLogger.cs
+++ b/src/FishingLogBook.Web/Diagnostics/DiagnosticLogger.cs
@@ -126,7 +126,7 @@ public sealed class DiagnosticLogger : IDiagnosticLogger
 
     private async Task RecordFailureAsync(Exception exception, string eventName, CancellationToken cancellationToken)
     {
-        _status.LastError = exception.GetType().Name;
+        _status.RecordFailure(DiagnosticOperations.Persist, exception);
         await _logging.LogErrorAsync(eventName, exception, cancellationToken);
     }
 

--- a/src/FishingLogBook.Web/Diagnostics/DiagnosticOperations.cs
+++ b/src/FishingLogBook.Web/Diagnostics/DiagnosticOperations.cs
@@ -1,0 +1,15 @@
+namespace FishingLogBook.Web.Diagnostics;
+
+public static class DiagnosticOperations
+{
+    public const string NetworkCheck = "DiagnosticNetworkCheck";
+    public const string QueueCount = "DiagnosticQueueCount";
+    public const string QueueRead = "DiagnosticQueueRead";
+    public const string Upload = "DiagnosticUpload";
+    public const string QueueDelete = "DiagnosticQueueDelete";
+    public const string FailedEventSave = "DiagnosticFailedEventSave";
+    public const string Persist = "DiagnosticPersist";
+    public const string Refresh = "DiagnosticRefresh";
+    public const string IsolatedProbe = "DiagnosticIsolatedProbe";
+    public const string ProductionProbe = "DiagnosticProductionProbe";
+}

--- a/src/FishingLogBook.Web/Diagnostics/DiagnosticProbeResult.cs
+++ b/src/FishingLogBook.Web/Diagnostics/DiagnosticProbeResult.cs
@@ -1,0 +1,16 @@
+namespace FishingLogBook.Web.Diagnostics;
+
+public sealed class DiagnosticProbeResult
+{
+    public string DatabaseName { get; init; } = string.Empty;
+
+    public string? LastCompletedStage { get; set; }
+
+    public string? FailedStage { get; set; }
+
+    public string? Error { get; set; }
+
+    public int? Count { get; set; }
+
+    public bool Succeeded => FailedStage is null && LastCompletedStage is not null;
+}

--- a/src/FishingLogBook.Web/Diagnostics/DiagnosticStatus.cs
+++ b/src/FishingLogBook.Web/Diagnostics/DiagnosticStatus.cs
@@ -1,14 +1,48 @@
+using FishingLogBook.Shared.Diagnostics;
+
 namespace FishingLogBook.Web.Diagnostics;
 
 public sealed class DiagnosticStatus
 {
     public int QueuedCount { get; set; }
 
+    public bool QueueCountAvailable { get; set; }
+
+    public string? LastOperation { get; set; }
+
     public string? LastError { get; set; }
+
+    public DateTimeOffset? LastErrorAtUtc { get; set; }
 
     public long? StorageUsageBytes { get; set; }
 
     public long? StorageQuotaBytes { get; set; }
 
     public bool? IsOnline { get; set; }
+
+    public void RecordSuccess(string operation)
+    {
+        LastOperation = operation;
+    }
+
+    public void RecordQueueCount(int count)
+    {
+        QueuedCount = count;
+        QueueCountAvailable = true;
+    }
+
+    public void MarkQueueCountUnavailable()
+    {
+        QueueCountAvailable = false;
+    }
+
+    public void RecordFailure(string operation, Exception exception)
+    {
+        LastOperation = operation;
+        LastErrorAtUtc = DateTimeOffset.UtcNow;
+        var message = DiagnosticMetadata.SafeErrorMessage(exception.Message, 120);
+        LastError = string.IsNullOrWhiteSpace(message)
+            ? $"{operation}: {exception.GetType().Name}"
+            : $"{operation}: {exception.GetType().Name}: {message}";
+    }
 }

--- a/src/FishingLogBook.Web/Diagnostics/DiagnosticSynchroniser.cs
+++ b/src/FishingLogBook.Web/Diagnostics/DiagnosticSynchroniser.cs
@@ -32,7 +32,10 @@ public sealed class DiagnosticSynchroniser : IDiagnosticSynchroniser
     {
         try
         {
-            if (!await _networkStatus.IsOnlineAsync(cancellationToken))
+            var isOnline = await RunAsync(
+                DiagnosticOperations.NetworkCheck,
+                () => _networkStatus.IsOnlineAsync(cancellationToken));
+            if (!isOnline)
             {
                 _status.IsOnline = false;
                 return;
@@ -40,11 +43,17 @@ public sealed class DiagnosticSynchroniser : IDiagnosticSynchroniser
 
             _status.IsOnline = true;
             await DrainQueueAsync(cancellationToken);
-            _status.QueuedCount = await _store.GetCountAsync(cancellationToken);
+            var count = await RunAsync(
+                DiagnosticOperations.QueueCount,
+                () => _store.GetCountAsync(cancellationToken));
+            _status.RecordQueueCount(count);
         }
-        catch (Exception exception)
+        catch (Exception)
         {
-            _status.LastError = exception.GetType().Name;
+            if (_status.LastOperation == DiagnosticOperations.QueueCount)
+            {
+                _status.MarkQueueCountUnavailable();
+            }
         }
     }
 
@@ -54,7 +63,9 @@ public sealed class DiagnosticSynchroniser : IDiagnosticSynchroniser
         var previousCount = int.MaxValue;
         for (var batch = 0; batch < maxBatches; batch++)
         {
-            var count = await _store.GetCountAsync(cancellationToken);
+            var count = await RunAsync(
+                DiagnosticOperations.QueueCount,
+                () => _store.GetCountAsync(cancellationToken));
             if (count == 0 || count >= previousCount)
             {
                 return;
@@ -70,7 +81,9 @@ public sealed class DiagnosticSynchroniser : IDiagnosticSynchroniser
 
     private async Task<bool> TryUploadNextBatchAsync(CancellationToken cancellationToken)
     {
-        var pending = await _store.GetPendingAsync(_config.MaxBatchSize, cancellationToken);
+        var pending = await RunAsync(
+            DiagnosticOperations.QueueRead,
+            () => _store.GetPendingAsync(_config.MaxBatchSize, cancellationToken));
         if (pending.Count == 0)
         {
             return false;
@@ -82,7 +95,9 @@ public sealed class DiagnosticSynchroniser : IDiagnosticSynchroniser
             .ToArray();
         if (expiredIds.Length > 0)
         {
-            await _store.RemoveAsync(expiredIds, cancellationToken);
+            await RunAsync(
+                DiagnosticOperations.QueueDelete,
+                () => _store.RemoveAsync(expiredIds, cancellationToken));
         }
 
         var ready = pending.Where(item => item.RetryCount < _config.MaxUploadAttempts).ToArray();
@@ -93,8 +108,12 @@ public sealed class DiagnosticSynchroniser : IDiagnosticSynchroniser
 
         try
         {
-            await _client.UploadBatchAsync(ready.Select(ToDto).ToArray(), cancellationToken);
-            await _store.RemoveAsync(ready.Select(item => item.Id).ToArray(), cancellationToken);
+            await RunAsync(
+                DiagnosticOperations.Upload,
+                () => _client.UploadBatchAsync(ready.Select(ToDto).ToArray(), cancellationToken));
+            await RunAsync(
+                DiagnosticOperations.QueueDelete,
+                () => _store.RemoveAsync(ready.Select(item => item.Id).ToArray(), cancellationToken));
             return true;
         }
         catch (HttpRequestException exception)
@@ -114,12 +133,37 @@ public sealed class DiagnosticSynchroniser : IDiagnosticSynchroniser
         Exception exception,
         CancellationToken cancellationToken)
     {
-        _status.LastError = exception.GetType().Name;
+        _status.RecordFailure(DiagnosticOperations.Upload, exception);
         foreach (var item in ready)
         {
             item.RetryCount++;
             item.SyncStatus = SyncStatus.FailedToSynchronise;
-            await _store.SaveAsync(item, cancellationToken);
+            await RunAsync(
+                DiagnosticOperations.FailedEventSave,
+                () => _store.SaveAsync(item, cancellationToken));
+        }
+    }
+
+    private async Task RunAsync(string operation, Func<Task> action)
+    {
+        await RunAsync(operation, async () =>
+        {
+            await action();
+            return 0;
+        });
+    }
+
+    private async Task<T> RunAsync<T>(string operation, Func<Task<T>> action)
+    {
+        _status.RecordSuccess(operation);
+        try
+        {
+            return await action();
+        }
+        catch (Exception exception)
+        {
+            _status.RecordFailure(operation, exception);
+            throw;
         }
     }
 

--- a/src/FishingLogBook.Web/Diagnostics/IDiagnosticIndexedDbProbe.cs
+++ b/src/FishingLogBook.Web/Diagnostics/IDiagnosticIndexedDbProbe.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Web.Diagnostics;
+
+public interface IDiagnosticIndexedDbProbe
+{
+    Task<DiagnosticProbeResult> RunAsync(
+        string databaseName,
+        bool writeTestRecord,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Diagnostics/IndexedDbDiagnosticEventStore.cs
+++ b/src/FishingLogBook.Web/Diagnostics/IndexedDbDiagnosticEventStore.cs
@@ -25,27 +25,22 @@ public sealed class IndexedDbDiagnosticEventStore : IDiagnosticEventStore
         _config = config;
     }
 
-    public async Task EnqueueAsync(DiagnosticEvent diagnosticEvent, CancellationToken cancellationToken)
+    public Task EnqueueAsync(DiagnosticEvent diagnosticEvent, CancellationToken cancellationToken)
     {
-        var module = await GetModuleAsync(cancellationToken);
-        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutSource.CancelAfter(_config.OperationTimeout);
-        await module.InvokeVoidAsync(
-            "putDiagnosticEvent",
-            timeoutSource.Token,
-            JsonSerializer.Serialize(diagnosticEvent, JsonOptions),
-            _config.MaxQueueSize);
+        return WithTimeoutAsync(
+            (module, token) => module.InvokeVoidAsync(
+                "putDiagnosticEvent",
+                token,
+                JsonSerializer.Serialize(diagnosticEvent, JsonOptions),
+                _config.MaxQueueSize).AsTask(),
+            cancellationToken);
     }
 
     public async Task<IReadOnlyList<DiagnosticEvent>> GetPendingAsync(int maxCount, CancellationToken cancellationToken)
     {
-        var module = await GetModuleAsync(cancellationToken);
-        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutSource.CancelAfter(_config.OperationTimeout);
-        var items = await module.InvokeAsync<string[]>(
-            "getPendingDiagnosticEvents",
-            timeoutSource.Token,
-            maxCount);
+        var items = await WithTimeoutAsync(
+            (module, token) => module.InvokeAsync<string[]>("getPendingDiagnosticEvents", token, maxCount).AsTask(),
+            cancellationToken);
         return (items ?? [])
             .Select(json => JsonSerializer.Deserialize<DiagnosticEvent>(json, JsonOptions))
             .Where(item => item is not null)
@@ -53,37 +48,55 @@ public sealed class IndexedDbDiagnosticEventStore : IDiagnosticEventStore
             .ToArray();
     }
 
-    public async Task RemoveAsync(IReadOnlyList<Guid> ids, CancellationToken cancellationToken)
+    public Task RemoveAsync(IReadOnlyList<Guid> ids, CancellationToken cancellationToken)
     {
-        var module = await GetModuleAsync(cancellationToken);
-        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutSource.CancelAfter(_config.OperationTimeout);
-        await module.InvokeVoidAsync(
-            "deleteDiagnosticEvents",
-            timeoutSource.Token,
-            JsonSerializer.Serialize(ids.Select(id => id.ToString("D")).ToArray()));
+        return WithTimeoutAsync(
+            (module, token) => module.InvokeVoidAsync(
+                "deleteDiagnosticEvents",
+                token,
+                JsonSerializer.Serialize(ids.Select(id => id.ToString("D")).ToArray())).AsTask(),
+            cancellationToken);
     }
 
-    public async Task<int> GetCountAsync(CancellationToken cancellationToken)
+    public Task<int> GetCountAsync(CancellationToken cancellationToken)
     {
-        var module = await GetModuleAsync(cancellationToken);
-        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        timeoutSource.CancelAfter(_config.OperationTimeout);
-        return await module.InvokeAsync<int>("getDiagnosticQueueCount", timeoutSource.Token);
+        return WithTimeoutAsync(
+            (module, token) => module.InvokeAsync<int>("getDiagnosticQueueCount", token).AsTask(),
+            cancellationToken);
     }
 
-    public async Task SaveAsync(DiagnosticEvent diagnosticEvent, CancellationToken cancellationToken)
+    public Task SaveAsync(DiagnosticEvent diagnosticEvent, CancellationToken cancellationToken)
     {
-        await EnqueueAsync(diagnosticEvent, cancellationToken);
+        return EnqueueAsync(diagnosticEvent, cancellationToken);
     }
 
     public async Task<StorageEstimate> GetStorageEstimateAsync(CancellationToken cancellationToken)
     {
-        var module = await GetModuleAsync(cancellationToken);
+        var estimate = await WithTimeoutAsync(
+            (module, token) => module.InvokeAsync<StorageEstimate?>("getStorageEstimate", token).AsTask(),
+            cancellationToken);
+        return estimate ?? new StorageEstimate();
+    }
+
+    private async Task WithTimeoutAsync(
+        Func<IJSObjectReference, CancellationToken, Task> action,
+        CancellationToken cancellationToken)
+    {
+        await WithTimeoutAsync(async (module, token) =>
+        {
+            await action(module, token);
+            return 0;
+        }, cancellationToken);
+    }
+
+    private async Task<T> WithTimeoutAsync<T>(
+        Func<IJSObjectReference, CancellationToken, Task<T>> action,
+        CancellationToken cancellationToken)
+    {
         using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutSource.CancelAfter(_config.OperationTimeout);
-        var estimate = await module.InvokeAsync<StorageEstimate?>("getStorageEstimate", timeoutSource.Token);
-        return estimate ?? new StorageEstimate();
+        var module = await GetModuleAsync(timeoutSource.Token);
+        return await action(module, timeoutSource.Token);
     }
 
     private async Task<IJSObjectReference> GetModuleAsync(CancellationToken cancellationToken)
@@ -96,8 +109,10 @@ public sealed class IndexedDbDiagnosticEventStore : IDiagnosticEventStore
         await _moduleLock.WaitAsync(cancellationToken);
         try
         {
-            _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
-            return _module;
+            return _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>(
+                "import",
+                cancellationToken,
+                ModulePath);
         }
         finally
         {

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -228,4 +228,25 @@
   <data name="Diagnostics_EmptyQueue" xml:space="preserve">
     <value>Aucun événement de diagnostic n’est en file</value>
   </data>
+  <data name="Diagnostics_QueueUnavailable" xml:space="preserve">
+    <value>Impossible de lire la file</value>
+  </data>
+  <data name="Diagnostics_LastOperation" xml:space="preserve">
+    <value>Dernière opération</value>
+  </data>
+  <data name="Diagnostics_IsolatedProbe" xml:space="preserve">
+    <value>Sonde isolée (FishingLogBookDiagnosticsTest)</value>
+  </data>
+  <data name="Diagnostics_IsolatedProbeFailed" xml:space="preserve">
+    <value>Échec de la sonde isolée à</value>
+  </data>
+  <data name="Diagnostics_ProductionProbe" xml:space="preserve">
+    <value>Sonde de production (FishingLogBookDiagnostics)</value>
+  </data>
+  <data name="Diagnostics_ProductionProbeFailed" xml:space="preserve">
+    <value>Échec de la sonde de production à</value>
+  </data>
+  <data name="Diagnostics_RetryProbe" xml:space="preserve">
+    <value>Réessayer la sonde de diagnostic</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -228,4 +228,25 @@
   <data name="Diagnostics_EmptyQueue" xml:space="preserve">
     <value>No diagnostic events are queued</value>
   </data>
+  <data name="Diagnostics_QueueUnavailable" xml:space="preserve">
+    <value>Unable to read queue</value>
+  </data>
+  <data name="Diagnostics_LastOperation" xml:space="preserve">
+    <value>Last operation</value>
+  </data>
+  <data name="Diagnostics_IsolatedProbe" xml:space="preserve">
+    <value>Isolated probe (FishingLogBookDiagnosticsTest)</value>
+  </data>
+  <data name="Diagnostics_IsolatedProbeFailed" xml:space="preserve">
+    <value>Isolated probe failed at</value>
+  </data>
+  <data name="Diagnostics_ProductionProbe" xml:space="preserve">
+    <value>Production probe (FishingLogBookDiagnostics)</value>
+  </data>
+  <data name="Diagnostics_ProductionProbeFailed" xml:space="preserve">
+    <value>Production probe failed at</value>
+  </data>
+  <data name="Diagnostics_RetryProbe" xml:space="preserve">
+    <value>Retry diagnostic probe</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Pages/Diagnostics/DiagnosticsInspector.razor
+++ b/src/FishingLogBook.Web/Pages/Diagnostics/DiagnosticsInspector.razor
@@ -6,11 +6,30 @@
 <MudContainer MaxWidth="MaxWidth.Small" Class="pa-4">
     <MudStack Spacing="3">
         <MudText Typo="Typo.h5">@Loc["Diagnostics_Title"]</MudText>
-        <MudText id="diagnostics-queued-count">@Loc["Diagnostics_QueuedCount"]: @_queuedCount</MudText>
+        <MudText id="diagnostics-queued-count">@QueueCountLabel</MudText>
+        <MudText id="diagnostics-last-operation">@Loc["Diagnostics_LastOperation"]: @(_lastOperation ?? Loc["Diagnostics_None"])</MudText>
         <MudText id="diagnostics-last-error">@Loc["Diagnostics_LastError"]: @(_lastError ?? Loc["Diagnostics_None"])</MudText>
         <MudText id="diagnostics-online">@Loc["Diagnostics_Online"]: @OnlineLabel</MudText>
         <MudText id="diagnostics-storage-usage">@Loc["Diagnostics_StorageUsage"]: @_usageLabel</MudText>
         <MudText id="diagnostics-storage-quota">@Loc["Diagnostics_StorageQuota"]: @_quotaLabel</MudText>
+        <MudText id="diagnostics-probe-isolated-stage">
+            @Loc["Diagnostics_IsolatedProbe"]: @(_isolatedProbe?.LastCompletedStage ?? Loc["Diagnostics_None"])
+        </MudText>
+        @if (_isolatedProbe?.FailedStage is not null)
+        {
+            <MudText id="diagnostics-probe-isolated-error">
+                @Loc["Diagnostics_IsolatedProbeFailed"]: @_isolatedProbe.FailedStage @(_isolatedProbe.Error)
+            </MudText>
+        }
+        <MudText id="diagnostics-probe-production-stage">
+            @Loc["Diagnostics_ProductionProbe"]: @(_productionProbe?.LastCompletedStage ?? Loc["Diagnostics_None"])
+        </MudText>
+        @if (_productionProbe?.FailedStage is not null)
+        {
+            <MudText id="diagnostics-probe-production-error">
+                @Loc["Diagnostics_ProductionProbeFailed"]: @_productionProbe.FailedStage @(_productionProbe.Error)
+            </MudText>
+        }
         <MudButton Variant="Variant.Filled"
                    Color="Color.Primary"
                    FullWidth="true"
@@ -19,13 +38,21 @@
                    id="refresh-diagnostics-button">
             @Loc["Action_Refresh"]
         </MudButton>
-        @if (_events.Count == 0)
+        <MudButton Variant="Variant.Outlined"
+                   Color="Color.Primary"
+                   FullWidth="true"
+                   Disabled="@_isLoading"
+                   OnClick="RetryProbesAsync"
+                   id="retry-diagnostics-probe-button">
+            @Loc["Diagnostics_RetryProbe"]
+        </MudButton>
+        @if (ShowEmptyQueue)
         {
             <MudText Typo="Typo.body2" Class="mud-text-secondary" id="diagnostic-queue-empty">
                 @Loc["Diagnostics_EmptyQueue"]
             </MudText>
         }
-        else
+        else if (_events.Count > 0)
         {
             <MudStack Spacing="2" id="diagnostic-queue">
                 @foreach (var diagnosticEvent in _events)

--- a/src/FishingLogBook.Web/Pages/Diagnostics/DiagnosticsInspector.razor.cs
+++ b/src/FishingLogBook.Web/Pages/Diagnostics/DiagnosticsInspector.razor.cs
@@ -22,6 +22,9 @@ public partial class DiagnosticsInspector : ComponentBase
     private IDiagnosticSynchroniser Synchroniser { get; set; } = default!;
 
     [Inject]
+    private IDiagnosticIndexedDbProbe Probe { get; set; } = default!;
+
+    [Inject]
     private INetworkStatus NetworkStatus { get; set; } = default!;
 
     [Inject]
@@ -32,11 +35,16 @@ public partial class DiagnosticsInspector : ComponentBase
 
     private IReadOnlyList<DiagnosticEvent> _events = [];
     private int _queuedCount;
+    private bool _queueCountAvailable;
+    private bool _eventsUnavailable;
     private string? _lastError;
+    private string? _lastOperation;
     private string _usageLabel = "-";
     private string _quotaLabel = "-";
     private bool? _isOnline;
     private bool _isLoading;
+    private DiagnosticProbeResult? _isolatedProbe;
+    private DiagnosticProbeResult? _productionProbe;
 
     private string OnlineLabel => _isOnline switch
     {
@@ -44,6 +52,12 @@ public partial class DiagnosticsInspector : ComponentBase
         false => Loc["Diagnostics_OnlineNo"],
         _ => Loc["Diagnostics_Unknown"]
     };
+
+    private string QueueCountLabel => _queueCountAvailable
+        ? $"{Loc["Diagnostics_QueuedCount"]}: {_queuedCount}"
+        : Loc["Diagnostics_QueueUnavailable"];
+
+    private bool ShowEmptyQueue => _queueCountAvailable && !_eventsUnavailable && _events.Count == 0;
 
     protected override async Task OnInitializedAsync()
     {
@@ -55,28 +69,105 @@ public partial class DiagnosticsInspector : ComponentBase
         _isLoading = true;
         try
         {
+            await RunProbesAsync();
             await SafeSynchroniseAsync();
+            await ReadQueueAsync();
+            await ReadOnlineAndStorageAsync();
+            await ApplyStatusLabelsAsync();
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task RetryProbesAsync()
+    {
+        _isLoading = true;
+        try
+        {
+            await RunProbesAsync();
+            await ApplyStatusLabelsAsync();
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task RunProbesAsync()
+    {
+        _isolatedProbe = await Probe.RunAsync(
+            BrowserDiagnosticIndexedDbProbe.IsolatedDatabaseName,
+            true,
+            CancellationToken.None);
+        _productionProbe = await Probe.RunAsync(
+            BrowserDiagnosticIndexedDbProbe.ProductionDatabaseName,
+            false,
+            CancellationToken.None);
+    }
+
+    private async Task ReadQueueAsync()
+    {
+        _queueCountAvailable = false;
+        _eventsUnavailable = false;
+        try
+        {
+            Status.RecordSuccess(DiagnosticOperations.QueueCount);
             _queuedCount = await Store.GetCountAsync(CancellationToken.None);
+            Status.RecordQueueCount(_queuedCount);
+            _queueCountAvailable = true;
+        }
+        catch (Exception exception)
+        {
+            Status.MarkQueueCountUnavailable();
+            Status.RecordFailure(DiagnosticOperations.QueueCount, exception);
+            TryToLogError("diagnostics queue count", exception);
+            _eventsUnavailable = true;
+            return;
+        }
+
+        try
+        {
+            Status.RecordSuccess(DiagnosticOperations.QueueRead);
             _events = await Store.GetPendingAsync(Config.MaxQueueSize, CancellationToken.None);
-            _lastError = await ReadLastErrorAsync();
+        }
+        catch (Exception exception)
+        {
+            _events = [];
+            _eventsUnavailable = true;
+            Status.RecordFailure(DiagnosticOperations.QueueRead, exception);
+            TryToLogError("diagnostics queue read", exception);
+        }
+    }
+
+    private async Task ReadOnlineAndStorageAsync()
+    {
+        try
+        {
             _isOnline = await NetworkStatus.IsOnlineAsync(CancellationToken.None);
+            Status.IsOnline = _isOnline;
+        }
+        catch (Exception exception)
+        {
+            Status.RecordFailure(DiagnosticOperations.NetworkCheck, exception);
+            TryToLogError("diagnostics online", exception);
+        }
+
+        try
+        {
             var estimate = await Store.GetStorageEstimateAsync(CancellationToken.None);
             _usageLabel = estimate.Usage?.ToString() ?? Loc["Diagnostics_UnavailableValue"];
             _quotaLabel = estimate.Quota?.ToString() ?? Loc["Diagnostics_UnavailableValue"];
-            Status.QueuedCount = _queuedCount;
-            Status.IsOnline = _isOnline;
             Status.StorageUsageBytes = estimate.Usage;
             Status.StorageQuotaBytes = estimate.Quota;
         }
         catch (Exception exception)
         {
-            await Logging.LogErrorAsync("diagnostics refresh", exception);
-            _lastError = await ReadLastErrorAsync() ?? exception.GetType().Name;
-            Status.LastError = exception.GetType().Name;
-        }
-        finally
-        {
-            _isLoading = false;
+            _usageLabel = Loc["Diagnostics_UnavailableValue"];
+            _quotaLabel = Loc["Diagnostics_UnavailableValue"];
+            Status.RecordFailure(DiagnosticOperations.Refresh, exception);
+            TryToLogError("diagnostics storage", exception);
         }
     }
 
@@ -88,17 +179,28 @@ public partial class DiagnosticsInspector : ComponentBase
         }
         catch (Exception exception)
         {
-            await Logging.LogErrorAsync("diagnostic upload", exception);
-            Status.LastError = exception.GetType().Name;
+            Status.RecordFailure(DiagnosticOperations.Upload, exception);
+            TryToLogError("diagnostic upload", exception);
         }
     }
 
-    private async Task<string?> ReadLastErrorAsync()
+    private async Task ApplyStatusLabelsAsync()
+    {
+        _lastOperation = Status.LastOperation;
+        if (_queueCountAvailable)
+        {
+            _queuedCount = Status.QueuedCount;
+        }
+
+        _lastError = Status.LastError ?? await ReadLoggedErrorAsync();
+    }
+
+    private async Task<string?> ReadLoggedErrorAsync()
     {
         var lastError = await Logging.GetLastErrorAsync();
         if (lastError is null)
         {
-            return Status.LastError;
+            return null;
         }
 
         if (string.IsNullOrWhiteSpace(lastError.ErrorType))
@@ -107,5 +209,10 @@ public partial class DiagnosticsInspector : ComponentBase
         }
 
         return $"{lastError.ErrorType}: {lastError.Message}";
+    }
+
+    private void TryToLogError(string source, Exception exception)
+    {
+        _ = Logging.LogErrorAsync(source, exception);
     }
 }

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<DiagnosticStatus>();
         services.AddScoped<ILoggingService, LoggingService>();
         services.AddScoped<IDiagnosticEventStore, IndexedDbDiagnosticEventStore>();
+        services.AddScoped<IDiagnosticIndexedDbProbe, BrowserDiagnosticIndexedDbProbe>();
         services.AddScoped<IDiagnosticLogger, DiagnosticLogger>();
         services.AddScoped<IDiagnosticSynchroniser, DiagnosticSynchroniser>();
         services.AddLocalization();

--- a/src/FishingLogBook.Web/wwwroot/js/diagnostic-probe.js
+++ b/src/FishingLogBook.Web/wwwroot/js/diagnostic-probe.js
@@ -1,0 +1,73 @@
+const version = 1;
+
+function withTimeout(promise, milliseconds, operationName) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`${operationName} timed out`)), milliseconds);
+        promise.then(
+            (value) => {
+                clearTimeout(timer);
+                resolve(value);
+            },
+            (error) => {
+                clearTimeout(timer);
+                reject(error);
+            });
+    });
+}
+
+function openDatabase(databaseName, storeName, timeoutMs) {
+    return withTimeout(new Promise((resolve, reject) => {
+        const request = indexedDB.open(databaseName, version);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(storeName)) {
+                db.createObjectStore(storeName, { keyPath: 'id' });
+            }
+        };
+        request.onsuccess = () => {
+            const db = request.result;
+            db.onversionchange = () => db.close();
+            db.onclose = () => { };
+            resolve(db);
+        };
+        request.onerror = () => reject(request.error);
+    }), timeoutMs, 'probe open');
+}
+
+export async function openProbeDatabase(databaseName, storeName, timeoutMs) {
+    const db = await openDatabase(databaseName, storeName, timeoutMs);
+    db.close();
+}
+
+export async function writeProbeRecord(databaseName, storeName, timeoutMs) {
+    const db = await openDatabase(databaseName, storeName, timeoutMs);
+    try {
+        await withTimeout(new Promise((resolve, reject) => {
+            const transaction = db.transaction(storeName, 'readwrite');
+            transaction.oncomplete = () => resolve();
+            transaction.onabort = () => reject(transaction.error || new Error('probe transaction aborted'));
+            transaction.onerror = () => reject(transaction.error);
+            transaction.objectStore(storeName).put({
+                id: 'probe',
+                timestampUtc: new Date().toISOString()
+            });
+        }), timeoutMs, 'probe write');
+    } finally {
+        db.close();
+    }
+}
+
+export async function countProbeRecords(databaseName, storeName, timeoutMs) {
+    const db = await openDatabase(databaseName, storeName, timeoutMs);
+    try {
+        return await withTimeout(new Promise((resolve, reject) => {
+            const transaction = db.transaction(storeName, 'readonly');
+            const request = transaction.objectStore(storeName).count();
+            request.onsuccess = () => resolve(request.result || 0);
+            request.onerror = () => reject(request.error);
+            transaction.onabort = () => reject(transaction.error || new Error('probe transaction aborted'));
+        }), timeoutMs, 'probe count');
+    } finally {
+        db.close();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DiagnosticLoggerTests/WhenTestingLog.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticLoggerTests/WhenTestingLog.cs
@@ -123,7 +123,8 @@ public class WhenTestingLog
 
         // Assert
         store.Items.Should().BeEmpty();
-        status.LastError.Should().Be(nameof(TimeoutException));
+        status.LastError.Should().Contain(DiagnosticOperations.Persist);
+        status.LastError.Should().Contain(nameof(TimeoutException));
     }
 
     private static DiagnosticLogger CreateLogger(

--- a/tests/FishingLogBook.Web.Tests/DiagnosticProbeTests/BaseDiagnosticIndexedDbProbeTest.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticProbeTests/BaseDiagnosticIndexedDbProbeTest.cs
@@ -1,0 +1,76 @@
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Diagnostics;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Tests.DiagnosticProbeTests;
+
+public class BaseDiagnosticIndexedDbProbeTest
+{
+    protected static BrowserDiagnosticIndexedDbProbe CreateSut(IJSRuntime jsRuntime, int timeoutMilliseconds = 1000)
+    {
+        return new BrowserDiagnosticIndexedDbProbe(
+            jsRuntime,
+            new DiagnosticsClientConfig { OperationTimeoutMilliseconds = timeoutMilliseconds });
+    }
+
+    protected sealed class HangingImportJsRuntime : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            return new ValueTask<TValue>(Hang<TValue>(cancellationToken));
+        }
+
+        private static async Task<TValue> Hang<TValue>(CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return default!;
+        }
+    }
+
+    protected sealed class RecordingProbeJsRuntime : IJSRuntime, IJSObjectReference
+    {
+        public List<string> DatabaseNames { get; } = [];
+
+        public List<string> StoreNames { get; } = [];
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            if (identifier == "import")
+            {
+                return ValueTask.FromResult((TValue)(object)this);
+            }
+
+            if (args is { Length: > 0 } && args[0] is string databaseName)
+            {
+                DatabaseNames.Add(databaseName);
+            }
+
+            if (args is { Length: > 1 } && args[1] is string storeName)
+            {
+                StoreNames.Add(storeName);
+            }
+
+            if (identifier == "countProbeRecords")
+            {
+                return ValueTask.FromResult((TValue)(object)1);
+            }
+
+            return default!;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DiagnosticProbeTests/WhenTestingIsolatedProbe.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticProbeTests/WhenTestingIsolatedProbe.cs
@@ -1,0 +1,28 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Diagnostics;
+
+namespace FishingLogBook.Web.Tests.DiagnosticProbeTests;
+
+public class WhenTestingIsolatedProbe : BaseDiagnosticIndexedDbProbeTest
+{
+    [Fact]
+    public async Task ItShouldUseTheIsolatedDatabaseName()
+    {
+        // Arrange
+        var js = new RecordingProbeJsRuntime();
+        var sut = CreateSut(js);
+
+        // Act
+        var result = await sut.RunAsync(
+            BrowserDiagnosticIndexedDbProbe.IsolatedDatabaseName,
+            true,
+            CancellationToken.None);
+
+        // Assert
+        result.Succeeded.Should().BeTrue();
+        result.LastCompletedStage.Should().Be(BrowserDiagnosticIndexedDbProbe.StageCountReturned);
+        js.DatabaseNames.Should().OnlyContain(name => name == BrowserDiagnosticIndexedDbProbe.IsolatedDatabaseName);
+        js.StoreNames.Should().OnlyContain(name => name == BrowserDiagnosticIndexedDbProbe.IsolatedStoreName);
+        js.DatabaseNames.Should().NotContain("FishingLogBook");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DiagnosticProbeTests/WhenTestingModuleImportNeverCompletes.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticProbeTests/WhenTestingModuleImportNeverCompletes.cs
@@ -1,0 +1,27 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Diagnostics;
+
+namespace FishingLogBook.Web.Tests.DiagnosticProbeTests;
+
+public class WhenTestingModuleImportNeverCompletes : BaseDiagnosticIndexedDbProbeTest
+{
+    [Fact]
+    public async Task ItShouldReportImportAsTheFailedStage()
+    {
+        // Arrange
+        var sut = CreateSut(new HangingImportJsRuntime(), 250);
+
+        // Act
+        var result = await sut.RunAsync(
+            BrowserDiagnosticIndexedDbProbe.IsolatedDatabaseName,
+            true,
+            CancellationToken.None);
+
+        // Assert
+        result.DatabaseName.Should().Be(BrowserDiagnosticIndexedDbProbe.IsolatedDatabaseName);
+        result.Succeeded.Should().BeFalse();
+        result.FailedStage.Should().Be(BrowserDiagnosticIndexedDbProbe.StageStartingImport);
+        result.LastCompletedStage.Should().BeNull();
+        result.Error.Should().Contain(nameof(TaskCanceledException));
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DiagnosticProbeTests/WhenTestingProductionProbe.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticProbeTests/WhenTestingProductionProbe.cs
@@ -1,0 +1,27 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Diagnostics;
+
+namespace FishingLogBook.Web.Tests.DiagnosticProbeTests;
+
+public class WhenTestingProductionProbe : BaseDiagnosticIndexedDbProbeTest
+{
+    [Fact]
+    public async Task ItShouldCountTheProductionStore()
+    {
+        // Arrange
+        var js = new RecordingProbeJsRuntime();
+        var sut = CreateSut(js);
+
+        // Act
+        var result = await sut.RunAsync(
+            BrowserDiagnosticIndexedDbProbe.ProductionDatabaseName,
+            false,
+            CancellationToken.None);
+
+        // Assert
+        result.Succeeded.Should().BeTrue();
+        js.DatabaseNames.Should().OnlyContain(name => name == BrowserDiagnosticIndexedDbProbe.ProductionDatabaseName);
+        js.StoreNames.Should().OnlyContain(name => name == BrowserDiagnosticIndexedDbProbe.ProductionStoreName);
+        js.StoreNames.Should().NotContain(BrowserDiagnosticIndexedDbProbe.IsolatedStoreName);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DiagnosticStoreTests/WhenTestingTimeout.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticStoreTests/WhenTestingTimeout.cs
@@ -1,0 +1,44 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Diagnostics;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Tests.DiagnosticStoreTests;
+
+public class WhenTestingTimeout
+{
+    [Fact]
+    public async Task ItShouldTimeOut_WhenModuleImportNeverCompletes()
+    {
+        // Arrange
+        var js = new HangingImportJsRuntime();
+        var sut = new IndexedDbDiagnosticEventStore(
+            js,
+            new DiagnosticsClientConfig { OperationTimeoutMilliseconds = 250 });
+
+        // Act
+        var act = async () => await sut.GetCountAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class HangingImportJsRuntime : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            return new ValueTask<TValue>(Hang<TValue>(cancellationToken));
+        }
+
+        private static async Task<TValue> Hang<TValue>(CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return default!;
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DiagnosticSynchroniserTests/WhenTestingSynchronise.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticSynchroniserTests/WhenTestingSynchronise.cs
@@ -151,12 +151,57 @@ public class WhenTestingSynchronise
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ItShouldRecordTheQueueCountOperation_WhenCountIsCanceled()
+    {
+        // Arrange
+        var store = Substitute.For<IDiagnosticEventStore>();
+        store.GetCountAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException("queue count canceled"));
+        var status = new DiagnosticStatus();
+        var sut = CreateSut(store, Substitute.For<IDiagnosticClient>(), online: true, status: status);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+
+        // Assert
+        status.QueueCountAvailable.Should().BeFalse();
+        status.LastOperation.Should().Be(DiagnosticOperations.QueueCount);
+        status.LastError.Should().Contain(DiagnosticOperations.QueueCount);
+        status.LastError.Should().Contain(nameof(TaskCanceledException));
+    }
+
+    [Fact]
+    public async Task ItShouldRecordTheUploadOperation_WhenHttpUploadIsCanceled()
+    {
+        // Arrange
+        var store = new MemoryDiagnosticEventStore();
+        store.Items.Add(CreateEvent());
+        var client = Substitute.For<IDiagnosticClient>();
+        client.UploadBatchAsync(
+                Arg.Any<IReadOnlyList<FishingLogBook.Shared.Dtos.ClientDiagnosticEventDto>>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException("upload canceled"));
+        var status = new DiagnosticStatus();
+        var sut = CreateSut(store, client, online: true, status: status);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+
+        // Assert
+        status.LastOperation.Should().BeOneOf(DiagnosticOperations.Upload, DiagnosticOperations.FailedEventSave, DiagnosticOperations.QueueCount);
+        status.LastError.Should().Contain(nameof(TaskCanceledException));
+        status.LastError.Should().Contain(DiagnosticOperations.Upload);
+        store.Items.Should().ContainSingle();
+    }
+
     private static DiagnosticSynchroniser CreateSut(
-        MemoryDiagnosticEventStore store,
+        IDiagnosticEventStore store,
         IDiagnosticClient client,
         bool online,
         int maxAttempts = 5,
-        int maxBatchSize = 50)
+        int maxBatchSize = 50,
+        DiagnosticStatus? status = null)
     {
         var network = Substitute.For<INetworkStatus>();
         network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(online);
@@ -164,7 +209,7 @@ public class WhenTestingSynchronise
             store,
             client,
             network,
-            new DiagnosticStatus(),
+            status ?? new DiagnosticStatus(),
             new DiagnosticsClientConfig { MaxBatchSize = maxBatchSize, MaxUploadAttempts = maxAttempts });
     }
 

--- a/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/BaseDiagnosticsInspectorTest.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/BaseDiagnosticsInspectorTest.cs
@@ -16,7 +16,8 @@ public class BaseDiagnosticsInspectorTest
         IDiagnosticSynchroniser? synchroniser = null,
         INetworkStatus? network = null,
         DiagnosticsClientConfig? config = null,
-        ILoggingService? logging = null)
+        ILoggingService? logging = null,
+        IDiagnosticIndexedDbProbe? probe = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -28,6 +29,7 @@ public class BaseDiagnosticsInspectorTest
         context.Services.AddSingleton(config ?? new DiagnosticsClientConfig { MaxQueueSize = 500 });
         context.Services.AddSingleton(network ?? OnlineNetwork());
         context.Services.AddSingleton(logging ?? SilentLogging());
+        context.Services.AddSingleton(probe ?? SilentProbe());
         context.Services.AddSingleton(Substitute.For<ICultureService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
@@ -60,5 +62,18 @@ public class BaseDiagnosticsInspectorTest
         logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         return logging;
+    }
+
+    protected static IDiagnosticIndexedDbProbe SilentProbe()
+    {
+        var probe = Substitute.For<IDiagnosticIndexedDbProbe>();
+        probe.RunAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult(new DiagnosticProbeResult
+            {
+                DatabaseName = callInfo.Arg<string>(),
+                LastCompletedStage = BrowserDiagnosticIndexedDbProbe.StageCountReturned,
+                Count = 0
+            }));
+        return probe;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/WhenTestingProbe.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/WhenTestingProbe.cs
@@ -1,0 +1,65 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Diagnostics;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Pages.Diagnostics;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.DiagnosticsInspectorTests;
+
+public class WhenTestingProbe : BaseDiagnosticsInspectorTest
+{
+    [Fact]
+    public async Task ItShouldShowTheIsolatedProbeStage()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var probe = Substitute.For<IDiagnosticIndexedDbProbe>();
+        probe.RunAsync(
+                BrowserDiagnosticIndexedDbProbe.IsolatedDatabaseName,
+                true,
+                Arg.Any<CancellationToken>())
+            .Returns(new DiagnosticProbeResult
+            {
+                DatabaseName = BrowserDiagnosticIndexedDbProbe.IsolatedDatabaseName,
+                LastCompletedStage = BrowserDiagnosticIndexedDbProbe.StageDatabaseOpened,
+                FailedStage = BrowserDiagnosticIndexedDbProbe.StageWriting,
+                Error = "TimeoutException"
+            });
+        probe.RunAsync(
+                BrowserDiagnosticIndexedDbProbe.ProductionDatabaseName,
+                false,
+                Arg.Any<CancellationToken>())
+            .Returns(new DiagnosticProbeResult
+            {
+                DatabaseName = BrowserDiagnosticIndexedDbProbe.ProductionDatabaseName,
+                LastCompletedStage = BrowserDiagnosticIndexedDbProbe.StageCountReturned,
+                Count = 2
+            });
+        await using var context = CreateContext(CreateStore(), probe: probe);
+
+        // Act
+        var cut = context.Render<DiagnosticsInspector>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#diagnostics-probe-isolated-stage").TextContent.Should()
+                .Contain(BrowserDiagnosticIndexedDbProbe.StageDatabaseOpened);
+            cut.Find("#diagnostics-probe-isolated-error").TextContent.Should()
+                .Contain(BrowserDiagnosticIndexedDbProbe.StageWriting);
+            cut.Find("#diagnostics-probe-production-stage").TextContent.Should()
+                .Contain(BrowserDiagnosticIndexedDbProbe.StageCountReturned);
+            cut.Find("#retry-diagnostics-probe-button").TextContent.Should()
+                .Contain("Retry diagnostic probe");
+        });
+        await probe.Received(1).RunAsync(
+            BrowserDiagnosticIndexedDbProbe.IsolatedDatabaseName,
+            true,
+            Arg.Any<CancellationToken>());
+        await probe.Received(1).RunAsync(
+            BrowserDiagnosticIndexedDbProbe.ProductionDatabaseName,
+            false,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/WhenTestingQueuedEvents.cs
+++ b/tests/FishingLogBook.Web.Tests/DiagnosticsInspectorTests/WhenTestingQueuedEvents.cs
@@ -72,6 +72,31 @@ public class WhenTestingQueuedEvents : BaseDiagnosticsInspectorTest
     }
 
     [Fact]
+    public async Task ItShouldNotTreatAFailedCountAsAnEmptyQueue()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = CreateStore();
+        store.GetCountAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("queue count timed out"));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<DiagnosticsInspector>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#diagnostics-queued-count").TextContent.Should().Contain("Unable to read queue");
+            cut.Find("#diagnostics-queued-count").TextContent.Should().NotContain("0");
+            cut.Find("#diagnostics-last-error").TextContent.Should().Contain(DiagnosticOperations.QueueCount);
+            cut.Find("#diagnostics-last-error").TextContent.Should().Contain(nameof(TimeoutException));
+            cut.Find("#diagnostics-last-operation").TextContent.Should().Contain(DiagnosticOperations.QueueCount);
+            cut.FindAll("#diagnostic-queue-empty").Should().BeEmpty();
+        });
+    }
+
+    [Fact]
     public async Task ItShouldShowFrenchEmptyQueue()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Bound location permission and capture so they cannot block Catch load or save.
- Make diagnostic logging best-effort so the diagnostics IndexedDB cannot delay Catch persist or reload.
- Add a Diagnostics status page with isolated and production IndexedDB probes; the production probe counts `diagnosticEvents` only.

Addresses #57

## Test plan
- [ ] iPhone 16 Pro / iOS 26: Catch load and save while offline
- [ ] Location deny, timeout, or failure still saves the catch
- [ ] Diagnostics page: isolated probe and production probe both reach DIAG-08
- [ ] Do not close #57 until the device acceptance criteria pass