### PR TITLE
[Auth] Include trusted email claim in Cognito API access token

### DIFF
--- a/.claude/rules/terraform.md
+++ b/.claude/rules/terraform.md
@@ -56,7 +56,8 @@ Never attempt to solve an application problem by provisioning additional infrast
   currently defines `neon_project`; R2 defines `cloudflare_r2_bucket` (photos); Pages
   defines `cloudflare_pages_project`; Grafana Cloud looks up an existing stack and
   defines a Loki `logs:write` access policy. Cognito defines the user pool, resource
-  server, public PWA app client, hosted-UI domain, and managed-login branding. Fly
+  server, public PWA app client, hosted-UI domain, managed-login branding, and a
+  Pre Token Generation Lambda that adds verified Email to access tokens. Fly
   remains a skeleton.
 
 ## Stack (who does what)

--- a/.claude/rules/testing-csharp.md
+++ b/.claude/rules/testing-csharp.md
@@ -460,11 +460,11 @@ Mapper = new Mapper(config);
 Builders such as `TestJwt` must represent the **application token contract**, not
 whatever an external provider emits by default.
 
-`TestJwt.Email` is present because the FishingLogBook API currently requires a
-trusted authenticated `email` claim in addition to `sub`. That is an application
-contract. It does **not** mean default Cognito access tokens universally contain
-Email. Aligning deployed Cognito tokens with this contract is a separate
-authentication follow-up; do not imply that Cognito always supplies Email.
+`TestJwt.Email` is present because the FishingLogBook API requires a trusted
+authenticated `email` claim in addition to `sub`. Cognito access tokens include
+that claim via a Pre Token Generation Lambda (event version V2_0) after a reviewed
+Terraform apply. `TestJwt` still represents the application contract, not a raw
+Cognito default token.
 
 ## Database-backed infrastructure tests
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -97,3 +97,19 @@ jobs:
 
       - name: Terraform validate
         run: terraform validate
+
+  cognito-lambda-test:
+    name: Cognito pre-token Lambda tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Test pre-token generation Lambda
+        run: node --test
+        working-directory: infrastructure/terraform/modules/cognito/lambda

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ secrets.json
 # Terraform — never commit state, secrets, plans, or local overrides.
 # .terraform.lock.hcl IS committed (provider version lock).
 **/.terraform/
+infrastructure/terraform/modules/cognito/.build/
 *.tfstate
 *.tfstate.*
 .terraform.tfstate.lock.info

--- a/BUILD.md
+++ b/BUILD.md
@@ -728,7 +728,9 @@ Blazor assemblies
 
 Terraform defines Amazon Cognito in `infrastructure/terraform/modules/cognito/`. Each
 environment has its own user pool, resource server, public PWA app client, hosted-UI
-domain, and managed-login branding. Apply is **manual only** — see `infrastructure/README.md`.
+domain, managed-login branding, and a Pre Token Generation Lambda that adds the
+verified email claim to access tokens. Apply is **manual only** — see
+`infrastructure/README.md`.
 
 ## Flow
 
@@ -796,6 +798,30 @@ The Cognito resource-server identifier is the same URL as `Auth:ApiResource`
 with RFC 8707 resource binding when those scopes belong to that URL identifier.
 The resulting API scope is `https://fishing-logbook-dev-api.fly.dev/access`.
 
+## Access token Email claim
+
+Cognito access tokens omit `email` by default. ID tokens include it when the `email`
+scope is requested; the API rejects ID tokens (`token_use` must be `access`).
+
+The supported mechanism is a Cognito **Pre Token Generation** Lambda trigger using
+event version **V2_0**. V1_0 customizes ID tokens only. V2_0 can add claims to
+**access** tokens and is available on this project's Essentials-tier user pool.
+`email` is not a forbidden override claim (`sub`, `token_use`, `aud`, `iss`, and
+similar remain untouched).
+
+The Lambda copies `event.request.userAttributes.email` onto
+`response.claimsAndScopeOverrideDetails.accessTokenGeneration.claimsToAddOrOverride.email`
+only when that email is present and `email_verified` is true. Missing or unverified
+email leaves the token unchanged; `CurrentUserMiddleware` then returns 401. The
+Lambda does not log email or other PII. It does not call `/userinfo`.
+
+JWT validation is unchanged: signature, issuer, lifetime, `aud`, `token_use==access`,
+`client_id`, and API scope still apply. After those checks, the API still requires
+the trusted `email` claim together with `sub`.
+
+Tokens include Email only after a reviewed Terraform apply of this Lambda in that
+environment.
+
 ## Public configuration after a reviewed apply
 
 Copy Terraform outputs into (these values are public identifiers, not secrets):
