### PR TITLE
FLB#15 | Capture optional Catch location without blocking save

### DIFF
--- a/src/FishingLogBook.Api/Endpoints/CatchEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/CatchEndpoints.cs
@@ -47,7 +47,8 @@ public static class CatchEndpoints
 
         if (response.Error is CatchHasNoPhotographsError
             or CatchPhotographIdentityError
-            or CatchOwnershipConflictError)
+            or CatchOwnershipConflictError
+            or CatchLocationInvalidError)
         {
             return Results.BadRequest(response);
         }

--- a/src/FishingLogBook.Application/Catches/Commands/UpsertCatchCommand.cs
+++ b/src/FishingLogBook.Application/Catches/Commands/UpsertCatchCommand.cs
@@ -74,5 +74,20 @@ public sealed class UpsertCatchCommandValidator : AbstractValidator<UpsertCatchC
         RuleForEach(command => command.Catch.Photographs)
             .Must((command, photograph) => photograph.CatchId == command.Catch.Id)
             .WithMessage("Each photograph must belong to the catch.");
+        When(command => command.Catch.Location is not null, () =>
+        {
+            RuleFor(command => command.Catch.Location!.Latitude)
+                .InclusiveBetween(CatchLocationConstants.MinLatitude, CatchLocationConstants.MaxLatitude);
+            RuleFor(command => command.Catch.Location!.Longitude)
+                .InclusiveBetween(CatchLocationConstants.MinLongitude, CatchLocationConstants.MaxLongitude);
+            RuleFor(command => command.Catch.Location!.CapturedOn)
+                .NotEqual(default(DateTimeOffset));
+            RuleFor(command => command.Catch.Location!.Source)
+                .NotEmpty();
+            RuleFor(command => command.Catch.Location!.Visibility)
+                .NotEmpty();
+            RuleFor(command => command.Catch.Location!.ConsentVersion)
+                .NotEmpty();
+        });
     }
 }

--- a/src/FishingLogBook.Application/Catches/Errors/CatchLocationInvalidError.cs
+++ b/src/FishingLogBook.Application/Catches/Errors/CatchLocationInvalidError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Catches.Errors;
+
+public sealed class CatchLocationInvalidError : Error
+{
+    public CatchLocationInvalidError()
+        : base("Catch location is invalid.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Services/CatchService.cs
+++ b/src/FishingLogBook.Application/Catches/Services/CatchService.cs
@@ -33,11 +33,18 @@ public sealed class CatchService : ICatchService
             return Result.Fail<CatchDto>(new CatchPhotographIdentityError());
         }
 
+        var location = ToLocation(args.Catch.Location);
+        if (args.Catch.Location is not null && location is null)
+        {
+            return Result.Fail<CatchDto>(new CatchLocationInvalidError());
+        }
+
         var catchRecord = new Catch
         {
             Id = args.Catch.Id,
             UserId = args.UserId,
             CaughtOn = args.Catch.CaughtOn,
+            Location = location,
             Photographs = photographs
                 .Select(photograph => new CatchPhotograph
                 {
@@ -55,5 +62,22 @@ public sealed class CatchService : ICatchService
         }
 
         return Result.Ok(saved.Value.Adapt<CatchDto>());
+    }
+
+    private static CatchLocation? ToLocation(CatchLocationDto? location)
+    {
+        if (location is null)
+        {
+            return null;
+        }
+
+        return CatchLocation.TryCreate(
+            location.Latitude,
+            location.Longitude,
+            location.AccuracyMetres,
+            location.CapturedOn,
+            location.Source,
+            location.Visibility,
+            location.ConsentVersion);
     }
 }

--- a/src/FishingLogBook.Application/Common/Mappings/CatchMappingRegistration.cs
+++ b/src/FishingLogBook.Application/Common/Mappings/CatchMappingRegistration.cs
@@ -15,6 +15,15 @@ public sealed class CatchMappingRegistration : IRegister
         config.NewConfig<UpsertCatchCommand, UpsertCatchArgs>();
         config.NewConfig<CatchPhotograph, CatchPhotographDto>()
             .MapWith(source => new CatchPhotographDto(source.Id, source.CatchId, source.ContentType));
+        config.NewConfig<CatchLocation, CatchLocationDto>()
+            .MapWith(source => new CatchLocationDto(
+                source.Latitude,
+                source.Longitude,
+                source.AccuracyMetres,
+                source.CapturedOn,
+                source.Source,
+                source.Visibility,
+                source.ConsentVersion));
         config.NewConfig<Catch, CatchDto>()
             .MapWith(source => new CatchDto(
                 source.Id,
@@ -24,7 +33,17 @@ public sealed class CatchMappingRegistration : IRegister
                         photograph.Id,
                         photograph.CatchId,
                         photograph.ContentType))
-                    .ToList())
+                    .ToList(),
+                source.Location == null
+                    ? null
+                    : new CatchLocationDto(
+                        source.Location.Latitude,
+                        source.Location.Longitude,
+                        source.Location.AccuracyMetres,
+                        source.Location.CapturedOn,
+                        source.Location.Source,
+                        source.Location.Visibility,
+                        source.Location.ConsentVersion))
             {
                 UserId = source.UserId
             });

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608171600_15_AddCatchLocation.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608171600_15_AddCatchLocation.sql
@@ -1,0 +1,35 @@
+ALTER TABLE "Catch"
+    ADD COLUMN IF NOT EXISTS "Latitude" double precision NULL,
+    ADD COLUMN IF NOT EXISTS "Longitude" double precision NULL,
+    ADD COLUMN IF NOT EXISTS "LocationAccuracyMetres" double precision NULL,
+    ADD COLUMN IF NOT EXISTS "LocationCapturedOn" timestamptz NULL,
+    ADD COLUMN IF NOT EXISTS "LocationSource" text NULL,
+    ADD COLUMN IF NOT EXISTS "LocationVisibility" text NULL,
+    ADD COLUMN IF NOT EXISTS "LocationConsentVersion" text NULL;
+
+ALTER TABLE "Catch"
+    DROP CONSTRAINT IF EXISTS "Catch_Location_Coherent";
+
+ALTER TABLE "Catch"
+    ADD CONSTRAINT "Catch_Location_Coherent" CHECK (
+        (
+            "Latitude" IS NULL
+            AND "Longitude" IS NULL
+            AND "LocationAccuracyMetres" IS NULL
+            AND "LocationCapturedOn" IS NULL
+            AND "LocationSource" IS NULL
+            AND "LocationVisibility" IS NULL
+            AND "LocationConsentVersion" IS NULL
+        )
+        OR
+        (
+            "Latitude" IS NOT NULL
+            AND "Longitude" IS NOT NULL
+            AND "Latitude" BETWEEN -90 AND 90
+            AND "Longitude" BETWEEN -180 AND 180
+            AND "LocationCapturedOn" IS NOT NULL
+            AND "LocationSource" IS NOT NULL
+            AND "LocationVisibility" IS NOT NULL
+            AND "LocationConsentVersion" IS NOT NULL
+        )
+    );

--- a/src/FishingLogBook.Domain/Catches/Catch.cs
+++ b/src/FishingLogBook.Domain/Catches/Catch.cs
@@ -8,5 +8,7 @@ public sealed class Catch
 
     public DateTimeOffset CaughtOn { get; init; }
 
+    public CatchLocation? Location { get; init; }
+
     public IReadOnlyList<CatchPhotograph> Photographs { get; init; } = [];
 }

--- a/src/FishingLogBook.Domain/Catches/CatchLocation.cs
+++ b/src/FishingLogBook.Domain/Catches/CatchLocation.cs
@@ -1,0 +1,53 @@
+namespace FishingLogBook.Domain.Catches;
+
+public sealed class CatchLocation
+{
+    public double Latitude { get; init; }
+
+    public double Longitude { get; init; }
+
+    public double? AccuracyMetres { get; init; }
+
+    public DateTimeOffset CapturedOn { get; init; }
+
+    public string Source { get; init; } = string.Empty;
+
+    public string Visibility { get; init; } = string.Empty;
+
+    public string ConsentVersion { get; init; } = string.Empty;
+
+    public static CatchLocation? TryCreate(
+        double latitude,
+        double longitude,
+        double? accuracyMetres,
+        DateTimeOffset capturedOn,
+        string? source,
+        string? visibility,
+        string? consentVersion)
+    {
+        if (!AreCoordinatesValid(latitude, longitude)
+            || capturedOn == default
+            || string.IsNullOrWhiteSpace(source)
+            || string.IsNullOrWhiteSpace(visibility)
+            || string.IsNullOrWhiteSpace(consentVersion))
+        {
+            return null;
+        }
+
+        return new CatchLocation
+        {
+            Latitude = latitude,
+            Longitude = longitude,
+            AccuracyMetres = accuracyMetres,
+            CapturedOn = capturedOn,
+            Source = source.Trim(),
+            Visibility = visibility.Trim(),
+            ConsentVersion = consentVersion.Trim()
+        };
+    }
+
+    public static bool AreCoordinatesValid(double latitude, double longitude)
+    {
+        return latitude is >= -90 and <= 90 && longitude is >= -180 and <= 180;
+    }
+}

