### PR TITLE
Add Cognito authentication for the PWA and API

### DIFF
--- a/.claude/rules/terraform.md
+++ b/.claude/rules/terraform.md
@@ -55,7 +55,8 @@ Never attempt to solve an application problem by provisioning additional infrast
 - Add resources **deliberately, one at a time, only when explicitly approved.** Neon
   currently defines `neon_project`; R2 defines `cloudflare_r2_bucket` (photos); Pages
   defines `cloudflare_pages_project`; Grafana Cloud looks up an existing stack and
-  defines a Loki `logs:write` access policy. Cognito and Fly remain skeletons.
+  defines a Loki `logs:write` access policy. Cognito defines the user pool, public PWA
+  app client, hosted-UI domain, and API resource server. Fly remains a skeleton.
 
 ## Stack (who does what)
 

--- a/.claude/rules/terraform.md
+++ b/.claude/rules/terraform.md
@@ -55,8 +55,9 @@ Never attempt to solve an application problem by provisioning additional infrast
 - Add resources **deliberately, one at a time, only when explicitly approved.** Neon
   currently defines `neon_project`; R2 defines `cloudflare_r2_bucket` (photos); Pages
   defines `cloudflare_pages_project`; Grafana Cloud looks up an existing stack and
-  defines a Loki `logs:write` access policy. Cognito defines the user pool, public PWA
-  app client, hosted-UI domain, and API resource server. Fly remains a skeleton.
+  defines a Loki `logs:write` access policy. Cognito defines the user pool, resource
+  server, public PWA app client, hosted-UI domain, and managed-login branding. Fly
+  remains a skeleton.
 
 ## Stack (who does what)
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # This repository's Release/Pages publish uses appsettings.Production.json as the
+      # Dev Cloudflare Pages overlay. GitHub `dev` environment AUTH_* variables must be
+      # set; missing values fail this step instead of emitting Dev defaults.
       - name: Apply public Auth configuration
         env:
           AUTH_AUTHORITY: ${{ vars.AUTH_AUTHORITY }}
@@ -59,18 +62,30 @@ jobs:
           python3 <<'PY'
           import json
           import os
+          import sys
           from pathlib import Path
+
+          required = [
+              "AUTH_AUTHORITY",
+              "AUTH_CLIENT_ID",
+              "AUTH_API_SCOPE",
+              "AUTH_API_RESOURCE",
+          ]
+          missing = [name for name in required if not os.environ.get(name, "").strip()]
+          if missing:
+              sys.exit(
+                  "Missing required GitHub environment variables: "
+                  + ", ".join(missing)
+                  + ". Set them on the GitHub dev environment."
+              )
 
           path = Path("src/FishingLogBook.Web/wwwroot/appsettings.Production.json")
           data = json.loads(path.read_text(encoding="utf-8"))