@@ -858,11 +884,10 @@ Email is never used to find a User, resolve a UserId, merge users, or prove
 ownership. Two different Provider+Subject identities may share the same email and
 remain different internal Users. Changing email does not change UserId.
 
-The FishingLogBook API currently requires the trusted `email` claim on the access
-token in addition to `sub`. That is an application contract, not a statement that
-default Cognito access tokens contain Email. `TestJwt` includes Email because tests
-must satisfy that API contract. Aligning deployed Cognito tokens is a separate
-authentication follow-up (GitHub issue for Cognito access-token Email).
+The FishingLogBook API requires the trusted `email` claim on the access token in
+addition to `sub`. Cognito includes that claim on access tokens via the Pre Token
+Generation Lambda (event version V2_0) described in §25. `TestJwt` includes Email
+because tests represent that same application contract. JWT validation is unchanged.
 
 `UNIQUE (Provider, Subject)` is the lookup key. Username, display name, and
 device id are not identity keys.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -58,8 +58,10 @@ handler, `ValidatedResponse`, validator). The API translates a validated access 
 into `Provider`, `Subject`, and authenticated `Email` and sends
 `ResolveCurrentUserCommand`. Email is account data, not the identity lookup key.
 The FishingLogBook API requires that trusted `email` claim on the access token together
-with `sub`. That is an application contract; default Cognito access tokens do not
-universally include Email. Aligning Cognito token issuance is a separate follow-up.
+with `sub`. Cognito access tokens include Email via a Pre Token Generation Lambda
+(event version V2_0) that copies the verified email user attribute. JWT validation
+is unchanged. Tokens include Email only after that Lambda is applied in the
+environment.
 
 Handlers call application services; services call repositories. Repositories own SQL
 transactions.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -82,6 +82,7 @@ Commit the resulting `.terraform.lock.hcl` in each environment directory.
 |---|---|---|
 | Cloudflare Pages + R2 | `cloudflare/cloudflare` | `CLOUDFLARE_API_TOKEN` |
 | Amazon Cognito | `hashicorp/aws` | standard AWS credentials / profile |
+| Lambda zip helper | `hashicorp/archive` | none |
 | Neon PostgreSQL | `kislerdm/neon` | `NEON_API_KEY` |
 | Grafana Cloud | `grafana/grafana` | `GRAFANA_CLOUD_ACCESS_POLICY_TOKEN` |
 | Fly.io API | **flyctl, not Terraform** | `flyctl auth` / `FLY_API_TOKEN` |
@@ -225,7 +226,10 @@ Do not apply Grafana in prod until you want a separate Loki write token for prod
 
 Cognito is the only AWS application service this project uses. Terraform owns the user
 pool, resource server, public PWA app client (`generate_secret = false`), hosted-UI
-domain, and managed-login branding. There is no client secret to output or store.
+domain, managed-login branding, and a Pre Token Generation Lambda (event version V2_0)
+that copies the verified email user attribute onto the **access** token. Cognito access
+tokens omit email by default; ID tokens are rejected by the API. There is no client
+secret to output or store. The Lambda does not log PII. JWT validation is unchanged.
 
 The PWA uses Authorization Code + PKCE S256 via
 `Microsoft.AspNetCore.Components.WebAssembly.Authentication`. FishingLogBook does not