--- a/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
@@ -74,15 +74,45 @@ public sealed class CatchRepository : ICatchRepository
         CancellationToken cancellationToken)
     {
         const string sql = """
-            INSERT INTO "Catch" ("Id", "UserId", "CaughtOn")
-            VALUES (@Id, @UserId, @CaughtOn)
+            INSERT INTO "Catch" (
+                "Id",
+                "UserId",
+                "CaughtOn",
+                "Latitude",
+                "Longitude",
+                "LocationAccuracyMetres",
+                "LocationCapturedOn",
+                "LocationSource",
+                "LocationVisibility",
+                "LocationConsentVersion")
+            VALUES (
+                @Id,
+                @UserId,
+                @CaughtOn,
+                @Latitude,
+                @Longitude,
+                @LocationAccuracyMetres,
+                @LocationCapturedOn,
+                @LocationSource,
+                @LocationVisibility,
+                @LocationConsentVersion)
             ON CONFLICT ("Id") DO UPDATE SET
-                "CaughtOn" = EXCLUDED."CaughtOn"
+                "CaughtOn" = EXCLUDED."CaughtOn",
+                "Latitude" = COALESCE(EXCLUDED."Latitude", "Catch"."Latitude"),
+                "Longitude" = COALESCE(EXCLUDED."Longitude", "Catch"."Longitude"),
+                "LocationAccuracyMetres" = CASE
+                    WHEN EXCLUDED."Latitude" IS NOT NULL THEN EXCLUDED."LocationAccuracyMetres"
+                    ELSE "Catch"."LocationAccuracyMetres"
+                END,
+                "LocationCapturedOn" = COALESCE(EXCLUDED."LocationCapturedOn", "Catch"."LocationCapturedOn"),
+                "LocationSource" = COALESCE(EXCLUDED."LocationSource", "Catch"."LocationSource"),
+                "LocationVisibility" = COALESCE(EXCLUDED."LocationVisibility", "Catch"."LocationVisibility"),
+                "LocationConsentVersion" = COALESCE(EXCLUDED."LocationConsentVersion", "Catch"."LocationConsentVersion")
             WHERE "Catch"."UserId" = EXCLUDED."UserId";
             """;
         await connection.ExecuteAsync(new CommandDefinition(
             sql,
-            new { catchRecord.Id, catchRecord.UserId, catchRecord.CaughtOn },
+            ToRow(catchRecord),
             transaction,
             cancellationToken: cancellationToken));
     }
@@ -121,7 +151,17 @@ public sealed class CatchRepository : ICatchRepository
         CancellationToken cancellationToken)
     {
         const string catchSql = """
-            SELECT "Id", "UserId", "CaughtOn"
+            SELECT
+                "Id",
+                "UserId",
+                "CaughtOn",
+                "Latitude",
+                "Longitude",
+                "LocationAccuracyMetres",
+                "LocationCapturedOn",
+                "LocationSource",
+                "LocationVisibility",
+                "LocationConsentVersion"
             FROM "Catch"
             WHERE "Id" = @Id;
             """;
@@ -152,8 +192,43 @@ public sealed class CatchRepository : ICatchRepository
             Id = catchRow.Id,
             UserId = catchRow.UserId,
             CaughtOn = catchRow.CaughtOn,
+            Location = ToLocation(catchRow),
             Photographs = photographs.ToArray()
         };
+    }
+
+    private static object ToRow(Catch catchRecord)
+    {
+        return new
+        {
+            catchRecord.Id,
+            catchRecord.UserId,
+            catchRecord.CaughtOn,
+            Latitude = catchRecord.Location?.Latitude,
+            Longitude = catchRecord.Location?.Longitude,
+            LocationAccuracyMetres = catchRecord.Location?.AccuracyMetres,
+            LocationCapturedOn = catchRecord.Location?.CapturedOn,
+            LocationSource = catchRecord.Location?.Source,
+            LocationVisibility = catchRecord.Location?.Visibility,
+            LocationConsentVersion = catchRecord.Location?.ConsentVersion
+        };
+    }
+
+    private static CatchLocation? ToLocation(CatchRow catchRow)
+    {
+        if (catchRow.Latitude is null || catchRow.Longitude is null)
+        {
+            return null;
+        }
+
+        return CatchLocation.TryCreate(
+            catchRow.Latitude.Value,
+            catchRow.Longitude.Value,
+            catchRow.LocationAccuracyMetres,
+            catchRow.LocationCapturedOn ?? default,
+            catchRow.LocationSource,
+            catchRow.LocationVisibility,
+            catchRow.LocationConsentVersion);
     }
 
     private sealed class CatchRow
@@ -163,5 +238,19 @@ public sealed class CatchRepository : ICatchRepository
         public Guid UserId { get; init; }
 
         public DateTimeOffset CaughtOn { get; init; }
+
+        public double? Latitude { get; init; }
+
+        public double? Longitude { get; init; }
+
+        public double? LocationAccuracyMetres { get; init; }
+
+        public DateTimeOffset? LocationCapturedOn { get; init; }
+
+        public string? LocationSource { get; init; }
+
+        public string? LocationVisibility { get; init; }
+
+        public string? LocationConsentVersion { get; init; }
     }
 }

--- a/src/FishingLogBook.Shared/Constants/CatchLocationConstants.cs
+++ b/src/FishingLogBook.Shared/Constants/CatchLocationConstants.cs
@@ -1,0 +1,18 @@
+namespace FishingLogBook.Shared.Constants;
+
+public static class CatchLocationConstants
+{
+    public const double MinLatitude = -90;
+
+    public const double MaxLatitude = 90;
+
+    public const double MinLongitude = -180;
+
+    public const double MaxLongitude = 180;
+
+    public static bool AreCoordinatesValid(double latitude, double longitude)
+    {
+        return latitude is >= MinLatitude and <= MaxLatitude
+            && longitude is >= MinLongitude and <= MaxLongitude;
+    }
+}

--- a/src/FishingLogBook.Shared/Dtos/CatchDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/CatchDto.cs
@@ -3,7 +3,8 @@ namespace FishingLogBook.Shared.Dtos;
 public sealed record CatchDto(
     Guid Id,
     DateTimeOffset CaughtOn,
-    IReadOnlyList<CatchPhotographDto> Photographs)
+    IReadOnlyList<CatchPhotographDto> Photographs,
+    CatchLocationDto? Location = null)
 {
     public Guid UserId { get; init; }
 }

--- a/src/FishingLogBook.Web/Browser/Location/ILocationService.cs
+++ b/src/FishingLogBook.Web/Browser/Location/ILocationService.cs
@@ -1,4 +1,4 @@
-using FishingLogBook.Web.Features.TestCatch.Models;
+using FishingLogBook.Web.Features.Catch.Models;
 
 namespace FishingLogBook.Web.Browser.Location;
 
@@ -8,7 +8,7 @@ public interface ILocationService
 
     Task DismissPromptAsync(CancellationToken cancellationToken);
 
-    Task<TestCatchLocationModel?> TryCaptureAsync(bool userRequested, CancellationToken cancellationToken);
+    Task<CatchLocationModel?> TryCaptureAsync(bool userRequested, CancellationToken cancellationToken);
 }
 
 public sealed record LocationPromptStatus(

--- a/src/FishingLogBook.Web/Browser/Location/LocationService.cs
+++ b/src/FishingLogBook.Web/Browser/Location/LocationService.cs
@@ -1,10 +1,10 @@
+using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Diagnostics;
 using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
-using FishingLogBook.Web.Features.TestCatch.Models;
-using FishingLogBook.Web.Features.TestCatch.Offline;
 using Microsoft.JSInterop;
 
 namespace FishingLogBook.Web.Browser.Location;
@@ -51,7 +51,7 @@ public sealed class LocationService : ILocationService
         await module.InvokeVoidAsync("setPromptDismissed", cancellationToken);
     }
 
-    public async Task<TestCatchLocationModel?> TryCaptureAsync(bool userRequested, CancellationToken cancellationToken)
+    public async Task<CatchLocationModel?> TryCaptureAsync(bool userRequested, CancellationToken cancellationToken)
     {
         try
         {
@@ -76,7 +76,7 @@ public sealed class LocationService : ILocationService
         }
     }
 
-    private async Task<TestCatchLocationModel?> CaptureAsync(bool userRequested, CancellationToken cancellationToken)
+    private async Task<CatchLocationModel?> CaptureAsync(bool userRequested, CancellationToken cancellationToken)
     {
         var status = await GetPromptStatusAsync(cancellationToken);
         if (!userRequested && !status.WillCaptureOnSave)
@@ -106,7 +106,13 @@ public sealed class LocationService : ILocationService
             capturedOn = DateTimeOffset.UtcNow;
         }
 
-        return new TestCatchLocationModel(
+        if (!CatchLocationConstants.AreCoordinatesValid(result.Latitude, result.Longitude))
+        {
+            await LogCaptureOutcomeAsync("unavailable", cancellationToken);
+            return null;
+        }
+
+        return new CatchLocationModel(
             result.Latitude,
             result.Longitude,
             result.Accuracy,

--- a/src/FishingLogBook.Web/BrowserTests/harness/index.html
+++ b/src/FishingLogBook.Web/BrowserTests/harness/index.html
@@ -82,6 +82,59 @@
                 );
                 return getAllCatchesWithPhotographs();
             },
+            async putAndGetProductionCatchWithLocation() {
+                const catchId = '11111111-1111-1111-1111-111111111111';
+                const photographId = '22222222-2222-2222-2222-222222222222';
+                await putCatchWithPhotographs(
+                    JSON.stringify({
+                        id: catchId,
+                        caughtOn: '2026-08-17T08:00:00+00:00',
+                        photographs: [{
+                            id: photographId,
+                            catchId,
+                            contentType: 'image/jpeg'
+                        }],
+                        location: {
+                            latitude: 53.2707,
+                            longitude: -9.0568,
+                            accuracyMetres: 12,
+                            capturedOn: '2026-08-17T08:00:00+00:00',
+                            source: 'DeviceGps',
+                            visibility: 'Private',
+                            consentVersion: '1'
+                        }
+                    }),
+                    [{
+                        id: photographId,
+                        catchId,
+                        contentType: 'image/jpeg',
+                        bytes: new Uint8Array([1, 2, 3])
+                    }]
+                );
+                return getAllCatchesWithPhotographs();
+            },
+            async putLegacyProductionCatchWithoutLocation() {
+                const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+                const photographId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+                await putCatchWithPhotographs(
+                    JSON.stringify({
+                        id: catchId,
+                        caughtOn: '2026-08-17T08:00:00+00:00',
+                        photographs: [{
+                            id: photographId,
+                            catchId,
+                            contentType: 'image/jpeg'
+                        }]
+                    }),
+                    [{
+                        id: photographId,
+                        catchId,
+                        contentType: 'image/jpeg',
+                        bytes: new Uint8Array([4, 5, 6])
+                    }]
+                );
+                return getAllCatchesWithPhotographs();
+            },
             async readProductionCatches() {
                 return getAllCatchesWithPhotographs();
             },