-          existing = data.get("Auth") or {}
-          scope = os.environ.get("AUTH_API_SCOPE") or existing.get("ApiScope") or "https://fishing-logbook-dev-api.fly.dev/access"
-          resource = os.environ.get("AUTH_API_RESOURCE") or existing.get("ApiResource") or "https://fishing-logbook-dev-api.fly.dev"
           data["Auth"] = {
-              "Authority": os.environ.get("AUTH_AUTHORITY") or existing.get("Authority") or "",
-              "ClientId": os.environ.get("AUTH_CLIENT_ID") or existing.get("ClientId") or "",
-              "ApiScope": scope,
-              "ApiResource": resource,
+              "Authority": os.environ["AUTH_AUTHORITY"].strip(),
+              "ClientId": os.environ["AUTH_CLIENT_ID"].strip(),
+              "ApiScope": os.environ["AUTH_API_SCOPE"].strip(),
+              "ApiResource": os.environ["AUTH_API_RESOURCE"].strip(),
           }
           path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
           PY

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -49,6 +49,32 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Apply public Auth configuration
+        env:
+          AUTH_AUTHORITY: ${{ vars.AUTH_AUTHORITY }}
+          AUTH_CLIENT_ID: ${{ vars.AUTH_CLIENT_ID }}
+          AUTH_API_SCOPE: ${{ vars.AUTH_API_SCOPE }}
+          AUTH_API_RESOURCE: ${{ vars.AUTH_API_RESOURCE }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("src/FishingLogBook.Web/wwwroot/appsettings.Production.json")
+          data = json.loads(path.read_text(encoding="utf-8"))
+          existing = data.get("Auth") or {}
+          scope = os.environ.get("AUTH_API_SCOPE") or existing.get("ApiScope") or "https://fishing-logbook-dev-api.fly.dev/access"
+          resource = os.environ.get("AUTH_API_RESOURCE") or existing.get("ApiResource") or "https://fishing-logbook-dev-api.fly.dev"
+          data["Auth"] = {
+              "Authority": os.environ.get("AUTH_AUTHORITY") or existing.get("Authority") or "",
+              "ClientId": os.environ.get("AUTH_CLIENT_ID") or existing.get("ClientId") or "",
+              "ApiScope": scope,
+              "ApiResource": resource,
+          }
+          path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+          PY
+
       - name: Publish Web
         run: dotnet publish src/FishingLogBook.Web --configuration Release -o artifacts/web
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -694,8 +694,8 @@ Blazor assemblies
 # 25. Authentication Infrastructure
 
 Terraform defines Amazon Cognito in `infrastructure/terraform/modules/cognito/`. Each
-environment has its own user pool, public PWA app client, hosted-UI domain, and API
-resource server. Apply is **manual only** — see `infrastructure/README.md`.
+environment has its own user pool, resource server, public PWA app client, hosted-UI
+domain, and managed-login branding. Apply is **manual only** — see `infrastructure/README.md`.
 
 ## Flow
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -767,13 +767,20 @@ The resulting API scope is `https://fishing-logbook-dev-api.fly.dev/access`.
 
 Copy Terraform outputs into (these values are public identifiers, not secrets):
 
-- Web `wwwroot/appsettings.Development.json` → `Auth:Authority`, `Auth:ClientId`
-  (`Auth:ApiScope` and `Auth:ApiResource` are already in appsettings)
+- Web `wwwroot/appsettings.Development.json` and API `appsettings.Development.json` →
+  `Auth:Authority`, `Auth:ClientId`, `Auth:ApiScope`, `Auth:ApiResource`
+- Web `wwwroot/appsettings.Production.json` is this repository's **Dev Cloudflare Pages
+  overlay** (Release publish). Keep Dev Auth there until a real production overlay exists.
+  Base `appsettings.json` must not contain environment Auth values.
 - GitHub `dev` environment **variables** (not secrets): `AUTH_AUTHORITY`, `AUTH_CLIENT_ID`,
   `AUTH_API_SCOPE` (`https://fishing-logbook-dev-api.fly.dev/access`), `AUTH_API_RESOURCE`
-  (`https://fishing-logbook-dev-api.fly.dev`)
-- Fly.io API env: `Auth__Authority`, `Auth__ClientId`, plus `Auth__ApiScope` and
-  `Auth__ApiResource` already set in `infrastructure/fly/fly.dev.toml`
+  (`https://fishing-logbook-dev-api.fly.dev`). Missing variables fail `deploy-web`.
+- Fly.io Dev API env in `infrastructure/fly/fly.dev.toml`: `Auth__Authority`,
+  `Auth__ClientId`, `Auth__ApiScope`, `Auth__ApiResource`
+
+API and Web startup fail if any of `Auth:Authority`, `Auth:ClientId`, `Auth:ApiResource`,
+or `Auth:ApiScope` is missing or whitespace. JWT validation always uses the configured
+`ApiResource` as `aud` and requires `ApiScope`.
 
 Local Web points at the **Dev** Cognito pool. Do not create a user pool on a laptop.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -693,24 +693,101 @@ Blazor assemblies
 
 # 25. Authentication Infrastructure
 
-Terraform should define Amazon Cognito infrastructure.
+Terraform defines Amazon Cognito in `infrastructure/terraform/modules/cognito/`. Each
+environment has its own user pool, public PWA app client, hosted-UI domain, and API
+resource server. Apply is **manual only** — see `infrastructure/README.md`.
 
-Initially define:
+## Flow
 
 ```text
-Dev User Pool
-Dev App Client
-Prod User Pool
-Prod App Client
+FishingLogBook PWA
+    -> Cognito managed login (email + password; no FishingLogBook login form)
+    -> Authorization Code callback (/authentication/login-callback)
+    -> Microsoft.AspNetCore.Components.WebAssembly.Authentication completes code + PKCE S256
+    -> Access token attached only to FishingLogBook API requests
 ```
 
-or an equivalent clearly isolated environment design.
+The PWA is a public browser client. There is **no Cognito client secret** in Blazor,
+`appsettings`, JavaScript, GitHub variables, Cloudflare Pages, or Terraform outputs.
 
-Use Authorization Code flow with PKCE for the PWA.
+OIDC `Authority` is the user-pool issuer:
 
-Do not use a client secret in the Blazor application.
+```text
+https://cognito-idp.<region>.amazonaws.com/<userPoolId>
+```
 
-External identity providers do not need to be implemented in the first vertical slice, but the Cognito configuration must allow them to be added later.
+Credential entry belongs to Cognito Hosted UI / Managed Login. FishingLogBook only has
+Sign in / Create account / Sign out actions.
+
+## Local and Dev callback URLs
+
+Exact URLs only (no wildcards). HTTP is allowed only for localhost.
+
+- `https://localhost:7005/authentication/login-callback`
+- `http://localhost:5019/authentication/login-callback`
+- `https://fishing-logbook-dev.pages.dev/authentication/login-callback`
+
+Logout URLs include the matching `/authentication/logout-callback` paths and site roots.
+
+Do not invent production callback URLs until the production web origin exists.
+
+## API JWT validation
+
+The API validates Cognito **access** tokens locally with ASP.NET Core JWT Bearer
+middleware (OIDC metadata / JWKS). It does not call Cognito on each request.
+
+Final validation requires all of:
+
+1. Valid signature
+2. Correct issuer
+3. Valid lifetime
+4. Correct `aud` (FishingLogBook API resource URI)
+5. `token_use` == `access`
+6. Correct `client_id` (PWA app client)
+7. Required API scope `https://fishing-logbook-dev-api.fly.dev/access`
+
+ID tokens are rejected even when `aud` is present.
+
+Cognito access tokens normally identify the app client with `client_id` and do **not**
+inherently contain `aud`. FishingLogBook explicitly requests RFC 8707 resource binding
+by setting Microsoft OIDC `ProviderOptions.AdditionalProviderParameters["resource"]`
+to `Auth:ApiResource`. Cognito then adds `aud` containing that FishingLogBook API
+resource URI. The API validates **both** `aud` and `client_id`.
+
+Dev `Auth:ApiResource` is `https://fishing-logbook-dev-api.fly.dev` (the current Dev
+Fly API URL). Local Blazor still requests that same audience when using the Dev Cognito
+pool; `aud` is an OAuth identifier, not a requirement that the HTTP Host match it.
+
+The Cognito resource-server identifier is the same URL as `Auth:ApiResource`
+(`https://fishing-logbook-dev-api.fly.dev`). Cognito only accepts custom scopes
+with RFC 8707 resource binding when those scopes belong to that URL identifier.
+The resulting API scope is `https://fishing-logbook-dev-api.fly.dev/access`.
+
+## Public configuration after a reviewed apply
+
+Copy Terraform outputs into (these values are public identifiers, not secrets):
+
+- Web `wwwroot/appsettings.Development.json` → `Auth:Authority`, `Auth:ClientId`
+  (`Auth:ApiScope` and `Auth:ApiResource` are already in appsettings)
+- GitHub `dev` environment **variables** (not secrets): `AUTH_AUTHORITY`, `AUTH_CLIENT_ID`,
+  `AUTH_API_SCOPE` (`https://fishing-logbook-dev-api.fly.dev/access`), `AUTH_API_RESOURCE`
+  (`https://fishing-logbook-dev-api.fly.dev`)
+- Fly.io API env: `Auth__Authority`, `Auth__ClientId`, plus `Auth__ApiScope` and
+  `Auth__ApiResource` already set in `infrastructure/fly/fly.dev.toml`
+
+Local Web points at the **Dev** Cognito pool. Do not create a user pool on a laptop.
+
+## Creating a test user
+
+1. Open the Cognito hosted UI (domain from `cognito_hosted_ui_domain`).
+2. Create an account with email and complete email verification.
+3. In the PWA, Sign in / Create account — Cognito collects credentials.
+4. After sign-in, `/test-catch` is available. Sign out must require sign-in again
+   before protected TestCatch API calls succeed.
+
+External identity providers are not enabled in this slice, but the user pool can accept
+them later. Internal `UserId` mapping is a later issue — do not persist Cognito `sub`
+as Catch.UserId.
 
 ---
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,9 @@
     <PackageVersion Include="dbup-postgresql" Version="7.0.1" />
     <PackageVersion Include="Mapster" Version="7.4.0" />
     <PackageVersion Include="MediatR" Version="12.5.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
@@ -22,6 +24,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -261,11 +261,14 @@ terraform output cognito_hosted_ui_domain
 terraform output cognito_api_scope
 ```
 
-Put `Authority` / `ClientId` into local Web `appsettings.Development.json`, GitHub `dev`
-**variables** `AUTH_AUTHORITY`, `AUTH_CLIENT_ID`, `AUTH_API_SCOPE`, `AUTH_API_RESOURCE`,
-and Fly `Auth__Authority`, `Auth__ClientId`. `Auth__ApiScope` and `Auth__ApiResource` are
-already in `infrastructure/fly/fly.dev.toml`. These are public identifiers — do not mark
-the client ID as a GitHub secret.
+Put `Authority`, `ClientId`, `ApiScope`, and `ApiResource` into local
+`appsettings.Development.json`, GitHub `dev` **variables** `AUTH_AUTHORITY`,
+`AUTH_CLIENT_ID`, `AUTH_API_SCOPE`, `AUTH_API_RESOURCE`, and Fly
+`Auth__Authority` / `Auth__ClientId` / `Auth__ApiScope` / `Auth__ApiResource` in
+`infrastructure/fly/fly.dev.toml`. Base `appsettings.json` must not silently represent
+Dev. Missing GitHub `AUTH_*` variables fail `deploy-web`. Missing Auth at API/Web
+startup throws. These are public identifiers — do not mark the client ID as a GitHub
+secret.
 
 Cognito resource-server identifier is the Dev API URL
 (`https://fishing-logbook-dev-api.fly.dev`). Custom scopes can only be requested

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -224,8 +224,8 @@ Do not apply Grafana in prod until you want a separate Loki write token for prod
 ## Amazon Cognito (authentication)
 
 Cognito is the only AWS application service this project uses. Terraform owns the user
-pool, public PWA app client (`generate_secret = false`), hosted-UI domain, and API
-resource server. There is no client secret to output or store.
+pool, resource server, public PWA app client (`generate_secret = false`), hosted-UI
+domain, and managed-login branding. There is no client secret to output or store.
 
 The PWA uses Authorization Code + PKCE S256 via
 `Microsoft.AspNetCore.Components.WebAssembly.Authentication`. FishingLogBook does not
@@ -247,9 +247,9 @@ Password policy: minimum 12 characters, upper + lower + number required, symbols
 required. Length over extra complexity.
 
 **Do not apply until you have reviewed `terraform plan`.** Expected new resources in
-Dev: user pool, resource server, app client, user-pool domain (4). Abort if the plan
-shows destroy/replace of Neon, R2, Pages, or Grafana. Prod must not be applied until
-real production callback/logout HTTPS URLs exist.
+Dev: user pool, resource server, public PWA app client, user-pool domain, managed-login
+branding (5). Abort if the plan shows destroy/replace of Neon, R2, Pages, or Grafana.
+Prod must not be applied until real production callback/logout HTTPS URLs exist.
 
 After a reviewed apply, copy **public** outputs:
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -2,9 +2,10 @@
 
 Infrastructure for FishingLogBook is defined with **Terraform** and is applied
 **manually only**. Neon (`neon_project`), R2 photos (`cloudflare_r2_bucket`), Pages
-(`cloudflare_pages_project`), and Grafana Cloud Loki write access are defined. Cognito
-and Fly remain skeletons. Further resources are added deliberately, one at a time, only
-when explicitly approved.
+(`cloudflare_pages_project`), Grafana Cloud Loki write access, and Cognito (user pool,
+public PWA client, hosted-UI domain, API resource server) are defined. Fly remains a
+skeleton. Further resources are added deliberately, one at a time, only when explicitly
+approved.
 
 ## ⚠️ Cost and safety warning
 
@@ -47,7 +48,7 @@ infrastructure/
 │   └── fly.prod.toml
 └── terraform/
     ├── adding-resources-to-terraform.md
-    ├── modules/                       # neon, r2 (photos), pages, grafana-cloud; cognito/fly naming only
+    ├── modules/                       # neon, r2, pages, grafana-cloud, cognito; fly naming only
     └── environments/
         ├── dev/
         └── prod/
@@ -219,6 +220,63 @@ dotnet user-secrets set "ExternalLogging:ApiToken" "<grafana_loki_write_token>" 
 ```
 
 Do not apply Grafana in prod until you want a separate Loki write token for production.
+
+## Amazon Cognito (authentication)
+
+Cognito is the only AWS application service this project uses. Terraform owns the user
+pool, public PWA app client (`generate_secret = false`), hosted-UI domain, and API
+resource server. There is no client secret to output or store.
+
+The PWA uses Authorization Code + PKCE S256 via
+`Microsoft.AspNetCore.Components.WebAssembly.Authentication`. FishingLogBook does not
+collect Cognito passwords. MFA is off (no SMS). Email is the username; Cognito sends
+verification with the default Cognito email quota (no SES).
+
+Token settings (explicit):
+
+| Token | Lifetime | Why |
+|---|---|---|
+| Access | 1 hour | Short-lived API bearer for a PWA |
+| ID | 1 hour | Matches access; used by the OIDC session, not the API |
+| Refresh | 30 days | Consumer app should not force daily re-login; rotation limits theft |
+| Refresh retry grace | 5 seconds | Enough for a flaky retry; Cognito max is 60 |
+
+Also enabled: token revocation, refresh rotation, `prevent_user_existence_errors`.
+
+Password policy: minimum 12 characters, upper + lower + number required, symbols not
+required. Length over extra complexity.
+
+**Do not apply until you have reviewed `terraform plan`.** Expected new resources in
+Dev: user pool, resource server, app client, user-pool domain (4). Abort if the plan
+shows destroy/replace of Neon, R2, Pages, or Grafana. Prod must not be applied until
+real production callback/logout HTTPS URLs exist.
+
+After a reviewed apply, copy **public** outputs:
+
+```powershell
+terraform output cognito_user_pool_id
+terraform output cognito_client_id
+terraform output cognito_authority
+terraform output cognito_hosted_ui_domain
+terraform output cognito_api_scope
+```
+
+Put `Authority` / `ClientId` into local Web `appsettings.Development.json`, GitHub `dev`
+**variables** `AUTH_AUTHORITY`, `AUTH_CLIENT_ID`, `AUTH_API_SCOPE`, `AUTH_API_RESOURCE`,
+and Fly `Auth__Authority`, `Auth__ClientId`. `Auth__ApiScope` and `Auth__ApiResource` are
+already in `infrastructure/fly/fly.dev.toml`. These are public identifiers — do not mark
+the client ID as a GitHub secret.
+
+Cognito resource-server identifier is the Dev API URL
+(`https://fishing-logbook-dev-api.fly.dev`). Custom scopes can only be requested
+together with RFC 8707 `resource` when they belong to that identifier. The PWA
+sends `resource` = `Auth:ApiResource` (the same URL). Cognito then puts that URL
+in access-token `aud`. The API scope is `https://fishing-logbook-dev-api.fly.dev/access`.
+The API validates both `aud` and `client_id`. Access tokens do not inherently contain
+`aud` unless resource binding is requested.
+
+Create a test user in Cognito Hosted UI (email + verification), then Sign in from the
+PWA. Sign-out must clear the OIDC session and send the browser to an allowed logout URL.
 
 ## Manual deployment process
 

--- a/infrastructure/fly/fly.dev.toml
+++ b/infrastructure/fly/fly.dev.toml
@@ -14,6 +14,13 @@ primary_region = "iad"
   ASPNETCORE_ENVIRONMENT = "Production"
   ASPNETCORE_HTTP_PORTS = "8080"
   ExternalLogging__Environment = "dev"
+  Cors__AllowedOrigins__0 = "https://fishing-logbook-dev.pages.dev"
+  Cors__AllowedOrigins__1 = "https://localhost:7005"
+  Cors__AllowedOrigins__2 = "http://localhost:5019"
+  Auth__Authority = "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06"
+  Auth__ClientId = "e80socqio7bpv79or57fb1e5l"
+  Auth__ApiScope = "https://fishing-logbook-dev-api.fly.dev/access"
+  Auth__ApiResource = "https://fishing-logbook-dev-api.fly.dev"
 
 [http_service]
   internal_port = 8080

--- a/infrastructure/terraform/adding-resources-to-terraform.md
+++ b/infrastructure/terraform/adding-resources-to-terraform.md
@@ -1,9 +1,11 @@
 # Adding Resources to Terraform
 
-All Terraform lives under `infrastructure/terraform/`. Cognito and Fly are still
-**skeletons**. Neon (`neon_project`), R2 (`cloudflare_r2_bucket` photos), and Pages
-(`cloudflare_pages_project`) are defined. Add further resources deliberately, one at a
-time, and only when explicitly approved. Read `.claude/rules/terraform.md` first.
+All Terraform lives under `infrastructure/terraform/`. Fly is still a **skeleton**.
+Neon (`neon_project`), R2 (`cloudflare_r2_bucket` photos), Pages
+(`cloudflare_pages_project`), Grafana Cloud Loki write access, and Cognito (user pool,
+public PWA client, hosted-UI domain, API resource server) are defined. Add further
+resources deliberately, one at a time, and only when explicitly approved. Read
+`.claude/rules/terraform.md` first.
 
 ## Step 1 — Pick the module
 

--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -1,8 +1,10 @@
 module "cognito" {
-  source        = "../../modules/cognito"
-  environment   = var.environment
-  callback_urls = var.cognito_callback_urls
-  logout_urls   = var.cognito_logout_urls
+  source                  = "../../modules/cognito"
+  environment             = var.environment
+  region                  = var.aws_region
+  api_resource_identifier = var.cognito_api_resource_identifier
+  callback_urls           = var.cognito_callback_urls
+  logout_urls             = var.cognito_logout_urls
 }
 
 module "neon" {

--- a/infrastructure/terraform/environments/dev/outputs.tf
+++ b/infrastructure/terraform/environments/dev/outputs.tf
@@ -3,6 +3,31 @@ output "cognito_resource_prefix" {
   value       = module.cognito.resource_prefix
 }
 
+output "cognito_user_pool_id" {
+  description = "Cognito user pool ID. Public identifier."
+  value       = module.cognito.user_pool_id
+}
+
+output "cognito_client_id" {
+  description = "Public PWA app client ID. Not a secret."
+  value       = module.cognito.client_id
+}
+
+output "cognito_authority" {
+  description = "OIDC issuer/authority for Blazor OIDC and API JWT validation."
+  value       = module.cognito.authority
+}
+
+output "cognito_hosted_ui_domain" {
+  description = "Cognito hosted UI / managed login hostname (no scheme)."
+  value       = module.cognito.hosted_ui_domain
+}
+
+output "cognito_api_scope" {
+  description = "Resource-server scope the PWA must request for FishingLogBook API access."
+  value       = module.cognito.api_scope
+}
+
 output "neon_project_name" {
   description = "Neon project name."
   value       = module.neon.project_name

--- a/infrastructure/terraform/environments/dev/terraform.tfvars.example
+++ b/infrastructure/terraform/environments/dev/terraform.tfvars.example
@@ -7,11 +7,31 @@
 
 environment = "dev"
 
+# Dev Cognito lives in eu-west-2. Do not rely on the variable default.
+aws_region = "eu-west-2"
+
+# Must be a URL. Cognito resource binding only accepts custom scopes that belong
+# to this identifier, and the Blazor OIDC resource parameter uses the same value.
+cognito_api_resource_identifier = "https://fishing-logbook-dev-api.fly.dev"
+
 # cloudflare_account_id = "<from dash.cloudflare.com → account ID>"
 # r2_location           = "enam"
 
-# cognito_callback_urls = ["https://<your-dev-web-domain>/authentication/login-callback"]
-# cognito_logout_urls   = ["https://<your-dev-web-domain>/"]
+# Dev callback/logout URLs default to local HTTPS/HTTP plus the Cloudflare Pages origin.
+# Override only if those application URLs change. Do not add wildcards or unrelated domains.
+# cognito_callback_urls = [
+#   "https://localhost:7005/authentication/login-callback",
+#   "http://localhost:5019/authentication/login-callback",
+#   "https://fishing-logbook-dev.pages.dev/authentication/login-callback",
+# ]
+# cognito_logout_urls = [
+#   "https://localhost:7005/authentication/logout-callback",
+#   "https://localhost:7005/",
+#   "http://localhost:5019/authentication/logout-callback",
+#   "http://localhost:5019/",
+#   "https://fishing-logbook-dev.pages.dev/authentication/logout-callback",
+#   "https://fishing-logbook-dev.pages.dev/",
+# ]
 
 # neon_org_id     = "<neon-organisation-id>"
 # neon_region     = "aws-us-east-1"

--- a/infrastructure/terraform/environments/dev/variables.tf
+++ b/infrastructure/terraform/environments/dev/variables.tf
@@ -6,8 +6,14 @@ variable "environment" {
 
 variable "aws_region" {
   type        = string
-  description = "AWS region for Cognito resources."
+  description = "AWS region for Cognito resources. Dev must set this in terraform.tfvars."
   default     = "us-east-1"
+}
+
+variable "cognito_api_resource_identifier" {
+  type        = string
+  description = "Cognito resource-server identifier and RFC 8707 resource/aud URI. Must match Auth:ApiResource."
+  default     = "https://fishing-logbook-dev-api.fly.dev"
 }
 
 variable "cloudflare_account_id" {
@@ -24,14 +30,25 @@ variable "r2_location" {
 
 variable "cognito_callback_urls" {
   type        = list(string)
-  description = "Allowed OAuth callback URLs for the PWA app client."
-  default     = []
+  description = "Exact OAuth callback URLs for the PWA app client."
+  default = [
+    "https://localhost:7005/authentication/login-callback",
+    "http://localhost:5019/authentication/login-callback",
+    "https://fishing-logbook-dev.pages.dev/authentication/login-callback",
+  ]
 }
 
 variable "cognito_logout_urls" {
   type        = list(string)
-  description = "Allowed sign-out redirect URLs for the PWA app client."
-  default     = []
+  description = "Exact sign-out redirect URLs for the PWA app client."
+  default = [
+    "https://localhost:7005/authentication/logout-callback",
+    "https://localhost:7005/",
+    "http://localhost:5019/authentication/logout-callback",
+    "http://localhost:5019/",
+    "https://fishing-logbook-dev.pages.dev/authentication/logout-callback",
+    "https://fishing-logbook-dev.pages.dev/",
+  ]
 }
 
 variable "neon_region" {

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -1,8 +1,10 @@
 module "cognito" {
-  source        = "../../modules/cognito"
-  environment   = var.environment
-  callback_urls = var.cognito_callback_urls
-  logout_urls   = var.cognito_logout_urls
+  source                  = "../../modules/cognito"
+  environment             = var.environment
+  region                  = var.aws_region
+  api_resource_identifier = var.cognito_api_resource_identifier
+  callback_urls           = var.cognito_callback_urls
+  logout_urls             = var.cognito_logout_urls
 }
 
 module "neon" {

--- a/infrastructure/terraform/environments/prod/outputs.tf
+++ b/infrastructure/terraform/environments/prod/outputs.tf
@@ -3,6 +3,31 @@ output "cognito_resource_prefix" {
   value       = module.cognito.resource_prefix
 }
 
+output "cognito_user_pool_id" {
+  description = "Cognito user pool ID. Public identifier."
+  value       = module.cognito.user_pool_id
+}
+
+output "cognito_client_id" {
+  description = "Public PWA app client ID. Not a secret."
+  value       = module.cognito.client_id
+}
+
+output "cognito_authority" {
+  description = "OIDC issuer/authority for Blazor OIDC and API JWT validation."
+  value       = module.cognito.authority
+}
+
+output "cognito_hosted_ui_domain" {
+  description = "Cognito hosted UI / managed login hostname (no scheme)."
+  value       = module.cognito.hosted_ui_domain
+}
+
+output "cognito_api_scope" {
+  description = "Resource-server scope the PWA must request for FishingLogBook API access."
+  value       = module.cognito.api_scope
+}
+
 output "neon_project_name" {
   description = "Neon project name."
   value       = module.neon.project_name

--- a/infrastructure/terraform/environments/prod/terraform.tfvars.example
+++ b/infrastructure/terraform/environments/prod/terraform.tfvars.example
@@ -10,11 +10,17 @@
 
 environment = "prod"
 
+# cognito_api_resource_identifier = "https://<production-api-host>"
+
 # cloudflare_account_id = "<from dash.cloudflare.com → account ID>"
 # r2_location           = "enam"
 
+# Production callback URLs are required before apply. Do not guess the production domain.
 # cognito_callback_urls = ["https://<your-prod-web-domain>/authentication/login-callback"]
-# cognito_logout_urls   = ["https://<your-prod-web-domain>/"]
+# cognito_logout_urls = [
+#   "https://<your-prod-web-domain>/authentication/logout-callback",
+#   "https://<your-prod-web-domain>/",
+# ]
 
 # neon_org_id     = "<neon-organisation-id>"
 # neon_region     = "aws-us-east-1"

--- a/infrastructure/terraform/environments/prod/variables.tf
+++ b/infrastructure/terraform/environments/prod/variables.tf
@@ -10,6 +10,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "cognito_api_resource_identifier" {
+  type        = string
+  description = "Cognito resource-server identifier and RFC 8707 resource/aud URI. Set to the production API URL before applying prod."
+  default     = ""
+}
+
 variable "cloudflare_account_id" {
   type        = string
   description = "Cloudflare account ID that owns the Pages project and R2 bucket. Account-specific; supply locally, never commit."

--- a/infrastructure/terraform/modules/cognito/main.tf
+++ b/infrastructure/terraform/modules/cognito/main.tf
@@ -1,16 +1,138 @@
-# Amazon Cognito module (skeleton).
+# Amazon Cognito user pool, public PWA app client, hosted-UI domain, and API resource
+# server for one environment.
 #
-# This module will define the FishingLogBook Cognito user pool and app client for a
-# single environment. It intentionally declares NO resources yet: infrastructure is
-# only created deliberately and manually (see infrastructure/README.md).
+# The PWA is a public browser client: generate_secret is false. OAuth is Authorization
+# Code only (no implicit, no client_credentials). PKCE S256 is enforced by the Blazor
+# OIDC library against this public client.
 #
-# Planned resources (added only when explicitly approved):
-#   - aws_cognito_user_pool
-#   - aws_cognito_user_pool_client (Authorization Code + PKCE, no client secret)
-#   - aws_cognito_user_pool_domain
-#
-# The PWA must use Authorization Code flow with PKCE and must NOT use a client secret.
+# Destroying the user pool permanently deletes registered users. prevent_destroy and
+# deletion_protection are both set.
 
 locals {
   resource_prefix = "fishing-logbook-${var.environment}"
+  api_identifier  = var.api_resource_identifier
+  api_scope_name  = "access"
+}
+
+resource "aws_cognito_user_pool" "this" {
+  name = "${local.resource_prefix}-users"
+
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+  mfa_configuration        = "OFF"
+  deletion_protection      = "ACTIVE"
+  user_pool_tier           = "ESSENTIALS"
+
+  username_configuration {
+    case_sensitive = false
+  }
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  admin_create_user_config {
+    allow_admin_create_user_only = false
+  }
+
+  email_configuration {
+    email_sending_account = "COGNITO_DEFAULT"
+  }
+
+  password_policy {
+    minimum_length                   = 12
+    require_lowercase                = true
+    require_numbers                  = true
+    require_uppercase                = true
+    require_symbols                  = false
+    temporary_password_validity_days = 7
+  }
+
+  user_attribute_update_settings {
+    attributes_require_verification_before_update = ["email"]
+  }
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+  }
+
+  tags = {
+    Environment = var.environment
+    Name        = "${local.resource_prefix}-users"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_cognito_resource_server" "api" {
+  identifier   = local.api_identifier
+  name         = "${local.resource_prefix}-api"
+  user_pool_id = aws_cognito_user_pool.this.id
+
+  scope {
+    scope_name        = local.api_scope_name
+    scope_description = "Access the FishingLogBook API"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_cognito_user_pool_client" "pwa" {
+  name         = "${local.resource_prefix}-pwa"
+  user_pool_id = aws_cognito_user_pool.this.id
+
+  generate_secret                      = false
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["code"]
+  allowed_oauth_scopes = [
+    "openid",
+    "email",
+    "profile",
+    "${local.api_identifier}/${local.api_scope_name}",
+  ]
+  supported_identity_providers = ["COGNITO"]
+  callback_urls                = var.callback_urls
+  logout_urls                  = var.logout_urls
+
+  prevent_user_existence_errors = "ENABLED"
+  enable_token_revocation       = true
+  auth_session_validity         = 3
+
+  access_token_validity  = 1
+  id_token_validity      = 1
+  refresh_token_validity = 30
+
+  token_validity_units {
+    access_token  = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
+  }
+
+  refresh_token_rotation {
+    feature                    = "ENABLED"
+    retry_grace_period_seconds = 5
+  }
+
+  explicit_auth_flows = []
+
+  depends_on = [aws_cognito_resource_server.api]
+}
+
+resource "aws_cognito_user_pool_domain" "this" {
+  domain                = local.resource_prefix
+  user_pool_id          = aws_cognito_user_pool.this.id
+  managed_login_version = 2
+}
+
+resource "aws_cognito_managed_login_branding" "pwa" {
+  user_pool_id                = aws_cognito_user_pool.this.id
+  client_id                   = aws_cognito_user_pool_client.pwa.id
+  use_cognito_provided_values = true
 }

--- a/infrastructure/terraform/modules/cognito/main.tf
+++ b/infrastructure/terraform/modules/cognito/main.tf
@@ -1,5 +1,5 @@
-# Amazon Cognito user pool, public PWA app client, hosted-UI domain, and API resource
-# server for one environment.
+# Amazon Cognito user pool, resource server, public PWA app client, hosted-UI domain,
+# and managed-login branding for one environment.
 #
 # The PWA is a public browser client: generate_secret is false. OAuth is Authorization
 # Code only (no implicit, no client_credentials). PKCE S256 is enforced by the Blazor

--- a/infrastructure/terraform/modules/cognito/outputs.tf
+++ b/infrastructure/terraform/modules/cognito/outputs.tf
@@ -1,4 +1,29 @@
 output "resource_prefix" {
-  description = "Naming prefix that Cognito resources will use once defined."
+  description = "Naming prefix used by Cognito resources."
   value       = local.resource_prefix
+}
+
+output "user_pool_id" {
+  description = "Cognito user pool ID. Public identifier."
+  value       = aws_cognito_user_pool.this.id
+}
+
+output "client_id" {
+  description = "Public PWA app client ID. Not a secret."
+  value       = aws_cognito_user_pool_client.pwa.id
+}
+
+output "authority" {
+  description = "OIDC issuer/authority for Blazor OIDC and API JWT validation."
+  value       = "https://cognito-idp.${var.region}.amazonaws.com/${aws_cognito_user_pool.this.id}"
+}
+
+output "hosted_ui_domain" {
+  description = "Cognito hosted UI / managed login hostname (no scheme)."
+  value       = "${aws_cognito_user_pool_domain.this.domain}.auth.${var.region}.amazoncognito.com"
+}
+
+output "api_scope" {
+  description = "Resource-server scope the PWA must request for FishingLogBook API access."
+  value       = "${local.api_identifier}/${local.api_scope_name}"
 }

--- a/infrastructure/terraform/modules/cognito/variables.tf
+++ b/infrastructure/terraform/modules/cognito/variables.tf
@@ -3,14 +3,58 @@ variable "environment" {
   description = "Deployment environment name (for example: dev or prod)."
 }
 
+variable "region" {
+  type        = string
+  description = "AWS region that hosts the user pool (used to build issuer and hosted-UI URLs)."
+}
+
+variable "api_resource_identifier" {
+  type        = string
+  description = "Cognito resource-server identifier and RFC 8707 resource/aud URI. Must be an https URL so custom scopes can be requested with resource binding."
+}
+
 variable "callback_urls" {
   type        = list(string)
-  description = "Allowed OAuth callback URLs for the PWA app client."
-  default     = []
+  description = "Exact OAuth callback URLs for the PWA app client. No wildcards."
+
+  validation {
+    condition     = length(var.callback_urls) > 0
+    error_message = "At least one callback URL is required when OAuth is enabled."
+  }
+
+  validation {
+    condition = alltrue([
+      for url in var.callback_urls : !strcontains(url, "*") && (
+        startswith(url, "https://") ||
+        startswith(url, "http://localhost:") ||
+        startswith(url, "http://localhost/") ||
+        startswith(url, "http://127.0.0.1:") ||
+        startswith(url, "http://127.0.0.1/")
+      )
+    ])
+    error_message = "Callback URLs must be exact (no wildcards). HTTPS is required except for localhost HTTP."
+  }
 }
 
 variable "logout_urls" {
   type        = list(string)
-  description = "Allowed sign-out redirect URLs for the PWA app client."
-  default     = []
+  description = "Exact sign-out redirect URLs for the PWA app client. No wildcards."
+
+  validation {
+    condition     = length(var.logout_urls) > 0
+    error_message = "At least one logout URL is required when OAuth is enabled."
+  }
+
+  validation {
+    condition = alltrue([
+      for url in var.logout_urls : !strcontains(url, "*") && (
+        startswith(url, "https://") ||
+        startswith(url, "http://localhost:") ||
+        startswith(url, "http://localhost/") ||
+        startswith(url, "http://127.0.0.1:") ||
+        startswith(url, "http://127.0.0.1/")
+      )
+    ])
+    error_message = "Logout URLs must be exact (no wildcards). HTTPS is required except for localhost HTTP."
+  }
 }

--- a/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
+++ b/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
@@ -42,7 +42,7 @@ public static class AuthenticationExtensions
         };
 
         options.Authority = authConfig.Authority;
-        options.RequireHttpsMetadata = authConfig.Authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+        options.RequireHttpsMetadata = true;
         options.MetadataAddress = $"{authConfig.Authority.TrimEnd('/')}/.well-known/openid-configuration";
     }
 

--- a/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
+++ b/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
@@ -2,7 +2,7 @@ using System.Security.Claims;
 using FishingLogBook.Api.Configuration;
 using FishingLogBook.Shared.Constants;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
 namespace FishingLogBook.Api.Authentication;
@@ -11,17 +11,24 @@ public static class AuthenticationExtensions
 {
     public static IServiceCollection AddFishingLogBookJwtBearer(
         this IServiceCollection services,
-        AuthConfig authConfig)
+        IConfiguration configuration)
     {
-        services.AddSingleton(authConfig);
+        services.AddOptions<AuthConfig>()
+            .Bind(configuration.GetSection(AuthConfig.SectionName))
+            .ValidateOnStart();
+        services.AddSingleton<IValidateOptions<AuthConfig>, AuthConfigStartupValidator>();
+        services.AddSingleton(sp => sp.GetRequiredService<IOptions<AuthConfig>>().Value);
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(options => ConfigureJwtBearer(options, authConfig));
+            .AddJwtBearer();
+        services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+            .Configure<AuthConfig>(ConfigureJwtBearer);
         services.AddAuthorization();
         return services;
     }
 
     private static void ConfigureJwtBearer(JwtBearerOptions options, AuthConfig authConfig)
     {
+        authConfig.EnsureRequired();
         options.MapInboundClaims = false;
         options.IncludeErrorDetails = false;
         options.TokenValidationParameters = CreateValidationParameters(authConfig);
@@ -34,16 +41,6 @@ public static class AuthenticationExtensions
             }
         };
 
-        if (string.IsNullOrWhiteSpace(authConfig.Authority))
-        {
-            options.RequireHttpsMetadata = false;
-            options.Configuration = new OpenIdConnectConfiguration
-            {
-                Issuer = "unconfigured"
-            };
-            return;
-        }
-
         options.Authority = authConfig.Authority;
         options.RequireHttpsMetadata = authConfig.Authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
         options.MetadataAddress = $"{authConfig.Authority.TrimEnd('/')}/.well-known/openid-configuration";
@@ -51,15 +48,12 @@ public static class AuthenticationExtensions
 
     private static TokenValidationParameters CreateValidationParameters(AuthConfig authConfig)
     {
-        var issuer = string.IsNullOrWhiteSpace(authConfig.Authority) ? "unconfigured" : authConfig.Authority;
         return new TokenValidationParameters
         {
             ValidateIssuer = true,
-            ValidIssuer = issuer,
+            ValidIssuer = authConfig.Authority,
             ValidateAudience = true,
-            ValidAudience = string.IsNullOrWhiteSpace(authConfig.ApiResource)
-                ? AuthConstants.DevApiResourceUri
-                : authConfig.ApiResource,
+            ValidAudience = authConfig.ApiResource,
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,
             ClockSkew = TimeSpan.FromSeconds(30)
@@ -87,7 +81,7 @@ public static class AuthenticationExtensions
             return Task.CompletedTask;
         }
 
-        if (!string.IsNullOrWhiteSpace(authConfig.ApiScope) && !HasScope(principal, authConfig.ApiScope))
+        if (!HasScope(principal, authConfig.ApiScope))
         {
             context.Fail("Missing required scope.");
             return Task.CompletedTask;
@@ -107,5 +101,21 @@ public static class AuthenticationExtensions
         var scopes = principal.FindAll("scope")
             .SelectMany(claim => claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
         return scopes.Contains(requiredScope, StringComparer.Ordinal);
+    }
+
+    private sealed class AuthConfigStartupValidator : IValidateOptions<AuthConfig>
+    {
+        public ValidateOptionsResult Validate(string? name, AuthConfig options)
+        {
+            try
+            {
+                options.EnsureRequired();
+                return ValidateOptionsResult.Success;
+            }
+            catch (InvalidOperationException exception)
+            {
+                return ValidateOptionsResult.Fail(exception.Message);
+            }
+        }
     }
 }

--- a/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
+++ b/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
@@ -1,0 +1,111 @@
+using System.Security.Claims;
+using FishingLogBook.Api.Configuration;
+using FishingLogBook.Shared.Constants;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FishingLogBook.Api.Authentication;
+
+public static class AuthenticationExtensions
+{
+    public static IServiceCollection AddFishingLogBookJwtBearer(
+        this IServiceCollection services,
+        AuthConfig authConfig)
+    {
+        services.AddSingleton(authConfig);
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options => ConfigureJwtBearer(options, authConfig));
+        services.AddAuthorization();
+        return services;
+    }
+
+    private static void ConfigureJwtBearer(JwtBearerOptions options, AuthConfig authConfig)
+    {
+        options.MapInboundClaims = false;
+        options.IncludeErrorDetails = false;
+        options.TokenValidationParameters = CreateValidationParameters(authConfig);
+        options.Events = new JwtBearerEvents
+        {
+            OnTokenValidated = context =>
+            {
+                var config = context.HttpContext.RequestServices.GetRequiredService<AuthConfig>();
+                return ValidateAccessToken(context, config);
+            }
+        };
+
+        if (string.IsNullOrWhiteSpace(authConfig.Authority))
+        {
+            options.RequireHttpsMetadata = false;
+            options.Configuration = new OpenIdConnectConfiguration
+            {
+                Issuer = "unconfigured"
+            };
+            return;
+        }
+
+        options.Authority = authConfig.Authority;
+        options.RequireHttpsMetadata = authConfig.Authority.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+        options.MetadataAddress = $"{authConfig.Authority.TrimEnd('/')}/.well-known/openid-configuration";
+    }
+
+    private static TokenValidationParameters CreateValidationParameters(AuthConfig authConfig)
+    {
+        var issuer = string.IsNullOrWhiteSpace(authConfig.Authority) ? "unconfigured" : authConfig.Authority;
+        return new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = issuer,
+            ValidateAudience = true,
+            ValidAudience = string.IsNullOrWhiteSpace(authConfig.ApiResource)
+                ? AuthConstants.DevApiResourceUri
+                : authConfig.ApiResource,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ClockSkew = TimeSpan.FromSeconds(30)
+        };
+    }
+
+    private static Task ValidateAccessToken(TokenValidatedContext context, AuthConfig authConfig)
+    {
+        var principal = context.Principal;
+        if (principal is null)
+        {
+            context.Fail("Missing principal.");
+            return Task.CompletedTask;
+        }
+
+        if (!HasClaim(principal, "token_use", AuthConstants.TokenUseAccess))
+        {
+            context.Fail("Access token required.");
+            return Task.CompletedTask;
+        }
+
+        if (!HasClaim(principal, "client_id", authConfig.ClientId))
+        {
+            context.Fail("Invalid client.");
+            return Task.CompletedTask;
+        }
+
+        if (!string.IsNullOrWhiteSpace(authConfig.ApiScope) && !HasScope(principal, authConfig.ApiScope))
+        {
+            context.Fail("Missing required scope.");
+            return Task.CompletedTask;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static bool HasClaim(ClaimsPrincipal principal, string type, string expected)
+    {
+        var value = principal.FindFirst(type)?.Value;
+        return string.Equals(value, expected, StringComparison.Ordinal);
+    }
+
+    private static bool HasScope(ClaimsPrincipal principal, string requiredScope)
+    {
+        var scopes = principal.FindAll("scope")
+            .SelectMany(claim => claim.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        return scopes.Contains(requiredScope, StringComparer.Ordinal);
+    }
+}

--- a/src/FishingLogBook.Api/Configuration/AuthConfig.cs
+++ b/src/FishingLogBook.Api/Configuration/AuthConfig.cs
@@ -11,4 +11,34 @@ public sealed class AuthConfig
     public string ApiScope { get; set; } = string.Empty;
 
     public string ApiResource { get; set; } = string.Empty;
+
+    public void EnsureRequired()
+    {
+        var missing = new List<string>();
+        if (string.IsNullOrWhiteSpace(Authority))
+        {
+            missing.Add("Auth:Authority");
+        }
+
+        if (string.IsNullOrWhiteSpace(ClientId))
+        {
+            missing.Add("Auth:ClientId");
+        }
+
+        if (string.IsNullOrWhiteSpace(ApiResource))
+        {
+            missing.Add("Auth:ApiResource");
+        }
+
+        if (string.IsNullOrWhiteSpace(ApiScope))
+        {
+            missing.Add("Auth:ApiScope");
+        }
+
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Auth configuration is incomplete. Missing or empty: " + string.Join(", ", missing) + ".");
+        }
+    }
 }

--- a/src/FishingLogBook.Api/Configuration/AuthConfig.cs
+++ b/src/FishingLogBook.Api/Configuration/AuthConfig.cs
@@ -1,0 +1,14 @@
+namespace FishingLogBook.Api.Configuration;
+
+public sealed class AuthConfig
+{
+    public const string SectionName = "Auth";
+
+    public string Authority { get; set; } = string.Empty;
+
+    public string ClientId { get; set; } = string.Empty;
+
+    public string ApiScope { get; set; } = string.Empty;
+
+    public string ApiResource { get; set; } = string.Empty;
+}

--- a/src/FishingLogBook.Api/Configuration/AuthConfig.cs
+++ b/src/FishingLogBook.Api/Configuration/AuthConfig.cs
@@ -40,5 +40,17 @@ public sealed class AuthConfig
             throw new InvalidOperationException(
                 "Auth configuration is incomplete. Missing or empty: " + string.Join(", ", missing) + ".");
         }
+
+        if (!IsAbsoluteHttpsUri(Authority))
+        {
+            throw new InvalidOperationException("Auth:Authority must be an absolute HTTPS URI.");
+        }
+    }
+
+    private static bool IsAbsoluteHttpsUri(string value)
+    {
+        return Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            && string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(uri.Host);
     }
 }

--- a/src/FishingLogBook.Api/Endpoints/TestCatchEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/TestCatchEndpoints.cs
@@ -10,27 +10,35 @@ public static class TestCatchEndpoints
         endpoints.MapPost("/api/test-catches", UpsertAsync)
             .WithName("UpsertTestCatch")
             .WithTags("TestCatch")
+            .RequireAuthorization()
             .Produces<TestCatchDto>(StatusCodes.Status200OK)
-            .Produces(StatusCodes.Status400BadRequest);
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized);
 
         endpoints.MapGet("/api/test-catches", ListAsync)
             .WithName("ListTestCatches")
             .WithTags("TestCatch")
-            .Produces<IReadOnlyList<TestCatchDto>>(StatusCodes.Status200OK);
+            .RequireAuthorization()
+            .Produces<IReadOnlyList<TestCatchDto>>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized);
 
         endpoints.MapPost("/api/test-catches/{id:guid}/photographs/upload-url", CreatePhotographUploadAsync)
             .WithName("CreateTestCatchPhotographUpload")
             .WithTags("TestCatch")
+            .RequireAuthorization()
             .Produces<PhotographUploadDto>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status503ServiceUnavailable);
 
         endpoints.MapPost("/api/test-catches/{id:guid}/photographs", RecordPhotographAsync)
             .WithName("RecordTestCatchPhotograph")
             .WithTags("TestCatch")
+            .RequireAuthorization()
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
 
         return endpoints;

--- a/src/FishingLogBook.Api/FishingLogBook.Api.csproj
+++ b/src/FishingLogBook.Api/FishingLogBook.Api.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" />

--- a/src/FishingLogBook.Api/FishingLogBook.Api.http
+++ b/src/FishingLogBook.Api/FishingLogBook.Api.http
@@ -10,4 +10,10 @@ Accept: application/json
 GET {{FishingLogBook.Api_HostAddress}}/api/system/database
 Accept: application/json
 
+### TestCatch (requires a Cognito access token; never commit real tokens)
+
+GET {{FishingLogBook.Api_HostAddress}}/api/test-catches
+Accept: application/json
+Authorization: Bearer <access-token>
+
 ###

--- a/src/FishingLogBook.Api/Program.cs
+++ b/src/FishingLogBook.Api/Program.cs
@@ -4,7 +4,6 @@ using FishingLogBook.Api.Endpoints;
 using FishingLogBook.Api.Logging;
 using FishingLogBook.Api.Middleware;
 using FishingLogBook.DependencyInjection;
-using FishingLogBook.Shared.Constants;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -16,19 +15,7 @@ const string webClientCorsPolicy = "WebClient";
 
 builder.Services.AddFishingLogBook(builder.Configuration);
 builder.Services.AddOpenApi();
-
-var authConfig = builder.Configuration.GetSection(AuthConfig.SectionName).Get<AuthConfig>() ?? new AuthConfig();
-if (string.IsNullOrWhiteSpace(authConfig.ApiScope))
-{
-    authConfig.ApiScope = AuthConstants.ApiScope;
-}
-
-if (string.IsNullOrWhiteSpace(authConfig.ApiResource))
-{
-    authConfig.ApiResource = AuthConstants.DevApiResourceUri;
-}
-
-builder.Services.AddFishingLogBookJwtBearer(authConfig);
+builder.Services.AddFishingLogBookJwtBearer(builder.Configuration);
 
 builder.Services.AddCors(options =>
 {
@@ -49,6 +36,7 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+_ = app.Services.GetRequiredService<AuthConfig>();
 
 app.Logger.LogInformation(
     "FishingLogBook API starting in {HostingEnvironment} environment.",

--- a/src/FishingLogBook.Api/Program.cs
+++ b/src/FishingLogBook.Api/Program.cs
@@ -1,7 +1,10 @@
+using FishingLogBook.Api.Authentication;
+using FishingLogBook.Api.Configuration;
 using FishingLogBook.Api.Endpoints;
 using FishingLogBook.Api.Logging;
 using FishingLogBook.Api.Middleware;
 using FishingLogBook.DependencyInjection;
+using FishingLogBook.Shared.Constants;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -14,22 +17,34 @@ const string webClientCorsPolicy = "WebClient";
 builder.Services.AddFishingLogBook(builder.Configuration);
 builder.Services.AddOpenApi();
 
+var authConfig = builder.Configuration.GetSection(AuthConfig.SectionName).Get<AuthConfig>() ?? new AuthConfig();
+if (string.IsNullOrWhiteSpace(authConfig.ApiScope))
+{
+    authConfig.ApiScope = AuthConstants.ApiScope;
+}
+
+if (string.IsNullOrWhiteSpace(authConfig.ApiResource))
+{
+    authConfig.ApiResource = AuthConstants.DevApiResourceUri;
+}
+
+builder.Services.AddFishingLogBookJwtBearer(authConfig);
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(webClientCorsPolicy, policy =>
     {
         var allowedOrigins = builder.Configuration
             .GetSection("Cors:AllowedOrigins")
-            .Get<string[]>() ?? Array.Empty<string>();
+            .Get<string[]>() ?? [];
 
-        if (allowedOrigins.Length > 0)
+        if (allowedOrigins.Length == 0)
         {
-            policy.WithOrigins(allowedOrigins).AllowAnyHeader().AllowAnyMethod();
+            policy.SetIsOriginAllowed(_ => false).AllowAnyHeader().AllowAnyMethod();
+            return;
         }
-        else
-        {
-            policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
-        }
+
+        policy.WithOrigins(allowedOrigins).AllowAnyHeader().AllowAnyMethod();
     });
 });
 
@@ -52,6 +67,8 @@ if (app.Environment.IsDevelopment())
 
 app.UseCors(webClientCorsPolicy);
 app.UseMiddleware<CorrelationIdMiddleware>();
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapSystemEndpoints();
 app.MapTestCatchEndpoints();

--- a/src/FishingLogBook.Api/appsettings.Development.json
+++ b/src/FishingLogBook.Api/appsettings.Development.json
@@ -11,6 +11,12 @@
       "http://localhost:5019"
     ]
   },
+  "Auth": {
+    "Authority": "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06",
+    "ClientId": "e80socqio7bpv79or57fb1e5l",
+    "ApiScope": "https://fishing-logbook-dev-api.fly.dev/access",
+    "ApiResource": "https://fishing-logbook-dev-api.fly.dev"
+  },
   "ObjectStorage": {
     "BucketName": "fishing-logbook-dev",
     "ServiceUrl": "set in user secrets fishinglogbook-api",

--- a/src/FishingLogBook.Api/appsettings.json
+++ b/src/FishingLogBook.Api/appsettings.json
@@ -12,6 +12,12 @@
   "Cors": {
     "AllowedOrigins": []
   },
+  "Auth": {
+    "Authority": "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06",
+    "ClientId": "e80socqio7bpv79or57fb1e5l",
+    "ApiScope": "https://fishing-logbook-dev-api.fly.dev/access",
+    "ApiResource": "https://fishing-logbook-dev-api.fly.dev"
+  },
   "ObjectStorage": {
     "ServiceUrl": "set in user secrets fishinglogbook-api",
     "BucketName": "fishing-logbook-dev",

--- a/src/FishingLogBook.Api/appsettings.json
+++ b/src/FishingLogBook.Api/appsettings.json
@@ -13,10 +13,10 @@
     "AllowedOrigins": []
   },
   "Auth": {
-    "Authority": "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06",
-    "ClientId": "e80socqio7bpv79or57fb1e5l",
-    "ApiScope": "https://fishing-logbook-dev-api.fly.dev/access",
-    "ApiResource": "https://fishing-logbook-dev-api.fly.dev"
+    "Authority": "",
+    "ClientId": "",
+    "ApiScope": "",
+    "ApiResource": ""
   },
   "ObjectStorage": {
     "ServiceUrl": "set in user secrets fishinglogbook-api",

--- a/src/FishingLogBook.Shared/Constants/AuthConstants.cs
+++ b/src/FishingLogBook.Shared/Constants/AuthConstants.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Shared.Constants;
+
+public static class AuthConstants
+{
+    public const string DevApiResourceUri = "https://fishing-logbook-dev-api.fly.dev";
+    public const string ApiScope = DevApiResourceUri + "/access";
+    public const string TokenUseAccess = "access";
+    public const string TokenUseId = "id";
+}

--- a/src/FishingLogBook.Shared/Constants/AuthConstants.cs
+++ b/src/FishingLogBook.Shared/Constants/AuthConstants.cs
@@ -2,8 +2,6 @@ namespace FishingLogBook.Shared.Constants;
 
 public static class AuthConstants
 {
-    public const string DevApiResourceUri = "https://fishing-logbook-dev-api.fly.dev";
-    public const string ApiScope = DevApiResourceUri + "/access";
     public const string TokenUseAccess = "access";
     public const string TokenUseId = "id";
 }

--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
@@ -44,4 +44,10 @@ public static class DiagnosticEventNames
 
     public const string LocationPermissionDenied = "LocationPermissionDenied";
     public const string LocationCaptureFailed = "LocationCaptureFailed";
+
+    public const string AuthStarted = "AuthStarted";
+    public const string AuthSucceeded = "AuthSucceeded";
+    public const string AuthFailed = "AuthFailed";
+    public const string TokenUnavailable = "TokenUnavailable";
+    public const string ApiUnauthorized = "ApiUnauthorized";
 }

--- a/src/FishingLogBook.Web/App.razor
+++ b/src/FishingLogBook.Web/App.razor
@@ -1,6 +1,15 @@
-﻿<Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(FishingLogBook.Web.Pages.NotFound.NotFound)">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-    </Found>
-</Router>
+﻿@using Microsoft.AspNetCore.Components.Authorization
+@using FishingLogBook.Web.Features.Authentication.Components.RedirectToLogin
+
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(FishingLogBook.Web.Pages.NotFound.NotFound)">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    <RedirectToLogin />
+                </NotAuthorized>
+            </AuthorizeRouteView>
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+    </Router>
+</CascadingAuthenticationState>

--- a/src/FishingLogBook.Web/Configuration/AuthConfig.cs
+++ b/src/FishingLogBook.Web/Configuration/AuthConfig.cs
@@ -11,4 +11,34 @@ public sealed class AuthConfig
     public string ApiScope { get; set; } = string.Empty;
 
     public string ApiResource { get; set; } = string.Empty;
+
+    public void EnsureRequired()
+    {
+        var missing = new List<string>();
+        if (string.IsNullOrWhiteSpace(Authority))
+        {
+            missing.Add("Auth:Authority");
+        }
+
+        if (string.IsNullOrWhiteSpace(ClientId))
+        {
+            missing.Add("Auth:ClientId");
+        }
+
+        if (string.IsNullOrWhiteSpace(ApiResource))
+        {
+            missing.Add("Auth:ApiResource");
+        }
+
+        if (string.IsNullOrWhiteSpace(ApiScope))
+        {
+            missing.Add("Auth:ApiScope");
+        }
+
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Auth configuration is incomplete. Missing or empty: " + string.Join(", ", missing) + ".");
+        }
+    }
 }