@@ -246,9 +250,12 @@ Also enabled: token revocation, refresh rotation, `prevent_user_existence_errors
 Password policy: minimum 12 characters, upper + lower + number required, symbols not
 required. Length over extra complexity.
 
-**Do not apply until you have reviewed `terraform plan`.** Expected new resources in
-Dev: user pool, resource server, public PWA app client, user-pool domain, managed-login
-branding (5). Abort if the plan shows destroy/replace of Neon, R2, Pages, or Grafana.
+**Do not apply until you have reviewed `terraform plan`.** For an existing Dev user
+pool, expect to **add** the Pre Token Generation Lambda, IAM role, log-group (7-day
+retention), basic-execution attachment, and invoke permission, and to **update** the
+user pool `lambda_config` in place. Abort if the plan shows replace/destroy of the
+user pool, Neon, R2, Pages, or Grafana. Tokens include Email only after this apply.
+
 Prod must not be applied until real production callback/logout HTTPS URLs exist.
 
 After a reviewed apply, copy **public** outputs:

--- a/infrastructure/terraform/adding-resources-to-terraform.md
+++ b/infrastructure/terraform/adding-resources-to-terraform.md
@@ -3,8 +3,9 @@
 All Terraform lives under `infrastructure/terraform/`. Fly is still a **skeleton**.
 Neon (`neon_project`), R2 (`cloudflare_r2_bucket` photos), Pages
 (`cloudflare_pages_project`), Grafana Cloud Loki write access, and Cognito (user pool,
-public PWA client, hosted-UI domain, API resource server) are defined. Add further
-resources deliberately, one at a time, and only when explicitly approved. Read
+public PWA client, hosted-UI domain, API resource server, Pre Token Generation Lambda)
+are defined. Add further resources deliberately, one at a time, and only when explicitly
+approved. Read
 `.claude/rules/terraform.md` first.
 
 ## Step 1 — Pick the module

--- a/infrastructure/terraform/environments/dev/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/dev/.terraform.lock.hcl
@@ -51,6 +51,30 @@ provider "registry.terraform.io/grafana/grafana" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.8"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "h1:i4jOdktQW0SDbjM3IC2ZSqdd881FzVY+V11XKkLPHrk=",
+    "h1:jdmKm+xl6ZcQrijxapnZ94RVuz/G4vk7hsIa1N0VT5Q=",
+    "h1:oRWx6ZDIdlNBF90L8TzV9X7pQ+P403hoCDiBfmUfhC0=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.59.0"
   constraints = "~> 6.59"

--- a/infrastructure/terraform/environments/dev/versions.tf
+++ b/infrastructure/terraform/environments/dev/versions.tf
@@ -19,6 +19,10 @@ terraform {
       source  = "grafana/grafana"
       version = "~> 4.45"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.8"
+    }
   }
 }
 
@@ -38,6 +42,9 @@ provider "neon" {}
 # Grafana Cloud. The management token is read from GRAFANA_CLOUD_ACCESS_POLICY_TOKEN.
 # Required only when grafana_cloud_stack_slug is set. Never commit the token.
 provider "grafana" {}
+
+# Zip helper for the Cognito Pre Token Generation Lambda. No credentials.
+provider "archive" {}
 
 # NOTE: Fly.io is intentionally NOT managed by a Terraform provider. The official
 # provider is archived/unmaintained and the community alternative is immature, so Fly

--- a/infrastructure/terraform/environments/prod/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/prod/.terraform.lock.hcl
@@ -51,6 +51,30 @@ provider "registry.terraform.io/grafana/grafana" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.8"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "h1:i4jOdktQW0SDbjM3IC2ZSqdd881FzVY+V11XKkLPHrk=",
+    "h1:jdmKm+xl6ZcQrijxapnZ94RVuz/G4vk7hsIa1N0VT5Q=",
+    "h1:oRWx6ZDIdlNBF90L8TzV9X7pQ+P403hoCDiBfmUfhC0=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.59.0"
   constraints = "~> 6.59"

--- a/infrastructure/terraform/environments/prod/versions.tf
+++ b/infrastructure/terraform/environments/prod/versions.tf
@@ -19,6 +19,10 @@ terraform {
       source  = "grafana/grafana"
       version = "~> 4.45"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.8"
+    }
   }
 }
 
@@ -38,6 +42,9 @@ provider "neon" {}
 # Grafana Cloud. The management token is read from GRAFANA_CLOUD_ACCESS_POLICY_TOKEN.
 # Required only when grafana_cloud_stack_slug is set. Never commit the token.
 provider "grafana" {}
+
+# Zip helper for the Cognito Pre Token Generation Lambda. No credentials.
+provider "archive" {}
 
 # NOTE: Fly.io is intentionally NOT managed by a Terraform provider. The official
 # provider is archived/unmaintained and the community alternative is immature, so Fly

--- a/infrastructure/terraform/modules/cognito/lambda.tf
+++ b/infrastructure/terraform/modules/cognito/lambda.tf
@@ -1,0 +1,75 @@
+# Pre Token Generation Lambda (event version V2_0) copies the verified email user
+# attribute onto the access token. Cognito access tokens omit email by default.
+# Essentials-tier pools support V2_0. Do not log PII. JWT validation is unchanged.
+
+data "archive_file" "pre_token_generation" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/index.mjs"
+  output_path = "${path.module}/.build/pre-token-generation.zip"
+}
+
+data "aws_iam_policy_document" "pre_token_generation_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "pre_token_generation" {
+  name               = "${local.resource_prefix}-pre-token-generation"
+  assume_role_policy = data.aws_iam_policy_document.pre_token_generation_assume.json
+
+  tags = {
+    Environment = var.environment
+    Name        = "${local.resource_prefix}-pre-token-generation"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "pre_token_generation_logs" {
+  role       = aws_iam_role.pre_token_generation.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_cloudwatch_log_group" "pre_token_generation" {
+  name              = "/aws/lambda/${local.resource_prefix}-pre-token-generation"
+  retention_in_days = 7
+
+  tags = {
+    Environment = var.environment
+    Name        = "${local.resource_prefix}-pre-token-generation"
+  }
+}
+
+resource "aws_lambda_function" "pre_token_generation" {
+  filename         = data.archive_file.pre_token_generation.output_path
+  source_code_hash = data.archive_file.pre_token_generation.output_base64sha256
+  function_name    = "${local.resource_prefix}-pre-token-generation"
+  role             = aws_iam_role.pre_token_generation.arn
+  handler          = "index.handler"
+  runtime          = "nodejs22.x"
+  architectures    = ["x86_64"]
+  timeout          = 5
+  memory_size      = 128
+
+  tags = {
+    Environment = var.environment
+    Name        = "${local.resource_prefix}-pre-token-generation"
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.pre_token_generation_logs,
+    aws_cloudwatch_log_group.pre_token_generation,
+  ]
+}
+
+resource "aws_lambda_permission" "allow_cognito_pre_token_generation" {
+  statement_id  = "AllowCognitoPreTokenGeneration"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.pre_token_generation.function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.this.arn
+}

--- a/infrastructure/terraform/modules/cognito/lambda/index.mjs
+++ b/infrastructure/terraform/modules/cognito/lambda/index.mjs
@@ -1,0 +1,39 @@
+// Cognito Pre Token Generation trigger (event version V2_0).
+// Copies the verified email user attribute onto the access token. Does not log PII.
+// Reserved claims (sub, token_use, aud, iss, client_id, and similar) are never set.
+
+export function applyAccessTokenEmail(event) {
+  const attributes = event?.request?.userAttributes ?? {};
+  const email = typeof attributes.email === "string" ? attributes.email.trim() : "";
+  const verified =
+    attributes.email_verified === true || attributes.email_verified === "true";
+
+  if (email.length === 0 || !verified) {
+    return event;
+  }
+
+  const response = event.response ?? {};
+  const details = response.claimsAndScopeOverrideDetails ?? {};
+  const accessTokenGeneration = details.accessTokenGeneration ?? {};
+  const claimsToAddOrOverride = {
+    ...(accessTokenGeneration.claimsToAddOrOverride ?? {}),
+    email
+  };
+
+  event.response = {
+    ...response,
+    claimsAndScopeOverrideDetails: {
+      ...details,
+      accessTokenGeneration: {
+        ...accessTokenGeneration,
+        claimsToAddOrOverride
+      }
+    }
+  };
+
+  return event;
+}
+
+export async function handler(event) {
+  return applyAccessTokenEmail(event);
+}

--- a/infrastructure/terraform/modules/cognito/lambda/index.test.mjs
+++ b/infrastructure/terraform/modules/cognito/lambda/index.test.mjs
@@ -1,0 +1,146 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applyAccessTokenEmail, handler } from "./index.mjs";
+
+function baseEvent(userAttributes = {}, accessTokenGeneration = {}) {
+  return {
+    version: "2",
+    triggerSource: "TokenGeneration_Authentication",
+    request: {
+      userAttributes: {
+        sub: "abc-sub",
+        email: "tester@example.test",
+        email_verified: "true",
+        ...userAttributes
+      }
+    },
+    response: {
+      claimsAndScopeOverrideDetails: {
+        accessTokenGeneration
+      }
+    }
+  };
+}
+
+describe("applyAccessTokenEmail", () => {
+  it("adds verified email to access token claims", () => {
+    const result = applyAccessTokenEmail(baseEvent());
+
+    assert.equal(
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride.email,
+      "tester@example.test"
+    );
+  });
+
+  it("treats boolean true as verified", () => {
+    const result = applyAccessTokenEmail(
+      baseEvent({ email_verified: true })
+    );
+
+    assert.equal(
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride.email,
+      "tester@example.test"
+    );
+  });
+
+  it("trims whitespace from the email value", () => {
+    const result = applyAccessTokenEmail(
+      baseEvent({ email: "  tester@example.test  " })
+    );
+
+    assert.equal(
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride.email,
+      "tester@example.test"
+    );
+  });
+
+  it("does not add email when unverified", () => {
+    const result = applyAccessTokenEmail(
+      baseEvent({ email_verified: "false" })
+    );
+
+    assert.equal(
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride,
+      undefined
+    );
+  });
+
+  it("does not add email when email is missing", () => {
+    const result = applyAccessTokenEmail(
+      baseEvent({ email: undefined })
+    );
+
+    assert.equal(
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride,
+      undefined
+    );
+  });
+
+  it("does not add email when email is whitespace", () => {
+    const result = applyAccessTokenEmail(baseEvent({ email: "   " }));
+
+    assert.equal(
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride,
+      undefined
+    );
+  });
+
+  it("does not add email when email_verified is missing", () => {
+    const result = applyAccessTokenEmail(
+      baseEvent({ email_verified: undefined })
+    );
+
+    assert.equal(
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride,
+      undefined
+    );
+  });
+
+  it("does not set reserved claims on the access token", () => {
+    const result = applyAccessTokenEmail(baseEvent());
+    const claims =
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride;
+
+    assert.equal(claims.sub, undefined);
+    assert.equal(claims.token_use, undefined);
+    assert.equal(claims.aud, undefined);
+    assert.equal(claims.iss, undefined);
+    assert.equal(claims.client_id, undefined);
+    assert.equal(result.request.userAttributes.sub, "abc-sub");
+  });
+
+  it("merges email with existing access-token claim overrides", () => {
+    const result = applyAccessTokenEmail(
+      baseEvent(
+        {},
+        { claimsToAddOrOverride: { custom: "keep-me" } }
+      )
+    );
+    const claims =
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride;
+
+    assert.equal(claims.custom, "keep-me");
+    assert.equal(claims.email, "tester@example.test");
+  });
+});
+
+describe("handler", () => {
+  it("returns the event with email on the access token", async () => {
+    const result = await handler(baseEvent());
+
+    assert.equal(
+      result.response.claimsAndScopeOverrideDetails.accessTokenGeneration
+        .claimsToAddOrOverride.email,
+      "tester@example.test"
+    );
+  });
+});

--- a/infrastructure/terraform/modules/cognito/main.tf
+++ b/infrastructure/terraform/modules/cognito/main.tf
@@ -1,9 +1,12 @@
 # Amazon Cognito user pool, resource server, public PWA app client, hosted-UI domain,
-# and managed-login branding for one environment.
+# managed-login branding, and Pre Token Generation Lambda (V2_0) for one environment.
 #
 # The PWA is a public browser client: generate_secret is false. OAuth is Authorization
 # Code only (no implicit, no client_credentials). PKCE S256 is enforced by the Blazor
 # OIDC library against this public client.
+#
+# Access tokens omit email by default. The V2_0 Pre Token Generation trigger copies the
+# verified email user attribute onto the access token. Essentials-tier pools support V2_0.
 #
 # Destroying the user pool permanently deletes registered users. prevent_destroy and
 # deletion_protection are both set.
@@ -57,6 +60,17 @@ resource "aws_cognito_user_pool" "this" {
 
   verification_message_template {
     default_email_option = "CONFIRM_WITH_CODE"
+  }
+
+  # pre_token_generation and pre_token_generation_config must use the same ARN.
+  # V2_0 is required so the trigger can add claims to access tokens (V1_0 is ID-token only).
+  lambda_config {
+    pre_token_generation = aws_lambda_function.pre_token_generation.arn
+
+    pre_token_generation_config {
+      lambda_arn     = aws_lambda_function.pre_token_generation.arn
+      lambda_version = "V2_0"
+    }
   }
 
   tags = {

--- a/tests/FishingLogBook.Api.Tests/TestSupport/TestJwt.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/TestJwt.cs
@@ -12,7 +12,8 @@ public static class TestJwt
     public const string ClientId = "test-pwa-client";
     public const string Subject = "test-subject";
 
-    // FishingLogBook API contract requires email; default Cognito access tokens may omit it.
+    // FishingLogBook API contract requires email. Cognito access tokens include it via
+    // the Pre Token Generation Lambda (V2_0) after a reviewed Terraform apply.
     public const string Email = "tester@example.test";
 
     public static readonly RsaSecurityKey SigningKey = CreateSigningKey();


### PR DESCRIPTION
## Summary
- Configure Cognito **Pre Token Generation** (event version **V2_0**) so FishingLogBook **access** tokens include the verified `email` user attribute. V1_0 is ID-token only; `/userinfo` is not used; JWT validation from PR #70 is unchanged.
- Add a Node.js Lambda, IAM role, 7-day log group, and invoke permission in the Cognito Terraform module. The Lambda copies email onto the access token only when `email_verified` is true; it does not log PII or override reserved claims.
- Cover the Lambda with `node --test` (CI job added). Update BUILD.md, Architecture, and related docs so the live token contract is the V2_0 trigger rather than a caveat that default Cognito access tokens omit Email.

Closes #72

## Manual apply (required for live tokens)
Terraform was **not** applied. Dev (and later Prod) access tokens include Email only after a reviewed `terraform plan` / `terraform apply`.

For an existing Dev user pool, expect to **add** the Lambda, IAM role, log group, basic-execution attachment, and invoke permission, and to **update** the user pool `lambda_config` in place. **Abort** if the plan shows replace/destroy of the user pool, Neon, R2, Pages, or Grafana.

## Test plan
- [x] `node --test` in `infrastructure/terraform/modules/cognito/lambda` (10 passed)
- [x] `terraform fmt -check -recursive`
- [x] `terraform init -backend=false` + `terraform validate` for dev and prod
- [ ] CI `build-test`, `javascript-test`, `javascript-browser-test`, `terraform-validate`, and new `cognito-lambda-test` jobs
- [ ] After merge: reviewed Dev `terraform apply`, then sign in and confirm the API access token contains `email` while `token_use` remains `access`
- [ ] Confirm a missing/unverified email still results in API 401 (middleware unchanged)