--- a/src/FishingLogBook.Web/BrowserTests/storage.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/storage.spec.js
@@ -57,6 +57,7 @@ test.describe('Production Catch IndexedDB', () => {
         expect(JSON.parse(records[0].json).id).toBe('11111111-1111-1111-1111-111111111111');
         expect(records[0].photographs[0].id).toBe('22222222-2222-2222-2222-222222222222');
         expect(records[0].photographs[0].bytesBase64).toBe(btoa(String.fromCharCode(1, 2, 3)));
+        expect(JSON.parse(records[0].json).location).toBeUndefined();
     });
 
     test('keeps Catch and photograph ids after close and reload', async ({ page }) => {
@@ -113,6 +114,40 @@ test.describe('Production Catch IndexedDB', () => {
 
         expect(result.threw).toBe(true);
         expect(result.items.map((item) => JSON.parse(item.json).id)).not.toContain('orphan-catch');
+    });
+
+    test('writes a Catch with location and keeps it after close and reload', async ({ page }) => {
+        await page.goto(`${harness}/index.html`);
+        await expect(page.locator('#status')).toHaveText('ready');
+        await page.evaluate(() => window.harness.putAndGetProductionCatchWithLocation());
+
+        await page.reload();
+        await expect(page.locator('#status')).toHaveText('ready');
+
+        const records = await page.evaluate(() => window.harness.readProductionCatches());
+        const catchRecord = JSON.parse(records[0].json);
+        expect(catchRecord.id).toBe('11111111-1111-1111-1111-111111111111');
+        expect(catchRecord.location).toEqual({
+            latitude: 53.2707,
+            longitude: -9.0568,
+            accuracyMetres: 12,
+            capturedOn: '2026-08-17T08:00:00+00:00',
+            source: 'DeviceGps',
+            visibility: 'Private',
+            consentVersion: '1'
+        });
+        expect(records[0].photographs[0].id).toBe('22222222-2222-2222-2222-222222222222');
+    });
+
+    test('still reads a Catch stored without a location property', async ({ page }) => {
+        await page.goto(`${harness}/index.html`);
+        await expect(page.locator('#status')).toHaveText('ready');
+
+        const records = await page.evaluate(() => window.harness.putLegacyProductionCatchWithoutLocation());
+        const catchRecord = JSON.parse(records[0].json);
+        expect(catchRecord.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+        expect(catchRecord.location).toBeUndefined();
+        expect(records[0].photographs[0].id).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
     });
 });
 

--- a/src/FishingLogBook.Web/Features/Catch/Models/CatchLocationModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Models/CatchLocationModel.cs
@@ -1,6 +1,6 @@
-namespace FishingLogBook.Web.Features.TestCatch.Models;
+namespace FishingLogBook.Web.Features.Catch.Models;
 
-public sealed record TestCatchLocationModel(
+public sealed record CatchLocationModel(
     double Latitude,
     double Longitude,
     double? AccuracyMetres,

--- a/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
@@ -4,4 +4,5 @@ public sealed record CatchModel(
     Guid Id,
     DateTimeOffset CaughtOn,
     IReadOnlyList<CatchPhotographModel> Photographs,
-    string? SpeciesName = null);
+    string? SpeciesName = null,
+    CatchLocationModel? Location = null);

--- a/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
@@ -24,7 +24,8 @@ internal static class CatchJson
                     photograph.Id,
                     photograph.CatchId,
                     photograph.ContentType))
-                .ToArray());
+                .ToArray(),
+            catchRecord.Location);
         return JsonSerializer.Serialize(metadata, Options);
     }
 
@@ -36,7 +37,8 @@ internal static class CatchJson
             metadata.Id,
             metadata.CaughtOn,
             OrderPhotographs(metadata.Photographs, photographs),
-            metadata.SpeciesName);
+            metadata.SpeciesName,
+            metadata.Location);
     }
 
     private static IReadOnlyList<CatchPhotographModel> OrderPhotographs(
@@ -61,7 +63,8 @@ internal static class CatchJson
         Guid Id,
         DateTimeOffset CaughtOn,
         string? SpeciesName,
-        IReadOnlyList<CatchPhotographMetadata> Photographs);
+        IReadOnlyList<CatchPhotographMetadata> Photographs,
+        CatchLocationModel? Location = null);
 
     private sealed record CatchPhotographMetadata(
         Guid Id,

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor
@@ -40,6 +40,45 @@
                     </div>
                 }
 
+                @if (!_isSaved && _locationPrompt.ShowExplainer)
+                {
+                    <MudStack Spacing="2" id="catch-location-explainer">
+                        <MudText Typo="Typo.body2">@Loc["Catch_LocationExplainer"]</MudText>
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_LocationPrivacy"]</MudText>
+                        <MudStack Row="true" Spacing="2">
+                            <MudButton Variant="Variant.Filled"
+                                       Color="Color.Primary"
+                                       OnClick="AllowLocationAsync"
+                                       id="catch-location-allow">
+                                @Loc["Catch_LocationAllow"]
+                            </MudButton>
+                            <MudButton Variant="Variant.Text"
+                                       Color="Color.Default"
+                                       OnClick="DismissLocationAsync"
+                                       id="catch-location-not-now">
+                                @Loc["Catch_LocationNotNow"]
+                            </MudButton>
+                        </MudStack>
+                    </MudStack>
+                }
+                else if (!_isSaved && _locationPrompt.WillCaptureOnSave)
+                {
+                    <MudText Typo="Typo.caption"
+                             Color="Color.Success"
+                             id="catch-location-status">
+                        @Loc["Catch_LocationOn"]
+                    </MudText>
+                }
+                else if (!_isSaved && _locationPrompt.ShowEnableLater)
+                {
+                    <MudButton Variant="Variant.Text"
+                               Color="Color.Primary"
+                               OnClick="AllowLocationAsync"
+                               id="catch-location-try-again">
+                        @Loc["Catch_LocationTryAgain"]
+                    </MudButton>
+                }
+
                 @if (_unsupportedFormat && !_isSaved)
                 {
                     <MudAlert Severity="Severity.Error" id="catch-photo-unsupported">@Loc["Catch_PhotoUnsupported"]</MudAlert>
@@ -87,6 +126,10 @@
                 @if (_isSaved)
                 {
                     <MudAlert Severity="Severity.Success" id="catch-saved">@Loc["Catch_Saved"]</MudAlert>
+                    @if (_locationSaved)
+                    {
+                        <MudText Typo="Typo.caption" id="catch-location-saved">@Loc["Catch_LocationSaved"]</MudText>
+                    }
                 }
 
                 @if (_saveFailed)

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
@@ -1,4 +1,5 @@
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Localization;
@@ -22,12 +23,24 @@ public partial class RecordCatch : ComponentBase, IDisposable
     private bool _isSaved;
     private bool _saveFailed;
     private bool _unsupportedFormat;
+    private bool _locationCaptureStarted;
+    private bool _locationSaved;
+    private LocationPromptStatus _locationPrompt = new(false, false, false);
+    private CatchLocationModel? _capturedLocation;
 
     [Inject]
     private ICatchStore CatchStore { get; set; } = default!;
 
     [Inject]
+    private ILocationService LocationService { get; set; } = default!;
+
+    [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshLocationPromptAsync();
+    }
 
     private bool CanSave
     {
@@ -104,6 +117,7 @@ public partial class RecordCatch : ComponentBase, IDisposable
         }
 
         _unsupportedFormat = rejectedUnsupported;
+        TryStartOpportunisticCapture();
     }
 
     private async Task AddPhotographAsync(IBrowserFile file)
@@ -203,10 +217,12 @@ public partial class RecordCatch : ComponentBase, IDisposable
                     photograph.ContentType,
                     photograph.Bytes))
                 .ToArray();
+            var location = _capturedLocation;
             await CatchStore.SaveAsync(
-                new CatchModel(catchId, _caughtOn ?? DateTimeOffset.Now, photographs),
+                new CatchModel(catchId, _caughtOn ?? DateTimeOffset.Now, photographs, Location: location),
                 _cancellationTokenSource.Token);
             _isSaved = true;
