### PR TITLE
FLB#13 | Establish the reusable platform capability model

### DIFF
--- a/src/FishingLogBook.Api/Authorization/PlatformCapabilityHttp.cs
+++ b/src/FishingLogBook.Api/Authorization/PlatformCapabilityHttp.cs
@@ -8,7 +8,7 @@ public static class PlatformCapabilityHttp
 {
     public static IResult From(ICurrentUser currentUser, ValidatedResponse response)
     {
-        if (!currentUser.IsResolved)
+        if (!currentUser.IsResolved || response.Error is CurrentUserUnresolvedError)
         {
             return Results.Unauthorized();
         }

--- a/src/FishingLogBook.Api/Authorization/PlatformCapabilityHttp.cs
+++ b/src/FishingLogBook.Api/Authorization/PlatformCapabilityHttp.cs
@@ -1,0 +1,35 @@
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+
+namespace FishingLogBook.Api.Authorization;
+
+public static class PlatformCapabilityHttp
+{
+    public static IResult From(ICurrentUser currentUser, ValidatedResponse response)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (response.Error is MissingPlatformCapabilityError)
+        {
+            return Results.Json(response, statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        if (response.ValidationErrors is { Count: > 0 })
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.NoContent();
+    }
+}

--- a/src/FishingLogBook.Application/Args/FindUserPlatformCapabilitiesArgs.cs
+++ b/src/FishingLogBook.Application/Args/FindUserPlatformCapabilitiesArgs.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class FindUserPlatformCapabilitiesArgs
+{
+    public Guid UserId { get; init; }
+}

--- a/src/FishingLogBook.Application/Args/FindUserPlatformCapabilityArgs.cs
+++ b/src/FishingLogBook.Application/Args/FindUserPlatformCapabilityArgs.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Domain.Enums;
+
+namespace FishingLogBook.Application.Args;
+
+public sealed class FindUserPlatformCapabilityArgs
+{
+    public Guid UserId { get; init; }
+
+    public PlatformCapabilityEnum Capability { get; init; }
+}

--- a/src/FishingLogBook.Application/Args/GrantPlatformCapabilityArgs.cs
+++ b/src/FishingLogBook.Application/Args/GrantPlatformCapabilityArgs.cs
@@ -1,0 +1,12 @@
+using FishingLogBook.Domain.Enums;
+
+namespace FishingLogBook.Application.Args;
+
+public sealed class GrantPlatformCapabilityArgs
+{
+    public Guid ActorUserId { get; init; }
+
+    public Guid TargetUserId { get; init; }
+
+    public PlatformCapabilityEnum Capability { get; init; }
+}

--- a/src/FishingLogBook.Application/Args/GrantPlatformCapabilityArgs.cs
+++ b/src/FishingLogBook.Application/Args/GrantPlatformCapabilityArgs.cs
@@ -4,8 +4,6 @@ namespace FishingLogBook.Application.Args;
 
 public sealed class GrantPlatformCapabilityArgs
 {
-    public Guid ActorUserId { get; init; }
-
     public Guid TargetUserId { get; init; }
 
     public PlatformCapabilityEnum Capability { get; init; }

--- a/src/FishingLogBook.Application/Args/RevokePlatformCapabilityArgs.cs
+++ b/src/FishingLogBook.Application/Args/RevokePlatformCapabilityArgs.cs
@@ -4,8 +4,6 @@ namespace FishingLogBook.Application.Args;
 
 public sealed class RevokePlatformCapabilityArgs
 {
-    public Guid ActorUserId { get; init; }
-
     public Guid TargetUserId { get; init; }
 
     public PlatformCapabilityEnum Capability { get; init; }

--- a/src/FishingLogBook.Application/Args/RevokePlatformCapabilityArgs.cs
+++ b/src/FishingLogBook.Application/Args/RevokePlatformCapabilityArgs.cs
@@ -1,0 +1,12 @@
+using FishingLogBook.Domain.Enums;
+
+namespace FishingLogBook.Application.Args;
+
+public sealed class RevokePlatformCapabilityArgs
+{
+    public Guid ActorUserId { get; init; }
+
+    public Guid TargetUserId { get; init; }
+
+    public PlatformCapabilityEnum Capability { get; init; }
+}

--- a/src/FishingLogBook.Application/Capabilities/Commands/GrantPlatformCapabilityCommand.cs
+++ b/src/FishingLogBook.Application/Capabilities/Commands/GrantPlatformCapabilityCommand.cs
@@ -10,8 +10,6 @@ namespace FishingLogBook.Application.Capabilities.Commands;
 
 public sealed class GrantPlatformCapabilityCommand : IRequest<GrantPlatformCapabilityResponse>
 {
-    public Guid ActorUserId { get; init; }
-
     public Guid TargetUserId { get; init; }
 
     public PlatformCapabilityEnum Capability { get; init; }
@@ -50,8 +48,6 @@ public sealed class GrantPlatformCapabilityCommandValidator : AbstractValidator<
 {
     public GrantPlatformCapabilityCommandValidator()
     {
-        RuleFor(command => command.ActorUserId)
-            .NotEmpty();
         RuleFor(command => command.TargetUserId)
             .NotEmpty();
         RuleFor(command => command.Capability)

--- a/src/FishingLogBook.Application/Capabilities/Commands/GrantPlatformCapabilityCommand.cs
+++ b/src/FishingLogBook.Application/Capabilities/Commands/GrantPlatformCapabilityCommand.cs
@@ -1,0 +1,60 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Domain.Enums;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace FishingLogBook.Application.Capabilities.Commands;
+
+public sealed class GrantPlatformCapabilityCommand : IRequest<GrantPlatformCapabilityResponse>
+{
+    public Guid ActorUserId { get; init; }
+
+    public Guid TargetUserId { get; init; }
+
+    public PlatformCapabilityEnum Capability { get; init; }
+}
+
+public sealed class GrantPlatformCapabilityResponse : ValidatedResponse
+{
+}
+
+public sealed class GrantPlatformCapabilityHandler : IRequestHandler<GrantPlatformCapabilityCommand, GrantPlatformCapabilityResponse>
+{
+    private readonly IPlatformCapabilityService _platformCapabilityService;
+
+    public GrantPlatformCapabilityHandler(IPlatformCapabilityService platformCapabilityService)
+    {
+        _platformCapabilityService = platformCapabilityService;
+    }
+
+    public async Task<GrantPlatformCapabilityResponse> Handle(
+        GrantPlatformCapabilityCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _platformCapabilityService.GrantAsync(
+            command.Adapt<GrantPlatformCapabilityArgs>(),
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<GrantPlatformCapabilityResponse>(result.Errors[0]);
+        }
+
+        return new GrantPlatformCapabilityResponse();
+    }
+}
+
+public sealed class GrantPlatformCapabilityCommandValidator : AbstractValidator<GrantPlatformCapabilityCommand>
+{
+    public GrantPlatformCapabilityCommandValidator()
+    {
+        RuleFor(command => command.ActorUserId)
+            .NotEmpty();
+        RuleFor(command => command.TargetUserId)
+            .NotEmpty();
+        RuleFor(command => command.Capability)
+            .IsInEnum();
+    }
+}

--- a/src/FishingLogBook.Application/Capabilities/Commands/RevokePlatformCapabilityCommand.cs
+++ b/src/FishingLogBook.Application/Capabilities/Commands/RevokePlatformCapabilityCommand.cs
@@ -1,0 +1,60 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Domain.Enums;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace FishingLogBook.Application.Capabilities.Commands;
+
+public sealed class RevokePlatformCapabilityCommand : IRequest<RevokePlatformCapabilityResponse>
+{
+    public Guid ActorUserId { get; init; }
+
+    public Guid TargetUserId { get; init; }
+
+    public PlatformCapabilityEnum Capability { get; init; }
+}
+
+public sealed class RevokePlatformCapabilityResponse : ValidatedResponse
+{
+}
+
+public sealed class RevokePlatformCapabilityHandler : IRequestHandler<RevokePlatformCapabilityCommand, RevokePlatformCapabilityResponse>
+{
+    private readonly IPlatformCapabilityService _platformCapabilityService;
+
+    public RevokePlatformCapabilityHandler(IPlatformCapabilityService platformCapabilityService)
+    {
+        _platformCapabilityService = platformCapabilityService;
+    }
+
+    public async Task<RevokePlatformCapabilityResponse> Handle(
+        RevokePlatformCapabilityCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _platformCapabilityService.RevokeAsync(
+            command.Adapt<RevokePlatformCapabilityArgs>(),
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<RevokePlatformCapabilityResponse>(result.Errors[0]);
+        }
+
+        return new RevokePlatformCapabilityResponse();
+    }
+}
+
+public sealed class RevokePlatformCapabilityCommandValidator : AbstractValidator<RevokePlatformCapabilityCommand>
+{
+    public RevokePlatformCapabilityCommandValidator()
+    {
+        RuleFor(command => command.ActorUserId)
+            .NotEmpty();
+        RuleFor(command => command.TargetUserId)
+            .NotEmpty();
+        RuleFor(command => command.Capability)
+            .IsInEnum();
+    }
+}

--- a/src/FishingLogBook.Application/Capabilities/Commands/RevokePlatformCapabilityCommand.cs
+++ b/src/FishingLogBook.Application/Capabilities/Commands/RevokePlatformCapabilityCommand.cs
@@ -10,8 +10,6 @@ namespace FishingLogBook.Application.Capabilities.Commands;
 
 public sealed class RevokePlatformCapabilityCommand : IRequest<RevokePlatformCapabilityResponse>
 {
-    public Guid ActorUserId { get; init; }
-
     public Guid TargetUserId { get; init; }
 
     public PlatformCapabilityEnum Capability { get; init; }
@@ -50,8 +48,6 @@ public sealed class RevokePlatformCapabilityCommandValidator : AbstractValidator
 {
     public RevokePlatformCapabilityCommandValidator()
     {
-        RuleFor(command => command.ActorUserId)
-            .NotEmpty();
         RuleFor(command => command.TargetUserId)
             .NotEmpty();
         RuleFor(command => command.Capability)

--- a/src/FishingLogBook.Application/Capabilities/Errors/CurrentUserUnresolvedError.cs
+++ b/src/FishingLogBook.Application/Capabilities/Errors/CurrentUserUnresolvedError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Capabilities.Errors;
+
+public sealed class CurrentUserUnresolvedError : Error
+{
+    public CurrentUserUnresolvedError()
+        : base("The current user is not resolved.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Capabilities/Errors/MissingPlatformCapabilityError.cs
+++ b/src/FishingLogBook.Application/Capabilities/Errors/MissingPlatformCapabilityError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Capabilities.Errors;
+
+public sealed class MissingPlatformCapabilityError : Error
+{
+    public MissingPlatformCapabilityError()
+        : base("The user does not have the required platform capability.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Capabilities/Services/PlatformCapabilityService.cs
+++ b/src/FishingLogBook.Application/Capabilities/Services/PlatformCapabilityService.cs
@@ -11,10 +11,14 @@ namespace FishingLogBook.Application.Capabilities.Services;
 public sealed class PlatformCapabilityService : IPlatformCapabilityService
 {
     private readonly IUserPlatformCapabilityRepository _userPlatformCapabilityRepository;
+    private readonly ICurrentUser _currentUser;
 
-    public PlatformCapabilityService(IUserPlatformCapabilityRepository userPlatformCapabilityRepository)
+    public PlatformCapabilityService(
+        IUserPlatformCapabilityRepository userPlatformCapabilityRepository,
+        ICurrentUser currentUser)
     {
         _userPlatformCapabilityRepository = userPlatformCapabilityRepository;
+        _currentUser = currentUser;
     }
 
     public Task<Result<bool>> HasAsync(
@@ -45,7 +49,7 @@ public sealed class PlatformCapabilityService : IPlatformCapabilityService
 
     public async Task<Result> GrantAsync(GrantPlatformCapabilityArgs args, CancellationToken cancellationToken)
     {
-        var authorised = await RequireAdministratorAsync(args.ActorUserId, cancellationToken);
+        var authorised = await RequireAdministratorAsync(cancellationToken);
         if (authorised.IsFailed)
         {
             return authorised;
@@ -62,7 +66,7 @@ public sealed class PlatformCapabilityService : IPlatformCapabilityService
 
     public async Task<Result> RevokeAsync(RevokePlatformCapabilityArgs args, CancellationToken cancellationToken)
     {
-        var authorised = await RequireAdministratorAsync(args.ActorUserId, cancellationToken);
+        var authorised = await RequireAdministratorAsync(cancellationToken);
         if (authorised.IsFailed)
         {
             return authorised;
@@ -77,10 +81,15 @@ public sealed class PlatformCapabilityService : IPlatformCapabilityService
             cancellationToken);
     }
 
-    private async Task<Result> RequireAdministratorAsync(Guid actorUserId, CancellationToken cancellationToken)
+    private async Task<Result> RequireAdministratorAsync(CancellationToken cancellationToken)
     {
+        if (!_currentUser.IsResolved)
+        {
+            return Result.Fail(new CurrentUserUnresolvedError());
+        }
+
         var hasAdministrator = await HasAsync(
-            actorUserId,
+            _currentUser.UserId,
             PlatformCapabilityEnum.Administrator,
             cancellationToken);
         if (hasAdministrator.IsFailed)

--- a/src/FishingLogBook.Application/Capabilities/Services/PlatformCapabilityService.cs
+++ b/src/FishingLogBook.Application/Capabilities/Services/PlatformCapabilityService.cs
@@ -1,0 +1,98 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Users;
+using FluentResults;
+
+namespace FishingLogBook.Application.Capabilities.Services;
+
+public sealed class PlatformCapabilityService : IPlatformCapabilityService
+{
+    private readonly IUserPlatformCapabilityRepository _userPlatformCapabilityRepository;
+
+    public PlatformCapabilityService(IUserPlatformCapabilityRepository userPlatformCapabilityRepository)
+    {
+        _userPlatformCapabilityRepository = userPlatformCapabilityRepository;
+    }
+
+    public Task<Result<bool>> HasAsync(
+        Guid userId,
+        PlatformCapabilityEnum capability,
+        CancellationToken cancellationToken)
+    {
+        return _userPlatformCapabilityRepository.HasAsync(
+            new FindUserPlatformCapabilityArgs
+            {
+                UserId = userId,
+                Capability = capability
+            },
+            cancellationToken);
+    }
+
+    public Task<Result<IReadOnlyList<PlatformCapabilityEnum>>> GetForUserAsync(
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        return _userPlatformCapabilityRepository.GetForUserAsync(
+            new FindUserPlatformCapabilitiesArgs
+            {
+                UserId = userId
+            },
+            cancellationToken);
+    }
+
+    public async Task<Result> GrantAsync(GrantPlatformCapabilityArgs args, CancellationToken cancellationToken)
+    {
+        var authorised = await RequireAdministratorAsync(args.ActorUserId, cancellationToken);
+        if (authorised.IsFailed)
+        {
+            return authorised;
+        }
+
+        return await _userPlatformCapabilityRepository.GrantAsync(
+            new UserPlatformCapability
+            {
+                UserId = args.TargetUserId,
+                Capability = args.Capability
+            },
+            cancellationToken);
+    }
+
+    public async Task<Result> RevokeAsync(RevokePlatformCapabilityArgs args, CancellationToken cancellationToken)
+    {
+        var authorised = await RequireAdministratorAsync(args.ActorUserId, cancellationToken);
+        if (authorised.IsFailed)
+        {
+            return authorised;
+        }
+
+        return await _userPlatformCapabilityRepository.RevokeAsync(
+            new FindUserPlatformCapabilityArgs
+            {
+                UserId = args.TargetUserId,
+                Capability = args.Capability
+            },
+            cancellationToken);
+    }
+
+    private async Task<Result> RequireAdministratorAsync(Guid actorUserId, CancellationToken cancellationToken)
+    {
+        var hasAdministrator = await HasAsync(
+            actorUserId,
+            PlatformCapabilityEnum.Administrator,
+            cancellationToken);
+        if (hasAdministrator.IsFailed)
+        {
+            return Result.Fail(hasAdministrator.Errors);
+        }
+
+        if (!hasAdministrator.Value)
+        {
+            return Result.Fail(new MissingPlatformCapabilityError());
+        }
+
+        return Result.Ok();
+    }
+}

--- a/src/FishingLogBook.Application/Common/Mappings/CapabilityMappingRegistration.cs
+++ b/src/FishingLogBook.Application/Common/Mappings/CapabilityMappingRegistration.cs
@@ -1,0 +1,14 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Commands;
+using Mapster;
+
+namespace FishingLogBook.Application.Common.Mappings;
+
+public sealed class CapabilityMappingRegistration : IRegister
+{
+    void IRegister.Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<GrantPlatformCapabilityCommand, GrantPlatformCapabilityArgs>();
+        config.NewConfig<RevokePlatformCapabilityCommand, RevokePlatformCapabilityArgs>();
+    }
+}

--- a/src/FishingLogBook.Application/Contracts/Repositories/IUserPlatformCapabilityRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/Repositories/IUserPlatformCapabilityRepository.cs
@@ -1,0 +1,19 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Users;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Repositories;
+
+public interface IUserPlatformCapabilityRepository
+{
+    Task<Result<bool>> HasAsync(FindUserPlatformCapabilityArgs args, CancellationToken cancellationToken);
+
+    Task<Result<IReadOnlyList<PlatformCapabilityEnum>>> GetForUserAsync(
+        FindUserPlatformCapabilitiesArgs args,
+        CancellationToken cancellationToken);
+
+    Task<Result> GrantAsync(UserPlatformCapability association, CancellationToken cancellationToken);
+
+    Task<Result> RevokeAsync(FindUserPlatformCapabilityArgs args, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Contracts/Services/IPlatformCapabilityService.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/IPlatformCapabilityService.cs
@@ -1,0 +1,21 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Services;
+
+public interface IPlatformCapabilityService
+{
+    Task<Result<bool>> HasAsync(
+        Guid userId,
+        PlatformCapabilityEnum capability,
+        CancellationToken cancellationToken);
+
+    Task<Result<IReadOnlyList<PlatformCapabilityEnum>>> GetForUserAsync(
+        Guid userId,
+        CancellationToken cancellationToken);
+
+    Task<Result> GrantAsync(GrantPlatformCapabilityArgs args, CancellationToken cancellationToken);
+
+    Task<Result> RevokeAsync(RevokePlatformCapabilityArgs args, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608171700_13_CreatePlatformCapability.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608171700_13_CreatePlatformCapability.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "PlatformCapability"
+(
+    "Code"      text        NOT NULL,
+    "CreatedOn" timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT "PkPlatformCapability" PRIMARY KEY ("Code")
+);
+
+CREATE TABLE IF NOT EXISTS "UserPlatformCapability"
+(
+    "UserId"         uuid        NOT NULL,
+    "CapabilityCode" text        NOT NULL,
+    "CreatedOn"      timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT "PkUserPlatformCapability" PRIMARY KEY ("UserId", "CapabilityCode"),
+    CONSTRAINT "FkUserPlatformCapabilityUser" FOREIGN KEY ("UserId") REFERENCES "User" ("Id"),
+    CONSTRAINT "FkUserPlatformCapabilityCode" FOREIGN KEY ("CapabilityCode") REFERENCES "PlatformCapability" ("Code")
+);

--- a/src/FishingLogBook.Db.Migrations/02_SeedData/202608171701_13_SeedPlatformCapability.sql
+++ b/src/FishingLogBook.Db.Migrations/02_SeedData/202608171701_13_SeedPlatformCapability.sql
@@ -1,0 +1,12 @@
+INSERT INTO "PlatformCapability" ("Code")
+SELECT v."Code"
+FROM (VALUES
+    ('Guide'),
+    ('FishingVenueManager'),
+    ('CompetitionOrganiser'),
+    ('Administrator')
+) AS v("Code")
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM "PlatformCapability" existing
+    WHERE existing."Code" = v."Code");

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using FishingLogBook.Application.Capabilities.Services;
 using FishingLogBook.Application.Catches.Services;
 using FishingLogBook.Application.Common.Behaviours;
 using FishingLogBook.Application.Common.Mappings;
@@ -50,6 +51,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserIdentityService, UserIdentityService>();
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<ICatchService, CatchService>();
+        services.AddScoped<IPlatformCapabilityService, PlatformCapabilityService>();
 
         return services;
     }
@@ -74,6 +76,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserIdentityRepository, UserIdentityRepository>();
         services.AddScoped<IProfileRepository, ProfileRepository>();
         services.AddScoped<ICatchRepository, CatchRepository>();
+        services.AddScoped<IUserPlatformCapabilityRepository, UserPlatformCapabilityRepository>();
         services.Configure<ObjectStorageConfig>(configuration.GetSection(ObjectStorageConfig.SectionName));
         services.Configure<DiagnosticsConfig>(configuration.GetSection(DiagnosticsConfig.SectionName));
         services.AddSingleton<IObjectStorage, S3CompatibleObjectStorage>();

--- a/src/FishingLogBook.Domain/Enums/PlatformCapabilityEnum.cs
+++ b/src/FishingLogBook.Domain/Enums/PlatformCapabilityEnum.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Domain.Enums;
+
+public enum PlatformCapabilityEnum
+{
+    Guide = 0,
+    FishingVenueManager = 1,
+    CompetitionOrganiser = 2,
+    Administrator = 3
+}

--- a/src/FishingLogBook.Domain/Users/UserPlatformCapability.cs
+++ b/src/FishingLogBook.Domain/Users/UserPlatformCapability.cs
@@ -1,0 +1,12 @@
+using FishingLogBook.Domain.Enums;
+
+namespace FishingLogBook.Domain.Users;
+
+public sealed class UserPlatformCapability
+{
+    public Guid UserId { get; init; }
+
+    public PlatformCapabilityEnum Capability { get; init; }
+
+    public DateTimeOffset CreatedOn { get; init; }
+}

--- a/src/FishingLogBook.Infrastructure/Persistence/UserPlatformCapabilityRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/UserPlatformCapabilityRepository.cs
@@ -1,0 +1,134 @@
+using Dapper;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Users;
+using FluentResults;
+using Npgsql;
+
+namespace FishingLogBook.Infrastructure.Persistence;
+
+public sealed class UserPlatformCapabilityRepository : IUserPlatformCapabilityRepository
+{
+    private const string FailedMessage = "Failed to persist platform capability.";
+
+    private readonly IDbConnectionFactory _connectionFactory;
+
+    public UserPlatformCapabilityRepository(IDbConnectionFactory connectionFactory)
+    {
+        _connectionFactory = connectionFactory;
+    }
+
+    public async Task<Result<bool>> HasAsync(
+        FindUserPlatformCapabilityArgs args,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM "UserPlatformCapability"
+                    WHERE "UserId" = @UserId AND "CapabilityCode" = @CapabilityCode);
+                """;
+            var exists = await connection.ExecuteScalarAsync<bool>(new CommandDefinition(
+                sql,
+                ToParameters(args.UserId, args.Capability),
+                cancellationToken: cancellationToken));
+            return Result.Ok(exists);
+        }
+        catch (Exception)
+        {
+            return Result.Fail<bool>(FailedMessage);
+        }
+    }
+
+    public async Task<Result<IReadOnlyList<PlatformCapabilityEnum>>> GetForUserAsync(
+        FindUserPlatformCapabilitiesArgs args,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                SELECT "CapabilityCode"
+                FROM "UserPlatformCapability"
+                WHERE "UserId" = @UserId;
+                """;
+            var codes = await connection.QueryAsync<string>(new CommandDefinition(
+                sql,
+                new { args.UserId },
+                cancellationToken: cancellationToken));
+            return Result.Ok<IReadOnlyList<PlatformCapabilityEnum>>(
+                codes.Select(ParseCapability).ToArray());
+        }
+        catch (Exception)
+        {
+            return Result.Fail<IReadOnlyList<PlatformCapabilityEnum>>(FailedMessage);
+        }
+    }
+
+    public async Task<Result> GrantAsync(UserPlatformCapability association, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                INSERT INTO "UserPlatformCapability" ("UserId", "CapabilityCode")
+                VALUES (@UserId, @CapabilityCode)
+                ON CONFLICT ("UserId", "CapabilityCode") DO NOTHING;
+                """;
+            await connection.ExecuteAsync(new CommandDefinition(
+                sql,
+                ToParameters(association.UserId, association.Capability),
+                cancellationToken: cancellationToken));
+            return Result.Ok();
+        }
+        catch (PostgresException exception) when (exception.SqlState == PostgresErrorCodes.ForeignKeyViolation)
+        {
+            return Result.Fail("Platform capability is invalid.");
+        }
+        catch (Exception)
+        {
+            return Result.Fail(FailedMessage);
+        }
+    }
+
+    public async Task<Result> RevokeAsync(
+        FindUserPlatformCapabilityArgs args,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                DELETE FROM "UserPlatformCapability"
+                WHERE "UserId" = @UserId AND "CapabilityCode" = @CapabilityCode;
+                """;
+            await connection.ExecuteAsync(new CommandDefinition(
+                sql,
+                ToParameters(args.UserId, args.Capability),
+                cancellationToken: cancellationToken));
+            return Result.Ok();
+        }
+        catch (Exception)
+        {
+            return Result.Fail(FailedMessage);
+        }
+    }
+
+    private static object ToParameters(Guid userId, PlatformCapabilityEnum capability)
+    {
+        return new
+        {
+            UserId = userId,
+            CapabilityCode = capability.ToString()
+        };
+    }
+
+    private static PlatformCapabilityEnum ParseCapability(string code)
+    {
+        return Enum.Parse<PlatformCapabilityEnum>(code);
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingUpsert.cs
@@ -2,7 +2,10 @@ using System.Net;
 using System.Net.Http.Json;
 using AwesomeAssertions;
 using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Application.Args;
 using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Users;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
 using FluentResults;
@@ -237,6 +240,80 @@ public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
                 && item.Location.Source == LocationDefaults.DeviceGps
                 && item.Location.Visibility == LocationDefaults.Private
                 && item.Location.ConsentVersion == LocationDefaults.ConsentVersion),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldUpsertWhenTheUserHasNoPlatformCapabilities()
+    {
+        // Arrange
+        var dto = ValidDto();
+        ResetCatchRepository();
+        _factory.UserPlatformCapabilityRepository.ClearReceivedCalls();
+        _factory.UserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(false));
+        _factory.UserPlatformCapabilityRepository
+            .GetForUserAsync(Arg.Any<FindUserPlatformCapabilitiesArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<PlatformCapabilityEnum>>([]));
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/catches", dto);
+        var body = await response.Content.ReadFromJsonAsync<CatchDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        current.Should().NotBeNull();
+        body.Should().NotBeNull();
+        body!.UserId.Should().Be(current!.UserId);
+        await _factory.CatchRepository.Received(1).UpsertAsync(
+            Arg.Is<Catch>(item => item.Id == dto.Id && item.UserId == current.UserId),
+            Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldUpsertWhenTheUserHasGuide()
+    {
+        // Arrange
+        var dto = ValidDto();
+        ResetCatchRepository();
+        _factory.UserPlatformCapabilityRepository.ClearReceivedCalls();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        _factory.UserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var args = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
+                return Result.Ok(
+                    args.UserId == current!.UserId && args.Capability == PlatformCapabilityEnum.Guide);
+            });
+        _factory.UserPlatformCapabilityRepository
+            .GetForUserAsync(Arg.Any<FindUserPlatformCapabilitiesArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<PlatformCapabilityEnum>>([PlatformCapabilityEnum.Guide]));
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/catches", dto);
+        var body = await response.Content.ReadFromJsonAsync<CatchDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().NotBeNull();
+        body!.UserId.Should().Be(current!.UserId);
+        await _factory.CatchRepository.Received(1).UpsertAsync(
+            Arg.Is<Catch>(item => item.Id == dto.Id && item.UserId == current.UserId),
+            Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/FishingLogBook.Api.Tests/DependencyInjectionTests/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Api.Tests/DependencyInjectionTests/WhenTestingContainer.cs
@@ -59,11 +59,13 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
         var userIdentityService = scope.ServiceProvider.GetRequiredService<IUserIdentityService>();
         var profileService = scope.ServiceProvider.GetRequiredService<IProfileService>();
+        var platformCapabilityService = scope.ServiceProvider.GetRequiredService<IPlatformCapabilityService>();
 
         // Assert
         mediator.Should().NotBeNull();
         userIdentityService.Should().NotBeNull();
         profileService.Should().NotBeNull();
+        platformCapabilityService.Should().NotBeNull();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Api.Tests/PlatformCapabilityEndpointsTests/WhenTestingGrant.cs
+++ b/tests/FishingLogBook.Api.Tests/PlatformCapabilityEndpointsTests/WhenTestingGrant.cs
@@ -1,0 +1,168 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Users;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.PlatformCapabilityEndpointsTests;
+
+public class WhenTestingGrant : IClassFixture<PlatformCapabilityApiFactory>
+{
+    private readonly PlatformCapabilityApiFactory _factory;
+
+    public WhenTestingGrant(PlatformCapabilityApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequestWhenAuthorizationIsMissing()
+    {
+        // Arrange
+        ResetCapabilityRepository();
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            TestGrantPlatformCapabilityStartupFilter.Path,
+            GrantBody(Guid.NewGuid(), PlatformCapabilityEnum.Guide));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnForbiddenWhenTheUserLacksAdministrator()
+    {
+        // Arrange
+        ResetCapabilityRepository();
+        var targetUserId = Guid.NewGuid();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            TestGrantPlatformCapabilityStartupFilter.Path,
+            GrantBody(targetUserId, PlatformCapabilityEnum.Guide));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        current.Should().NotBeNull();
+        await _factory.UserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(args =>
+                args.UserId == current!.UserId
+                && args.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldIgnoreClientSpoofedAdministratorClaims()
+    {
+        // Arrange
+        ResetCapabilityRepository();
+        var spoofedUserId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+        var targetUserId = Guid.NewGuid();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            TestGrantPlatformCapabilityStartupFilter.Path,
+            new
+            {
+                targetUserId,
+                capability = PlatformCapabilityEnum.Guide,
+                userId = spoofedUserId,
+                administrator = true,
+                capabilities = new[] { "Administrator" }
+            });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        current.Should().NotBeNull();
+        current!.UserId.Should().NotBe(spoofedUserId);
+        await _factory.UserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(args =>
+                args.UserId == current.UserId
+                && args.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(args => args.UserId == spoofedUserId),
+            Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldGrantWhenTheUserHasAdministrator()
+    {
+        // Arrange
+        ResetCapabilityRepository();
+        var targetUserId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        _factory.UserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var args = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
+                var isAdministrator = args.UserId == current!.UserId
+                    && args.Capability == PlatformCapabilityEnum.Administrator;
+                return Result.Ok(isAdministrator);
+            });
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            TestGrantPlatformCapabilityStartupFilter.Path,
+            GrantBody(targetUserId, PlatformCapabilityEnum.Guide));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await _factory.UserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(args =>
+                args.UserId == current!.UserId
+                && args.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.Received(1).GrantAsync(
+            Arg.Is<UserPlatformCapability>(association =>
+                association.UserId == targetUserId
+                && association.Capability == PlatformCapabilityEnum.Guide),
+            Arg.Any<CancellationToken>());
+    }
+
+    private void ResetCapabilityRepository()
+    {
+        _factory.UserPlatformCapabilityRepository.ClearReceivedCalls();
+        _factory.UserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(false));
+        _factory.UserPlatformCapabilityRepository
+            .GrantAsync(Arg.Any<UserPlatformCapability>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+    }
+
+    private static object GrantBody(Guid targetUserId, PlatformCapabilityEnum capability)
+    {
+        return new
+        {
+            targetUserId,
+            capability
+        };
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/SwaggerTests/WhenTestingProduction.cs
+++ b/tests/FishingLogBook.Api.Tests/SwaggerTests/WhenTestingProduction.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Net.Http.Json;
 using AwesomeAssertions;
-using FishingLogBook.Api.Tests;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Domain.Enums;
 
 namespace FishingLogBook.Api.Tests.SwaggerTests;
 
@@ -26,6 +28,27 @@ public class WhenTestingProduction : IClassFixture<SystemApiFactory>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         body.Should().Contain("FishingLogBook");
+        body.Should().NotContain("__test");
+        body.Should().NotContain("platform-capabilities");
+    }
+
+    [Fact]
+    public async Task ItShouldNotExposeAPublicGrantEndpoint()
+    {
+        // Arrange
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var publicGrant = await client.PostAsJsonAsync(
+            "/api/platform-capabilities/grant",
+            new { targetUserId = Guid.NewGuid(), capability = PlatformCapabilityEnum.Guide });
+        var testGrant = await client.PostAsJsonAsync(
+            TestGrantPlatformCapabilityStartupFilter.Path,
+            new { targetUserId = Guid.NewGuid(), capability = PlatformCapabilityEnum.Guide });
+
+        // Assert
+        publicGrant.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        testGrant.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -6,6 +6,7 @@ using FishingLogBook.Application.Args;
 using FishingLogBook.Application.Contracts;
 using FishingLogBook.Application.Contracts.Repositories;
 using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Enums;
 using FishingLogBook.Domain.Profiles;
 using FishingLogBook.Domain.Users;
 using FishingLogBook.Tests.Common.TestSupport;
@@ -20,7 +21,7 @@ using NSubstitute;
 
 namespace FishingLogBook.Api.Tests;
 
-public sealed class SystemApiFactory : WebApplicationFactory<Program>
+public class SystemApiFactory : WebApplicationFactory<Program>
 {
     private readonly ConcurrentDictionary<string, Guid> _userIds = new(StringComparer.Ordinal);
 
@@ -35,6 +36,9 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
     public IProfileRepository ProfileRepository { get; } = Substitute.For<IProfileRepository>();
 
     public ICatchRepository CatchRepository { get; } = Substitute.For<ICatchRepository>();
+
+    public IUserPlatformCapabilityRepository UserPlatformCapabilityRepository { get; } =
+        Substitute.For<IUserPlatformCapabilityRepository>();
 
     public bool MappingFailed { get; set; }
 
@@ -66,6 +70,18 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
         CatchRepository
             .UpsertAsync(Arg.Any<Catch>(), Arg.Any<CancellationToken>())
             .Returns(call => Result.Ok(call.ArgAt<Catch>(0)));
+        UserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(false));
+        UserPlatformCapabilityRepository
+            .GetForUserAsync(Arg.Any<FindUserPlatformCapabilitiesArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<PlatformCapabilityEnum>>([]));
+        UserPlatformCapabilityRepository
+            .GrantAsync(Arg.Any<UserPlatformCapability>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+        UserPlatformCapabilityRepository
+            .RevokeAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
     }
 
     public HttpClient CreateAuthenticatedClient(string? accessToken = null)
@@ -117,7 +133,14 @@ public sealed class SystemApiFactory : WebApplicationFactory<Program>
             services.AddSingleton(ProfileRepository);
             services.RemoveAll<ICatchRepository>();
             services.AddSingleton(CatchRepository);
+            services.RemoveAll<IUserPlatformCapabilityRepository>();
+            services.AddSingleton(UserPlatformCapabilityRepository);
+            ConfigureAdditionalTestServices(services);
         });
+    }
+
+    protected virtual void ConfigureAdditionalTestServices(IServiceCollection services)
+    {
     }
 
     private Result<Guid?> ResolveFind(string subject)

--- a/tests/FishingLogBook.Api.Tests/TestSupport/PlatformCapabilityApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/PlatformCapabilityApiFactory.cs
@@ -1,0 +1,13 @@
+using FishingLogBook.Api.Tests.TestSupport;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FishingLogBook.Api.Tests;
+
+public sealed class PlatformCapabilityApiFactory : SystemApiFactory
+{
+    protected override void ConfigureAdditionalTestServices(IServiceCollection services)
+    {
+        services.AddSingleton<IStartupFilter, TestGrantPlatformCapabilityStartupFilter>();
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TestSupport/TestGrantPlatformCapabilityStartupFilter.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/TestGrantPlatformCapabilityStartupFilter.cs
@@ -56,7 +56,6 @@ internal sealed class TestGrantPlatformCapabilityStartupFilter : IStartupFilter
         var response = await mediator.Send(
             new GrantPlatformCapabilityCommand
             {
-                ActorUserId = currentUser.UserId,
                 TargetUserId = body.TargetUserId,
                 Capability = body.Capability
             },

--- a/tests/FishingLogBook.Api.Tests/TestSupport/TestGrantPlatformCapabilityStartupFilter.cs
+++ b/tests/FishingLogBook.Api.Tests/TestSupport/TestGrantPlatformCapabilityStartupFilter.cs
@@ -1,0 +1,79 @@
+using FishingLogBook.Api.Authorization;
+using FishingLogBook.Application.Capabilities.Commands;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Domain.Enums;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace FishingLogBook.Api.Tests.TestSupport;
+
+internal sealed class TestGrantPlatformCapabilityStartupFilter : IStartupFilter
+{
+    public const string Path = "/__test/platform-capabilities/grant";
+
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return app =>
+        {
+            next(app);
+            Map(app);
+        };
+    }
+
+    private static void Map(IApplicationBuilder app)
+    {
+        IEndpointRouteBuilder? endpoints = app as IEndpointRouteBuilder;
+        if (endpoints is null &&
+            app.Properties.TryGetValue("__EndpointRouteBuilder", out var stored))
+        {
+            endpoints = stored as IEndpointRouteBuilder;
+        }
+
+        if (endpoints is null)
+        {
+            throw new InvalidOperationException("The test grant endpoint could not be mapped.");
+        }
+
+        endpoints.MapPost(Path, GrantAsync)
+            .ExcludeFromDescription()
+            .RequireAuthorization();
+    }
+
+    private static async Task<IResult> GrantAsync(
+        GrantPlatformCapabilityRequest body,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new GrantPlatformCapabilityCommand
+            {
+                ActorUserId = currentUser.UserId,
+                TargetUserId = body.TargetUserId,
+                Capability = body.Capability
+            },
+            cancellationToken);
+        return PlatformCapabilityHttp.From(currentUser, response);
+    }
+}
+
+internal sealed class GrantPlatformCapabilityRequest
+{
+    public Guid TargetUserId { get; init; }
+
+    public PlatformCapabilityEnum Capability { get; init; }
+
+    public Guid? UserId { get; init; }
+
+    public bool Administrator { get; init; }
+
+    public IReadOnlyList<string>? Capabilities { get; init; }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandTests/BaseGrantPlatformCapabilityCommandTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandTests/BaseGrantPlatformCapabilityCommandTest.cs
@@ -1,0 +1,18 @@
+using FishingLogBook.Application.Capabilities.Commands;
+using FishingLogBook.Application.Contracts.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Commands.GrantPlatformCapabilityCommandTests;
+
+public class BaseGrantPlatformCapabilityCommandTest
+{
+    protected readonly IPlatformCapabilityService MockPlatformCapabilityService =
+        Substitute.For<IPlatformCapabilityService>();
+
+    protected readonly GrantPlatformCapabilityHandler Sut;
+
+    protected BaseGrantPlatformCapabilityCommandTest()
+    {
+        Sut = new GrantPlatformCapabilityHandler(MockPlatformCapabilityService);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandTests/WhenTestingHandle.cs
@@ -1,0 +1,74 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Commands;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Common.Mappings;
+using FishingLogBook.Domain.Enums;
+using FluentResults;
+using Mapster;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Commands.GrantPlatformCapabilityCommandTests;
+
+public class WhenTestingHandle : BaseGrantPlatformCapabilityCommandTest
+{
+    public WhenTestingHandle()
+    {
+        ((IRegister)new CapabilityMappingRegistration()).Register(TypeAdapterConfig.GlobalSettings);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheServiceDeniesTheActor()
+    {
+        // Arrange
+        var command = ValidCommand();
+        MockPlatformCapabilityService
+            .GrantAsync(Arg.Any<GrantPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail(new MissingPlatformCapabilityError()));
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsFailure.Should().BeTrue();
+        response.Error.Should().BeOfType<MissingPlatformCapabilityError>();
+        await MockPlatformCapabilityService.Received(1).GrantAsync(
+            Arg.Is<GrantPlatformCapabilityArgs>(args =>
+                args.ActorUserId == command.ActorUserId
+                && args.TargetUserId == command.TargetUserId
+                && args.Capability == command.Capability),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSucceedWhenTheServiceGrants()
+    {
+        // Arrange
+        var command = ValidCommand();
+        MockPlatformCapabilityService
+            .GrantAsync(Arg.Any<GrantPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsSuccess.Should().BeTrue();
+        await MockPlatformCapabilityService.Received(1).GrantAsync(
+            Arg.Is<GrantPlatformCapabilityArgs>(args =>
+                args.ActorUserId == command.ActorUserId
+                && args.TargetUserId == command.TargetUserId
+                && args.Capability == PlatformCapabilityEnum.Guide),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static GrantPlatformCapabilityCommand ValidCommand()
+    {
+        return new GrantPlatformCapabilityCommand
+        {
+            ActorUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Capability = PlatformCapabilityEnum.Guide
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandTests/WhenTestingHandle.cs
@@ -34,14 +34,13 @@ public class WhenTestingHandle : BaseGrantPlatformCapabilityCommandTest
         response.Error.Should().BeOfType<MissingPlatformCapabilityError>();
         await MockPlatformCapabilityService.Received(1).GrantAsync(
             Arg.Is<GrantPlatformCapabilityArgs>(args =>
-                args.ActorUserId == command.ActorUserId
-                && args.TargetUserId == command.TargetUserId
+                args.TargetUserId == command.TargetUserId
                 && args.Capability == command.Capability),
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ItShouldSucceedWhenTheServiceGrants()
+    public async Task ItShouldMapOnlyTargetUserIdAndCapability()
     {
         // Arrange
         var command = ValidCommand();
@@ -54,10 +53,11 @@ public class WhenTestingHandle : BaseGrantPlatformCapabilityCommandTest
 
         // Assert
         response.IsSuccess.Should().BeTrue();
+        typeof(GrantPlatformCapabilityCommand).GetProperty("ActorUserId").Should().BeNull();
+        typeof(GrantPlatformCapabilityArgs).GetProperty("ActorUserId").Should().BeNull();
         await MockPlatformCapabilityService.Received(1).GrantAsync(
             Arg.Is<GrantPlatformCapabilityArgs>(args =>
-                args.ActorUserId == command.ActorUserId
-                && args.TargetUserId == command.TargetUserId
+                args.TargetUserId == command.TargetUserId
                 && args.Capability == PlatformCapabilityEnum.Guide),
             Arg.Any<CancellationToken>());
     }
@@ -66,7 +66,6 @@ public class WhenTestingHandle : BaseGrantPlatformCapabilityCommandTest
     {
         return new GrantPlatformCapabilityCommand
         {
-            ActorUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
             TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
             Capability = PlatformCapabilityEnum.Guide
         };

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandValidatorTests/BaseGrantPlatformCapabilityCommandValidatorTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandValidatorTests/BaseGrantPlatformCapabilityCommandValidatorTest.cs
@@ -1,0 +1,8 @@
+using FishingLogBook.Application.Capabilities.Commands;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Commands.GrantPlatformCapabilityCommandValidatorTests;
+
+public class BaseGrantPlatformCapabilityCommandValidatorTest
+{
+    protected readonly GrantPlatformCapabilityCommandValidator Sut = new();
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,73 @@
+using FishingLogBook.Application.Capabilities.Commands;
+using FishingLogBook.Domain.Enums;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Commands.GrantPlatformCapabilityCommandValidatorTests;
+
+public class WhenTestingValidate : BaseGrantPlatformCapabilityCommandValidatorTest
+{
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenActorUserIdIsEmpty()
+    {
+        // Arrange
+        var command = Command(actorUserId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.ActorUserId);
+    }
+
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenTargetUserIdIsEmpty()
+    {
+        // Arrange
+        var command = Command(targetUserId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.TargetUserId);
+    }
+
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenCapabilityIsNotDefined()
+    {
+        // Arrange
+        var command = Command(capability: (PlatformCapabilityEnum)999);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Capability);
+    }
+
+    [Fact]
+    public void ItShouldNotHaveValidationErrorsForAValidCommand()
+    {
+        // Arrange
+        var command = Command();
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static GrantPlatformCapabilityCommand Command(
+        Guid? actorUserId = null,
+        Guid? targetUserId = null,
+        PlatformCapabilityEnum capability = PlatformCapabilityEnum.Guide)
+    {
+        return new GrantPlatformCapabilityCommand
+        {
+            ActorUserId = actorUserId ?? Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TargetUserId = targetUserId ?? Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Capability = capability
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/GrantPlatformCapabilityCommandValidatorTests/WhenTestingValidate.cs
@@ -7,19 +7,6 @@ namespace FishingLogBook.Application.Tests.Capabilities.Commands.GrantPlatformCa
 public class WhenTestingValidate : BaseGrantPlatformCapabilityCommandValidatorTest
 {
     [Fact]
-    public void ItShouldHaveAValidationErrorWhenActorUserIdIsEmpty()
-    {
-        // Arrange
-        var command = Command(actorUserId: Guid.Empty);
-
-        // Act
-        var result = Sut.TestValidate(command);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(c => c.ActorUserId);
-    }
-
-    [Fact]
     public void ItShouldHaveAValidationErrorWhenTargetUserIdIsEmpty()
     {
         // Arrange
@@ -59,13 +46,11 @@ public class WhenTestingValidate : BaseGrantPlatformCapabilityCommandValidatorTe
     }
 
     private static GrantPlatformCapabilityCommand Command(
-        Guid? actorUserId = null,
         Guid? targetUserId = null,
         PlatformCapabilityEnum capability = PlatformCapabilityEnum.Guide)
     {
         return new GrantPlatformCapabilityCommand
         {
-            ActorUserId = actorUserId ?? Guid.Parse("11111111-1111-1111-1111-111111111111"),
             TargetUserId = targetUserId ?? Guid.Parse("22222222-2222-2222-2222-222222222222"),
             Capability = capability
         };

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandTests/BaseRevokePlatformCapabilityCommandTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandTests/BaseRevokePlatformCapabilityCommandTest.cs
@@ -1,0 +1,18 @@
+using FishingLogBook.Application.Capabilities.Commands;
+using FishingLogBook.Application.Contracts.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Commands.RevokePlatformCapabilityCommandTests;
+
+public class BaseRevokePlatformCapabilityCommandTest
+{
+    protected readonly IPlatformCapabilityService MockPlatformCapabilityService =
+        Substitute.For<IPlatformCapabilityService>();
+
+    protected readonly RevokePlatformCapabilityHandler Sut;
+
+    protected BaseRevokePlatformCapabilityCommandTest()
+    {
+        Sut = new RevokePlatformCapabilityHandler(MockPlatformCapabilityService);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandTests/WhenTestingHandle.cs
@@ -1,0 +1,74 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Commands;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Common.Mappings;
+using FishingLogBook.Domain.Enums;
+using FluentResults;
+using Mapster;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Commands.RevokePlatformCapabilityCommandTests;
+
+public class WhenTestingHandle : BaseRevokePlatformCapabilityCommandTest
+{
+    public WhenTestingHandle()
+    {
+        ((IRegister)new CapabilityMappingRegistration()).Register(TypeAdapterConfig.GlobalSettings);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheServiceDeniesTheActor()
+    {
+        // Arrange
+        var command = ValidCommand();
+        MockPlatformCapabilityService
+            .RevokeAsync(Arg.Any<RevokePlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail(new MissingPlatformCapabilityError()));
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsFailure.Should().BeTrue();
+        response.Error.Should().BeOfType<MissingPlatformCapabilityError>();
+        await MockPlatformCapabilityService.Received(1).RevokeAsync(
+            Arg.Is<RevokePlatformCapabilityArgs>(args =>
+                args.ActorUserId == command.ActorUserId
+                && args.TargetUserId == command.TargetUserId
+                && args.Capability == command.Capability),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSucceedWhenTheServiceRevokes()
+    {
+        // Arrange
+        var command = ValidCommand();
+        MockPlatformCapabilityService
+            .RevokeAsync(Arg.Any<RevokePlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsSuccess.Should().BeTrue();
+        await MockPlatformCapabilityService.Received(1).RevokeAsync(
+            Arg.Is<RevokePlatformCapabilityArgs>(args =>
+                args.ActorUserId == command.ActorUserId
+                && args.TargetUserId == command.TargetUserId
+                && args.Capability == PlatformCapabilityEnum.CompetitionOrganiser),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static RevokePlatformCapabilityCommand ValidCommand()
+    {
+        return new RevokePlatformCapabilityCommand
+        {
+            ActorUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Capability = PlatformCapabilityEnum.CompetitionOrganiser
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandTests/WhenTestingHandle.cs
@@ -34,14 +34,13 @@ public class WhenTestingHandle : BaseRevokePlatformCapabilityCommandTest
         response.Error.Should().BeOfType<MissingPlatformCapabilityError>();
         await MockPlatformCapabilityService.Received(1).RevokeAsync(
             Arg.Is<RevokePlatformCapabilityArgs>(args =>
-                args.ActorUserId == command.ActorUserId
-                && args.TargetUserId == command.TargetUserId
+                args.TargetUserId == command.TargetUserId
                 && args.Capability == command.Capability),
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ItShouldSucceedWhenTheServiceRevokes()
+    public async Task ItShouldMapOnlyTargetUserIdAndCapability()
     {
         // Arrange
         var command = ValidCommand();
@@ -54,10 +53,11 @@ public class WhenTestingHandle : BaseRevokePlatformCapabilityCommandTest
 
         // Assert
         response.IsSuccess.Should().BeTrue();
+        typeof(RevokePlatformCapabilityCommand).GetProperty("ActorUserId").Should().BeNull();
+        typeof(RevokePlatformCapabilityArgs).GetProperty("ActorUserId").Should().BeNull();
         await MockPlatformCapabilityService.Received(1).RevokeAsync(
             Arg.Is<RevokePlatformCapabilityArgs>(args =>
-                args.ActorUserId == command.ActorUserId
-                && args.TargetUserId == command.TargetUserId
+                args.TargetUserId == command.TargetUserId
                 && args.Capability == PlatformCapabilityEnum.CompetitionOrganiser),
             Arg.Any<CancellationToken>());
     }
@@ -66,7 +66,6 @@ public class WhenTestingHandle : BaseRevokePlatformCapabilityCommandTest
     {
         return new RevokePlatformCapabilityCommand
         {
-            ActorUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
             TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
             Capability = PlatformCapabilityEnum.CompetitionOrganiser
         };

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandValidatorTests/BaseRevokePlatformCapabilityCommandValidatorTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandValidatorTests/BaseRevokePlatformCapabilityCommandValidatorTest.cs
@@ -1,0 +1,8 @@
+using FishingLogBook.Application.Capabilities.Commands;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Commands.RevokePlatformCapabilityCommandValidatorTests;
+
+public class BaseRevokePlatformCapabilityCommandValidatorTest
+{
+    protected readonly RevokePlatformCapabilityCommandValidator Sut = new();
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandValidatorTests/WhenTestingValidate.cs
@@ -7,19 +7,6 @@ namespace FishingLogBook.Application.Tests.Capabilities.Commands.RevokePlatformC
 public class WhenTestingValidate : BaseRevokePlatformCapabilityCommandValidatorTest
 {
     [Fact]
-    public void ItShouldHaveAValidationErrorWhenActorUserIdIsEmpty()
-    {
-        // Arrange
-        var command = Command(actorUserId: Guid.Empty);
-
-        // Act
-        var result = Sut.TestValidate(command);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(c => c.ActorUserId);
-    }
-
-    [Fact]
     public void ItShouldHaveAValidationErrorWhenTargetUserIdIsEmpty()
     {
         // Arrange
@@ -59,13 +46,11 @@ public class WhenTestingValidate : BaseRevokePlatformCapabilityCommandValidatorT
     }
 
     private static RevokePlatformCapabilityCommand Command(
-        Guid? actorUserId = null,
         Guid? targetUserId = null,
         PlatformCapabilityEnum capability = PlatformCapabilityEnum.FishingVenueManager)
     {
         return new RevokePlatformCapabilityCommand
         {
-            ActorUserId = actorUserId ?? Guid.Parse("11111111-1111-1111-1111-111111111111"),
             TargetUserId = targetUserId ?? Guid.Parse("22222222-2222-2222-2222-222222222222"),
             Capability = capability
         };

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Commands/RevokePlatformCapabilityCommandValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,73 @@
+using FishingLogBook.Application.Capabilities.Commands;
+using FishingLogBook.Domain.Enums;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Commands.RevokePlatformCapabilityCommandValidatorTests;
+
+public class WhenTestingValidate : BaseRevokePlatformCapabilityCommandValidatorTest
+{
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenActorUserIdIsEmpty()
+    {
+        // Arrange
+        var command = Command(actorUserId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.ActorUserId);
+    }
+
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenTargetUserIdIsEmpty()
+    {
+        // Arrange
+        var command = Command(targetUserId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.TargetUserId);
+    }
+
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenCapabilityIsNotDefined()
+    {
+        // Arrange
+        var command = Command(capability: (PlatformCapabilityEnum)999);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Capability);
+    }
+
+    [Fact]
+    public void ItShouldNotHaveValidationErrorsForAValidCommand()
+    {
+        // Arrange
+        var command = Command();
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static RevokePlatformCapabilityCommand Command(
+        Guid? actorUserId = null,
+        Guid? targetUserId = null,
+        PlatformCapabilityEnum capability = PlatformCapabilityEnum.FishingVenueManager)
+    {
+        return new RevokePlatformCapabilityCommand
+        {
+            ActorUserId = actorUserId ?? Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TargetUserId = targetUserId ?? Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Capability = capability
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/BasePlatformCapabilityServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/BasePlatformCapabilityServiceTest.cs
@@ -1,0 +1,18 @@
+using FishingLogBook.Application.Capabilities.Services;
+using FishingLogBook.Application.Contracts.Repositories;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Services.PlatformCapabilityServiceTests;
+
+public class BasePlatformCapabilityServiceTest
+{
+    protected readonly IUserPlatformCapabilityRepository MockUserPlatformCapabilityRepository =
+        Substitute.For<IUserPlatformCapabilityRepository>();
+
+    protected readonly PlatformCapabilityService Sut;
+
+    protected BasePlatformCapabilityServiceTest()
+    {
+        Sut = new PlatformCapabilityService(MockUserPlatformCapabilityRepository);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/BasePlatformCapabilityServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/BasePlatformCapabilityServiceTest.cs
@@ -1,18 +1,27 @@
 using FishingLogBook.Application.Capabilities.Services;
 using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
 using NSubstitute;
 
 namespace FishingLogBook.Application.Tests.Capabilities.Services.PlatformCapabilityServiceTests;
 
 public class BasePlatformCapabilityServiceTest
 {
+    protected static readonly Guid CurrentUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    protected static readonly Guid TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
     protected readonly IUserPlatformCapabilityRepository MockUserPlatformCapabilityRepository =
         Substitute.For<IUserPlatformCapabilityRepository>();
+
+    protected readonly ICurrentUser MockCurrentUser = Substitute.For<ICurrentUser>();
 
     protected readonly PlatformCapabilityService Sut;
 
     protected BasePlatformCapabilityServiceTest()
     {
-        Sut = new PlatformCapabilityService(MockUserPlatformCapabilityRepository);
+        MockCurrentUser.IsResolved.Returns(true);
+        MockCurrentUser.UserId.Returns(CurrentUserId);
+        Sut = new PlatformCapabilityService(MockUserPlatformCapabilityRepository, MockCurrentUser);
     }
 }

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingGetForUser.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingGetForUser.cs
@@ -1,0 +1,74 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Services.PlatformCapabilityServiceTests;
+
+public class WhenTestingGetForUser : BasePlatformCapabilityServiceTest
+{
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheRepositoryFails()
+    {
+        // Arrange
+        var userId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        MockUserPlatformCapabilityRepository
+            .GetForUserAsync(Arg.Any<FindUserPlatformCapabilitiesArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<IReadOnlyList<PlatformCapabilityEnum>>("Failed to persist platform capability."));
+
+        // Act
+        var result = await Sut.GetForUserAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        await MockUserPlatformCapabilityRepository.Received(1).GetForUserAsync(
+            Arg.Is<FindUserPlatformCapabilitiesArgs>(args => args.UserId == userId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnAnEmptyListWhenTheUserHasNoCapabilities()
+    {
+        // Arrange
+        var userId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        MockUserPlatformCapabilityRepository
+            .GetForUserAsync(Arg.Any<FindUserPlatformCapabilitiesArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<PlatformCapabilityEnum>>([]));
+
+        // Act
+        var result = await Sut.GetForUserAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+        await MockUserPlatformCapabilityRepository.Received(1).GetForUserAsync(
+            Arg.Is<FindUserPlatformCapabilitiesArgs>(args => args.UserId == userId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnThePersistedCapabilities()
+    {
+        // Arrange
+        var userId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        IReadOnlyList<PlatformCapabilityEnum> capabilities =
+        [
+            PlatformCapabilityEnum.Guide,
+            PlatformCapabilityEnum.CompetitionOrganiser
+        ];
+        MockUserPlatformCapabilityRepository
+            .GetForUserAsync(Arg.Any<FindUserPlatformCapabilitiesArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(capabilities));
+
+        // Act
+        var result = await Sut.GetForUserAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Equal(capabilities);
+        await MockUserPlatformCapabilityRepository.Received(1).GetForUserAsync(
+            Arg.Is<FindUserPlatformCapabilitiesArgs>(args => args.UserId == userId),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingGrant.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingGrant.cs
@@ -1,0 +1,170 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Users;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Services.PlatformCapabilityServiceTests;
+
+public class WhenTestingGrant : BasePlatformCapabilityServiceTest
+{
+    [Fact]
+    public async Task ItShouldFailWhenTheActorLookupFails()
+    {
+        // Arrange
+        var args = GrantArgs();
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<bool>("Failed to persist platform capability."));
+
+        // Act
+        var result = await Sut.GrantAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Failed to persist platform capability.");
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == args.ActorUserId
+                && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheActorLacksAdministrator()
+    {
+        // Arrange
+        var args = GrantArgs();
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(false));
+
+        // Act
+        var result = await Sut.GrantAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<MissingPlatformCapabilityError>();
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == args.ActorUserId
+                && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().RevokeAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFailureWhenGrantPersistenceFails()
+    {
+        // Arrange
+        var args = GrantArgs();
+        GivenActorIsAdministrator(args.ActorUserId);
+        MockUserPlatformCapabilityRepository
+            .GrantAsync(Arg.Any<UserPlatformCapability>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail("Failed to persist platform capability."));
+
+        // Act
+        var result = await Sut.GrantAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        await MockUserPlatformCapabilityRepository.Received(1).GrantAsync(
+            Arg.Is<UserPlatformCapability>(association =>
+                association.UserId == args.TargetUserId
+                && association.Capability == args.Capability),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotRemoveOtherCapabilitiesWhenGranting()
+    {
+        // Arrange
+        var args = GrantArgs(capability: PlatformCapabilityEnum.Administrator);
+        GivenActorIsAdministrator(args.ActorUserId);
+        MockUserPlatformCapabilityRepository
+            .GrantAsync(Arg.Any<UserPlatformCapability>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        // Act
+        var result = await Sut.GrantAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockUserPlatformCapabilityRepository.Received(1).GrantAsync(
+            Arg.Is<UserPlatformCapability>(association =>
+                association.UserId == args.TargetUserId
+                && association.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().RevokeAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldGrantWhenTheActorHasAdministrator()
+    {
+        // Arrange
+        var args = GrantArgs();
+        GivenActorIsAdministrator(args.ActorUserId);
+        MockUserPlatformCapabilityRepository
+            .GrantAsync(Arg.Any<UserPlatformCapability>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        // Act
+        var result = await Sut.GrantAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == args.ActorUserId
+                && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.Received(1).GrantAsync(
+            Arg.Is<UserPlatformCapability>(association =>
+                association.UserId == args.TargetUserId
+                && association.Capability == PlatformCapabilityEnum.Guide),
+            Arg.Any<CancellationToken>());
+        Enum.GetNames<PlatformCapabilityEnum>().Should().NotContain("Angler");
+        Enum.GetNames<PlatformCapabilityEnum>().Should().NotContain("ClubAdmin");
+        Enum.GetNames<PlatformCapabilityEnum>().Should().Equal(
+            nameof(PlatformCapabilityEnum.Guide),
+            nameof(PlatformCapabilityEnum.FishingVenueManager),
+            nameof(PlatformCapabilityEnum.CompetitionOrganiser),
+            nameof(PlatformCapabilityEnum.Administrator));
+    }
+
+    private void GivenActorIsAdministrator(Guid actorUserId)
+    {
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var lookup = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
+                return Result.Ok(
+                    lookup.UserId == actorUserId
+                    && lookup.Capability == PlatformCapabilityEnum.Administrator);
+            });
+    }
+
+    private static GrantPlatformCapabilityArgs GrantArgs(
+        PlatformCapabilityEnum capability = PlatformCapabilityEnum.Guide)
+    {
+        return new GrantPlatformCapabilityArgs
+        {
+            ActorUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Capability = capability
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingGrant.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingGrant.cs
@@ -11,6 +11,28 @@ namespace FishingLogBook.Application.Tests.Capabilities.Services.PlatformCapabil
 public class WhenTestingGrant : BasePlatformCapabilityServiceTest
 {
     [Fact]
+    public async Task ItShouldFailWhenTheCurrentUserIsNotResolved()
+    {
+        // Arrange
+        MockCurrentUser.IsResolved.Returns(false);
+        MockCurrentUser.UserId.Returns(Guid.Parse("99999999-9999-9999-9999-999999999999"));
+        var args = GrantArgs();
+
+        // Act
+        var result = await Sut.GrantAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CurrentUserUnresolvedError>();
+        await MockUserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldFailWhenTheActorLookupFails()
     {
         // Arrange
@@ -27,7 +49,7 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
         result.Errors[0].Message.Should().Be("Failed to persist platform capability.");
         await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
             Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
-                lookup.UserId == args.ActorUserId
+                lookup.UserId == CurrentUserId
                 && lookup.Capability == PlatformCapabilityEnum.Administrator),
             Arg.Any<CancellationToken>());
         await MockUserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
@@ -36,7 +58,7 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
     }
 
     [Fact]
-    public async Task ItShouldFailWhenTheActorLacksAdministrator()
+    public async Task ItShouldFailWhenTheCurrentUserLacksAdministrator()
     {
         // Arrange
         var args = GrantArgs();
@@ -52,8 +74,11 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
         result.Errors[0].Should().BeOfType<MissingPlatformCapabilityError>();
         await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
             Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
-                lookup.UserId == args.ActorUserId
+                lookup.UserId == CurrentUserId
                 && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup => lookup.UserId == args.TargetUserId),
             Arg.Any<CancellationToken>());
         await MockUserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
             Arg.Any<UserPlatformCapability>(),
@@ -64,11 +89,42 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
     }
 
     [Fact]
+    public async Task ItShouldNotAuthorizeUsingTheTargetUserId()
+    {
+        // Arrange
+        var args = GrantArgs();
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var lookup = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
+                return Result.Ok(
+                    lookup.UserId == args.TargetUserId
+                    && lookup.Capability == PlatformCapabilityEnum.Administrator);
+            });
+
+        // Act
+        var result = await Sut.GrantAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<MissingPlatformCapabilityError>();
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == CurrentUserId
+                && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldReturnFailureWhenGrantPersistenceFails()
     {
         // Arrange
         var args = GrantArgs();
-        GivenActorIsAdministrator(args.ActorUserId);
+        GivenCurrentUserIsAdministrator();
         MockUserPlatformCapabilityRepository
             .GrantAsync(Arg.Any<UserPlatformCapability>(), Arg.Any<CancellationToken>())
             .Returns(Result.Fail("Failed to persist platform capability."));
@@ -90,7 +146,7 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
     {
         // Arrange
         var args = GrantArgs(capability: PlatformCapabilityEnum.Administrator);
-        GivenActorIsAdministrator(args.ActorUserId);
+        GivenCurrentUserIsAdministrator();
         MockUserPlatformCapabilityRepository
             .GrantAsync(Arg.Any<UserPlatformCapability>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok());
@@ -111,11 +167,11 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
     }
 
     [Fact]
-    public async Task ItShouldGrantWhenTheActorHasAdministrator()
+    public async Task ItShouldGrantWhenTheCurrentUserHasAdministrator()
     {
         // Arrange
         var args = GrantArgs();
-        GivenActorIsAdministrator(args.ActorUserId);
+        GivenCurrentUserIsAdministrator();
         MockUserPlatformCapabilityRepository
             .GrantAsync(Arg.Any<UserPlatformCapability>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok());
@@ -127,12 +183,15 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
         result.IsSuccess.Should().BeTrue();
         await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
             Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
-                lookup.UserId == args.ActorUserId
+                lookup.UserId == CurrentUserId
                 && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup => lookup.UserId == args.TargetUserId),
             Arg.Any<CancellationToken>());
         await MockUserPlatformCapabilityRepository.Received(1).GrantAsync(
             Arg.Is<UserPlatformCapability>(association =>
-                association.UserId == args.TargetUserId
+                association.UserId == TargetUserId
                 && association.Capability == PlatformCapabilityEnum.Guide),
             Arg.Any<CancellationToken>());
         Enum.GetNames<PlatformCapabilityEnum>().Should().NotContain("Angler");
@@ -144,7 +203,7 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
             nameof(PlatformCapabilityEnum.Administrator));
     }
 
-    private void GivenActorIsAdministrator(Guid actorUserId)
+    private void GivenCurrentUserIsAdministrator()
     {
         MockUserPlatformCapabilityRepository
             .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
@@ -152,7 +211,7 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
             {
                 var lookup = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
                 return Result.Ok(
-                    lookup.UserId == actorUserId
+                    lookup.UserId == CurrentUserId
                     && lookup.Capability == PlatformCapabilityEnum.Administrator);
             });
     }
@@ -162,8 +221,7 @@ public class WhenTestingGrant : BasePlatformCapabilityServiceTest
     {
         return new GrantPlatformCapabilityArgs
         {
-            ActorUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
-            TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            TargetUserId = TargetUserId,
             Capability = capability
         };
     }

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingHas.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingHas.cs
@@ -1,0 +1,73 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Services.PlatformCapabilityServiceTests;
+
+public class WhenTestingHas : BasePlatformCapabilityServiceTest
+{
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheRepositoryFails()
+    {
+        // Arrange
+        var userId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<bool>("Failed to persist platform capability."));
+
+        // Act
+        var result = await Sut.HasAsync(userId, PlatformCapabilityEnum.Guide, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Failed to persist platform capability.");
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(args =>
+                args.UserId == userId && args.Capability == PlatformCapabilityEnum.Guide),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFalseWhenTheUserHasNoCapabilities()
+    {
+        // Arrange
+        var userId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(false));
+
+        // Act
+        var result = await Sut.HasAsync(userId, PlatformCapabilityEnum.Administrator, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(args =>
+                args.UserId == userId && args.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTrueWhenTheUserHasTheCapability()
+    {
+        // Arrange
+        var userId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(true));
+
+        // Act
+        var result = await Sut.HasAsync(userId, PlatformCapabilityEnum.Guide, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(args =>
+                args.UserId == userId && args.Capability == PlatformCapabilityEnum.Guide),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingRevoke.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingRevoke.cs
@@ -11,7 +11,29 @@ namespace FishingLogBook.Application.Tests.Capabilities.Services.PlatformCapabil
 public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
 {
     [Fact]
-    public async Task ItShouldFailWhenTheActorLacksAdministrator()
+    public async Task ItShouldFailWhenTheCurrentUserIsNotResolved()
+    {
+        // Arrange
+        MockCurrentUser.IsResolved.Returns(false);
+        MockCurrentUser.UserId.Returns(Guid.Parse("99999999-9999-9999-9999-999999999999"));
+        var args = RevokeArgs();
+
+        // Act
+        var result = await Sut.RevokeAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CurrentUserUnresolvedError>();
+        await MockUserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().RevokeAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheCurrentUserLacksAdministrator()
     {
         // Arrange
         var args = RevokeArgs();
@@ -27,8 +49,11 @@ public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
         result.Errors[0].Should().BeOfType<MissingPlatformCapabilityError>();
         await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
             Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
-                lookup.UserId == args.ActorUserId
+                lookup.UserId == CurrentUserId
                 && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup => lookup.UserId == args.TargetUserId),
             Arg.Any<CancellationToken>());
         await MockUserPlatformCapabilityRepository.DidNotReceive().RevokeAsync(
             Arg.Any<FindUserPlatformCapabilityArgs>(),
@@ -39,11 +64,42 @@ public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
     }
 
     [Fact]
+    public async Task ItShouldNotAuthorizeUsingTheTargetUserId()
+    {
+        // Arrange
+        var args = RevokeArgs();
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var lookup = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
+                return Result.Ok(
+                    lookup.UserId == args.TargetUserId
+                    && lookup.Capability == PlatformCapabilityEnum.Administrator);
+            });
+
+        // Act
+        var result = await Sut.RevokeAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<MissingPlatformCapabilityError>();
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == CurrentUserId
+                && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().RevokeAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldReturnFailureWhenRevokePersistenceFails()
     {
         // Arrange
         var args = RevokeArgs();
-        GivenActorIsAdministrator(args.ActorUserId);
+        GivenCurrentUserIsAdministrator();
         MockUserPlatformCapabilityRepository
             .RevokeAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
             .Returns(Result.Fail("Failed to persist platform capability."));
@@ -65,7 +121,7 @@ public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
     {
         // Arrange
         var args = RevokeArgs();
-        GivenActorIsAdministrator(args.ActorUserId);
+        GivenCurrentUserIsAdministrator();
         MockUserPlatformCapabilityRepository
             .RevokeAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok());
@@ -75,9 +131,14 @@ public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
 
         // Assert
         result.IsSuccess.Should().BeTrue();
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == CurrentUserId
+                && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
         await MockUserPlatformCapabilityRepository.Received(1).RevokeAsync(
             Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
-                lookup.UserId == args.TargetUserId
+                lookup.UserId == TargetUserId
                 && lookup.Capability == PlatformCapabilityEnum.Guide),
             Arg.Any<CancellationToken>());
         await MockUserPlatformCapabilityRepository.DidNotReceive().RevokeAsync(
@@ -89,7 +150,7 @@ public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
             Arg.Any<CancellationToken>());
     }
 
-    private void GivenActorIsAdministrator(Guid actorUserId)
+    private void GivenCurrentUserIsAdministrator()
     {
         MockUserPlatformCapabilityRepository
             .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
@@ -97,7 +158,7 @@ public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
             {
                 var lookup = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
                 return Result.Ok(
-                    lookup.UserId == actorUserId
+                    lookup.UserId == CurrentUserId
                     && lookup.Capability == PlatformCapabilityEnum.Administrator);
             });
     }
@@ -106,8 +167,7 @@ public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
     {
         return new RevokePlatformCapabilityArgs
         {
-            ActorUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
-            TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            TargetUserId = TargetUserId,
             Capability = PlatformCapabilityEnum.Guide
         };
     }

--- a/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingRevoke.cs
+++ b/tests/FishingLogBook.Application.Tests/Capabilities/Services/PlatformCapabilityServiceTests/WhenTestingRevoke.cs
@@ -1,0 +1,114 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Users;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Capabilities.Services.PlatformCapabilityServiceTests;
+
+public class WhenTestingRevoke : BasePlatformCapabilityServiceTest
+{
+    [Fact]
+    public async Task ItShouldFailWhenTheActorLacksAdministrator()
+    {
+        // Arrange
+        var args = RevokeArgs();
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(false));
+
+        // Act
+        var result = await Sut.RevokeAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<MissingPlatformCapabilityError>();
+        await MockUserPlatformCapabilityRepository.Received(1).HasAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == args.ActorUserId
+                && lookup.Capability == PlatformCapabilityEnum.Administrator),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().RevokeAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFailureWhenRevokePersistenceFails()
+    {
+        // Arrange
+        var args = RevokeArgs();
+        GivenActorIsAdministrator(args.ActorUserId);
+        MockUserPlatformCapabilityRepository
+            .RevokeAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail("Failed to persist platform capability."));
+
+        // Act
+        var result = await Sut.RevokeAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        await MockUserPlatformCapabilityRepository.Received(1).RevokeAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == args.TargetUserId
+                && lookup.Capability == PlatformCapabilityEnum.Guide),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRevokeOnlyTheRequestedCapability()
+    {
+        // Arrange
+        var args = RevokeArgs();
+        GivenActorIsAdministrator(args.ActorUserId);
+        MockUserPlatformCapabilityRepository
+            .RevokeAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        // Act
+        var result = await Sut.RevokeAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockUserPlatformCapabilityRepository.Received(1).RevokeAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.UserId == args.TargetUserId
+                && lookup.Capability == PlatformCapabilityEnum.Guide),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().RevokeAsync(
+            Arg.Is<FindUserPlatformCapabilityArgs>(lookup =>
+                lookup.Capability == PlatformCapabilityEnum.CompetitionOrganiser),
+            Arg.Any<CancellationToken>());
+        await MockUserPlatformCapabilityRepository.DidNotReceive().GrantAsync(
+            Arg.Any<UserPlatformCapability>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private void GivenActorIsAdministrator(Guid actorUserId)
+    {
+        MockUserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var lookup = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
+                return Result.Ok(
+                    lookup.UserId == actorUserId
+                    && lookup.Capability == PlatformCapabilityEnum.Administrator);
+            });
+    }
+
+    private static RevokePlatformCapabilityArgs RevokeArgs()
+    {
+        return new RevokePlatformCapabilityArgs
+        {
+            ActorUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            TargetUserId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            Capability = PlatformCapabilityEnum.Guide
+        };
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/BaseUserPlatformCapabilityRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/BaseUserPlatformCapabilityRepositoryTest.cs
@@ -1,0 +1,91 @@
+using Dapper;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Users;
+using FishingLogBook.Infrastructure.Persistence;
+using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+using FishingLogBook.Tests.Common.Builders;
+
+namespace FishingLogBook.Infrastructure.Tests.Integration.Capabilities.UserPlatformCapabilityRepositoryTests;
+
+[Collection(PostgresCollection.Name)]
+public abstract class BaseUserPlatformCapabilityRepositoryTest
+{
+    protected readonly UserPlatformCapabilityRepository Sut;
+    protected readonly UserIdentityRepository Users;
+    protected readonly NpgsqlConnectionFactory ConnectionFactory;
+
+    protected BaseUserPlatformCapabilityRepositoryTest(PostgresFixture fixture)
+    {
+        ConnectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
+        Sut = new UserPlatformCapabilityRepository(ConnectionFactory);
+        Users = new UserIdentityRepository(ConnectionFactory);
+    }
+
+    protected async Task<Guid> CreateUserAsync()
+    {
+        var user = new UserBuilder()
+            .WithEmail($"{Guid.NewGuid():N}@example.test")
+            .Build();
+        var identity = new UserIdentityBuilder()
+            .ForUser(user)
+            .Build();
+        var created = await Users.CreateAsync(user, identity, CancellationToken.None);
+        if (created.IsFailed)
+        {
+            throw new InvalidOperationException(created.Errors[0].Message);
+        }
+
+        return created.Value;
+    }
+
+    protected static UserPlatformCapability Association(Guid userId, PlatformCapabilityEnum capability)
+    {
+        return new UserPlatformCapability
+        {
+            UserId = userId,
+            Capability = capability
+        };
+    }
+
+    protected static FindUserPlatformCapabilityArgs Lookup(Guid userId, PlatformCapabilityEnum capability)
+    {
+        return new FindUserPlatformCapabilityArgs
+        {
+            UserId = userId,
+            Capability = capability
+        };
+    }
+
+    protected async Task<int> CountForUserAsync(Guid userId)
+    {
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        return await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT COUNT(*)
+            FROM "UserPlatformCapability"
+            WHERE "UserId" = @UserId;
+            """,
+            new { UserId = userId });
+    }
+
+    protected async Task<int> CountForUserCapabilityAsync(Guid userId, PlatformCapabilityEnum capability)
+    {
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        return await connection.ExecuteScalarAsync<int>(
+            """
+            SELECT COUNT(*)
+            FROM "UserPlatformCapability"
+            WHERE "UserId" = @UserId AND "CapabilityCode" = @CapabilityCode;
+            """,
+            new { UserId = userId, CapabilityCode = capability.ToString() });
+    }
+
+    protected async Task<IReadOnlyList<string>> SeededCodesAsync()
+    {
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var codes = await connection.QueryAsync<string>(
+            """SELECT "Code" FROM "PlatformCapability" ORDER BY "Code";""");
+        return codes.ToArray();
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingGetForUser.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingGetForUser.cs
@@ -1,0 +1,77 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+
+namespace FishingLogBook.Infrastructure.Tests.Integration.Capabilities.UserPlatformCapabilityRepositoryTests;
+
+public class WhenTestingGetForUser : BaseUserPlatformCapabilityRepositoryTest
+{
+    public WhenTestingGetForUser(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldReturnEmptyWhenTheUserHasNoCapabilities()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+
+        // Act
+        var result = await Sut.GetForUserAsync(
+            new FindUserPlatformCapabilitiesArgs { UserId = userId },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnAnotherUsersCapabilities()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        var granted = await Sut.GrantAsync(
+            Association(otherUserId, PlatformCapabilityEnum.Guide),
+            CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetForUserAsync(
+            new FindUserPlatformCapabilitiesArgs { UserId = userId },
+            CancellationToken.None);
+
+        // Assert
+        granted.IsSuccess.Should().BeTrue();
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnAllCapabilitiesForTheUser()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+        await Sut.GrantAsync(
+            Association(userId, PlatformCapabilityEnum.CompetitionOrganiser),
+            CancellationToken.None);
+        await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Administrator), CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetForUserAsync(
+            new FindUserPlatformCapabilitiesArgs { UserId = userId },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(
+        [
+            PlatformCapabilityEnum.Guide,
+            PlatformCapabilityEnum.CompetitionOrganiser,
+            PlatformCapabilityEnum.Administrator
+        ]);
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingGrant.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingGrant.cs
@@ -1,0 +1,209 @@
+using AwesomeAssertions;
+using Dapper;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+using Npgsql;
+
+namespace FishingLogBook.Infrastructure.Tests.Integration.Capabilities.UserPlatformCapabilityRepositoryTests;
+
+public class WhenTestingGrant : BaseUserPlatformCapabilityRepositoryTest
+{
+    public WhenTestingGrant(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheUserDoesNotExist()
+    {
+        // Arrange
+        var missingUserId = Guid.NewGuid();
+
+        // Act
+        var result = await Sut.GrantAsync(
+            Association(missingUserId, PlatformCapabilityEnum.Guide),
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Platform capability is invalid.");
+        (await CountForUserAsync(missingUserId)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnknownCapabilityCode()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var act = () => connection.ExecuteAsync(
+            """
+            INSERT INTO "UserPlatformCapability" ("UserId", "CapabilityCode")
+            VALUES (@UserId, @CapabilityCode);
+            """,
+            new { UserId = userId, CapabilityCode = "Angler" });
+
+        // Act
+        // Assert
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.ForeignKeyViolation);
+        (await CountForUserAsync(userId)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAClubScopedCapabilityCode()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var act = () => connection.ExecuteAsync(
+            """
+            INSERT INTO "UserPlatformCapability" ("UserId", "CapabilityCode")
+            VALUES (@UserId, @CapabilityCode);
+            """,
+            new { UserId = userId, CapabilityCode = "ClubAdmin" });
+
+        // Act
+        // Assert
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.ForeignKeyViolation);
+        (await CountForUserAsync(userId)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectADuplicateUserCapabilityPair()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var granted = await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var act = () => connection.ExecuteAsync(
+            """
+            INSERT INTO "UserPlatformCapability" ("UserId", "CapabilityCode")
+            VALUES (@UserId, @CapabilityCode);
+            """,
+            new { UserId = userId, CapabilityCode = nameof(PlatformCapabilityEnum.Guide) });
+
+        // Act
+        // Assert
+        granted.IsSuccess.Should().BeTrue();
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.UniqueViolation);
+        (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.Guide)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldSeedOnlySpecialistCapabilities()
+    {
+        // Arrange
+        // Act
+        var codes = await SeededCodesAsync();
+
+        // Assert
+        codes.Should().Equal(
+            nameof(PlatformCapabilityEnum.Administrator),
+            nameof(PlatformCapabilityEnum.CompetitionOrganiser),
+            nameof(PlatformCapabilityEnum.FishingVenueManager),
+            nameof(PlatformCapabilityEnum.Guide));
+        codes.Should().NotContain("Angler");
+        codes.Should().NotContain("ClubAdmin");
+        codes.Should().NotContain("ClubMember");
+        codes.Should().NotContain("ClubOfficer");
+        codes.Should().NotContain("ClubCompetitionOrganiser");
+    }
+
+    [Fact]
+    public async Task ItShouldGrantIdempotently()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+
+        // Act
+        var first = await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+        var second = await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Assert
+        first.IsSuccess.Should().BeTrue();
+        second.IsSuccess.Should().BeTrue();
+        (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.Guide)).Should().Be(1);
+        (await CountForUserAsync(userId)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldAllowTheSameCapabilityOnDifferentUsers()
+    {
+        // Arrange
+        var userA = await CreateUserAsync();
+        var userB = await CreateUserAsync();
+
+        // Act
+        var grantedA = await Sut.GrantAsync(Association(userA, PlatformCapabilityEnum.Guide), CancellationToken.None);
+        var grantedB = await Sut.GrantAsync(Association(userB, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Assert
+        grantedA.IsSuccess.Should().BeTrue();
+        grantedB.IsSuccess.Should().BeTrue();
+        (await CountForUserCapabilityAsync(userA, PlatformCapabilityEnum.Guide)).Should().Be(1);
+        (await CountForUserCapabilityAsync(userB, PlatformCapabilityEnum.Guide)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldPersistMultipleCapabilitiesForTheSameUser()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+
+        // Act
+        var guide = await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+        var organiser = await Sut.GrantAsync(
+            Association(userId, PlatformCapabilityEnum.CompetitionOrganiser),
+            CancellationToken.None);
+        var administrator = await Sut.GrantAsync(
+            Association(userId, PlatformCapabilityEnum.Administrator),
+            CancellationToken.None);
+
+        // Assert
+        guide.IsSuccess.Should().BeTrue();
+        organiser.IsSuccess.Should().BeTrue();
+        administrator.IsSuccess.Should().BeTrue();
+        (await CountForUserAsync(userId)).Should().Be(3);
+        (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.Guide)).Should().Be(1);
+        (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.CompetitionOrganiser)).Should().Be(1);
+        (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.Administrator)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldPreventDeletingAUserThatHasCapabilities()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var granted = await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        await connection.ExecuteAsync(
+            """DELETE FROM "UserIdentity" WHERE "UserId" = @Id;""",
+            new { Id = userId });
+
+        try
+        {
+            var act = () => connection.ExecuteAsync(
+                """DELETE FROM "User" WHERE "Id" = @Id;""",
+                new { Id = userId });
+
+            // Act
+            // Assert
+            granted.IsSuccess.Should().BeTrue();
+            var exception = await act.Should().ThrowAsync<PostgresException>();
+            exception.Which.SqlState.Should().Be(PostgresErrorCodes.ForeignKeyViolation);
+            (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.Guide)).Should().Be(1);
+        }
+        finally
+        {
+            await connection.ExecuteAsync(
+                """DELETE FROM "UserPlatformCapability" WHERE "UserId" = @Id;""",
+                new { Id = userId });
+            await connection.ExecuteAsync(
+                """DELETE FROM "User" WHERE "Id" = @Id;""",
+                new { Id = userId });
+        }
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingHas.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingHas.cs
@@ -1,0 +1,61 @@
+using AwesomeAssertions;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+
+namespace FishingLogBook.Infrastructure.Tests.Integration.Capabilities.UserPlatformCapabilityRepositoryTests;
+
+public class WhenTestingHas : BaseUserPlatformCapabilityRepositoryTest
+{
+    public WhenTestingHas(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFalseWhenTheUserHasNoCapabilities()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+
+        // Act
+        var result = await Sut.HasAsync(Lookup(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFalseForADifferentCapability()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var granted = await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Act
+        var result = await Sut.HasAsync(
+            Lookup(userId, PlatformCapabilityEnum.Administrator),
+            CancellationToken.None);
+
+        // Assert
+        granted.IsSuccess.Should().BeTrue();
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTrueWhenTheCapabilityExists()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var granted = await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Act
+        var result = await Sut.HasAsync(Lookup(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Assert
+        granted.IsSuccess.Should().BeTrue();
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingRevoke.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingRevoke.cs
@@ -1,0 +1,70 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+
+namespace FishingLogBook.Infrastructure.Tests.Integration.Capabilities.UserPlatformCapabilityRepositoryTests;
+
+public class WhenTestingRevoke : BaseUserPlatformCapabilityRepositoryTest
+{
+    public WhenTestingRevoke(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldSucceedWhenTheCapabilityIsNotPresent()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+
+        // Act
+        var result = await Sut.RevokeAsync(Lookup(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        (await CountForUserAsync(userId)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldLeaveUnrelatedCapabilitiesInPlace()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+        await Sut.GrantAsync(
+            Association(userId, PlatformCapabilityEnum.CompetitionOrganiser),
+            CancellationToken.None);
+
+        // Act
+        var result = await Sut.RevokeAsync(Lookup(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.Guide)).Should().Be(0);
+        (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.CompetitionOrganiser)).Should().Be(1);
+        (await CountForUserAsync(userId)).Should().Be(1);
+        var remaining = await Sut.GetForUserAsync(
+            new FindUserPlatformCapabilitiesArgs { UserId = userId },
+            CancellationToken.None);
+        remaining.Value.Should().Equal(PlatformCapabilityEnum.CompetitionOrganiser);
+    }
+
+    [Fact]
+    public async Task ItShouldRemoveOnlyTheRequestedAssociation()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        await Sut.GrantAsync(Association(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+        await Sut.GrantAsync(Association(otherUserId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Act
+        var result = await Sut.RevokeAsync(Lookup(userId, PlatformCapabilityEnum.Guide), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        (await CountForUserCapabilityAsync(userId, PlatformCapabilityEnum.Guide)).Should().Be(0);
+        (await CountForUserCapabilityAsync(otherUserId, PlatformCapabilityEnum.Guide)).Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary
- Establishes the reusable **platform** capability model on the internal FishingLogBook `UserId` from #9. Cognito/OIDC still answers who the person is; persisted capabilities answer what they may do.
- One normal `User` may hold zero, one, or many specialist capabilities. They are not mutually exclusive and are not separate account types.
- Personal Catch / profile / logbook remains **baseline behaviour** for every resolved User. `Angler` is not seeded, not on `PlatformCapabilityEnum`, and not an authorization check.
- Persisted catalogue: `Guide`, `FishingVenueManager`, `CompetitionOrganiser`, `Administrator`. Club roles stay out of this model (#32).
- Application contract `IPlatformCapabilityService` (Has / Grant / Revoke / Get). Grant and Revoke require the **actor** to already have `Administrator`. No public self-grant HTTP endpoint. No capability caching. `ICurrentUser` is unchanged.
- Server authorization: unauthenticated **401**; authenticated without the required capability **403** and protected work is not executed; client-sent UserId / capability claims are ignored.

Closes #13

## Migrations (apply after merge)
- `202608171700_13_CreatePlatformCapability.sql` — `PlatformCapability` lookup + `UserPlatformCapability` association, unique `(UserId, CapabilityCode)`, FKs to `User` and lookup, no `ON DELETE CASCADE`
- `202608171701_13_SeedPlatformCapability.sql` — seeds the four specialist codes only

No Terraform. No Web UI / no new user-visible copy.

## Test plan
- [ ] Apply the two #13 DbUp scripts in the target environment.
- [ ] Authenticated User with **zero** capability rows can still record a Catch / use personal logbook.
- [ ] Grant `Guide` on that same internal `UserId`; personal Catch still works; `Guide` is persisted once even if granted twice.
- [ ] Grant `Guide` + `CompetitionOrganiser`, then `Administrator`: all three remain. Revoke `Guide`: `CompetitionOrganiser` remains.
- [ ] Unauthenticated grant-style request returns **401**.
- [ ] Authenticated User without `Administrator` is **403** and no capability row is written.
- [ ] Authenticated User with persisted `Administrator` can grant a specialist capability.
- [ ] Client body/header claiming `Administrator` / a capability array / another UserId does not grant access.
- [ ] OpenAPI / production routes do not expose `/api/platform-capabilities/grant` or `/__test/platform-capabilities/grant`.
- [ ] Confirm no `Angler`, `ClubAdmin`, `ClubOfficer`, `ClubMember`, or `ClubCompetitionOrganiser` platform capability exists.

## Self review
- Issue/AC: PASS — AC1–AC13 covered. Angler is baseline behaviour only; no `PlatformCapabilityEnum.Angler`; no `HasCapability(Angler)`; no Angler seed row.
- Architecture/CQRS: PASS — Grant/Revoke are Commands → handler → `IPlatformCapabilityService` → `IUserPlatformCapabilityRepository`. Capability **checks** are `HasAsync`, not Commands. `ICurrentUser` remains `UserId` / `Email` / `IsResolved`. No MediatR auth pipeline. No Cognito groups/claims as source of truth.
- Rules: PASS — Domain enum in `Enums/`; Mapster command → Args; expand-only DbUp; `WhenTesting{Method}`; AwesomeAssertions; `Received(n)` / `DidNotReceive` / `Arg.Is`.
- Security/privacy: PASS — validated token → internal UserId → persisted capabilities. 403 is server-side. UI hiding is not used as authorization. No public self-grant endpoint. Test-host-only grant route is not mapped in production `Program.cs`.
- Database/migrations: PASS — unique pair, FKs, specialist seed only, no cascade, no club-role columns, no booleans on `User`.
- Tests/coverage: PASS — Application grant/revoke/has/idempotency/deny; API 401/403/allow/spoof/no public grant; Catch still upserts with zero capabilities; Testcontainers uniqueness, coexistence, FK, seed catalogue.
- Browser: N/A — no UI. Playwright not warranted.
- Web/UI/localisation: N/A — no new copy or menus.
- Code smells: PASS — no generic RBAC engine; platform vs club axes kept separate.
- CI/deployment: PASS — apply the two #13 scripts; no Terraform.

Findings discovered during self-review:
1. SHOULD FIX — a User-delete FK test left a User without `UserIdentity` and broke shared Testcontainers identity tests.

Fixes made:
1. Isolated that FK test and clean up capability/user rows in `try/finally`.

Remaining deliberate gaps:
- No production first-Administrator bootstrap / Admin UI (out of scope).
- Grant/Revoke are not public HTTP; 401/403 is proven through a test-host route using the production mapping helper.
- Club-scoped roles remain #32.
- Guide / venue / competition screens remain #37 / #25 / #40.