--- a/src/FishingLogBook.Web/Configuration/AuthConfig.cs
+++ b/src/FishingLogBook.Web/Configuration/AuthConfig.cs
@@ -1,0 +1,14 @@
+namespace FishingLogBook.Web.Configuration;
+
+public sealed class AuthConfig
+{
+    public const string SectionName = "Auth";
+
+    public string Authority { get; set; } = string.Empty;
+
+    public string ClientId { get; set; } = string.Empty;
+
+    public string ApiScope { get; set; } = string.Empty;
+
+    public string ApiResource { get; set; } = string.Empty;
+}

--- a/src/FishingLogBook.Web/Configuration/HttpClientNames.cs
+++ b/src/FishingLogBook.Web/Configuration/HttpClientNames.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Web.Configuration;
+
+public static class HttpClientNames
+{
+    public const string AuthorizedApi = "FishingLogBook.Api";
+
+    public const string Anonymous = "FishingLogBook.Anonymous";
+}

--- a/src/FishingLogBook.Web/Features/Authentication/Components/LoginDisplay/LoginDisplay.razor
+++ b/src/FishingLogBook.Web/Features/Authentication/Components/LoginDisplay/LoginDisplay.razor
@@ -1,0 +1,24 @@
+<AuthorizeView>
+    <Authorized>
+        <MudButton Variant="Variant.Text"
+                   Color="Color.Inherit"
+                   OnClick="BeginSignOut"
+                   id="auth-sign-out-button">
+            @Loc["Auth_SignOut"]
+        </MudButton>
+    </Authorized>
+    <NotAuthorized>
+        <MudButton Variant="Variant.Text"
+                   Color="Color.Inherit"
+                   OnClick="BeginSignIn"
+                   id="auth-sign-in-button">
+            @Loc["Auth_SignIn"]
+        </MudButton>
+        <MudButton Variant="Variant.Text"
+                   Color="Color.Inherit"
+                   OnClick="BeginSignIn"
+                   id="auth-create-account-button">
+            @Loc["Auth_CreateAccount"]
+        </MudButton>
+    </NotAuthorized>
+</AuthorizeView>