+            _locationSaved = location is not null;
         }
         catch (Exception)
         {
@@ -226,6 +242,89 @@ public partial class RecordCatch : ComponentBase, IDisposable
         _isSaved = false;
         _saveFailed = false;
         _unsupportedFormat = false;
+        _capturedLocation = null;
+        _locationCaptureStarted = false;
+        _locationSaved = false;
+    }
+
+    private async Task AllowLocationAsync()
+    {
+        if (_photographs.Count > 0)
+        {
+            if (!_locationCaptureStarted)
+            {
+                _locationCaptureStarted = true;
+                _ = CaptureLocationInBackgroundAsync(userRequested: true);
+            }
+        }
+        else
+        {
+            try
+            {
+                await LocationService.TryCaptureAsync(true, _cancellationTokenSource.Token);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        await RefreshLocationPromptAsync();
+    }
+
+    private async Task DismissLocationAsync()
+    {
+        try
+        {
+            await LocationService.DismissPromptAsync(_cancellationTokenSource.Token);
+        }
+        catch (Exception)
+        {
+        }
+
+        await RefreshLocationPromptAsync();
+    }
+
+    private void TryStartOpportunisticCapture()
+    {
+        if (_isSaved || _locationCaptureStarted || _photographs.Count == 0 || !_locationPrompt.WillCaptureOnSave)
+        {
+            return;
+        }
+
+        _locationCaptureStarted = true;
+        _ = CaptureLocationInBackgroundAsync(userRequested: false);
+    }
+
+    private async Task CaptureLocationInBackgroundAsync(bool userRequested)
+    {
+        try
+        {
+            var location = await LocationService.TryCaptureAsync(
+                userRequested,
+                _cancellationTokenSource.Token);
+            if (location is not null
+                && CatchLocationConstants.AreCoordinatesValid(location.Latitude, location.Longitude))
+            {
+                _capturedLocation = location;
+            }
+        }
+        catch (Exception)
+        {
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task RefreshLocationPromptAsync()
+    {
+        try
+        {
+            _locationPrompt = await LocationService.GetPromptStatusAsync(_cancellationTokenSource.Token);
+        }
+        catch (Exception)
+        {
+            _locationPrompt = new LocationPromptStatus(false, true, false);
+        }
     }
 
     public void Dispose()

--- a/src/FishingLogBook.Web/Features/TestCatch/Models/TestCatchModel.cs
+++ b/src/FishingLogBook.Web/Features/TestCatch/Models/TestCatchModel.cs
@@ -1,4 +1,5 @@
 using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
 
 namespace FishingLogBook.Web.Features.TestCatch.Models;
 
@@ -9,4 +10,4 @@ public sealed record TestCatchModel(
     string? Notes,
     SyncStatus SyncStatus,
     TestCatchPhotographModel? Photograph = null,
-    TestCatchLocationModel? Location = null);
+    CatchLocationModel? Location = null);

--- a/src/FishingLogBook.Web/Features/TestCatch/Offline/TestCatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/TestCatch/Offline/TestCatchSynchroniser.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
@@ -255,7 +256,7 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
             cancellationToken);
     }
 
-    private static CatchLocationDto? ToRemoteLocation(TestCatchLocationModel? location)
+    private static CatchLocationDto? ToRemoteLocation(CatchLocationModel? location)
     {
         if (location is null)
         {
@@ -272,14 +273,14 @@ public sealed class TestCatchSynchroniser : ITestCatchSynchroniser
             location.ConsentVersion);
     }
 
-    private static TestCatchLocationModel? FromRemoteLocation(CatchLocationDto? location)
+    private static CatchLocationModel? FromRemoteLocation(CatchLocationDto? location)
     {
         if (location is null)
         {
             return null;
         }
 
-        return new TestCatchLocationModel(
+        return new CatchLocationModel(
             location.Latitude,
             location.Longitude,
             location.AccuracyMetres,

--- a/src/FishingLogBook.Web/Features/TestCatch/Pages/TestCatchLog/TestCatchLog.razor.cs
+++ b/src/FishingLogBook.Web/Features/TestCatch/Pages/TestCatchLog/TestCatchLog.razor.cs
@@ -2,6 +2,7 @@ using FishingLogBook.Shared.Diagnostics;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
@@ -287,7 +288,7 @@ public partial class TestCatchLog : ComponentBase, IDisposable
         await InvokeAsync(StateHasChanged);
     }
 
-    private async Task<TestCatchLocationModel?> TryCaptureLocationAsync()
+    private async Task<CatchLocationModel?> TryCaptureLocationAsync()
     {
         try
         {

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -315,6 +315,27 @@
   <data name="Catch_SaveFailed" xml:space="preserve">
     <value>La prise n'a pas pu être enregistrée. Réessayez.</value>
   </data>
+  <data name="Catch_LocationExplainer" xml:space="preserve">
+    <value>La localisation peut aider à se souvenir de l'endroit de la prise.</value>
+  </data>
+  <data name="Catch_LocationPrivacy" xml:space="preserve">
+    <value>Votre spot de pêche exact reste privé par défaut.</value>
+  </data>
+  <data name="Catch_LocationAllow" xml:space="preserve">
+    <value>Autoriser la localisation</value>
+  </data>
+  <data name="Catch_LocationNotNow" xml:space="preserve">
+    <value>Pas maintenant</value>
+  </data>
+  <data name="Catch_LocationTryAgain" xml:space="preserve">
+    <value>Réessayer la localisation</value>
+  </data>
+  <data name="Catch_LocationSaved" xml:space="preserve">
+    <value>Localisation enregistrée</value>
+  </data>
+  <data name="Catch_LocationOn" xml:space="preserve">
+    <value>Localisation activée</value>
+  </data>
   <data name="Catch_LogbookPageTitle" xml:space="preserve">
     <value>FishingLogBook - Prises</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -315,6 +315,27 @@
   <data name="Catch_SaveFailed" xml:space="preserve">
     <value>The catch could not be saved. Try again.</value>
   </data>
+  <data name="Catch_LocationExplainer" xml:space="preserve">
+    <value>Location can help remember where a catch was made.</value>
+  </data>
+  <data name="Catch_LocationPrivacy" xml:space="preserve">
+    <value>Your exact fishing spot stays private by default.</value>
+  </data>
+  <data name="Catch_LocationAllow" xml:space="preserve">
+    <value>Allow location</value>
+  </data>
+  <data name="Catch_LocationNotNow" xml:space="preserve">
+    <value>Not now</value>
+  </data>
+  <data name="Catch_LocationTryAgain" xml:space="preserve">
+    <value>Try location again</value>
+  </data>
+  <data name="Catch_LocationSaved" xml:space="preserve">
+    <value>Location saved</value>
+  </data>
+  <data name="Catch_LocationOn" xml:space="preserve">
+    <value>Location on</value>
+  </data>
   <data name="Catch_LogbookPageTitle" xml:space="preserve">
     <value>FishingLogBook - Catches</value>
   </data>

--- a/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingUpsert.cs
@@ -154,8 +154,89 @@ public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
         body.CaughtOn.Should().Be(dto.CaughtOn);
         body.UserId.Should().Be(current!.UserId);
         body.Photographs.Should().ContainSingle();
+        body.Location.Should().BeNull();
         await _factory.CatchRepository.Received(1).UpsertAsync(
-            Arg.Is<Catch>(item => item.Id == dto.Id && item.Photographs.Count == 1),
+            Arg.Is<Catch>(item => item.Id == dto.Id && item.Photographs.Count == 1 && item.Location == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnInvalidLocation()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var dto = new CatchDto(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographDto(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg)],
+            new CatchLocationDto(
+                91,
+                -9.0568,
+                12,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion));
+        ResetCatchRepository();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/catches", dto);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.CatchRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Catch>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistOwnerLocationAsPrivateDeviceGps()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        var capturedOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z");
+        var location = new CatchLocationDto(
+            53.2707,
+            -9.0568,
+            12,
+            capturedOn,
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        var dto = new CatchDto(
+            catchId,
+            capturedOn,
+            [new CatchPhotographDto(photographId, catchId, PhotographContentTypeConstants.Jpeg)],
+            location);
+        ResetCatchRepository();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/catches", dto);
+        var body = await response.Content.ReadFromJsonAsync<CatchDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().NotBeNull();
+        body!.UserId.Should().Be(current!.UserId);
+        body.Location.Should().Be(location);
+        body.Location!.Visibility.Should().Be(LocationDefaults.Private);
+        body.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        body.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+        await _factory.CatchRepository.Received(1).UpsertAsync(
+            Arg.Is<Catch>(item =>
+                item.Id == catchId
+                && item.UserId == current.UserId
+                && item.Location != null
+                && item.Location.Latitude == 53.2707
+                && item.Location.Longitude == -9.0568
+                && item.Location.AccuracyMetres == 12
+                && item.Location.Source == LocationDefaults.DeviceGps
+                && item.Location.Visibility == LocationDefaults.Private
+                && item.Location.ConsentVersion == LocationDefaults.ConsentVersion),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/UpsertCatchCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/UpsertCatchCommandValidatorTests/WhenTestingValidate.cs
@@ -132,6 +132,110 @@ public class WhenTestingValidate : BaseUpsertCatchCommandValidatorTest
         result.ShouldNotHaveAnyValidationErrors();
     }
 
+    [Theory]
+    [InlineData(91)]
+    [InlineData(-91)]
+    public void ItShouldHaveAValidationErrorWhenLatitudeIsOutOfRange(double latitude)
+    {
+        // Arrange
+        var command = Command(location: ValidLocation() with { Latitude = latitude });
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Catch.Location!.Latitude);
+    }
+
+    [Theory]
+    [InlineData(181)]
+    [InlineData(-181)]
+    public void ItShouldHaveAValidationErrorWhenLongitudeIsOutOfRange(double longitude)
+    {
+        // Arrange
+        var command = Command(location: ValidLocation() with { Longitude = longitude });
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Catch.Location!.Longitude);
+    }
+
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenLocationCapturedOnIsMissing()
+    {
+        // Arrange
+        var command = Command(location: ValidLocation() with { CapturedOn = default });
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Catch.Location!.CapturedOn);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void ItShouldHaveAValidationErrorWhenLocationSourceIsMissing(string source)
+    {
+        // Arrange
+        var command = Command(location: ValidLocation() with { Source = source });
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Catch.Location!.Source);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void ItShouldHaveAValidationErrorWhenLocationVisibilityIsMissing(string visibility)
+    {
+        // Arrange
+        var command = Command(location: ValidLocation() with { Visibility = visibility });
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Catch.Location!.Visibility);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void ItShouldHaveAValidationErrorWhenLocationConsentVersionIsMissing(string consentVersion)
+    {
+        // Arrange
+        var command = Command(location: ValidLocation() with { ConsentVersion = consentVersion });
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Catch.Location!.ConsentVersion);
+    }
+
+    [Theory]
+    [InlineData(-90, -180)]
+    [InlineData(90, 180)]
+    [InlineData(0, 0)]
+    public void ItShouldAcceptBoundaryCoordinates(double latitude, double longitude)
+    {
+        // Arrange
+        var command = Command(location: ValidLocation() with { Latitude = latitude, Longitude = longitude });
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
     [Fact]
     public void ItShouldNotHaveValidationErrorsForAValidCommand()
     {
@@ -145,12 +249,38 @@ public class WhenTestingValidate : BaseUpsertCatchCommandValidatorTest
         result.ShouldNotHaveAnyValidationErrors();
     }
 
+    [Fact]
+    public void ItShouldNotHaveValidationErrorsForAValidLocatedCommand()
+    {
+        // Arrange
+        var command = Command(location: ValidLocation());
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static CatchLocationDto ValidLocation()
+    {
+        return new CatchLocationDto(
+            53.2707,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+    }
+
     private static UpsertCatchCommand Command(
         Guid? userId = null,
         Guid? catchId = null,
         DateTimeOffset caughtOn = new(),
         bool useDefaultCaughtOn = false,
-        IReadOnlyList<CatchPhotographDto>? photographs = null)
+        IReadOnlyList<CatchPhotographDto>? photographs = null,
+        CatchLocationDto? location = null)
     {
         var resolvedCatchId = catchId ?? Guid.NewGuid();
         return new UpsertCatchCommand
@@ -164,7 +294,8 @@ public class WhenTestingValidate : BaseUpsertCatchCommandValidatorTest
                 photographs ??
                 [
                     new CatchPhotographDto(Guid.NewGuid(), resolvedCatchId, PhotographContentTypeConstants.Jpeg)
-                ])
+                ],
+                location)
         };
     }
 }

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingUpsert.cs
@@ -133,13 +133,78 @@ public class WhenTestingUpsert : BaseCatchServiceTest
                 && item.Id == catchId
                 && item.Photographs.Count == 1
                 && item.Photographs[0].Id == photographId
-                && item.Photographs[0].CatchId == catchId),
+                && item.Photographs[0].CatchId == catchId
+                && item.Location == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenLocationIsInvalid()
+    {
+        // Arrange
+        var args = Args(location: new CatchLocationDto(
+            91,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion));
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CatchLocationInvalidError>();
+        await MockCatchRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Catch>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistAValidPrivateDeviceLocation()
+    {
+        // Arrange
+        var capturedOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z");
+        var location = new CatchLocationDto(
+            53.2707,
+            -9.0568,
+            12,
+            capturedOn,
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        var args = Args(location: location);
+        MockCatchRepository
+            .UpsertAsync(Arg.Any<Catch>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(call.ArgAt<Catch>(0)));
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Location.Should().Be(location);
+        await MockCatchRepository.Received(1).UpsertAsync(
+            Arg.Is<Catch>(item =>
+                item.Id == args.Catch.Id
+                && item.UserId == args.UserId
+                && item.Location != null
+                && item.Location.Latitude == 53.2707
+                && item.Location.Longitude == -9.0568
+                && item.Location.AccuracyMetres == 12
+                && item.Location.CapturedOn == capturedOn
+                && item.Location.Source == LocationDefaults.DeviceGps
+                && item.Location.Visibility == LocationDefaults.Private
+                && item.Location.ConsentVersion == LocationDefaults.ConsentVersion),
             Arg.Any<CancellationToken>());
     }
 
     private static UpsertCatchArgs Args(
         Guid? catchId = null,
-        IReadOnlyList<CatchPhotographDto>? photographs = null)
+        IReadOnlyList<CatchPhotographDto>? photographs = null,
+        CatchLocationDto? location = null)
     {
         var resolvedCatchId = catchId ?? Guid.NewGuid();
         return new UpsertCatchArgs
@@ -151,7 +216,8 @@ public class WhenTestingUpsert : BaseCatchServiceTest
                 photographs ??
                 [
                     new CatchPhotographDto(Guid.NewGuid(), resolvedCatchId, PhotographContentTypeConstants.Jpeg)
-                ])
+                ],
+                location)
         };
     }
 }

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/BaseCatchRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/BaseCatchRepositoryTest.cs
@@ -2,6 +2,7 @@ using FishingLogBook.Domain.Catches;
 using FishingLogBook.Infrastructure.Persistence;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Tests.Common.Builders;
 
 namespace FishingLogBook.Infrastructure.Tests.Integration.Catches.CatchRepositoryTests;
@@ -60,6 +61,33 @@ public abstract class BaseCatchRepositoryTest
             UserId = userId,
             CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             Photographs = photos
+        };
+    }
+
+    protected static CatchLocation SampleLocation(
+        double latitude = 53.2707,
+        double longitude = -9.0568,
+        double? accuracyMetres = 12)
+    {
+        return CatchLocation.TryCreate(
+            latitude,
+            longitude,
+            accuracyMetres,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion)!;
+    }
+
+    protected static Catch WithLocation(Catch catchRecord, CatchLocation location)
+    {
+        return new Catch
+        {
+            Id = catchRecord.Id,
+            UserId = catchRecord.UserId,
+            CaughtOn = catchRecord.CaughtOn,
+            Location = location,
+            Photographs = catchRecord.Photographs
         };
     }
 }

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingGetById.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingGetById.cs
@@ -44,5 +44,6 @@ public class WhenTestingGetById : BaseCatchRepositoryTest
         result.Value.Photographs.Should().ContainSingle();
         result.Value.Photographs[0].Id.Should().Be(catchRecord.Photographs[0].Id);
         result.Value.Photographs[0].CatchId.Should().Be(catchRecord.Id);
+        result.Value.Location.Should().BeNull();
     }
 }

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpsert.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Application.Catches.Errors;
 using FishingLogBook.Domain.Catches;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
 using Npgsql;
 
 namespace FishingLogBook.Infrastructure.Tests.Integration.Catches.CatchRepositoryTests;
@@ -79,6 +80,217 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
         loaded.Value!.Id.Should().Be(original.Id);
         loaded.Value.CaughtOn.Should().Be(updated.CaughtOn);
         loaded.Value.Photographs[0].Id.Should().Be(original.Photographs[0].Id);
+        loaded.Value.Location.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldRoundTripACatchWithNoLocationColumns()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var catchRecord = NewCatch(userId);
+
+        // Act
+        var result = await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Location.Should().BeNull();
+        loaded.Value.Should().NotBeNull();
+        loaded.Value!.Location.Should().BeNull();
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var row = await connection.QuerySingleAsync(
+            """
+            SELECT
+                "Latitude",
+                "Longitude",
+                "LocationAccuracyMetres",
+                "LocationCapturedOn",
+                "LocationSource",
+                "LocationVisibility",
+                "LocationConsentVersion"
+            FROM "Catch"
+            WHERE "Id" = @Id;
+            """,
+            new { catchRecord.Id });
+        ((object?)row.Latitude).Should().BeNull();
+        ((object?)row.Longitude).Should().BeNull();
+        ((object?)row.LocationAccuracyMetres).Should().BeNull();
+        ((object?)row.LocationCapturedOn).Should().BeNull();
+        ((object?)row.LocationSource).Should().BeNull();
+        ((object?)row.LocationVisibility).Should().BeNull();
+        ((object?)row.LocationConsentVersion).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldRoundTripALocatedCatchWithPrivateDeviceGpsDefaults()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var location = SampleLocation();
+        var catchRecord = WithLocation(NewCatch(userId), location);
+
+        // Act
+        var result = await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        loaded.Value.Should().NotBeNull();
+        loaded.Value!.Location.Should().NotBeNull();
+        loaded.Value.Location!.Latitude.Should().Be(location.Latitude);
+        loaded.Value.Location.Longitude.Should().Be(location.Longitude);
+        loaded.Value.Location.AccuracyMetres.Should().Be(location.AccuracyMetres);
+        loaded.Value.Location.CapturedOn.Should().Be(location.CapturedOn);
+        loaded.Value.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        loaded.Value.Location.Visibility.Should().Be(LocationDefaults.Private);
+        loaded.Value.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+    }
+
+    [Fact]
+    public async Task ItShouldRoundTripLocationWhenAccuracyIsMissing()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var location = SampleLocation(accuracyMetres: null);
+        var catchRecord = WithLocation(NewCatch(userId), location);
+
+        // Act
+        var result = await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Location.Should().NotBeNull();
+        result.Value.Location!.AccuracyMetres.Should().BeNull();
+        result.Value.Location.Latitude.Should().Be(53.2707);
+        result.Value.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+    }
+
+    [Fact]
+    public async Task ItShouldKeepExistingLocationWhenLaterUpsertOmitsIt()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var location = SampleLocation();
+        var original = WithLocation(NewCatch(userId), location);
+        await Sut.UpsertAsync(original, CancellationToken.None);
+        var updatedCaughtOn = DateTimeOffset.Parse("2026-08-17T12:00:00Z");
+        var updated = new Catch
+        {
+            Id = original.Id,
+            UserId = userId,
+            CaughtOn = updatedCaughtOn,
+            Photographs = original.Photographs
+        };
+
+        // Act
+        var result = await Sut.UpsertAsync(updated, CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(original.Id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        loaded.Value.Should().NotBeNull();
+        loaded.Value!.CaughtOn.Should().Be(updatedCaughtOn);
+        loaded.Value.Location.Should().NotBeNull();
+        loaded.Value.Location!.Latitude.Should().Be(location.Latitude);
+        loaded.Value.Location.Longitude.Should().Be(location.Longitude);
+        loaded.Value.Location.AccuracyMetres.Should().Be(location.AccuracyMetres);
+        loaded.Value.Location.Visibility.Should().Be(LocationDefaults.Private);
+        loaded.Value.Photographs[0].Id.Should().Be(original.Photographs[0].Id);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectHalfCoordinates()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var act = () => connection.ExecuteAsync(
+            """
+            INSERT INTO "Catch" ("Id", "UserId", "CaughtOn", "Latitude")
+            VALUES (@Id, @UserId, @CaughtOn, @Latitude);
+            """,
+            new
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                CaughtOn = DateTimeOffset.UtcNow,
+                Latitude = 53.2707
+            });
+
+        // Act
+        // Assert
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.CheckViolation);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectLocationMetadataWithoutCoordinates()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var act = () => connection.ExecuteAsync(
+            """
+            INSERT INTO "Catch" (
+                "Id",
+                "UserId",
+                "CaughtOn",
+                "LocationCapturedOn",
+                "LocationSource",
+                "LocationVisibility",
+                "LocationConsentVersion")
+            VALUES (
+                @Id,
+                @UserId,
+                @CaughtOn,
+                @LocationCapturedOn,
+                @LocationSource,
+                @LocationVisibility,
+                @LocationConsentVersion);
+            """,
+            new
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                CaughtOn = DateTimeOffset.UtcNow,
+                LocationCapturedOn = DateTimeOffset.UtcNow,
+                LocationSource = LocationDefaults.DeviceGps,
+                LocationVisibility = LocationDefaults.Private,
+                LocationConsentVersion = LocationDefaults.ConsentVersion
+            });
+
+        // Act
+        // Assert
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.CheckViolation);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectCoordinatesMissingRequiredLocationMetadata()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var act = () => connection.ExecuteAsync(
+            """
+            INSERT INTO "Catch" ("Id", "UserId", "CaughtOn", "Latitude", "Longitude")
+            VALUES (@Id, @UserId, @CaughtOn, @Latitude, @Longitude);
+            """,
+            new
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                CaughtOn = DateTimeOffset.UtcNow,
+                Latitude = 53.2707,
+                Longitude = -9.0568
+            });
+
+        // Act
+        // Assert
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.CheckViolation);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Shared.Tests/Serialization/WhenTestingWebSerialization.cs
+++ b/tests/FishingLogBook.Shared.Tests/Serialization/WhenTestingWebSerialization.cs
@@ -80,6 +80,56 @@ public class WhenTestingWebSerialization : BaseSerializationTest
     }
 
     [Fact]