--- a/src/FishingLogBook.Web/Features/Authentication/Components/LoginDisplay/LoginDisplay.razor.cs
+++ b/src/FishingLogBook.Web/Features/Authentication/Components/LoginDisplay/LoginDisplay.razor.cs
@@ -1,0 +1,25 @@
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Authentication.Components.LoginDisplay;
+
+public partial class LoginDisplay : ComponentBase
+{
+    [Inject]
+    private NavigationManager Navigation { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private void BeginSignIn()
+    {
+        Navigation.NavigateToLogin("authentication/login");
+    }
+
+    private void BeginSignOut()
+    {
+        Navigation.NavigateToLogout("authentication/logout");
+    }
+}

--- a/src/FishingLogBook.Web/Features/Authentication/Components/RedirectToLogin/RedirectToLogin.razor.cs
+++ b/src/FishingLogBook.Web/Features/Authentication/Components/RedirectToLogin/RedirectToLogin.razor.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+
+namespace FishingLogBook.Web.Features.Authentication.Components.RedirectToLogin;
+
+public partial class RedirectToLogin : ComponentBase
+{
+    [Inject]
+    private NavigationManager Navigation { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        Navigation.NavigateToLogin("authentication/login");
+    }
+}

--- a/src/FishingLogBook.Web/Features/Authentication/Pages/Authentication/Authentication.razor
+++ b/src/FishingLogBook.Web/Features/Authentication/Pages/Authentication/Authentication.razor
@@ -1,0 +1,3 @@
+@page "/authentication/{action}"
+
+<RemoteAuthenticatorView Action="@Action" />

--- a/src/FishingLogBook.Web/Features/Authentication/Pages/Authentication/Authentication.razor.cs
+++ b/src/FishingLogBook.Web/Features/Authentication/Pages/Authentication/Authentication.razor.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Components;
+
+namespace FishingLogBook.Web.Features.Authentication.Pages.Authentication;
+
+public partial class Authentication : ComponentBase
+{
+    [Parameter]
+    public string? Action { get; set; }
+}

--- a/src/FishingLogBook.Web/Features/TestCatch/Pages/TestCatchLog/TestCatchLog.razor
+++ b/src/FishingLogBook.Web/Features/TestCatch/Pages/TestCatchLog/TestCatchLog.razor
@@ -1,5 +1,7 @@
 @page "/test-catch"
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Forms
+@attribute [Authorize]
 
 <PageTitle>@Loc["TestCatch_PageTitle"]</PageTitle>
 

--- a/src/FishingLogBook.Web/Features/TestCatch/Services/TestCatchClient.cs
+++ b/src/FishingLogBook.Web/Features/TestCatch/Services/TestCatchClient.cs
@@ -1,28 +1,31 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.TestCatch.Models;
 
 namespace FishingLogBook.Web.Features.TestCatch.Services;
 
 public sealed class TestCatchClient : ITestCatchClient
 {
-    private readonly HttpClient _httpClient;
+    private readonly HttpClient _apiClient;
+    private readonly HttpClient _anonymousClient;
 
-    public TestCatchClient(HttpClient httpClient)
+    public TestCatchClient(IHttpClientFactory httpClientFactory)
     {
-        _httpClient = httpClient;
+        _apiClient = httpClientFactory.CreateClient(HttpClientNames.AuthorizedApi);
+        _anonymousClient = httpClientFactory.CreateClient(HttpClientNames.Anonymous);
     }
 
     public async Task UpsertAsync(TestCatchDto testCatch, CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.PostAsJsonAsync("api/test-catches", testCatch, cancellationToken);
+        using var response = await _apiClient.PostAsJsonAsync("api/test-catches", testCatch, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task<IReadOnlyList<TestCatchDto>> GetAllAsync(CancellationToken cancellationToken)
     {
-        var catches = await _httpClient.GetFromJsonAsync<IReadOnlyList<TestCatchDto>>(
+        var catches = await _apiClient.GetFromJsonAsync<IReadOnlyList<TestCatchDto>>(
             "api/test-catches",
             cancellationToken);
 
@@ -34,7 +37,7 @@ public sealed class TestCatchClient : ITestCatchClient
         PhotographUploadRequestDto request,
         CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.PostAsJsonAsync(
+        using var response = await _apiClient.PostAsJsonAsync(
             $"api/test-catches/{testCatchId:D}/photographs/upload-url",
             request,
             cancellationToken);
@@ -51,7 +54,7 @@ public sealed class TestCatchClient : ITestCatchClient
     {
         using var content = new ByteArrayContent(bytes);
         content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-        using var response = await _httpClient.PutAsync(uploadUrl, content, cancellationToken);
+        using var response = await _anonymousClient.PutAsync(uploadUrl, content, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
@@ -60,7 +63,7 @@ public sealed class TestCatchClient : ITestCatchClient
         RecordPhotographDto request,
         CancellationToken cancellationToken)
     {
-        using var response = await _httpClient.PostAsJsonAsync(
+        using var response = await _apiClient.PostAsJsonAsync(
             $"api/test-catches/{testCatchId:D}/photographs",
             request,
             cancellationToken);

--- a/src/FishingLogBook.Web/FishingLogBook.Web.csproj
+++ b/src/FishingLogBook.Web/FishingLogBook.Web.csproj
@@ -13,7 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
     <PackageReference Include="MudBlazor" />
   </ItemGroup>

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
@@ -22,6 +22,7 @@
             @Loc["Diagnostics_Nav"]
         </MudButton>
         <LanguageSwitcher />
+        <LoginDisplay />
         <MudIconButton Icon="@ThemeToggleIcon"
                        Color="Color.Inherit"
                        Edge="Edge.End"

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -252,4 +252,13 @@
   <data name="Diagnostics_ProductionNotInitialised" xml:space="preserve">
     <value>Base de données de diagnostic de production non initialisée</value>
   </data>
+  <data name="Auth_SignIn" xml:space="preserve">
+    <value>Connexion</value>
+  </data>
+  <data name="Auth_CreateAccount" xml:space="preserve">
+    <value>Créer un compte</value>
+  </data>
+  <data name="Auth_SignOut" xml:space="preserve">
+    <value>Déconnexion</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -252,4 +252,13 @@
   <data name="Diagnostics_ProductionNotInitialised" xml:space="preserve">
     <value>Production diagnostic database not initialised</value>
   </data>
+  <data name="Auth_SignIn" xml:space="preserve">
+    <value>Sign in</value>
+  </data>
+  <data name="Auth_CreateAccount" xml:space="preserve">
+    <value>Create account</value>
+  </data>
+  <data name="Auth_SignOut" xml:space="preserve">
+    <value>Sign out</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Program.cs
+++ b/src/FishingLogBook.Web/Program.cs
@@ -1,4 +1,3 @@
-using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Localization;
@@ -19,15 +18,7 @@ if (string.Equals(diagnosticsConfig.MinimumPersistLevel, "Warning", StringCompar
 }
 
 var authConfig = builder.Configuration.GetSection(AuthConfig.SectionName).Get<AuthConfig>() ?? new AuthConfig();
-if (string.IsNullOrWhiteSpace(authConfig.ApiScope))
-{
-    authConfig.ApiScope = AuthConstants.ApiScope;
-}
-
-if (string.IsNullOrWhiteSpace(authConfig.ApiResource))
-{
-    authConfig.ApiResource = AuthConstants.DevApiResourceUri;
-}
+authConfig.EnsureRequired();
 
 var apiBaseAddress = string.IsNullOrWhiteSpace(apiConfig.BaseUrl)
     ? builder.HostEnvironment.BaseAddress

--- a/src/FishingLogBook.Web/Program.cs
+++ b/src/FishingLogBook.Web/Program.cs
@@ -1,3 +1,4 @@
+using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Localization;
@@ -17,11 +18,22 @@ if (string.Equals(diagnosticsConfig.MinimumPersistLevel, "Warning", StringCompar
     diagnosticsConfig.MinimumPersistLevel = "Information";
 }
 
+var authConfig = builder.Configuration.GetSection(AuthConfig.SectionName).Get<AuthConfig>() ?? new AuthConfig();
+if (string.IsNullOrWhiteSpace(authConfig.ApiScope))
+{
+    authConfig.ApiScope = AuthConstants.ApiScope;
+}
+
+if (string.IsNullOrWhiteSpace(authConfig.ApiResource))
+{
+    authConfig.ApiResource = AuthConstants.DevApiResourceUri;
+}
+
 var apiBaseAddress = string.IsNullOrWhiteSpace(apiConfig.BaseUrl)
     ? builder.HostEnvironment.BaseAddress
     : apiConfig.BaseUrl;
 
-builder.Services.AddFishingLogBookWeb(apiConfig, diagnosticsConfig, new Uri(apiBaseAddress));
+builder.Services.AddFishingLogBookWeb(apiConfig, diagnosticsConfig, authConfig, new Uri(apiBaseAddress));
 
 var host = builder.Build();
 await host.Services.GetRequiredService<ICultureService>().InitializeAsync();

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using FishingLogBook.Web.Features.TestCatch.Models;
 using FishingLogBook.Web.Features.TestCatch.Offline;
 using FishingLogBook.Web.Features.TestCatch.Services;
 using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
 using MudBlazor.Services;
@@ -21,22 +22,25 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         ApiConfig apiConfig,
         DiagnosticsClientConfig diagnosticsConfig,
+        AuthConfig authConfig,
         Uri apiBaseAddress)
     {
         services.AddSingleton(apiConfig);
         services.AddSingleton(diagnosticsConfig);
+        services.AddSingleton(authConfig);
         services.AddScoped<CorrelationContext>();
-        services.AddScoped(sp =>
+        services.AddTransient<CorrelationDelegatingHandler>();
+        services.AddTransient(sp => CreateApiAuthorizationMessageHandler(sp, authConfig, apiBaseAddress));
+        RegisterHttpClients(services, apiBaseAddress);
+        services.AddHttpClient<ISystemStatusClient, SystemStatusClient>(client =>
         {
-            var handler = new CorrelationDelegatingHandler(sp.GetRequiredService<CorrelationContext>())
-            {
-                InnerHandler = new HttpClientHandler()
-            };
-            return new HttpClient(handler) { BaseAddress = apiBaseAddress };
-        });
-        services.AddScoped<ISystemStatusClient, SystemStatusClient>();
+            client.BaseAddress = apiBaseAddress;
+        }).AddHttpMessageHandler<CorrelationDelegatingHandler>();
+        services.AddHttpClient<IDiagnosticClient, DiagnosticClient>(client =>
+        {
+            client.BaseAddress = apiBaseAddress;
+        }).AddHttpMessageHandler<CorrelationDelegatingHandler>();
         services.AddScoped<ITestCatchClient, TestCatchClient>();
-        services.AddScoped<IDiagnosticClient, DiagnosticClient>();
         services.AddScoped<INetworkService, NetworkService>();
         services.AddScoped<ILocationService, LocationService>();
         services.AddScoped<ITestCatchJsonStore, IndexedDbTestCatchJsonStore>();
@@ -53,7 +57,61 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICultureService, CultureService>();
         services.AddMudServices();
         services.AddTransient<MudLocalizer, FishingLogBookMudLocalizer>();
+        services.AddOidcAuthentication(options => ConfigureOidc(options, authConfig));
 
         return services;
+    }
+
+    private static void RegisterHttpClients(IServiceCollection services, Uri apiBaseAddress)
+    {
+        services.AddHttpClient(HttpClientNames.AuthorizedApi, client =>
+        {
+            client.BaseAddress = apiBaseAddress;
+        })
+            .AddHttpMessageHandler<AuthorizationMessageHandler>()
+            .AddHttpMessageHandler<CorrelationDelegatingHandler>();
+
+        services.AddHttpClient(HttpClientNames.Anonymous, client =>
+        {
+            client.BaseAddress = apiBaseAddress;
+        }).AddHttpMessageHandler<CorrelationDelegatingHandler>();
+    }
+
+    private static AuthorizationMessageHandler CreateApiAuthorizationMessageHandler(
+        IServiceProvider services,
+        AuthConfig authConfig,
+        Uri apiBaseAddress)
+    {
+        var handler = new AuthorizationMessageHandler(
+            services.GetRequiredService<IAccessTokenProvider>(),
+            services.GetRequiredService<Microsoft.AspNetCore.Components.NavigationManager>());
+        var authorizedUrl = apiBaseAddress.ToString().TrimEnd('/');
+        var scopes = string.IsNullOrWhiteSpace(authConfig.ApiScope)
+            ? Array.Empty<string>()
+            : [authConfig.ApiScope];
+        handler.ConfigureHandler([authorizedUrl], scopes);
+        return handler;
+    }
+
+    private static void ConfigureOidc(
+        Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationOptions<OidcProviderOptions> options,
+        AuthConfig authConfig)
+    {
+        options.ProviderOptions.Authority = authConfig.Authority;
+        options.ProviderOptions.ClientId = authConfig.ClientId;
+        options.ProviderOptions.ResponseType = "code";
+        options.ProviderOptions.DefaultScopes.Clear();
+        options.ProviderOptions.DefaultScopes.Add("openid");
+        options.ProviderOptions.DefaultScopes.Add("profile");
+        options.ProviderOptions.DefaultScopes.Add("email");
+        if (!string.IsNullOrWhiteSpace(authConfig.ApiScope))
+        {
+            options.ProviderOptions.DefaultScopes.Add(authConfig.ApiScope);
+        }
+
+        if (!string.IsNullOrWhiteSpace(authConfig.ApiResource))
+        {
+            options.ProviderOptions.AdditionalProviderParameters["resource"] = authConfig.ApiResource;
+        }
     }
 }

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ServiceCollectionExtensions
         AuthConfig authConfig,
         Uri apiBaseAddress)
     {
+        authConfig.EnsureRequired();
         services.AddSingleton(apiConfig);
         services.AddSingleton(diagnosticsConfig);
         services.AddSingleton(authConfig);
@@ -86,10 +87,7 @@ public static class ServiceCollectionExtensions
             services.GetRequiredService<IAccessTokenProvider>(),
             services.GetRequiredService<Microsoft.AspNetCore.Components.NavigationManager>());
         var authorizedUrl = apiBaseAddress.ToString().TrimEnd('/');
-        var scopes = string.IsNullOrWhiteSpace(authConfig.ApiScope)
-            ? Array.Empty<string>()
-            : [authConfig.ApiScope];
-        handler.ConfigureHandler([authorizedUrl], scopes);
+        handler.ConfigureHandler([authorizedUrl], [authConfig.ApiScope]);
         return handler;
     }
 
@@ -104,14 +102,7 @@ public static class ServiceCollectionExtensions
         options.ProviderOptions.DefaultScopes.Add("openid");
         options.ProviderOptions.DefaultScopes.Add("profile");
         options.ProviderOptions.DefaultScopes.Add("email");
-        if (!string.IsNullOrWhiteSpace(authConfig.ApiScope))
-        {
-            options.ProviderOptions.DefaultScopes.Add(authConfig.ApiScope);
-        }
-
-        if (!string.IsNullOrWhiteSpace(authConfig.ApiResource))
-        {
-            options.ProviderOptions.AdditionalProviderParameters["resource"] = authConfig.ApiResource;
-        }
+        options.ProviderOptions.DefaultScopes.Add(authConfig.ApiScope);
+        options.ProviderOptions.AdditionalProviderParameters["resource"] = authConfig.ApiResource;
     }
 }

--- a/src/FishingLogBook.Web/_Imports.razor
+++ b/src/FishingLogBook.Web/_Imports.razor
@@ -1,9 +1,12 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.Extensions.Localization
 @using Microsoft.JSInterop
@@ -13,6 +16,8 @@
 @using FishingLogBook.Web.Browser.Network
 @using FishingLogBook.Web.Common
 @using FishingLogBook.Web.Components.LanguageSwitcher
+@using FishingLogBook.Web.Features.Authentication.Components.LoginDisplay
+@using FishingLogBook.Web.Features.Authentication.Components.RedirectToLogin
 @using FishingLogBook.Web.Features.Diagnostics.Models
 @using FishingLogBook.Web.Features.Diagnostics.Services
 @using FishingLogBook.Web.Features.Diagnostics.Storage

--- a/src/FishingLogBook.Web/wwwroot/appsettings.Development.json
+++ b/src/FishingLogBook.Web/wwwroot/appsettings.Development.json
@@ -2,6 +2,12 @@
   "Api": {
     "BaseUrl": "https://localhost:7256"
   },
+  "Auth": {
+    "Authority": "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06",
+    "ClientId": "e80socqio7bpv79or57fb1e5l",
+    "ApiScope": "https://fishing-logbook-dev-api.fly.dev/access",
+    "ApiResource": "https://fishing-logbook-dev-api.fly.dev"
+  },
   "Diagnostics": {
     "ShowInspector": true,
     "MinimumPersistLevel": "Information"

--- a/src/FishingLogBook.Web/wwwroot/appsettings.Production.json
+++ b/src/FishingLogBook.Web/wwwroot/appsettings.Production.json
@@ -2,6 +2,12 @@
   "Api": {
     "BaseUrl": "https://fishing-logbook-dev-api.fly.dev"
   },
+  "Auth": {
+    "Authority": "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06",
+    "ClientId": "e80socqio7bpv79or57fb1e5l",
+    "ApiScope": "https://fishing-logbook-dev-api.fly.dev/access",
+    "ApiResource": "https://fishing-logbook-dev-api.fly.dev"
+  },
   "Diagnostics": {
     "ShowInspector": true,
     "MinimumPersistLevel": "Information"

--- a/src/FishingLogBook.Web/wwwroot/appsettings.json
+++ b/src/FishingLogBook.Web/wwwroot/appsettings.json
@@ -3,10 +3,10 @@
     "BaseUrl": ""
   },
   "Auth": {
-    "Authority": "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06",
-    "ClientId": "e80socqio7bpv79or57fb1e5l",
-    "ApiScope": "https://fishing-logbook-dev-api.fly.dev/access",
-    "ApiResource": "https://fishing-logbook-dev-api.fly.dev"
+    "Authority": "",
+    "ClientId": "",
+    "ApiScope": "",
+    "ApiResource": ""
   },
   "Diagnostics": {
     "ShowInspector": true,

--- a/src/FishingLogBook.Web/wwwroot/appsettings.json
+++ b/src/FishingLogBook.Web/wwwroot/appsettings.json
@@ -2,6 +2,12 @@
   "Api": {
     "BaseUrl": ""
   },
+  "Auth": {
+    "Authority": "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06",
+    "ClientId": "e80socqio7bpv79or57fb1e5l",
+    "ApiScope": "https://fishing-logbook-dev-api.fly.dev/access",
+    "ApiResource": "https://fishing-logbook-dev-api.fly.dev"
+  },
   "Diagnostics": {
     "ShowInspector": true,
     "MinimumPersistLevel": "Warning",

--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -38,6 +38,7 @@
         <a href="." class="reload">Reload</a>
         <span class="dismiss">🗙</span>
     </div>
+    <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script type="module">

--- a/tests/FishingLogBook.Api.Tests/ConfigurationTests/WhenTestingEnsureRequired.cs
+++ b/tests/FishingLogBook.Api.Tests/ConfigurationTests/WhenTestingEnsureRequired.cs
@@ -39,6 +39,25 @@ public class WhenTestingEnsureRequired
         act.Should().NotThrow();
     }
 
+    [Theory]
+    [InlineData("http://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool")]
+    [InlineData("http://127.0.0.1/us-east-1_testpool")]
+    [InlineData("cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool")]
+    [InlineData("https://")]
+    public void ItShouldThrowWhenAuthorityIsNotAnAbsoluteHttpsUri(string authority)
+    {
+        // Arrange
+        var authConfig = CreateCompleteAuthConfig();
+        authConfig.Authority = authority;
+
+        // Act
+        var act = authConfig.EnsureRequired;
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().ContainAll("Auth:Authority", "HTTPS");
+    }
+
     private static AuthConfig CreateCompleteAuthConfig()
     {
         return new AuthConfig

--- a/tests/FishingLogBook.Api.Tests/ConfigurationTests/WhenTestingEnsureRequired.cs
+++ b/tests/FishingLogBook.Api.Tests/ConfigurationTests/WhenTestingEnsureRequired.cs
@@ -1,0 +1,52 @@
+using AwesomeAssertions;
+using FishingLogBook.Api.Configuration;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Tests.Common.TestSupport;
+
+namespace FishingLogBook.Api.Tests.ConfigurationTests;
+
+public class WhenTestingEnsureRequired
+{
+    [Theory]
+    [InlineData("Authority", "Auth:Authority")]
+    [InlineData("ClientId", "Auth:ClientId")]
+    [InlineData("ApiResource", "Auth:ApiResource")]
+    [InlineData("ApiScope", "Auth:ApiScope")]
+    public void ItShouldThrowWhenRequiredValueIsMissing(string propertyName, string configurationKey)
+    {
+        // Arrange
+        var authConfig = CreateCompleteAuthConfig();
+        typeof(AuthConfig).GetProperty(propertyName)!.SetValue(authConfig, " ");
+
+        // Act
+        var act = authConfig.EnsureRequired;
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain(configurationKey);
+    }
+
+    [Fact]
+    public void ItShouldNotThrowWhenAllRequiredValuesArePresent()
+    {
+        // Arrange
+        var authConfig = CreateCompleteAuthConfig();
+
+        // Act
+        var act = authConfig.EnsureRequired;
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    private static AuthConfig CreateCompleteAuthConfig()
+    {
+        return new AuthConfig
+        {
+            Authority = TestJwt.Issuer,
+            ClientId = TestJwt.ClientId,
+            ApiResource = TestAuthConstants.ApiResource,
+            ApiScope = TestAuthConstants.ApiScope
+        };
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/ConfigurationTests/WhenTestingIncompleteStartup.cs
+++ b/tests/FishingLogBook.Api.Tests/ConfigurationTests/WhenTestingIncompleteStartup.cs
@@ -1,0 +1,25 @@
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+
+namespace FishingLogBook.Api.Tests.ConfigurationTests;
+
+public class WhenTestingIncompleteStartup
+{
+    [Theory]
+    [InlineData("Auth:Authority")]
+    [InlineData("Auth:ClientId")]
+    [InlineData("Auth:ApiResource")]
+    [InlineData("Auth:ApiScope")]
+    public void ItShouldFailToStartWhenRequiredAuthSettingIsMissing(string omittedKey)
+    {
+        // Arrange
+        using var factory = new IncompleteAuthApiFactory(omittedKey);
+
+        // Act
+        var act = () => _ = factory.Services;
+
+        // Assert
+        act.Should().Throw<Exception>()
+            .Which.ToString().Should().Contain(omittedKey);
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/ConfigurationTests/WhenTestingInvalidAuthority.cs
+++ b/tests/FishingLogBook.Api.Tests/ConfigurationTests/WhenTestingInvalidAuthority.cs
@@ -1,0 +1,23 @@
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+
+namespace FishingLogBook.Api.Tests.ConfigurationTests;
+
+public class WhenTestingInvalidAuthority
+{
+    [Theory]
+    [InlineData("http://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool")]
+    [InlineData("cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool")]
+    public void ItShouldFailToStartWhenAuthorityIsNotAnAbsoluteHttpsUri(string authority)
+    {
+        // Arrange
+        using var factory = new InvalidAuthorityApiFactory(authority);
+
+        // Act
+        var act = () => _ = factory.Services;
+
+        // Assert
+        act.Should().Throw<Exception>()
+            .Which.ToString().Should().ContainAll("Auth:Authority", "HTTPS");
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/DependencyInjectionTests/DependencyInjectionApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/DependencyInjectionTests/DependencyInjectionApiFactory.cs
@@ -1,5 +1,5 @@
 using FishingLogBook.Api.Tests.TestSupport;
-using FishingLogBook.Shared.Constants;
+using FishingLogBook.Tests.Common.TestSupport;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -22,8 +22,8 @@ public sealed class DependencyInjectionApiFactory : WebApplicationFactory<Progra
                     "Host=127.0.0.1;Database=fishing-logbook-di-test;Username=test;Password=test",
                 ["Auth:Authority"] = TestJwt.Issuer,
                 ["Auth:ClientId"] = TestJwt.ClientId,
-                ["Auth:ApiScope"] = AuthConstants.ApiScope,
-                ["Auth:ApiResource"] = AuthConstants.DevApiResourceUri
+                ["Auth:ApiScope"] = TestAuthConstants.ApiScope,
+                ["Auth:ApiResource"] = TestAuthConstants.ApiResource
             });
         });
 

--- a/tests/FishingLogBook.Api.Tests/DependencyInjectionTests/DependencyInjectionApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/DependencyInjectionTests/DependencyInjectionApiFactory.cs
@@ -1,5 +1,8 @@
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Shared.Constants;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -16,9 +19,15 @@ public sealed class DependencyInjectionApiFactory : WebApplicationFactory<Progra
             configuration.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ConnectionStrings:Postgres"] =
-                    "Host=127.0.0.1;Database=fishing-logbook-di-test;Username=test;Password=test"
+                    "Host=127.0.0.1;Database=fishing-logbook-di-test;Username=test;Password=test",
+                ["Auth:Authority"] = TestJwt.Issuer,
+                ["Auth:ClientId"] = TestJwt.ClientId,
+                ["Auth:ApiScope"] = AuthConstants.ApiScope,
+                ["Auth:ApiResource"] = AuthConstants.DevApiResourceUri
             });
         });
+
+        builder.ConfigureTestServices(TestAuthentication.ConfigureJwtBearer);
 
         builder.UseDefaultServiceProvider((_, options) =>
         {

--- a/tests/FishingLogBook.Api.Tests/FishingLogBook.Api.Tests.csproj
+++ b/tests/FishingLogBook.Api.Tests/FishingLogBook.Api.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -2,7 +2,7 @@ using System.Net.Http.Headers;
 using FishingLogBook.Api.Configuration;
 using FishingLogBook.Api.Tests.TestSupport;
 using FishingLogBook.Application.Contracts;
-using FishingLogBook.Shared.Constants;
+using FishingLogBook.Tests.Common.TestSupport;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -54,8 +54,8 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
             {
                 Authority = TestJwt.Issuer,
                 ClientId = TestJwt.ClientId,
-                ApiScope = AuthConstants.ApiScope,
-                ApiResource = AuthConstants.DevApiResourceUri
+                ApiScope = TestAuthConstants.ApiScope,
+                ApiResource = TestAuthConstants.ApiResource
             });
             TestAuthentication.ConfigureJwtBearer(services);
             services.RemoveAll<ISystemRepository>();

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -1,4 +1,8 @@
+using System.Net.Http.Headers;
+using FishingLogBook.Api.Configuration;
+using FishingLogBook.Api.Tests.TestSupport;
 using FishingLogBook.Application.Contracts;
+using FishingLogBook.Shared.Constants;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -17,20 +21,43 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
 
     public IObjectStorage ObjectStorage { get; } = Substitute.For<IObjectStorage>();
 
+    public HttpClient CreateAuthenticatedClient(string? accessToken = null)
+    {
+        var client = CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", accessToken ?? TestJwt.CreateAccessToken());
+        return client;
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Production");
 
         builder.ConfigureAppConfiguration((_, configuration) =>
         {
-            configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            var values = new Dictionary<string, string?>
             {
                 ["ConnectionStrings:Postgres"] = string.Empty
-            });
+            };
+            foreach (var pair in TestAuthentication.Configuration)
+            {
+                values[pair.Key] = pair.Value;
+            }
+
+            configuration.AddInMemoryCollection(values);
         });
 
         builder.ConfigureTestServices(services =>
         {
+            services.RemoveAll<AuthConfig>();
+            services.AddSingleton(new AuthConfig
+            {
+                Authority = TestJwt.Issuer,
+                ClientId = TestJwt.ClientId,
+                ApiScope = AuthConstants.ApiScope,
+                ApiResource = AuthConstants.DevApiResourceUri
+            });
+            TestAuthentication.ConfigureJwtBearer(services);
             services.RemoveAll<ISystemRepository>();
             services.AddScoped(_ => SystemRepository);
             services.RemoveAll<ITestCatchRepository>();

--- a/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingAuthorization.cs
+++ b/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingAuthorization.cs
@@ -1,0 +1,177 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Domain.TestCatches;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.TestCatchEndpointsTests;
+
+public class WhenTestingAuthorization : IClassFixture<SystemApiFactory>
+{
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingAuthorization(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenAuthorizationHeaderIsMissing()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenTheBearerTokenIsInvalid()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "not-a-jwt");
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenTheAccessTokenHasExpired()
+    {
+        // Arrange
+        var token = TestJwt.CreateAccessToken(expires: DateTime.UtcNow.AddMinutes(-2));
+        var client = _factory.CreateAuthenticatedClient(token);
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenTheIssuerIsWrong()
+    {
+        // Arrange
+        var token = TestJwt.CreateAccessToken(issuer: "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_other");
+        var client = _factory.CreateAuthenticatedClient(token);
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenTheAudienceIsMissing()
+    {
+        // Arrange
+        var token = TestJwt.CreateAccessToken(includeAudience: false);
+        var client = _factory.CreateAuthenticatedClient(token);
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenTheAudienceIsWrong()
+    {
+        // Arrange
+        var token = TestJwt.CreateAccessToken(audience: "https://other-api.example");
+        var client = _factory.CreateAuthenticatedClient(token);
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenTheAppClientIsWrong()
+    {
+        // Arrange
+        var token = TestJwt.CreateAccessToken(clientId: "other-client");
+        var client = _factory.CreateAuthenticatedClient(token);
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenAnIdTokenIsPresented()
+    {
+        // Arrange
+        var token = TestJwt.CreateAccessToken(tokenUse: AuthConstants.TokenUseId);
+        var client = _factory.CreateAuthenticatedClient(token);
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequest_WhenTheApiScopeIsMissing()
+    {
+        // Arrange
+        var token = TestJwt.CreateAccessToken(scope: "openid profile email");
+        var client = _factory.CreateAuthenticatedClient(token);
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ItShouldAllowTheRequest_WhenAValidAccessTokenIsPresented()
+    {
+        // Arrange
+        _factory.TestCatchRepository
+            .GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<TestCatchRecord>>([]));
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.GetAsync("/api/test-catches");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<IReadOnlyList<TestCatchDto>>();
+        body.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldAllowHealth_WhenUnauthenticated()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/health");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingPhotograph.cs
+++ b/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingPhotograph.cs
@@ -22,7 +22,7 @@ public class WhenTestingPhotograph : IClassFixture<SystemApiFactory>
         // Arrange
         _factory.ObjectStorage.ClearReceivedCalls();
         _factory.ObjectStorage.IsConfigured.Returns(false);
-        var client = _factory.CreateClient();
+        var client = _factory.CreateAuthenticatedClient();
         var catchId = Guid.Parse("1a2b3c4d-5e6f-7081-92a3-b4c5d6e7f809");
         var request = new PhotographUploadRequestDto(Guid.NewGuid(), "image/jpeg");
 
@@ -60,7 +60,7 @@ public class WhenTestingPhotograph : IClassFixture<SystemApiFactory>
         _factory.ObjectStorage
             .CreateUploadUrlAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
             .Returns(new Uri("https://storage.test/upload"));
-        var client = _factory.CreateClient();
+        var client = _factory.CreateAuthenticatedClient();
         var request = new PhotographUploadRequestDto(photographId, "image/jpeg");
 
         // Act
@@ -93,7 +93,7 @@ public class WhenTestingPhotograph : IClassFixture<SystemApiFactory>
             .GetByIdAsync(catchId, Arg.Any<CancellationToken>())
             .Returns(record);
         _factory.TestCatchRepository.ClearReceivedCalls();
-        var client = _factory.CreateClient();
+        var client = _factory.CreateAuthenticatedClient();
         var request = new RecordPhotographDto(photographId, objectKey, "image/jpeg");
 
         // Act

--- a/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingUpsert.cs
@@ -30,7 +30,7 @@ public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
         _factory.TestCatchRepository
             .UpsertAsync(Arg.Any<TestCatchRecord>(), Arg.Any<CancellationToken>())
             .Returns(record);
-        var client = _factory.CreateClient();
+        var client = _factory.CreateAuthenticatedClient();
         var dto = new TestCatchDto(record.Id, record.SpeciesName, record.CaughtOn, record.Notes);
 
         // Act
@@ -54,7 +54,7 @@ public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
     {
         // Arrange
         _factory.TestCatchRepository.ClearReceivedCalls();
-        var client = _factory.CreateClient();
+        var client = _factory.CreateAuthenticatedClient();
         var dto = new TestCatchDto(Guid.NewGuid(), "  ", DateTimeOffset.UtcNow, null);
 
         // Act
@@ -96,7 +96,7 @@ public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
         _factory.TestCatchRepository
             .UpsertAsync(Arg.Any<TestCatchRecord>(), Arg.Any<CancellationToken>())
             .Returns(record);
-        var client = _factory.CreateClient();
+        var client = _factory.CreateAuthenticatedClient();
         var dto = new TestCatchDto(record.Id, record.SpeciesName, record.CaughtOn, record.Notes, Location: location);
 
         // Act
@@ -139,7 +139,7 @@ public class WhenTestingList : IClassFixture<SystemApiFactory>
         _factory.TestCatchRepository
             .GetAllAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<TestCatchRecord>>([record]));
-        var client = _factory.CreateClient();
+        var client = _factory.CreateAuthenticatedClient();
 
         // Act
         var response = await client.GetAsync("/api/test-catches");

--- a/tests/FishingLogBook.Api.Tests/TestSupport/IncompleteAuthApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/IncompleteAuthApiFactory.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace FishingLogBook.Api.Tests.TestSupport;
+
+public sealed class IncompleteAuthApiFactory : WebApplicationFactory<Program>
+{
+    private readonly string _omittedKey;
+
+    public IncompleteAuthApiFactory(string omittedKey)
+    {
+        _omittedKey = omittedKey;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureAppConfiguration((_, configuration) =>
+        {
+            var values = new Dictionary<string, string?>(TestAuthentication.Configuration)
+            {
+                ["ConnectionStrings:Postgres"] =
+                    "Host=127.0.0.1;Database=fishing-logbook-auth-test;Username=test;Password=test"
+            };
+            values[_omittedKey] = " ";
+            configuration.AddInMemoryCollection(values);
+        });
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TestSupport/InvalidAuthorityApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/InvalidAuthorityApiFactory.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace FishingLogBook.Api.Tests.TestSupport;
+
+public sealed class InvalidAuthorityApiFactory : WebApplicationFactory<Program>
+{
+    private readonly string _authority;
+
+    public InvalidAuthorityApiFactory(string authority)
+    {
+        _authority = authority;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+        builder.ConfigureAppConfiguration((_, configuration) =>
+        {
+            var values = new Dictionary<string, string?>(TestAuthentication.Configuration)
+            {
+                ["ConnectionStrings:Postgres"] =
+                    "Host=127.0.0.1;Database=fishing-logbook-auth-test;Username=test;Password=test",
+                ["Auth:Authority"] = _authority
+            };
+            configuration.AddInMemoryCollection(values);
+        });
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TestSupport/TestAuthentication.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/TestAuthentication.cs
@@ -1,0 +1,44 @@
+using FishingLogBook.Shared.Constants;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace FishingLogBook.Api.Tests.TestSupport;
+
+public static class TestAuthentication
+{
+    public static Dictionary<string, string?> Configuration { get; } = new()
+    {
+        ["Auth:Authority"] = TestJwt.Issuer,
+        ["Auth:ClientId"] = TestJwt.ClientId,
+        ["Auth:ApiScope"] = AuthConstants.ApiScope,
+        ["Auth:ApiResource"] = AuthConstants.DevApiResourceUri
+    };
+
+    public static void ConfigureJwtBearer(IServiceCollection services)
+    {
+        services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+        {
+            var configuration = new OpenIdConnectConfiguration
+            {
+                Issuer = TestJwt.Issuer
+            };
+            configuration.SigningKeys.Add(TestJwt.SigningKey);
+            options.Authority = string.Empty;
+            options.MetadataAddress = string.Empty;
+            options.RequireHttpsMetadata = false;
+            options.Configuration = configuration;
+            options.ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(configuration);
+            options.TokenValidationParameters.ValidIssuer = TestJwt.Issuer;
+            options.TokenValidationParameters.IssuerSigningKey = TestJwt.SigningKey;
+            options.TokenValidationParameters.ValidateIssuerSigningKey = true;
+            options.TokenValidationParameters.ValidateIssuer = true;
+            options.TokenValidationParameters.ValidateAudience = true;
+            options.TokenValidationParameters.ValidAudience = AuthConstants.DevApiResourceUri;
+            options.TokenValidationParameters.ValidateLifetime = true;
+            options.TokenValidationParameters.ClockSkew = TimeSpan.FromSeconds(30);
+            options.MapInboundClaims = false;
+        });
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TestSupport/TestAuthentication.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/TestAuthentication.cs
@@ -1,4 +1,4 @@
-using FishingLogBook.Shared.Constants;
+using FishingLogBook.Tests.Common.TestSupport;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Protocols;
@@ -12,8 +12,8 @@ public static class TestAuthentication
     {
         ["Auth:Authority"] = TestJwt.Issuer,
         ["Auth:ClientId"] = TestJwt.ClientId,
-        ["Auth:ApiScope"] = AuthConstants.ApiScope,
-        ["Auth:ApiResource"] = AuthConstants.DevApiResourceUri
+        ["Auth:ApiScope"] = TestAuthConstants.ApiScope,
+        ["Auth:ApiResource"] = TestAuthConstants.ApiResource
     };
 
     public static void ConfigureJwtBearer(IServiceCollection services)
@@ -35,7 +35,7 @@ public static class TestAuthentication
             options.TokenValidationParameters.ValidateIssuerSigningKey = true;
             options.TokenValidationParameters.ValidateIssuer = true;
             options.TokenValidationParameters.ValidateAudience = true;
-            options.TokenValidationParameters.ValidAudience = AuthConstants.DevApiResourceUri;
+            options.TokenValidationParameters.ValidAudience = TestAuthConstants.ApiResource;
             options.TokenValidationParameters.ValidateLifetime = true;
             options.TokenValidationParameters.ClockSkew = TimeSpan.FromSeconds(30);
             options.MapInboundClaims = false;

--- a/tests/FishingLogBook.Api.Tests/TestSupport/TestJwt.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/TestJwt.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Tests.Common.TestSupport;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
@@ -27,7 +28,7 @@ public static class TestJwt
         var descriptor = new SecurityTokenDescriptor
         {
             Issuer = issuer ?? Issuer,
-            Audience = includeAudience ? audience ?? AuthConstants.DevApiResourceUri : null,
+            Audience = includeAudience ? audience ?? TestAuthConstants.ApiResource : null,
             NotBefore = notBefore,
             Expires = expiresAt,
             SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256),
@@ -36,7 +37,7 @@ public static class TestJwt
                 ["sub"] = Subject,
                 ["token_use"] = tokenUse ?? AuthConstants.TokenUseAccess,
                 ["client_id"] = clientId ?? ClientId,
-                ["scope"] = scope ?? $"openid profile email {AuthConstants.ApiScope}"
+                ["scope"] = scope ?? $"openid profile email {TestAuthConstants.ApiScope}"
             }
         };
 

--- a/tests/FishingLogBook.Api.Tests/TestSupport/TestJwt.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/TestJwt.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using FishingLogBook.Shared.Constants;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FishingLogBook.Api.Tests.TestSupport;
+
+public static class TestJwt
+{
+    public const string Issuer = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool";
+    public const string ClientId = "test-pwa-client";
+    public const string Subject = "test-subject";
+
+    public static readonly RsaSecurityKey SigningKey = CreateSigningKey();
+
+    public static string CreateAccessToken(
+        string? issuer = null,
+        string? clientId = null,
+        string? tokenUse = null,
+        string? scope = null,
+        string? audience = null,
+        bool includeAudience = true,
+        DateTime? expires = null)
+    {
+        var expiresAt = expires ?? DateTime.UtcNow.AddMinutes(15);
+        var notBefore = expiresAt.AddMinutes(-30);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = issuer ?? Issuer,
+            Audience = includeAudience ? audience ?? AuthConstants.DevApiResourceUri : null,
+            NotBefore = notBefore,
+            Expires = expiresAt,
+            SigningCredentials = new SigningCredentials(SigningKey, SecurityAlgorithms.RsaSha256),
+            Claims = new Dictionary<string, object>
+            {
+                ["sub"] = Subject,
+                ["token_use"] = tokenUse ?? AuthConstants.TokenUseAccess,
+                ["client_id"] = clientId ?? ClientId,
+                ["scope"] = scope ?? $"openid profile email {AuthConstants.ApiScope}"
+            }
+        };
+
+        return new JsonWebTokenHandler().CreateToken(descriptor);
+    }
+
+    private static RsaSecurityKey CreateSigningKey()
+    {
+        var rsa = RSA.Create(2048);
+        return new RsaSecurityKey(rsa)
+        {
+            KeyId = "test-key"
+        };
+    }
+}

--- a/tests/FishingLogBook.Tests.Common/TestSupport/TestAuthConstants.cs
+++ b/tests/FishingLogBook.Tests.Common/TestSupport/TestAuthConstants.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Tests.Common.TestSupport;
+
+public static class TestAuthConstants
+{
+    public const string ApiResource = "https://fishing-logbook-dev-api.fly.dev";
+    public const string ApiScope = ApiResource + "/access";
+}

--- a/tests/FishingLogBook.Web.Tests/Configuration/AuthConfigTests/WhenTestingEnsureRequired.cs
+++ b/tests/FishingLogBook.Web.Tests/Configuration/AuthConfigTests/WhenTestingEnsureRequired.cs
@@ -1,0 +1,51 @@
+using AwesomeAssertions;
+using FishingLogBook.Tests.Common.TestSupport;
+using FishingLogBook.Web.Configuration;
+
+namespace FishingLogBook.Web.Tests.Configuration.AuthConfigTests;
+
+public class WhenTestingEnsureRequired
+{
+    [Theory]
+    [InlineData(nameof(AuthConfig.Authority), "Auth:Authority")]
+    [InlineData(nameof(AuthConfig.ClientId), "Auth:ClientId")]
+    [InlineData(nameof(AuthConfig.ApiResource), "Auth:ApiResource")]
+    [InlineData(nameof(AuthConfig.ApiScope), "Auth:ApiScope")]
+    public void ItShouldThrowWhenRequiredValueIsMissing(string propertyName, string configurationKey)
+    {
+        // Arrange
+        var authConfig = CreateCompleteAuthConfig();
+        typeof(AuthConfig).GetProperty(propertyName)!.SetValue(authConfig, " ");
+
+        // Act
+        var act = authConfig.EnsureRequired;
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain(configurationKey);
+    }
+
+    [Fact]
+    public void ItShouldNotThrowWhenAllRequiredValuesArePresent()
+    {
+        // Arrange
+        var authConfig = CreateCompleteAuthConfig();
+
+        // Act
+        var act = authConfig.EnsureRequired;
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    private static AuthConfig CreateCompleteAuthConfig()
+    {
+        return new AuthConfig
+        {
+            Authority = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
+            ClientId = "test-pwa-client",
+            ApiResource = TestAuthConstants.ApiResource,
+            ApiScope = TestAuthConstants.ApiScope
+        };
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Configuration/AuthConfigTests/WhenTestingIncompleteRegistration.cs
+++ b/tests/FishingLogBook.Web.Tests/Configuration/AuthConfigTests/WhenTestingIncompleteRegistration.cs
@@ -1,0 +1,27 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Tests.DependencyInjection;
+
+namespace FishingLogBook.Web.Tests.Configuration.AuthConfigTests;
+
+public class WhenTestingIncompleteRegistration : BaseDependencyInjectionTest
+{
+    [Theory]
+    [InlineData(nameof(AuthConfig.Authority), "Auth:Authority")]
+    [InlineData(nameof(AuthConfig.ClientId), "Auth:ClientId")]
+    [InlineData(nameof(AuthConfig.ApiResource), "Auth:ApiResource")]
+    [InlineData(nameof(AuthConfig.ApiScope), "Auth:ApiScope")]
+    public void ItShouldFailToBuildWhenRequiredAuthValueIsMissing(string propertyName, string configurationKey)
+    {
+        // Arrange
+        var authConfig = CreateCompleteAuthConfig();
+        typeof(AuthConfig).GetProperty(propertyName)!.SetValue(authConfig, string.Empty);
+
+        // Act
+        var act = () => CreateProvider(authConfig);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain(configurationKey);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DependencyInjection/BaseDependencyInjectionTest.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjection/BaseDependencyInjectionTest.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Configuration;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +19,13 @@ public class BaseDependencyInjectionTest
         services.AddFishingLogBookWeb(
             new ApiConfig { BaseUrl = "https://example.test/" },
             new DiagnosticsClientConfig(),
+            new AuthConfig
+            {
+                Authority = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
+                ClientId = "test-pwa-client",
+                ApiScope = AuthConstants.ApiScope,
+                ApiResource = AuthConstants.DevApiResourceUri
+            },
             new Uri("https://example.test/"));
 
         return services.BuildServiceProvider(new ServiceProviderOptions

--- a/tests/FishingLogBook.Web.Tests/DependencyInjection/BaseDependencyInjectionTest.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjection/BaseDependencyInjectionTest.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
-using FishingLogBook.Shared.Constants;
+using FishingLogBook.Tests.Common.TestSupport;
+using FishingLogBook.Web;
 using FishingLogBook.Web.Configuration;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,7 +11,7 @@ namespace FishingLogBook.Web.Tests.DependencyInjection;
 
 public class BaseDependencyInjectionTest
 {
-    protected static ServiceProvider CreateProvider()
+    protected static ServiceProvider CreateProvider(AuthConfig? authConfig = null)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -19,13 +20,7 @@ public class BaseDependencyInjectionTest
         services.AddFishingLogBookWeb(
             new ApiConfig { BaseUrl = "https://example.test/" },
             new DiagnosticsClientConfig(),
-            new AuthConfig
-            {
-                Authority = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
-                ClientId = "test-pwa-client",
-                ApiScope = AuthConstants.ApiScope,
-                ApiResource = AuthConstants.DevApiResourceUri
-            },
+            authConfig ?? CreateCompleteAuthConfig(),
             new Uri("https://example.test/"));
 
         return services.BuildServiceProvider(new ServiceProviderOptions
@@ -33,6 +28,17 @@ public class BaseDependencyInjectionTest
             ValidateScopes = true,
             ValidateOnBuild = true
         });
+    }
+
+    protected static AuthConfig CreateCompleteAuthConfig()
+    {
+        return new AuthConfig
+        {
+            Authority = "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_testpool",
+            ClientId = "test-pwa-client",
+            ApiScope = TestAuthConstants.ApiScope,
+            ApiResource = TestAuthConstants.ApiResource
+        };
     }
 
     protected static IReadOnlyCollection<Type> GetComponentInjectedServiceTypes()

--- a/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
@@ -1,5 +1,5 @@
 using AwesomeAssertions;
-using FishingLogBook.Shared.Constants;
+using FishingLogBook.Tests.Common.TestSupport;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Diagnostics.Models;
@@ -87,7 +87,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         oidc.ClientId.Should().Be("test-pwa-client");
         typeof(OidcProviderOptions).GetProperty("ClientSecret").Should().BeNull();
         oidc.DefaultScopes.Should().Contain("openid");
-        oidc.DefaultScopes.Should().Contain(AuthConstants.ApiScope);
+        oidc.DefaultScopes.Should().Contain(TestAuthConstants.ApiScope);
     }
 
     [Fact]
@@ -105,7 +105,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
 
         // Assert
         oidc.AdditionalProviderParameters.Should().ContainKey("resource");
-        oidc.AdditionalProviderParameters["resource"].Should().Be(AuthConstants.DevApiResourceUri);
+        oidc.AdditionalProviderParameters["resource"].Should().Be(TestAuthConstants.ApiResource);
         oidc.ResponseType.Should().Be("code");
         typeof(OidcProviderOptions).GetProperty("ClientSecret").Should().BeNull();
     }

--- a/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Browser.Location;
-using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
@@ -9,8 +10,10 @@ using FishingLogBook.Web.Features.TestCatch.Models;
 using FishingLogBook.Web.Features.TestCatch.Offline;
 using FishingLogBook.Web.Features.TestCatch.Services;
 using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 
 namespace FishingLogBook.Web.Tests.DependencyInjection;
 
@@ -57,5 +60,53 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         injectedTypes.Should().Contain(typeof(ILocationService));
         injectedTypes.Should().Contain(typeof(IStringLocalizer<UiStrings>));
         resolve.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ItShouldRegisterAuthorizedAndAnonymousHttpClients()
+    {
+        // Arrange
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+
+        // Act
+        var apiClient = factory.CreateClient(HttpClientNames.AuthorizedApi);
+        var anonymousClient = factory.CreateClient(HttpClientNames.Anonymous);
+
+        // Assert
+        apiClient.BaseAddress.Should().Be(new Uri("https://example.test/"));
+        anonymousClient.BaseAddress.Should().Be(new Uri("https://example.test/"));
+        scope.ServiceProvider.GetRequiredService<IAccessTokenProvider>().Should().NotBeNull();
+        scope.ServiceProvider.GetRequiredService<ITestCatchClient>().Should().BeOfType<TestCatchClient>();
+        var oidc = scope.ServiceProvider
+            .GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>()
+            .Value
+            .ProviderOptions;
+        oidc.ResponseType.Should().Be("code");
+        oidc.ClientId.Should().Be("test-pwa-client");
+        typeof(OidcProviderOptions).GetProperty("ClientSecret").Should().BeNull();
+        oidc.DefaultScopes.Should().Contain("openid");
+        oidc.DefaultScopes.Should().Contain(AuthConstants.ApiScope);
+    }
+
+    [Fact]
+    public void ItShouldRequestTheConfiguredApiResourceThroughStandardOidcOptions()
+    {
+        // Arrange
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        // Act
+        var oidc = scope.ServiceProvider
+            .GetRequiredService<IOptionsSnapshot<RemoteAuthenticationOptions<OidcProviderOptions>>>()
+            .Value
+            .ProviderOptions;
+
+        // Assert
+        oidc.AdditionalProviderParameters.Should().ContainKey("resource");
+        oidc.AdditionalProviderParameters["resource"].Should().Be(AuthConstants.DevApiResourceUri);
+        oidc.ResponseType.Should().Be("code");
+        typeof(OidcProviderOptions).GetProperty("ClientSecret").Should().BeNull();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/LoginDisplayTests/BaseLoginDisplayTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/LoginDisplayTests/BaseLoginDisplayTest.cs
@@ -1,0 +1,32 @@
+using Bunit;
+using Bunit.TestDoubles;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Authentication.Components.LoginDisplayTests;
+
+public class BaseLoginDisplayTest
+{
+    protected static BunitContext CreateContext(bool isAuthenticated)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        var authorization = context.AddAuthorization();
+        if (isAuthenticated)
+        {
+            authorization.SetAuthorized("tester@example.test");
+        }
+        else
+        {
+            authorization.SetNotAuthorized();
+        }
+
+        context.Services.AddSingleton(Substitute.For<ICultureService>());
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/LoginDisplayTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/LoginDisplayTests/WhenTestingRender.cs
@@ -1,0 +1,90 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Authentication.Components.LoginDisplay;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FishingLogBook.Web.Tests.Features.Authentication.Components.LoginDisplayTests;
+
+public class WhenTestingRender : BaseLoginDisplayTest
+{
+    [Fact]
+    public async Task ItShouldShowSignIn_WhenUnauthenticated()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(isAuthenticated: false);
+
+        // Act
+        var cut = context.Render<LoginDisplay>();
+
+        // Assert
+        cut.Find("#auth-sign-in-button").TextContent.Should().Contain("Sign in");
+        cut.Find("#auth-create-account-button").TextContent.Should().Contain("Create account");
+        cut.FindAll("#auth-sign-out-button").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchSignIn_WhenUnauthenticated()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        await using var context = CreateContext(isAuthenticated: false);
+
+        // Act
+        var cut = context.Render<LoginDisplay>();
+
+        // Assert
+        cut.Find("#auth-sign-in-button").TextContent.Should().Contain("Connexion");
+        cut.Find("#auth-create-account-button").TextContent.Should().Contain("Créer un compte");
+    }
+
+    [Fact]
+    public async Task ItShouldShowSignOut_WhenAuthenticated()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(isAuthenticated: true);
+
+        // Act
+        var cut = context.Render<LoginDisplay>();
+
+        // Assert
+        cut.Find("#auth-sign-out-button").TextContent.Should().Contain("Sign out");
+        cut.FindAll("#auth-sign-in-button").Should().BeEmpty();
+        cut.FindAll("#auth-create-account-button").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNavigateToLogin_WhenSignInIsClicked()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(isAuthenticated: false);
+        var cut = context.Render<LoginDisplay>();
+
+        // Act
+        cut.Find("#auth-sign-in-button").Click();
+        var uri = context.Services.GetRequiredService<NavigationManager>().Uri;
+
+        // Assert
+        uri.Should().Contain("authentication/login");
+    }
+
+    [Fact]
+    public async Task ItShouldNavigateToLogout_WhenSignOutIsClicked()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(isAuthenticated: true);
+        var cut = context.Render<LoginDisplay>();
+
+        // Act
+        cut.Find("#auth-sign-out-button").Click();
+        var uri = context.Services.GetRequiredService<NavigationManager>().Uri;
+
+        // Assert
+        uri.Should().Contain("authentication/logout");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/RedirectToLoginTests/WhenTestingRedirect.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/RedirectToLoginTests/WhenTestingRedirect.cs
@@ -1,0 +1,31 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Authentication.Components.RedirectToLogin;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+
+namespace FishingLogBook.Web.Tests.Features.Authentication.Components.RedirectToLoginTests;
+
+public class WhenTestingRedirect
+{
+    [Fact]
+    public async Task ItShouldNavigateToLogin()
+    {
+        // Arrange
+        await using var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddAuthorizationCore();
+        context.Services.AddSingleton<AuthenticationStateProvider>(new TestAuthenticationStateProvider(false));
+        context.Services.AddCascadingAuthenticationState();
+
+        // Act
+        context.Render<RedirectToLogin>();
+        var uri = context.Services.GetRequiredService<NavigationManager>().Uri;
+
+        // Assert
+        uri.Should().Contain("authentication/login");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Authentication/Pages/AuthenticationTests/WhenTestingRoute.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Authentication/Pages/AuthenticationTests/WhenTestingRoute.cs
@@ -1,0 +1,22 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Components;
+using AuthenticationPage = FishingLogBook.Web.Features.Authentication.Pages.Authentication.Authentication;
+
+namespace FishingLogBook.Web.Tests.Features.Authentication.Pages.AuthenticationTests;
+
+public class WhenTestingRoute
+{
+    [Fact]
+    public void ItShouldMapTheOidcCallbackPath()
+    {
+        // Arrange
+        // Act
+        var route = typeof(AuthenticationPage)
+            .GetCustomAttributes(inherit: false)
+            .OfType<RouteAttribute>()
+            .Single();
+
+        // Assert
+        route.Template.Should().Be("/authentication/{action}");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/TestCatch/Pages/TestCatchLogTests/WhenTestingAuthorization.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/TestCatch/Pages/TestCatchLogTests/WhenTestingAuthorization.cs
@@ -1,0 +1,22 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.TestCatch.Pages.TestCatchLog;
+using Microsoft.AspNetCore.Authorization;
+
+namespace FishingLogBook.Web.Tests.Features.TestCatch.Pages.TestCatchLogTests;
+
+public class WhenTestingAuthorization
+{
+    [Fact]
+    public void ItShouldRequireAnAuthenticatedUser()
+    {
+        // Arrange
+        // Act
+        var authorize = typeof(TestCatchLog)
+            .GetCustomAttributes(inherit: true)
+            .OfType<AuthorizeAttribute>()
+            .SingleOrDefault();
+
+        // Assert
+        authorize.Should().NotBeNull();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/TestCatch/Services/TestCatchClientTests/WhenTestingHttpClients.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/TestCatch/Services/TestCatchClientTests/WhenTestingHttpClients.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.TestCatch.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.TestCatch.Services.TestCatchClientTests;
+
+public class WhenTestingHttpClients
+{
+    [Fact]
+    public async Task ItShouldCallTheAuthorizedApiClient_WhenListingCatches()
+    {
+        // Arrange
+        var apiHandler = new RecordingHandler("""[]""");
+        var anonymousHandler = new RecordingHandler("""ok""");
+        var client = CreateClient(apiHandler, anonymousHandler);
+
+        // Act
+        var result = await client.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+        apiHandler.LastRequest.Should().NotBeNull();
+        apiHandler.LastRequest!.RequestUri!.PathAndQuery.Should().Be("/api/test-catches");
+        anonymousHandler.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldNotAttachABearerToken_WhenUploadingToObjectStorage()
+    {
+        // Arrange
+        var apiHandler = new RecordingHandler("""ok""");
+        var anonymousHandler = new RecordingHandler("""ok""");
+        var client = CreateClient(apiHandler, anonymousHandler);
+        var uploadUrl = "https://storage.example.test/photos/upload";
+
+        // Act
+        await client.UploadPhotographAsync(uploadUrl, [1, 2, 3], "image/jpeg", CancellationToken.None);
+
+        // Assert
+        apiHandler.LastRequest.Should().BeNull();
+        anonymousHandler.LastRequest.Should().NotBeNull();
+        anonymousHandler.LastRequest!.RequestUri.Should().Be(new Uri(uploadUrl));
+        anonymousHandler.LastRequest.Headers.Authorization.Should().BeNull();
+        anonymousHandler.LastRequest.Content!.Headers.ContentType.Should().Be(new MediaTypeHeaderValue("image/jpeg"));
+    }
+
+    private static TestCatchClient CreateClient(RecordingHandler apiHandler, RecordingHandler anonymousHandler)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(HttpClientNames.AuthorizedApi)
+            .Returns(new HttpClient(apiHandler) { BaseAddress = new Uri("https://api.test/") });
+        factory.CreateClient(HttpClientNames.Anonymous)
+            .Returns(new HttpClient(anonymousHandler));
+        return new TestCatchClient(factory);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly string _responseBody;
+
+        public RecordingHandler(string responseBody)
+        {
+            _responseBody = responseBody;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_responseBody, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/FishingLogBook.Web.Tests.csproj
+++ b/tests/FishingLogBook.Web.Tests/FishingLogBook.Web.Tests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\FishingLogBook.Web\FishingLogBook.Web.csproj" />
     <ProjectReference Include="..\..\src\FishingLogBook.Shared\FishingLogBook.Shared.csproj" />
+    <ProjectReference Include="..\FishingLogBook.Tests.Common\FishingLogBook.Tests.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/FishingLogBook.Web.Tests/FishingLogBook.Web.Tests.csproj
+++ b/tests/FishingLogBook.Web.Tests/FishingLogBook.Web.Tests.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="bunit" />
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
@@ -1,4 +1,5 @@
 using Bunit;
+using Bunit.TestDoubles;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
@@ -8,12 +9,22 @@ namespace FishingLogBook.Web.Tests.Layouts.MainLayoutTests;
 
 public class BaseMainLayoutTest
 {
-    protected static BunitContext CreateContext()
+    protected static BunitContext CreateContext(bool isAuthenticated = false)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
+        var authorization = context.AddAuthorization();
+        if (isAuthenticated)
+        {
+            authorization.SetAuthorized("tester@example.test");
+        }
+        else
+        {
+            authorization.SetNotAuthorized();
+        }
+
         context.Services.AddSingleton(Substitute.For<ICultureService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingAuthentication.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingAuthentication.cs
@@ -1,0 +1,39 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Layouts.MainLayout;
+using FishingLogBook.Web.Localization;
+
+namespace FishingLogBook.Web.Tests.Layouts.MainLayoutTests;
+
+public class WhenTestingAuthentication : BaseMainLayoutTest
+{
+    [Fact]
+    public async Task ItShouldShowSignIn_WhenUnauthenticated()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(isAuthenticated: false);
+
+        // Act
+        var cut = context.Render<MainLayout>();
+
+        // Assert
+        cut.Find("#auth-sign-in-button").TextContent.Should().Contain("Sign in");
+        cut.FindAll("#auth-sign-out-button").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldShowSignOut_WhenAuthenticated()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(isAuthenticated: true);
+
+        // Act
+        var cut = context.Render<MainLayout>();
+
+        // Assert
+        cut.Find("#auth-sign-out-button").TextContent.Should().Contain("Sign out");
+        cut.FindAll("#auth-sign-in-button").Should().BeEmpty();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/TestSupport/TestAuthenticationStateProvider.cs
+++ b/tests/FishingLogBook.Web.Tests/TestSupport/TestAuthenticationStateProvider.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace FishingLogBook.Web.Tests.TestSupport;
+
+public sealed class TestAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private readonly ClaimsPrincipal _user;
+
+    public TestAuthenticationStateProvider(bool isAuthenticated, string name = "tester@example.test")
+    {
+        if (isAuthenticated)
+        {
+            var identity = new ClaimsIdentity(
+                [
+                    new Claim(ClaimTypes.Name, name),
+                    new Claim("email", name)
+                ],
+                authenticationType: "Test");
+            _user = new ClaimsPrincipal(identity);
+            return;
+        }
+
+        _user = new ClaimsPrincipal(new ClaimsIdentity());
+    }
+
+    public override Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        return Task.FromResult(new AuthenticationState(_user));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Amazon Cognito Managed Login for the Blazor PWA using standard Microsoft OIDC (authorization code + PKCE).
- Validate Cognito access tokens on the API (signature, issuer, lifetime, aud, token_use, client_id, and API scope).
- Provision Dev Cognito in Terraform (eu-west-2) and wire public Auth configuration for local, Fly, and GitHub Pages.

Closes #10

## Test plan
- [ ] Sign in and create account locally against Dev Cognito (`https://localhost:7005`)
- [ ] Confirm Test Catch requires login; System status and Diagnostics remain public
- [ ] Confirm API `/api/test-catches` rejects unauthenticated requests and accepts a valid access token