+    public void ItShouldRoundTripCatchDtoLocationUsingWebDefaults()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var original = new CatchDto(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographDto(Guid.NewGuid(), catchId, "image/jpeg")],
+            new CatchLocationDto(
+                53.2707,
+                -9.0568,
+                12,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion));
+
+        // Act
+        var json = JsonSerializer.Serialize(original, WebOptions);
+        var deserialized = JsonSerializer.Deserialize<CatchDto>(json, WebOptions);
+
+        // Assert
+        json.Should().Contain("\"latitude\":53.2707");
+        deserialized.Should().BeEquivalentTo(original);
+        deserialized!.Location.Should().NotBeNull();
+        deserialized.Location!.Visibility.Should().Be(LocationDefaults.Private);
+        deserialized.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        deserialized.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+    }
+
+    [Fact]
+    public void ItShouldRoundTripCatchDtoWithoutLocationUsingWebDefaults()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var original = new CatchDto(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographDto(Guid.NewGuid(), catchId, "image/jpeg")]);
+
+        // Act
+        var json = JsonSerializer.Serialize(original, WebOptions);
+        var deserialized = JsonSerializer.Deserialize<CatchDto>(json, WebOptions);
+
+        // Assert
+        deserialized.Should().BeEquivalentTo(original);
+        deserialized!.Location.Should().BeNull();
+    }
+
+    [Fact]
     public void ItShouldRoundTripProfileDtoWithoutPreciseCoordinates()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Browser/Location/WhenTestingTimeout.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Location/WhenTestingTimeout.cs
@@ -1,14 +1,9 @@
 using AwesomeAssertions;
 using FishingLogBook.Shared.Diagnostics;
 using FishingLogBook.Web.Browser.Location;
-using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
-using FishingLogBook.Web.Features.SystemStatus.Services;
-using FishingLogBook.Web.Features.TestCatch.Models;
-using FishingLogBook.Web.Features.TestCatch.Offline;
-using FishingLogBook.Web.Features.TestCatch.Services;
 using Microsoft.JSInterop;
 using NSubstitute;
 

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 
@@ -45,5 +46,82 @@ public class WhenTestingDeserialize : BaseCatchJsonTest
                 PhotographContentTypeConstants.Png,
                 PhotographContentTypeConstants.Webp);
         restored.Photographs.Should().OnlyContain(photograph => photograph.CatchId == catchId);
+    }
+
+    [Fact]
+    public void ItShouldReadLegacyMetadataWithoutALocationProperty()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var photographId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var json = """
+            {"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","caughtOn":"2026-08-17T08:00:00+00:00","speciesName":null,"photographs":[{"id":"11111111-1111-1111-1111-111111111111","catchId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","contentType":"image/jpeg"}]}
+            """;
+        var photographs = new[]
+        {
+            new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])
+        };
+
+        // Act
+        var restored = CatchJson.Deserialize(json, photographs);
+
+        // Assert
+        restored.Id.Should().Be(catchId);
+        restored.Location.Should().BeNull();
+        restored.Photographs.Should().ContainSingle(photograph => photograph.Id == photographId);
+    }
+
+    [Fact]
+    public void ItShouldRoundTripANullLocation()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        var catchRecord = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])]);
+
+        // Act
+        var restored = CatchJson.Deserialize(
+            CatchJson.SerializeMetadata(catchRecord),
+            catchRecord.Photographs);
+
+        // Assert
+        restored.Location.Should().BeNull();
+        restored.Id.Should().Be(catchId);
+    }
+
+    [Fact]
+    public void ItShouldRoundTripCapturedLocationAndAccuracy()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        var location = new CatchLocationModel(
+            53.2707,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        var catchRecord = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])],
+            Location: location);
+
+        // Act
+        var json = CatchJson.SerializeMetadata(catchRecord);
+        var restored = CatchJson.Deserialize(json, catchRecord.Photographs);
+
+        // Assert
+        json.Should().Contain("\"latitude\":53.2707");
+        json.Should().Contain("\"accuracyMetres\":12");
+        restored.Location.Should().Be(location);
+        restored.Location!.Visibility.Should().Be(LocationDefaults.Private);
+        restored.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        restored.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingSave.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.Catch.Models;
 
 namespace FishingLogBook.Web.Tests.Features.Catch.Offline.CatchStoreTests;
@@ -131,5 +132,109 @@ public class WhenTestingSave : BaseCatchStoreTest
         saved[0].Photographs[0].Bytes.Should().Equal(10);
         saved[0].Photographs[1].Bytes.Should().Equal(20);
         saved[0].Photographs[2].Bytes.Should().Equal(30);
+    }
+
+    [Fact]
+    public async Task ItShouldKeepACatchWithoutLocationAfterReopen()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        await Sut.SaveAsync(
+            new CatchModel(
+                catchId,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])]),
+            CancellationToken.None);
+        var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
+
+        // Act
+        var saved = await reopened.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle();
+        saved[0].Id.Should().Be(catchId);
+        saved[0].Location.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepLocationAndAccuracyAfterReopen()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        var location = new CatchLocationModel(
+            53.2707,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        await Sut.SaveAsync(
+            new CatchModel(
+                catchId,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])],
+                Location: location),
+            CancellationToken.None);
+        var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
+
+        // Act
+        var saved = await reopened.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().ContainSingle();
+        saved[0].Id.Should().Be(catchId);
+        saved[0].Location.Should().Be(location);
+        saved[0].Location!.AccuracyMetres.Should().Be(12);
+        saved[0].Photographs[0].Id.Should().Be(photographId);
+    }
+
+    [Fact]
+    public async Task ItShouldKeepIndependentLocationsForSeparatelySavedCatches()
+    {
+        // Arrange
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var firstLocation = new CatchLocationModel(
+            53.2707,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        var secondLocation = new CatchLocationModel(
+            53.3498,
+            -6.2603,
+            8,
+            DateTimeOffset.Parse("2026-08-17T09:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        await Sut.SaveAsync(
+            new CatchModel(
+                firstId,
+                DateTimeOffset.UtcNow,
+                [new CatchPhotographModel(Guid.NewGuid(), firstId, PhotographContentTypeConstants.Jpeg, [1])],
+                Location: firstLocation),
+            CancellationToken.None);
+
+        // Act
+        await Sut.SaveAsync(
+            new CatchModel(
+                secondId,
+                DateTimeOffset.UtcNow,
+                [new CatchPhotographModel(Guid.NewGuid(), secondId, PhotographContentTypeConstants.Jpeg, [2])],
+                Location: secondLocation),
+            CancellationToken.None);
+        var saved = await Sut.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        saved.Should().HaveCount(2);
+        saved.Single(item => item.Id == firstId).Location.Should().Be(firstLocation);
+        saved.Single(item => item.Id == secondId).Location.Should().Be(secondLocation);
+        firstLocation.Should().NotBe(secondLocation);
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
@@ -1,5 +1,8 @@
 using Bunit;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Location;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
 using FishingLogBook.Web.Localization;
@@ -12,15 +15,86 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Pages.RecordCatchTests;
 
 public class BaseRecordCatchTest
 {
-    protected static BunitContext CreateContext(ICatchStore store)
+    protected static BunitContext CreateContext(ICatchStore store, ILocationService? location = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
         context.Services.AddSingleton(store);
+        context.Services.AddSingleton(location ?? QuietLocation());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
+    }
+
+    protected static ILocationService QuietLocation()
+    {
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new LocationPromptStatus(false, false, false));
+        location.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((CatchLocationModel?)null);
+        return location;
+    }
+
+    protected static ILocationService GrantedLocation(params CatchLocationModel[] captured)
+    {
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new LocationPromptStatus(false, false, true));
+        location.TryCaptureAsync(false, Arg.Any<CancellationToken>())
+            .Returns(captured[0], captured.Skip(1).ToArray());
+        return location;
+    }
+
+    protected static ILocationService PromptLocation()
+    {
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new LocationPromptStatus(true, false, false));
+        location.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((CatchLocationModel?)null);
+        return location;
+    }
+
+    protected static ILocationService DeniedLocation()
+    {
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new LocationPromptStatus(false, true, false));
+        location.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((CatchLocationModel?)null);
+        return location;
+    }
+
+    protected static ILocationService HangingCaptureLocation()
+    {
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new LocationPromptStatus(false, false, true));
+        location.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var token = call.ArgAt<CancellationToken>(1);
+                var completion = new TaskCompletionSource<CatchLocationModel?>();
+                token.Register(() => completion.TrySetCanceled(token));
+                return completion.Task;
+            });
+        return location;
+    }
+
+    protected static CatchLocationModel SampleLocation(
+        double latitude = 53.2707,
+        double longitude = -9.0568)
+    {
+        return new CatchLocationModel(
+            latitude,
+            longitude,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
     }
 
     protected static InputFileContent PhotographFile(string name, string contentType, params byte[] bytes)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingLocation.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingLocation.cs
@@ -1,0 +1,413 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Location;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components.Forms;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.RecordCatchTests;
+
+public class WhenTestingLocation : BaseRecordCatchTest
+{
+    [Fact]
+    public async Task ItShouldNotRequestCoordinatesWhenRecordCatchOpens()
+    {
+        // Arrange
+        var store = Substitute.For<ICatchStore>();
+        var location = GrantedLocation(SampleLocation());
+        await using var context = CreateContext(store, location);
+
+        // Act
+        var cut = context.Render<RecordCatch>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#save-catch-button").Should().NotBeNull());
+        await location.Received(1).GetPromptStatusAsync(Arg.Any<CancellationToken>());
+        await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        cut.FindAll("#catch-location").Should().BeEmpty();
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-status").TextContent.Should().Contain("Location on"));
+        cut.FindAll("#catch-location-explainer").Should().BeEmpty();
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotStartCaptureWhenThePhotographIsUnsupported()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var location = GrantedLocation(SampleLocation());
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+
+        // Act
+        cut.FindComponents<InputFile>()[0].UploadFiles(
+            PhotographFile("catch.heic", "image/heic", 0x00, 0x01, 0x02));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-photo-unsupported").TextContent.Should().Contain("This photo format isn't supported"));
+        await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        cut.FindAll("#catch-photo-carousel").Should().BeEmpty();
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotStartASecondCaptureWhenMorePhotographsAreAdded()
+    {
+        // Arrange
+        var store = Substitute.For<ICatchStore>();
+        var location = GrantedLocation(SampleLocation());
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+
+        // Act
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("first.jpg", 0xFF, 0xD8, 0x01));
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("second.jpg", 0xFF, 0xD8, 0x02));
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("third.jpg", 0xFF, 0xD8, 0x03));
+
+        // Assert
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSaveWithoutLocationWhenPermissionIsDenied()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var location = DeniedLocation();
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+        cut.WaitForAssertion(() => cut.Find("#catch-location-try-again").Should().NotBeNull());
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.Location == null && catchRecord.Photographs.Count == 1),
+            Arg.Any<CancellationToken>());
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device");
+            cut.Find("#catch-photo-carousel").Should().NotBeNull();
+            cut.Find("#catch-record-another").Should().NotBeNull();
+        });
+        cut.FindAll("#catch-location-saved").Should().BeEmpty();
+        cut.FindAll("#catch-location-explainer").Should().BeEmpty();
+        cut.FindAll("#catch-location").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldSaveWithoutLocationWhenCaptureFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new LocationPromptStatus(false, false, true));
+        location.TryCaptureAsync(false, Arg.Any<CancellationToken>())
+            .Returns((CatchLocationModel?)null);
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.Location == null),
+            Arg.Any<CancellationToken>());
+        cut.WaitForAssertion(() => cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device"));
+        cut.FindAll("#catch-location-saved").Should().BeEmpty();
+        cut.Find("#catch-photo-carousel").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldSaveWithoutWaitingWhenLocationCaptureIsStillPending()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var location = HangingCaptureLocation();
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.Location == null && catchRecord.Photographs.Count == 1),
+            Arg.Any<CancellationToken>());
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device");
+            cut.Find("#catch-record-another").Should().NotBeNull();
+        });
+        cut.FindAll("#catch-location-saved").Should().BeEmpty();
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectInvalidCoordinatesAndStillSaveTheCatch()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var invalid = SampleLocation(latitude: 91);
+        var location = GrantedLocation(invalid);
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.Location == null),
+            Arg.Any<CancellationToken>());
+        cut.WaitForAssertion(() => cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device"));
+        cut.FindAll("#catch-location-saved").Should().BeEmpty();
+        cut.FindAll("#catch-location").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldExplainLocationBeforeRequestingPermission()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var location = PromptLocation();
+        await using var context = CreateContext(store, location);
+
+        // Act
+        var cut = context.Render<RecordCatch>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-location-explainer").TextContent.Should()
+                .Contain("Location can help remember where a catch was made.");
+            cut.Find("#catch-location-explainer").TextContent.Should()
+                .Contain("Your exact fishing spot stays private by default.");
+            cut.Find("#catch-location-allow").TextContent.Should().Contain("Allow location");
+            cut.Find("#catch-location-not-now").TextContent.Should().Contain("Not now");
+        });
+        await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        cut.FindAll("#catch-location").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldShowLocationOnAfterAllow()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                new LocationPromptStatus(true, false, false),
+                new LocationPromptStatus(false, false, true));
+        location.TryCaptureAsync(true, Arg.Any<CancellationToken>())
+            .Returns((CatchLocationModel?)null);
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+        cut.WaitForAssertion(() => cut.Find("#catch-location-allow").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#catch-location-allow").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("#catch-location-explainer").Should().BeEmpty();
+            cut.Find("#catch-location-status").TextContent.Should().Contain("Location on");
+        });
+        cut.FindAll("#catch-location").Should().BeEmpty();
+        await location.Received(1).TryCaptureAsync(true, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchLocationOnCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var store = Substitute.For<ICatchStore>();
+        var location = GrantedLocation(SampleLocation());
+        await using var context = CreateContext(store, location);
+
+        // Act
+        var cut = context.Render<RecordCatch>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-status").TextContent.Should().Contain("Localisation activée"));
+        await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchLocationExplainerCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var store = Substitute.For<ICatchStore>();
+        var location = PromptLocation();
+        await using var context = CreateContext(store, location);
+
+        // Act
+        var cut = context.Render<RecordCatch>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-location-explainer").TextContent.Should()
+                .Contain("La localisation peut aider à se souvenir de l'endroit de la prise.");
+            cut.Find("#catch-location-explainer").TextContent.Should()
+                .Contain("Votre spot de pêche exact reste privé par défaut.");
+            cut.Find("#catch-location-allow").TextContent.Should().Contain("Autoriser la localisation");
+            cut.Find("#catch-location-not-now").TextContent.Should().Contain("Pas maintenant");
+        });
+        await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDismissTheExplainerWhenNotNowIsChosen()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var location = Substitute.For<ILocationService>();
+        location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                new LocationPromptStatus(true, false, false),
+                new LocationPromptStatus(false, true, false));
+        location.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((CatchLocationModel?)null);
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+        cut.WaitForAssertion(() => cut.Find("#catch-location-not-now").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#catch-location-not-now").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("#catch-location-explainer").Should().BeEmpty();
+            cut.Find("#catch-location-try-again").Should().NotBeNull();
+        });
+        await location.Received(1).DismissPromptAsync(Arg.Any<CancellationToken>());
+        await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotReuseCatchALocationOrCaptureImmediatelyWhenRecordingAnother()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var firstLocation = SampleLocation(53.2707, -9.0568);
+        var secondLocation = SampleLocation(53.3498, -6.2603);
+        var saved = new List<CatchModel>();
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                saved.Add(call.ArgAt<CatchModel>(0));
+                return Task.CompletedTask;
+            });
+        var location = GrantedLocation(firstLocation, secondLocation);
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("first.jpg", 0xFF, 0xD8, 0x01));
+        await cut.Find("#save-catch-button").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#catch-record-another").Should().NotBeNull());
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+
+        // Act
+        await cut.Find("#catch-record-another").ClickAsync();
+
+        // Assert
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+        cut.FindAll("#catch-location-saved").Should().BeEmpty();
+        cut.Find("#catch-location-status").TextContent.Should().Contain("Location on");
+        cut.Find("#save-catch-button").HasAttribute("disabled").Should().BeTrue();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("second.jpg", 0xFF, 0xD8, 0x02));
+        await location.Received(2).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+        await cut.Find("#save-catch-button").ClickAsync();
+        cut.WaitForAssertion(() => saved.Should().HaveCount(2));
+        saved[0].Id.Should().NotBe(saved[1].Id);
+        saved[0].Location.Should().Be(firstLocation);
+        saved[1].Location.Should().Be(secondLocation);
+        saved[1].Location.Should().NotBe(saved[0].Location);
+        await store.Received(2).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.Location != null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistLocationWhenTheFirstValidPhotographStartsCapture()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var captured = SampleLocation();
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var location = GrantedLocation(captured);
+        await using var context = CreateContext(store, location);
+        var cut = context.Render<RecordCatch>();
+        await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+
+        // Act
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Location == captured
+                && catchRecord.Location!.Source == LocationDefaults.DeviceGps
+                && catchRecord.Location.Visibility == LocationDefaults.Private
+                && catchRecord.Location.ConsentVersion == LocationDefaults.ConsentVersion
+                && catchRecord.Photographs.Count == 1),
+            Arg.Any<CancellationToken>());
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device");
+            cut.Find("#catch-location-saved").TextContent.Should().Contain("Location saved");
+            cut.Find("#catch-photo-carousel").Should().NotBeNull();
+            cut.Find("#catch-record-another").Should().NotBeNull();
+        });
+        cut.FindAll("#catch-location").Should().BeEmpty();
+        cut.FindAll("#catch-location-status").Should().BeEmpty();
+        cut.Find("#catch-location-saved").TextContent.Should().NotContain("53.2707");
+        await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Bunit;
+using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
@@ -46,6 +47,7 @@ public class WhenTestingSave : BaseRecordCatchTest
         cut.FindAll("#catch-length").Should().BeEmpty();
         cut.FindAll("#catch-notes").Should().BeEmpty();
         cut.FindAll("#catch-location").Should().BeEmpty();
+        cut.FindAll("#catch-location-status").Should().BeEmpty();
         cut.FindAll("#test-catch-location-explainer").Should().BeEmpty();
         await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
     }
@@ -90,7 +92,8 @@ public class WhenTestingSave : BaseRecordCatchTest
                 catchRecord.Id != Guid.Empty
                 && catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Id != Guid.Empty
-                && catchRecord.SpeciesName == null),
+                && catchRecord.SpeciesName == null
+                && catchRecord.Location == null),
             Arg.Any<CancellationToken>());
     }
 
@@ -118,7 +121,8 @@ public class WhenTestingSave : BaseRecordCatchTest
                 && catchRecord.Photographs[0].Id == photographId
                 && catchRecord.Photographs[0].CatchId == catchRecord.Id
                 && catchRecord.SpeciesName == null
-                && catchRecord.CaughtOn != default),
+                && catchRecord.CaughtOn != default
+                && catchRecord.Location == null),
             Arg.Any<CancellationToken>());
         cut.WaitForAssertion(() =>
         {
@@ -134,6 +138,9 @@ public class WhenTestingSave : BaseRecordCatchTest
         cut.FindAll("#catch-photo-remove").Should().BeEmpty();
         cut.FindAll("#catch-take-photo").Should().BeEmpty();
         cut.FindAll("#catch-choose-photo").Should().BeEmpty();
+        cut.FindAll("#catch-location-saved").Should().BeEmpty();
+        cut.FindAll("#catch-location-status").Should().BeEmpty();
+        cut.FindAll("#catch-location").Should().BeEmpty();
         cut.FindComponents<InputFile>().Should().BeEmpty();
     }
 
@@ -250,6 +257,7 @@ public class WhenTestingSave : BaseRecordCatchTest
 
         // Assert
         injected.Should().Contain(typeof(ICatchStore));
+        injected.Should().Contain(typeof(ILocationService));
         injected.Should().NotContain(typeof(HttpClient));
         injected.Should().NotContain(type =>
             type.Name.Contains("Client", StringComparison.Ordinal)

--- a/tests/FishingLogBook.Web.Tests/Features/TestCatch/Offline/TestCatchStoreTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/TestCatch/Offline/TestCatchStoreTests/WhenTestingSave.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.TestCatch.Models;
 using FishingLogBook.Web.Features.TestCatch.Offline;
 
@@ -52,7 +53,7 @@ public class WhenTestingSave : BaseTestCatchStoreTest
     public async Task ItShouldStillContainLocation_WhenNewStoreReadsSamePersistence()
     {
         // Arrange
-        var location = new TestCatchLocationModel(
+        var location = new CatchLocationModel(
             53.2707,
             -9.0568,
             12,

--- a/tests/FishingLogBook.Web.Tests/Features/TestCatch/Offline/TestCatchSynchroniserTests/WhenTestingSynchronise.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/TestCatch/Offline/TestCatchSynchroniserTests/WhenTestingSynchronise.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.SystemStatus.Services;
 using FishingLogBook.Web.Features.TestCatch.Models;
 using FishingLogBook.Web.Features.TestCatch.Offline;
@@ -235,7 +236,7 @@ public class WhenTestingSynchronise
     public async Task ItShouldSendLocationWithTheCatch_WhenSynchronising()
     {
         // Arrange
-        var location = new TestCatchLocationModel(
+        var location = new CatchLocationModel(
             53.2707,
             -9.0568,
             12,

--- a/tests/FishingLogBook.Web.Tests/Features/TestCatch/Pages/TestCatchLogTests/BaseTestCatchLogTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/TestCatch/Pages/TestCatchLogTests/BaseTestCatchLogTest.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
@@ -69,7 +70,7 @@ public class BaseTestCatchLogTest
         location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
             .Returns(_ => Hang<LocationPromptStatus>());
         location.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
-            .Returns(_ => Hang<TestCatchLocationModel?>());
+            .Returns(_ => Hang<CatchLocationModel?>());
         return location;
     }
 
@@ -93,11 +94,11 @@ public class BaseTestCatchLogTest
         location.GetPromptStatusAsync(Arg.Any<CancellationToken>())
             .Returns(new LocationPromptStatus(false, true, false));
         location.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
-            .Returns((TestCatchLocationModel?)null);
+            .Returns((CatchLocationModel?)null);
         return location;
     }
 
-    protected static ILocationService GrantedLocation(TestCatchLocationModel captured)
+    protected static ILocationService GrantedLocation(CatchLocationModel captured)
     {
         var location = Substitute.For<ILocationService>();
         location.GetPromptStatusAsync(Arg.Any<CancellationToken>())

--- a/tests/FishingLogBook.Web.Tests/Features/TestCatch/Pages/TestCatchLogTests/WhenTestingLocationGranted.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/TestCatch/Pages/TestCatchLogTests/WhenTestingLocationGranted.cs
@@ -3,6 +3,7 @@ using Bunit;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.SystemStatus.Services;
 using FishingLogBook.Web.Features.TestCatch.Models;
 using FishingLogBook.Web.Features.TestCatch.Offline;
@@ -20,7 +21,7 @@ public class WhenTestingLocationGranted : BaseTestCatchLogTest
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        var captured = new TestCatchLocationModel(
+        var captured = new CatchLocationModel(
             53.2707,
             -9.0568,
             12,

--- a/tests/FishingLogBook.Web.Tests/Features/TestCatch/Pages/TestCatchLogTests/WhenTestingLocationRemove.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/TestCatch/Pages/TestCatchLogTests/WhenTestingLocationRemove.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.TestCatch.Models;
 using FishingLogBook.Web.Features.TestCatch.Offline;
 using FishingLogBook.Web.Features.TestCatch.Pages.TestCatchLog;
@@ -22,7 +23,7 @@ public class WhenTestingLocationRemove : BaseTestCatchLogTest
             DateTimeOffset.Parse("2026-08-15T12:00:00Z"),
             null,
             SyncStatus.Synchronised,
-            Location: new TestCatchLocationModel(
+            Location: new CatchLocationModel(
                 53.2707,
                 -9.0568,
                 12,


### PR DESCRIPTION
## Summary
- Signed-in anglers recording a production Catch on `/catches/record` can optionally have device location stored with that Catch. Location is enrichment only: denied, unavailable, timeout, invalid coordinates, and in-flight GPS never block Save.
- Opening Record Catch queries permission and may show a compact explainer. It does **not** call `getCurrentPosition`. The first valid photograph starts one opportunistic capture when permission is already granted. A second/third photograph does not start a parallel capture. Unsupported photographs do not start capture.
- Save uses location if it is already available and otherwise saves immediately without it. It does not await the outstanding GPS task.
- After Allow, or when permission is already granted, a compact **Location on** caption is shown (no coordinates). After a successful save with location, **Location saved** is shown. **Record another catch** clears Catch A location and waits for Catch B's first valid photograph.
- Captured locations persist `DeviceGps` / `Private` / consent `1`. Owner `POST /api/catches` may include location for later #17. No public API/DTO exposes precise coordinates. Record Catch does not call the API.
- Expand-only migration `202608171600_15_AddCatchLocation.sql` adds nullable location columns on `"Catch"` plus CHECK `Catch_Location_Coherent` so location is all-null or a complete object. Accuracy may stay null. Upsert of unrelated Catch data does not erase existing location. The #14 migration is unchanged.

Closes #15

## TestCatch transition

| Area | Decision |
| --- | --- |
| `ILocationService` / `LocationService` / `LocationPromptStatus` | REFACTOR / GENERALISE to `CatchLocationModel`. One service. |
| `wwwroot/js/browser/location.js` + timeouts 8000/2000 | REUSE |
| `flb-location-prompt-dismissed` | REUSE |
| `CatchLocationDto` + `LocationDefaults` | REUSE on owner Catch contract |
| `TestCatchLocationModel` | REFACTOR → `Features/Catch/Models/CatchLocationModel` |
| Capture during TestCatch save | TEMPORARILY KEEP on TestCatch; Record Catch captures on first valid photograph |
| Explainer UI | REFACTOR — compact `Catch_*` keys on Record Catch |
| Nested `location` in IndexedDB JSON | REUSE pattern in `CatchJson` |
| TestCatch SQL / repo / API / synchroniser | TEMPORARILY KEEP — not wired to production Catch |
| TestCatch list **Remove location** | DO NOT COPY onto #15 Record Catch |
| Parallel `ICatchLocationService` | DO NOT ADD |

## Test plan
- [ ] Open Record Catch with location permission not yet asked: compact explainer appears; no GPS request until Allow.
- [ ] Tap **Allow location**: explainer is replaced by **Location on** (no coordinates).
- [ ] With permission already granted: opening Record Catch shows **Location on** and does not request coordinates until the first valid photograph.
- [ ] Add a JPEG: capture starts in the background; Save still works immediately. If location arrived in time it is stored; if GPS is still pending/failed the Catch saves without location.
- [ ] Add HEIC/unsupported: capture does not start. Add a second/third valid photo: no extra parallel capture.
- [ ] Save with location: Catch stays visible, carousel stays, **Location saved** appears, raw lat/lng do not.
- [ ] **Record another catch**: Catch A location is not reused; **Location on** remains if permission is granted; Catch B capture starts only after B's first valid photograph.
- [ ] Close/reopen offline: a Catch saved with location retains CatchId, photographs, CaughtOn, coordinates and accuracy.
- [ ] Apply migration `202608171600_15_AddCatchLocation.sql` in the target environment before using the server Catch API with location.

## Self review
- Issue/AC: PASS — AC1–AC14 covered (granted/denied/explainer/unavailable/slow GPS/offline persist/close-reopen/another Catch/privacy/#14 UX/invalid coordinates/no sync/first-photo capture/coherent DB). Compact **Location on** status added after Allow so granted state is visible.
- Architecture/CQRS: PASS — `POST /api/catches` → mediator → `ICatchService` → `ICatchRepository`; UI → `ICatchStore` + `ILocationService` only. No production Catch synchroniser. No `ICatchLocationService`.
- Rules: PASS — coordinate limits live in `CatchLocationConstants`; Domain `CatchLocation` has no Shared dependency.
- Security/privacy: PASS — owner from authenticated `UserId`; captured locations default Private; no public DTO exposes precise coordinates.
- Database/migrations: PASS — expand-only `#15` script; `#14` untouched; CHECK rejects half coordinates, metadata-without-coords, and coords-without-required-metadata. Accuracy remains nullable.
- Tests/coverage: PASS — Record Catch bUnit (open does not capture; first valid photo starts capture; unsupported does not; second/third photo does not start a parallel capture; Record another does not reuse Catch A; Catch B's first photo captures independently; Allow shows Location on; Save never waits); CatchJson/store round-trips; validator/service/API; Testcontainers CHECK + no-erase upsert; Playwright IndexedDB location close/reopen.
- Browser: PASS for IndexedDB location JSON via the JS harness. Authenticated Blazor Record Catch / real-device geolocation remains #76. Compensated by bUnit permission/capture/save tests, `LocationService` timeout tests, and Vitest `location.js`.
- Web/UI/localisation: PASS — EN/FR for explainer, privacy, Allow, Not now, Try again, Location on, Location saved. No raw lat/lng on the waterside screen.
- Code smells: PASS — Mapster uses `== null` because expression trees cannot contain `is`.
- CI/deployment: PASS — apply `202608171600_15_AddCatchLocation.sql`; no Terraform

Findings discovered during self-review:
1. SHOULD FIX — coordinate helper originally lived under `Dtos/` without a Dto suffix — moved to `CatchLocationConstants`.
2. SHOULD FIX — invalid owner location would have returned 503 — mapped `CatchLocationInvalidError` to HTTP 400.
3. SHOULD FIX — after Allow / already-granted, the explainer disappeared with no confirmation — compact **Location on** status added.

Fixes made:
1. Moved limits/validation helper to `Shared/Constants/CatchLocationConstants.cs`.
2. Mapped `CatchLocationInvalidError` to HTTP 400.
3. Show `#catch-location-status` when `WillCaptureOnSave` and the Catch is not yet saved.

Remaining deliberate gaps:
- Authenticated Blazor Playwright / real-device geolocation is #76.
- Location sharing / visibility UI is #16.
- Production Catch sync is #17.
- Location editing / Remove location is #19.
- FishingVenue association is #27.
- TestCatch still captures during save until that path is retired. `/test-catch` remains reachable by URL.