### PR TITLE
FLB#16 | enforce owner-controlled catch location visibility

### DIFF
--- a/.cursor/rules/read-claude-rules.mdc
+++ b/.cursor/rules/read-claude-rules.mdc
@@ -9,6 +9,7 @@ Before planning, coding, testing, committing, or touching infrastructure, read t
 
 | Work | Read |
 |------|------|
+| GitHub issues, PRs, reviews, commits, branches or pushes | `.claude/rules/github-operations.md` |
 | Planning or implementing a GitHub issue | `.claude/rules/product-workflow.md` |
 | After implementation and tests, before declaring complete or PR-ready | `.claude/rules/self-review.md` |
 | C# (API, Application, Domain, Infrastructure, Shared) | `.claude/rules/csharp.md` |

--- a/src/FishingLogBook.Api/Endpoints/CatchEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/CatchEndpoints.cs
@@ -1,5 +1,7 @@
+using FishingLogBook.Application.Capabilities.Errors;
 using FishingLogBook.Application.Catches.Commands;
 using FishingLogBook.Application.Catches.Errors;
+using FishingLogBook.Application.Catches.Queries;
 using FishingLogBook.Application.Contracts.Services;
 using FishingLogBook.Shared.Dtos;
 using MediatR;
@@ -17,6 +19,26 @@ public static class CatchEndpoints
             .Produces<CatchDto>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        endpoints.MapGet("/api/catches/{catchId:guid}", GetAsync)
+            .WithName("GetCatch")
+            .WithTags("Catches")
+            .RequireAuthorization()
+            .Produces<CatchViewDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        endpoints.MapPatch("/api/catches/{catchId:guid}/location-visibility", UpdateLocationVisibilityAsync)
+            .WithName("UpdateCatchLocationVisibility")
+            .WithTags("Catches")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status503ServiceUnavailable);
 
         return endpoints;
@@ -61,5 +83,93 @@ public static class CatchEndpoints
         }
 
         return Results.Ok(response.Catch);
+    }
+
+    private static async Task<IResult> GetAsync(
+        Guid catchId,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new GetCatchQuery { CatchId = catchId },
+            cancellationToken);
+        if (response.Error is CurrentUserUnresolvedError)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (response.Error is CatchNotFoundError)
+        {
+            return Results.NotFound();
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.Ok(response.Catch);
+    }
+
+    private static async Task<IResult> UpdateLocationVisibilityAsync(
+        Guid catchId,
+        UpdateCatchLocationVisibilityDto body,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new UpdateCatchLocationVisibilityCommand
+            {
+                CatchId = catchId,
+                Visibility = body.Visibility
+            },
+            cancellationToken);
+        if (response.Error is CurrentUserUnresolvedError)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (response.ValidationErrors is { Count: > 0 })
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.Error is CatchNotFoundError)
+        {
+            return Results.NotFound();
+        }
+
+        if (response.Error is CatchNotOwnedError)
+        {
+            return Results.Json(response, statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        if (response.Error is CatchHasNoLocationError)
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.NoContent();
     }
 }

--- a/src/FishingLogBook.Api/FishingLogBook.Api.http
+++ b/src/FishingLogBook.Api/FishingLogBook.Api.http
@@ -98,3 +98,20 @@ Authorization: Bearer <access-token>
 }
 
 ###
+
+GET {{FishingLogBook.Api_HostAddress}}/api/catches/00000000-0000-0000-0000-000000000000
+Accept: application/json
+Authorization: Bearer <access-token>
+
+###
+
+PATCH {{FishingLogBook.Api_HostAddress}}/api/catches/00000000-0000-0000-0000-000000000000/location-visibility
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <access-token>
+
+{
+  "visibility": "Private"
+}
+
+###

--- a/src/FishingLogBook.Application/Args/GetCatchArgs.cs
+++ b/src/FishingLogBook.Application/Args/GetCatchArgs.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class GetCatchArgs
+{
+    public Guid CatchId { get; init; }
+}

--- a/src/FishingLogBook.Application/Args/PersistCatchLocationVisibilityArgs.cs
+++ b/src/FishingLogBook.Application/Args/PersistCatchLocationVisibilityArgs.cs
@@ -1,0 +1,10 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class PersistCatchLocationVisibilityArgs
+{
+    public Guid CatchId { get; init; }
+
+    public Guid UserId { get; init; }
+
+    public string Visibility { get; init; } = string.Empty;
+}

--- a/src/FishingLogBook.Application/Args/UpdateCatchLocationVisibilityArgs.cs
+++ b/src/FishingLogBook.Application/Args/UpdateCatchLocationVisibilityArgs.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class UpdateCatchLocationVisibilityArgs
+{
+    public Guid CatchId { get; init; }
+
+    public string Visibility { get; init; } = string.Empty;
+}

--- a/src/FishingLogBook.Application/Catches/Commands/UpdateCatchLocationVisibilityCommand.cs
+++ b/src/FishingLogBook.Application/Catches/Commands/UpdateCatchLocationVisibilityCommand.cs
@@ -1,0 +1,59 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace FishingLogBook.Application.Catches.Commands;
+
+public sealed class UpdateCatchLocationVisibilityCommand : IRequest<UpdateCatchLocationVisibilityResponse>
+{
+    public Guid CatchId { get; init; }
+
+    public string Visibility { get; init; } = string.Empty;
+}
+
+public sealed class UpdateCatchLocationVisibilityResponse : ValidatedResponse
+{
+}
+
+public sealed class UpdateCatchLocationVisibilityHandler
+    : IRequestHandler<UpdateCatchLocationVisibilityCommand, UpdateCatchLocationVisibilityResponse>
+{
+    private readonly ICatchService _catchService;
+
+    public UpdateCatchLocationVisibilityHandler(ICatchService catchService)
+    {
+        _catchService = catchService;
+    }
+
+    public async Task<UpdateCatchLocationVisibilityResponse> Handle(
+        UpdateCatchLocationVisibilityCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _catchService.UpdateLocationVisibilityAsync(
+            command.Adapt<UpdateCatchLocationVisibilityArgs>(),
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<UpdateCatchLocationVisibilityResponse>(result.Errors[0]);
+        }
+
+        return new UpdateCatchLocationVisibilityResponse();
+    }
+}
+
+public sealed class UpdateCatchLocationVisibilityCommandValidator
+    : AbstractValidator<UpdateCatchLocationVisibilityCommand>
+{
+    public UpdateCatchLocationVisibilityCommandValidator()
+    {
+        RuleFor(command => command.CatchId)
+            .NotEmpty();
+        RuleFor(command => command.Visibility)
+            .Must(LocationDefaults.IsKnownVisibility)
+            .WithMessage("Location visibility is not supported.");
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Commands/UpsertCatchCommand.cs
+++ b/src/FishingLogBook.Application/Catches/Commands/UpsertCatchCommand.cs
@@ -85,7 +85,8 @@ public sealed class UpsertCatchCommandValidator : AbstractValidator<UpsertCatchC
             RuleFor(command => command.Catch.Location!.Source)
                 .NotEmpty();
             RuleFor(command => command.Catch.Location!.Visibility)
-                .NotEmpty();
+                .Must(LocationDefaults.IsKnownVisibility)
+                .WithMessage("Location visibility is not supported.");
             RuleFor(command => command.Catch.Location!.ConsentVersion)
                 .NotEmpty();
         });

--- a/src/FishingLogBook.Application/Catches/Errors/CatchHasNoLocationError.cs
+++ b/src/FishingLogBook.Application/Catches/Errors/CatchHasNoLocationError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Catches.Errors;
+
+public sealed class CatchHasNoLocationError : Error
+{
+    public CatchHasNoLocationError()
+        : base("Location visibility cannot be changed when the catch has no location.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Errors/CatchNotFoundError.cs
+++ b/src/FishingLogBook.Application/Catches/Errors/CatchNotFoundError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Catches.Errors;
+
+public sealed class CatchNotFoundError : Error
+{
+    public CatchNotFoundError()
+        : base("The catch was not found.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Errors/CatchNotOwnedError.cs
+++ b/src/FishingLogBook.Application/Catches/Errors/CatchNotOwnedError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Catches.Errors;
+
+public sealed class CatchNotOwnedError : Error
+{
+    public CatchNotOwnedError()
+        : base("Only the catch owner may change location visibility.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Queries/GetCatchQuery.cs
+++ b/src/FishingLogBook.Application/Catches/Queries/GetCatchQuery.cs
@@ -1,0 +1,52 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace FishingLogBook.Application.Catches.Queries;
+
+public sealed class GetCatchQuery : IRequest<GetCatchResponse>
+{
+    public Guid CatchId { get; init; }
+}
+
+public sealed class GetCatchResponse : ValidatedResponse
+{
+    public CatchViewDto? Catch { get; init; }
+}
+
+public sealed class GetCatchHandler : IRequestHandler<GetCatchQuery, GetCatchResponse>
+{
+    private readonly ICatchService _catchService;
+
+    public GetCatchHandler(ICatchService catchService)
+    {
+        _catchService = catchService;
+    }
+
+    public async Task<GetCatchResponse> Handle(GetCatchQuery query, CancellationToken cancellationToken)
+    {
+        var result = await _catchService.GetViewAsync(query.Adapt<GetCatchArgs>(), cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<GetCatchResponse>(result.Errors[0]);
+        }
+
+        return new GetCatchResponse
+        {
+            Catch = result.Value
+        };
+    }
+}
+
+public sealed class GetCatchQueryValidator : AbstractValidator<GetCatchQuery>
+{
+    public GetCatchQueryValidator()
+    {
+        RuleFor(query => query.CatchId)
+            .NotEmpty();
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Services/CatchLocationPrivacyService.cs
+++ b/src/FishingLogBook.Application/Catches/Services/CatchLocationPrivacyService.cs
@@ -1,0 +1,116 @@
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Catches.Services;
+
+public sealed class CatchLocationPrivacyService : ICatchLocationPrivacyService
+{
+    public Task<CatchLocationExposureDto?> GetExposureAsync(
+        Catch catchRecord,
+        Guid viewerUserId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(Shape(catchRecord, viewerUserId));
+    }
+
+    private static CatchLocationExposureDto? Shape(Catch catchRecord, Guid viewerUserId)
+    {
+        if (catchRecord.Location is null)
+        {
+            return null;
+        }
+
+        if (viewerUserId == catchRecord.UserId)
+        {
+            return Exact(catchRecord.Location);
+        }
+
+        if (!Enum.TryParse<LocationVisibilityEnum>(catchRecord.Location.Visibility, ignoreCase: false, out var visibility))
+        {
+            return Hidden(catchRecord.Location.Visibility);
+        }
+
+        return visibility switch
+        {
+            LocationVisibilityEnum.Private => Hidden(catchRecord.Location.Visibility),
+            LocationVisibilityEnum.Approximate => Approximate(catchRecord.Location),
+            LocationVisibilityEnum.FishingVenueOnly => VenueOnly(catchRecord.Location.Visibility),
+            LocationVisibilityEnum.Public => Exact(catchRecord.Location),
+            _ => Hidden(catchRecord.Location.Visibility)
+        };
+    }
+
+    private static CatchLocationExposureDto Exact(CatchLocation location)
+    {
+        return new CatchLocationExposureDto
+        {
+            Visibility = location.Visibility,
+            Mode = LocationDefaults.ExposureExact,
+            Latitude = location.Latitude,
+            Longitude = location.Longitude,
+            AccuracyMetres = location.AccuracyMetres,
+            CapturedOn = location.CapturedOn,
+            Source = location.Source
+        };
+    }
+
+    private static CatchLocationExposureDto Approximate(CatchLocation location)
+    {
+        return new CatchLocationExposureDto
+        {
+            Visibility = location.Visibility,
+            Mode = LocationDefaults.ExposureApproximate,
+            ApproximateLatitude = ClampLatitude(Quantize(location.Latitude)),
+            ApproximateLongitude = WrapLongitude(Quantize(location.Longitude)),
+            ApproximateCellSizeMetres = CatchLocationConstants.ApproximateCellSizeMetres
+        };
+    }
+
+    private static CatchLocationExposureDto VenueOnly(string visibility)
+    {
+        return new CatchLocationExposureDto
+        {
+            Visibility = visibility,
+            Mode = LocationDefaults.ExposureFishingVenue
+        };
+    }
+
+    private static CatchLocationExposureDto Hidden(string visibility)
+    {
+        return new CatchLocationExposureDto
+        {
+            Visibility = visibility,
+            Mode = LocationDefaults.ExposureNone
+        };
+    }
+
+    private static double Quantize(double value)
+    {
+        var grid = CatchLocationConstants.ApproximateGridDegrees;
+        return Math.Floor(value / grid) * grid + (grid / 2.0);
+    }
+
+    private static double ClampLatitude(double latitude)
+    {
+        return Math.Clamp(latitude, CatchLocationConstants.MinLatitude, CatchLocationConstants.MaxLatitude);
+    }
+
+    private static double WrapLongitude(double longitude)
+    {
+        if (longitude > CatchLocationConstants.MaxLongitude)
+        {
+            return longitude - 360;
+        }
+
+        if (longitude < CatchLocationConstants.MinLongitude)
+        {
+            return longitude + 360;
+        }
+
+        return longitude;
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Services/CatchService.cs
+++ b/src/FishingLogBook.Application/Catches/Services/CatchService.cs
@@ -1,4 +1,5 @@
 using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
 using FishingLogBook.Application.Catches.Errors;
 using FishingLogBook.Application.Contracts.Repositories;
 using FishingLogBook.Application.Contracts.Services;
@@ -12,10 +13,17 @@ namespace FishingLogBook.Application.Catches.Services;
 public sealed class CatchService : ICatchService
 {
     private readonly ICatchRepository _catchRepository;
+    private readonly ICurrentUser _currentUser;
+    private readonly ICatchLocationPrivacyService _catchLocationPrivacyService;
 
-    public CatchService(ICatchRepository catchRepository)
+    public CatchService(
+        ICatchRepository catchRepository,
+        ICurrentUser currentUser,
+        ICatchLocationPrivacyService catchLocationPrivacyService)
     {
         _catchRepository = catchRepository;
+        _currentUser = currentUser;
+        _catchLocationPrivacyService = catchLocationPrivacyService;
     }
 
     public async Task<Result<CatchDto>> UpsertAsync(UpsertCatchArgs args, CancellationToken cancellationToken)
@@ -62,6 +70,76 @@ public sealed class CatchService : ICatchService
         }
 
         return Result.Ok(saved.Value.Adapt<CatchDto>());
+    }
+
+    public async Task<Result<CatchViewDto>> GetViewAsync(GetCatchArgs args, CancellationToken cancellationToken)
+    {
+        var loaded = await LoadForCurrentUserAsync(args.CatchId, cancellationToken);
+        if (loaded.IsFailed)
+        {
+            return Result.Fail<CatchViewDto>(loaded.Errors);
+        }
+
+        var exposure = await _catchLocationPrivacyService.GetExposureAsync(
+            loaded.Value,
+            _currentUser.UserId,
+            cancellationToken);
+        return Result.Ok(new CatchViewDto(
+            loaded.Value.Id,
+            loaded.Value.UserId,
+            loaded.Value.CaughtOn,
+            exposure));
+    }
+
+    public async Task<Result> UpdateLocationVisibilityAsync(
+        UpdateCatchLocationVisibilityArgs args,
+        CancellationToken cancellationToken)
+    {
+        var loaded = await LoadForCurrentUserAsync(args.CatchId, cancellationToken);
+        if (loaded.IsFailed)
+        {
+            return loaded.ToResult();
+        }
+
+        if (loaded.Value.UserId != _currentUser.UserId)
+        {
+            return Result.Fail(new CatchNotOwnedError());
+        }
+
+        if (loaded.Value.Location is null)
+        {
+            return Result.Fail(new CatchHasNoLocationError());
+        }
+
+        return await _catchRepository.UpdateLocationVisibilityAsync(
+            new PersistCatchLocationVisibilityArgs
+            {
+                CatchId = args.CatchId,
+                UserId = _currentUser.UserId,
+                Visibility = args.Visibility
+            },
+            cancellationToken);
+    }
+
+    private async Task<Result<Catch>> LoadForCurrentUserAsync(Guid catchId, CancellationToken cancellationToken)
+    {
+        if (!_currentUser.IsResolved)
+        {
+            return Result.Fail<Catch>(new CurrentUserUnresolvedError());
+        }
+
+        var loaded = await _catchRepository.GetByIdAsync(catchId, cancellationToken);
+        if (loaded.IsFailed)
+        {
+            return Result.Fail<Catch>(loaded.Errors);
+        }
+
+        if (loaded.Value is null)
+        {
+            return Result.Fail<Catch>(new CatchNotFoundError());
+        }
+
+        return Result.Ok(loaded.Value);
     }
 
     private static CatchLocation? ToLocation(CatchLocationDto? location)

--- a/src/FishingLogBook.Application/Common/Mappings/CatchMappingRegistration.cs
+++ b/src/FishingLogBook.Application/Common/Mappings/CatchMappingRegistration.cs
@@ -1,5 +1,6 @@
 using FishingLogBook.Application.Args;
 using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Application.Catches.Queries;
 using FishingLogBook.Domain.Catches;
 using FishingLogBook.Shared.Dtos;
 using Mapster;
@@ -12,7 +13,9 @@ public sealed class CatchMappingRegistration : IRegister
     {
         config.NewConfig<CatchDto, CatchDto>()
             .MapWith(source => source);
+        config.NewConfig<GetCatchQuery, GetCatchArgs>();
         config.NewConfig<UpsertCatchCommand, UpsertCatchArgs>();
+        config.NewConfig<UpdateCatchLocationVisibilityCommand, UpdateCatchLocationVisibilityArgs>();
         config.NewConfig<CatchPhotograph, CatchPhotographDto>()
             .MapWith(source => new CatchPhotographDto(source.Id, source.CatchId, source.ContentType));
         config.NewConfig<CatchLocation, CatchLocationDto>()

--- a/src/FishingLogBook.Application/Contracts/Repositories/ICatchRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/Repositories/ICatchRepository.cs
@@ -1,3 +1,4 @@
+using FishingLogBook.Application.Args;
 using FishingLogBook.Domain.Catches;
 using FluentResults;
 
@@ -8,4 +9,8 @@ public interface ICatchRepository
     Task<Result<Catch?>> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 
     Task<Result<Catch>> UpsertAsync(Catch catchRecord, CancellationToken cancellationToken);
+
+    Task<Result> UpdateLocationVisibilityAsync(
+        PersistCatchLocationVisibilityArgs args,
+        CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Application/Contracts/Services/ICatchLocationPrivacyService.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/ICatchLocationPrivacyService.cs
@@ -1,0 +1,12 @@
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Contracts.Services;
+
+public interface ICatchLocationPrivacyService
+{
+    Task<CatchLocationExposureDto?> GetExposureAsync(
+        Catch catchRecord,
+        Guid viewerUserId,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Contracts/Services/ICatchService.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/ICatchService.cs
@@ -7,4 +7,10 @@ namespace FishingLogBook.Application.Contracts.Services;
 public interface ICatchService
 {
     Task<Result<CatchDto>> UpsertAsync(UpsertCatchArgs args, CancellationToken cancellationToken);
+
+    Task<Result<CatchViewDto>> GetViewAsync(GetCatchArgs args, CancellationToken cancellationToken);
+
+    Task<Result> UpdateLocationVisibilityAsync(
+        UpdateCatchLocationVisibilityArgs args,
+        CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608171800_16_ConstrainCatchLocationVisibility.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608171800_16_ConstrainCatchLocationVisibility.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "Catch"
+    DROP CONSTRAINT IF EXISTS "Catch_LocationVisibility_Allowed";
+
+ALTER TABLE "Catch"
+    ADD CONSTRAINT "Catch_LocationVisibility_Allowed" CHECK (
+        "LocationVisibility" IS NULL
+        OR "LocationVisibility" IN ('Private', 'Approximate', 'FishingVenueOnly', 'Public')
+    );

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserIdentityService, UserIdentityService>();
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<ICatchService, CatchService>();
+        services.AddScoped<ICatchLocationPrivacyService, CatchLocationPrivacyService>();
         services.AddScoped<IPlatformCapabilityService, PlatformCapabilityService>();
 
         return services;

--- a/src/FishingLogBook.Domain/Catches/CatchLocation.cs
+++ b/src/FishingLogBook.Domain/Catches/CatchLocation.cs
@@ -1,3 +1,5 @@
+using FishingLogBook.Domain.Enums;
+
 namespace FishingLogBook.Domain.Catches;
 
 public sealed class CatchLocation
@@ -25,10 +27,12 @@ public sealed class CatchLocation
         string? visibility,
         string? consentVersion)
     {
+        var trimmedVisibility = visibility?.Trim();
         if (!AreCoordinatesValid(latitude, longitude)
             || capturedOn == default
             || string.IsNullOrWhiteSpace(source)
-            || string.IsNullOrWhiteSpace(visibility)
+            || string.IsNullOrWhiteSpace(trimmedVisibility)
+            || !Enum.TryParse<LocationVisibilityEnum>(trimmedVisibility, ignoreCase: false, out _)
             || string.IsNullOrWhiteSpace(consentVersion))
         {
             return null;
@@ -41,7 +45,7 @@ public sealed class CatchLocation
             AccuracyMetres = accuracyMetres,
             CapturedOn = capturedOn,
             Source = source.Trim(),
-            Visibility = visibility.Trim(),
+            Visibility = trimmedVisibility!,
             ConsentVersion = consentVersion.Trim()
         };
     }

--- a/src/FishingLogBook.Domain/Enums/LocationExposureModeEnum.cs
+++ b/src/FishingLogBook.Domain/Enums/LocationExposureModeEnum.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Domain.Enums;
+
+public enum LocationExposureModeEnum
+{
+    None = 0,
+    Exact = 1,
+    Approximate = 2,
+    FishingVenue = 3
+}

--- a/src/FishingLogBook.Domain/Enums/LocationVisibilityEnum.cs
+++ b/src/FishingLogBook.Domain/Enums/LocationVisibilityEnum.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Domain.Enums;
+
+public enum LocationVisibilityEnum
+{
+    Private = 0,
+    Approximate = 1,
+    FishingVenueOnly = 2,
+    Public = 3
+}

--- a/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
@@ -1,4 +1,5 @@
 using Dapper;
+using FishingLogBook.Application.Args;
 using FishingLogBook.Application.Catches.Errors;
 using FishingLogBook.Application.Contracts;
 using FishingLogBook.Application.Contracts.Repositories;
@@ -64,6 +65,39 @@ public sealed class CatchRepository : ICatchRepository
         catch (Exception)
         {
             return Result.Fail<Catch>(FailedMessage);
+        }
+    }
+
+    public async Task<Result> UpdateLocationVisibilityAsync(
+        PersistCatchLocationVisibilityArgs args,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                UPDATE "Catch"
+                SET "LocationVisibility" = @Visibility
+                WHERE "Id" = @CatchId
+                  AND "UserId" = @UserId
+                  AND "Latitude" IS NOT NULL;
+                """;
+            var updated = await connection.ExecuteAsync(new CommandDefinition(
+                sql,
+                new
+                {
+                    args.CatchId,
+                    args.UserId,
+                    args.Visibility
+                },
+                cancellationToken: cancellationToken));
+            return updated == 1
+                ? Result.Ok()
+                : Result.Fail("Failed to save the catch.");
+        }
+        catch (Exception)
+        {
+            return Result.Fail("Failed to save the catch.");
         }
     }
 

--- a/src/FishingLogBook.Shared/Constants/CatchLocationConstants.cs
+++ b/src/FishingLogBook.Shared/Constants/CatchLocationConstants.cs
@@ -10,6 +10,10 @@ public static class CatchLocationConstants
 
     public const double MaxLongitude = 180;
 
+    public const double ApproximateGridDegrees = 0.05;
+
+    public const double ApproximateCellSizeMetres = 5566;
+
     public static bool AreCoordinatesValid(double latitude, double longitude)
     {
         return latitude is >= MinLatitude and <= MaxLatitude

--- a/src/FishingLogBook.Shared/Dtos/CatchLocationDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/CatchLocationDto.cs
@@ -15,5 +15,24 @@ public static class LocationDefaults
 
     public const string Private = "Private";
 
+    public const string Approximate = "Approximate";
+
+    public const string FishingVenueOnly = "FishingVenueOnly";
+
+    public const string Public = "Public";
+
+    public const string ExposureNone = "None";
+
+    public const string ExposureExact = "Exact";
+
+    public const string ExposureApproximate = "Approximate";
+
+    public const string ExposureFishingVenue = "FishingVenue";
+
     public const string ConsentVersion = "1";
+
+    public static bool IsKnownVisibility(string? visibility)
+    {
+        return visibility is Private or Approximate or FishingVenueOnly or Public;
+    }
 }

--- a/src/FishingLogBook.Shared/Dtos/CatchLocationExposureDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/CatchLocationExposureDto.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed class CatchLocationExposureDto
+{
+    public string Visibility { get; init; } = string.Empty;
+
+    public string Mode { get; init; } = string.Empty;
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Latitude { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? Longitude { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? AccuracyMetres { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTimeOffset? CapturedOn { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Source { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? ApproximateLatitude { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? ApproximateLongitude { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? ApproximateCellSizeMetres { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? FishingVenueId { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? FishingVenueName { get; init; }
+}

--- a/src/FishingLogBook.Shared/Dtos/CatchViewDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/CatchViewDto.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record CatchViewDto(
+    Guid Id,
+    Guid UserId,
+    DateTimeOffset CaughtOn,
+    CatchLocationExposureDto? Location = null);

--- a/src/FishingLogBook.Shared/Dtos/UpdateCatchLocationVisibilityDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/UpdateCatchLocationVisibilityDto.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record UpdateCatchLocationVisibilityDto(string Visibility);

--- a/src/FishingLogBook.Web/BrowserTests/harness/index.html
+++ b/src/FishingLogBook.Web/BrowserTests/harness/index.html
@@ -45,6 +45,7 @@
                 await putCatchWithPhotographs(
                     JSON.stringify({
                         id: catchId,
+                        userId: ownerUserId,
                         caughtOn: '2026-08-17T08:00:00+00:00',
                         photographs: [{
                             id: photographId,
@@ -69,6 +70,7 @@
                 await putCatchWithPhotographs(
                     JSON.stringify({
                         id: catchId,
+                        userId: ownerUserId,
                         caughtOn: '2026-08-17T08:00:00+00:00',
                         photographs: [
                             { id: photoA, catchId, contentType: 'image/jpeg' },
@@ -90,6 +92,7 @@
                 await putCatchWithPhotographs(
                     JSON.stringify({
                         id: catchId,
+                        userId: ownerUserId,
                         caughtOn: '2026-08-17T08:00:00+00:00',
                         photographs: [{
                             id: photographId,
@@ -121,6 +124,7 @@
                 await putCatchWithPhotographs(
                     JSON.stringify({
                         id: catchId,
+                        userId: ownerUserId,
                         caughtOn: '2026-08-17T08:00:00+00:00',
                         photographs: [{
                             id: photographId,
@@ -139,6 +143,37 @@
             },
             async readProductionCatches() {
                 return getAllCatchesWithPhotographs(ownerUserId);
+            },
+            async putUnscopedProductionCatchThenReadAsFirstSigner() {
+                const catchId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+                const photographId = 'unscoped-photo';
+                const firstSignerUserId = '22222222-2222-2222-2222-222222222222';
+                await putCatchWithPhotographs(
+                    JSON.stringify({
+                        id: catchId,
+                        caughtOn: '2026-08-17T08:00:00+00:00',
+                        photographs: [{
+                            id: photographId,
+                            catchId,
+                            contentType: 'image/jpeg'
+                        }],
+                        location: {
+                            latitude: 53.2707,
+                            longitude: -9.0568
+                        }
+                    }),
+                    [{
+                        id: photographId,
+                        catchId,
+                        contentType: 'image/jpeg',
+                        bytes: new Uint8Array([4, 5, 6])
+                    }]
+                );
+                return {
+                    firstSignerView: await getAllCatchesWithPhotographs(firstSignerUserId),
+                    originalOwnerView: await getAllCatchesWithPhotographs(ownerUserId),
+                    stored: await readRawProductionCatch(catchId)
+                };
             },
             async putProductionCatchWithoutPhotographId() {
                 try {
@@ -168,6 +203,21 @@
                     const names = [...db.objectStoreNames];
                     db.close();
                     resolve(names.sort());
+                };
+                request.onerror = () => reject(request.error);
+            });
+        }
+
+        function readRawProductionCatch(id) {
+            return new Promise((resolve, reject) => {
+                const request = indexedDB.open('FishingLogBook');
+                request.onsuccess = () => {
+                    const db = request.result;
+                    const transaction = db.transaction('catches', 'readonly');
+                    const getRequest = transaction.objectStore('catches').get(id);
+                    getRequest.onsuccess = () => resolve(getRequest.result);
+                    getRequest.onerror = () => reject(getRequest.error);
+                    transaction.oncomplete = () => db.close();
                 };
                 request.onerror = () => reject(request.error);
             });

--- a/src/FishingLogBook.Web/BrowserTests/harness/index.html
+++ b/src/FishingLogBook.Web/BrowserTests/harness/index.html
@@ -11,6 +11,8 @@
         import { getTestCatchPhotograph, putTestCatchPhotograph } from '../../wwwroot/js/storage/photo-store.js';
         import { putDiagnosticEvent } from '../../wwwroot/js/storage/diagnostic-store.js';
 
+        const ownerUserId = '11111111-1111-1111-1111-111111111111';
+
         window.harness = {
             async putAndGetCatch() {
                 await putTestCatch(JSON.stringify({ id: 'harness-catch', notes: 'persisted' }));
@@ -57,7 +59,7 @@
                         bytes: new Uint8Array([1, 2, 3])
                     }]
                 );
-                return getAllCatchesWithPhotographs();
+                return getAllCatchesWithPhotographs(ownerUserId);
             },
             async putAndGetProductionCatchWithThreePhotographs() {
                 const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
@@ -80,7 +82,7 @@
                         { id: photoB, catchId, contentType: 'image/png', bytes: new Uint8Array([2, 2, 2]) }
                     ]
                 );
-                return getAllCatchesWithPhotographs();
+                return getAllCatchesWithPhotographs(ownerUserId);
             },
             async putAndGetProductionCatchWithLocation() {
                 const catchId = '11111111-1111-1111-1111-111111111111';
@@ -111,7 +113,7 @@
                         bytes: new Uint8Array([1, 2, 3])
                     }]
                 );
-                return getAllCatchesWithPhotographs();
+                return getAllCatchesWithPhotographs(ownerUserId);
             },
             async putLegacyProductionCatchWithoutLocation() {
                 const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
@@ -133,10 +135,10 @@
                         bytes: new Uint8Array([4, 5, 6])
                     }]
                 );
-                return getAllCatchesWithPhotographs();
+                return getAllCatchesWithPhotographs(ownerUserId);
             },
             async readProductionCatches() {
-                return getAllCatchesWithPhotographs();
+                return getAllCatchesWithPhotographs(ownerUserId);
             },
             async putProductionCatchWithoutPhotographId() {
                 try {
@@ -151,9 +153,9 @@
                             bytes: new Uint8Array([9])
                         }]
                     );
-                    return { threw: false, items: await getAllCatchesWithPhotographs() };
+                    return { threw: false, items: await getAllCatchesWithPhotographs(ownerUserId) };
                 } catch {
-                    return { threw: true, items: await getAllCatchesWithPhotographs() };
+                    return { threw: true, items: await getAllCatchesWithPhotographs(ownerUserId) };
                 }
             }
         };

--- a/src/FishingLogBook.Web/BrowserTests/harness/index.html
+++ b/src/FishingLogBook.Web/BrowserTests/harness/index.html
@@ -45,6 +45,7 @@
                 await putCatchWithPhotographs(
                     JSON.stringify({
                         id: catchId,
+                        userId: ownerUserId,
                         caughtOn: '2026-08-17T08:00:00+00:00',
                         photographs: [{
                             id: photographId,
@@ -69,6 +70,7 @@
                 await putCatchWithPhotographs(
                     JSON.stringify({
                         id: catchId,
+                        userId: ownerUserId,
                         caughtOn: '2026-08-17T08:00:00+00:00',
                         photographs: [
                             { id: photoA, catchId, contentType: 'image/jpeg' },
@@ -90,6 +92,7 @@
                 await putCatchWithPhotographs(
                     JSON.stringify({
                         id: catchId,
+                        userId: ownerUserId,
                         caughtOn: '2026-08-17T08:00:00+00:00',
                         photographs: [{
                             id: photographId,
@@ -121,6 +124,7 @@
                 await putCatchWithPhotographs(
                     JSON.stringify({
                         id: catchId,
+                        userId: ownerUserId,
                         caughtOn: '2026-08-17T08:00:00+00:00',
                         photographs: [{
                             id: photographId,
@@ -139,6 +143,39 @@
             },
             async readProductionCatches() {
                 return getAllCatchesWithPhotographs(ownerUserId);
+            },
+            async readProductionCatchesFor(userId) {
+                return getAllCatchesWithPhotographs(userId);
+            },
+            async putLegacyUnscopedProductionCatchWithLocation() {
+                const catchId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+                const photographId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+                await putCatchWithPhotographs(
+                    JSON.stringify({
+                        id: catchId,
+                        caughtOn: '2026-08-17T08:00:00+00:00',
+                        photographs: [{
+                            id: photographId,
+                            catchId,
+                            contentType: 'image/jpeg'
+                        }],
+                        location: {
+                            latitude: 53.2707,
+                            longitude: -9.0568,
+                            accuracyMetres: 12,
+                            capturedOn: '2026-08-17T08:00:00+00:00',
+                            source: 'DeviceGps',
+                            visibility: 'Private',
+                            consentVersion: '1'
+                        }
+                    }),
+                    [{
+                        id: photographId,
+                        catchId,
+                        contentType: 'image/jpeg',
+                        bytes: new Uint8Array([4, 5, 6])
+                    }]
+                );
             },
             async putProductionCatchWithoutPhotographId() {
                 try {

--- a/src/FishingLogBook.Web/BrowserTests/storage.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/storage.spec.js
@@ -139,6 +139,23 @@ test.describe('Production Catch IndexedDB', () => {
         expect(records[0].photographs[0].id).toBe('22222222-2222-2222-2222-222222222222');
     });
 
+    test('does not expose a legacy unowned Catch to the first signed-in user', async ({ page }) => {
+        await page.goto(`${harness}/index.html`);
+        await expect(page.locator('#status')).toHaveText('ready');
+        await page.evaluate(() => window.harness.putLegacyUnscopedProductionCatchWithLocation());
+
+        const firstSignedIn = await page.evaluate(() =>
+            window.harness.readProductionCatchesFor('22222222-2222-2222-2222-222222222222'));
+        const originalOwner = await page.evaluate(() => window.harness.readProductionCatches());
+        const payload = JSON.stringify({ firstSignedIn, originalOwner });
+
+        expect(firstSignedIn).toEqual([]);
+        expect(originalOwner).toEqual([]);
+        expect(payload).not.toContain('53.2707');
+        expect(payload).not.toContain('-9.0568');
+        expect(payload).not.toContain('dddddddd-dddd-dddd-dddd-dddddddddddd');
+    });
+
     test('still reads a Catch stored without a location property', async ({ page }) => {
         await page.goto(`${harness}/index.html`);
         await expect(page.locator('#status')).toHaveText('ready');

--- a/src/FishingLogBook.Web/BrowserTests/storage.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/storage.spec.js
@@ -149,6 +149,20 @@ test.describe('Production Catch IndexedDB', () => {
         expect(catchRecord.location).toBeUndefined();
         expect(records[0].photographs[0].id).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
     });
+
+    test('does not let the first signed-in user read or adopt a legacy unscoped Catch', async ({ page }) => {
+        await page.goto(`${harness}/index.html`);
+        await expect(page.locator('#status')).toHaveText('ready');
+
+        const result = await page.evaluate(() => window.harness.putUnscopedProductionCatchThenReadAsFirstSigner());
+
+        expect(result.firstSignerView).toEqual([]);
+        expect(result.originalOwnerView).toEqual([]);
+        expect(JSON.stringify(result.firstSignerView)).not.toContain('53.2707');
+        expect(JSON.stringify(result.firstSignerView)).not.toContain('unscoped-photo');
+        expect(result.stored.userId).toBeUndefined();
+        expect(result.stored.location).toEqual({ latitude: 53.2707, longitude: -9.0568 });
+    });
 });
 
 test.describe('service worker application shell', () => {

--- a/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
@@ -5,4 +5,5 @@ public sealed record CatchModel(
     DateTimeOffset CaughtOn,
     IReadOnlyList<CatchPhotographModel> Photographs,
     string? SpeciesName = null,
-    CatchLocationModel? Location = null);
+    CatchLocationModel? Location = null,
+    Guid UserId = default);

--- a/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
@@ -25,7 +25,8 @@ internal static class CatchJson
                     photograph.CatchId,
                     photograph.ContentType))
                 .ToArray(),
-            catchRecord.Location);
+            catchRecord.Location,
+            catchRecord.UserId);
         return JsonSerializer.Serialize(metadata, Options);
     }
 
@@ -38,7 +39,8 @@ internal static class CatchJson
             metadata.CaughtOn,
             OrderPhotographs(metadata.Photographs, photographs),
             metadata.SpeciesName,
-            metadata.Location);
+            metadata.Location,
+            metadata.UserId);
     }
 
     private static IReadOnlyList<CatchPhotographModel> OrderPhotographs(
@@ -64,7 +66,8 @@ internal static class CatchJson
         DateTimeOffset CaughtOn,
         string? SpeciesName,
         IReadOnlyList<CatchPhotographMetadata> Photographs,
-        CatchLocationModel? Location = null);
+        CatchLocationModel? Location = null,
+        Guid UserId = default);
 
     private sealed record CatchPhotographMetadata(
         Guid Id,

--- a/src/FishingLogBook.Web/Features/Catch/Offline/ICatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/ICatchStore.cs
@@ -6,5 +6,5 @@ public interface ICatchStore
 {
     Task SaveAsync(CatchModel catchRecord, CancellationToken cancellationToken);
 
-    Task<IReadOnlyList<CatchModel>> GetAllAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyList<CatchModel>> GetAllAsync(Guid ownerUserId, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Features/Catch/Offline/IndexedDbCatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/IndexedDbCatchStore.cs
@@ -101,30 +101,7 @@ public sealed class IndexedDbCatchStore : ICatchStore
             },
             cancellationToken,
             _logging);
-        return await AdoptUnscopedAsync(loaded, ownerUserId, cancellationToken);
-    }
-
-    private async Task<IReadOnlyList<CatchModel>> AdoptUnscopedAsync(
-        IReadOnlyList<CatchModel> loaded,
-        Guid ownerUserId,
-        CancellationToken cancellationToken)
-    {
-        var visible = LocalCatchVisibility.ForOwner(loaded, ownerUserId);
-        var adopted = new List<CatchModel>(visible.Count);
-        foreach (var catchRecord in visible)
-        {
-            if (catchRecord.UserId != Guid.Empty)
-            {
-                adopted.Add(catchRecord);
-                continue;
-            }
-
-            var owned = catchRecord with { UserId = ownerUserId };
-            await SaveAsync(owned, cancellationToken);
-            adopted.Add(owned);
-        }
-
-        return adopted;
+        return LocalCatchVisibility.ForOwner(loaded, ownerUserId);
     }
 
     private static CatchModel ToModel(StoredCatchRecord record)

--- a/src/FishingLogBook.Web/Features/Catch/Offline/IndexedDbCatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/IndexedDbCatchStore.cs
@@ -32,6 +32,11 @@ public sealed class IndexedDbCatchStore : ICatchStore
 
     public async Task SaveAsync(CatchModel catchRecord, CancellationToken cancellationToken)
     {
+        if (catchRecord.UserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch requires an owner.");
+        }
+
         if (catchRecord.Photographs.Count == 0
             || catchRecord.Photographs.Any(photograph => photograph.Bytes is not { Length: > 0 }))
         {
@@ -67,9 +72,16 @@ public sealed class IndexedDbCatchStore : ICatchStore
             _logging);
     }
 
-    public async Task<IReadOnlyList<CatchModel>> GetAllAsync(CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<CatchModel>> GetAllAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
     {
-        return await OfflineOperation.ExecuteAsync(
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
+        var loaded = await OfflineOperation.ExecuteAsync(
             "read",
             StoreName,
             DiagnosticEventNames.OfflineDbReadStarted,
@@ -83,13 +95,36 @@ public sealed class IndexedDbCatchStore : ICatchStore
                 var module = await GetModuleAsync(token);
                 var records = await module.InvokeAsync<StoredCatchRecord[]>(
                     "getAllCatchesWithPhotographs",
-                    token);
-                return (IReadOnlyList<CatchModel>)(records ?? [])
-                    .Select(ToModel)
-                    .ToArray();
+                    token,
+                    ownerUserId.ToString("D"));
+                return (IReadOnlyList<CatchModel>)(records ?? []).Select(ToModel).ToArray();
             },
             cancellationToken,
             _logging);
+        return await AdoptUnscopedAsync(loaded, ownerUserId, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<CatchModel>> AdoptUnscopedAsync(
+        IReadOnlyList<CatchModel> loaded,
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        var visible = LocalCatchVisibility.ForOwner(loaded, ownerUserId);
+        var adopted = new List<CatchModel>(visible.Count);
+        foreach (var catchRecord in visible)
+        {
+            if (catchRecord.UserId != Guid.Empty)
+            {
+                adopted.Add(catchRecord);
+                continue;
+            }
+
+            var owned = catchRecord with { UserId = ownerUserId };
+            await SaveAsync(owned, cancellationToken);
+            adopted.Add(owned);
+        }
+
+        return adopted;
     }
 
     private static CatchModel ToModel(StoredCatchRecord record)

--- a/src/FishingLogBook.Web/Features/Catch/Offline/LocalCatchVisibility.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/LocalCatchVisibility.cs
@@ -1,0 +1,27 @@
+using FishingLogBook.Web.Features.Catch.Models;
+
+namespace FishingLogBook.Web.Features.Catch.Offline;
+
+internal static class LocalCatchVisibility
+{
+    public static IReadOnlyList<CatchModel> ForOwner(
+        IReadOnlyList<CatchModel> records,
+        Guid ownerUserId)
+    {
+        var hasForeignOwner = records.Any(record =>
+            record.UserId != Guid.Empty && record.UserId != ownerUserId);
+        return records
+            .Where(record => IsVisibleTo(record, ownerUserId, hasForeignOwner))
+            .ToArray();
+    }
+
+    private static bool IsVisibleTo(CatchModel record, Guid ownerUserId, bool hasForeignOwner)
+    {
+        if (record.UserId == ownerUserId)
+        {
+            return true;
+        }
+
+        return record.UserId == Guid.Empty && !hasForeignOwner;
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Offline/LocalCatchVisibility.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/LocalCatchVisibility.cs
@@ -8,20 +8,13 @@ internal static class LocalCatchVisibility
         IReadOnlyList<CatchModel> records,
         Guid ownerUserId)
     {
-        var hasForeignOwner = records.Any(record =>
-            record.UserId != Guid.Empty && record.UserId != ownerUserId);
-        return records
-            .Where(record => IsVisibleTo(record, ownerUserId, hasForeignOwner))
-            .ToArray();
-    }
-
-    private static bool IsVisibleTo(CatchModel record, Guid ownerUserId, bool hasForeignOwner)
-    {
-        if (record.UserId == ownerUserId)
+        if (ownerUserId == Guid.Empty)
         {
-            return true;
+            return [];
         }
 
-        return record.UserId == Guid.Empty && !hasForeignOwner;
+        return records
+            .Where(record => record.UserId == ownerUserId)
+            .ToArray();
     }
 }

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
@@ -53,6 +53,15 @@
                                 <MudText Typo="Typo.caption" id="@($"catch-time-{catchRecord.Id:D}")">
                                     @catchRecord.CaughtOn.ToString("g")
                                 </MudText>
+                                @if (catchRecord.Location is not null)
+                                {
+                                    <MudButton Variant="Variant.Text"
+                                               Color="Color.Primary"
+                                               Href="@($"/catches/{catchRecord.Id:D}/location-privacy")"
+                                               id="@($"catch-location-privacy-{catchRecord.Id:D}")">
+                                        @Loc["Catch_ManageLocationPrivacy"]
+                                    </MudButton>
+                                }
                             </MudStack>
                         </MudStack>
                     </MudPaper>

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
@@ -1,5 +1,6 @@
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -17,6 +18,9 @@ public partial class CatchList : ComponentBase, IDisposable
     private ICatchStore CatchStore { get; set; } = default!;
 
     [Inject]
+    private ILocalCatchOwnerService LocalCatchOwner { get; set; } = default!;
+
+    [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
@@ -30,7 +34,8 @@ public partial class CatchList : ComponentBase, IDisposable
         _loadFailed = false;
         try
         {
-            var saved = await CatchStore.GetAllAsync(_cancellationTokenSource.Token);
+            var ownerUserId = await LocalCatchOwner.GetUserIdAsync(_cancellationTokenSource.Token);
+            var saved = await CatchStore.GetAllAsync(ownerUserId, _cancellationTokenSource.Token);
             _catches = saved
                 .OrderByDescending(catchRecord => catchRecord.CaughtOn)
                 .ToArray();

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor
@@ -1,0 +1,84 @@
+@page "/catches/{CatchId:guid}/location-privacy"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
+
+<PageTitle>@Loc["Catch_LocationPrivacyPageTitle"]</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Class="pa-4">
+    <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
+        <MudText Typo="Typo.h4" Align="Align.Center" id="catch-location-privacy-title">
+            @Loc["Catch_LocationPrivacyTitle"]
+        </MudText>
+        <MudText Typo="Typo.subtitle1" Align="Align.Center" Class="mud-text-secondary">
+            @Loc["Catch_LocationPrivacySubtitle"]
+        </MudText>
+
+        @if (_loadFailed)
+        {
+            <MudAlert Severity="Severity.Error" id="catch-location-privacy-load-failed">
+                @Loc["Catch_LocationPrivacyLoadFailed"]
+            </MudAlert>
+        }
+        else if (_missingLocation)
+        {
+            <MudAlert Severity="Severity.Info" id="catch-location-privacy-no-location">
+                @Loc["Catch_LocationPrivacyNoLocation"]
+            </MudAlert>
+        }
+        else if (_isLoading)
+        {
+            <MudProgressCircular Indeterminate="true" Color="Color.Primary" Class="align-self-center"
+                                 id="catch-location-privacy-loading" />
+        }
+        else
+        {
+            <MudRadioGroup T="string" Value="_visibility" ValueChanged="OnVisibilityChanged"
+                           id="catch-location-privacy-options">
+                <MudStack Spacing="2">
+                    <MudRadio T="string" Value="@LocationDefaults.Private" id="catch-location-privacy-private">
+                        @Loc["Catch_LocationVisibilityPrivate"]
+                    </MudRadio>
+                    <MudRadio T="string" Value="@LocationDefaults.Approximate" id="catch-location-privacy-approximate">
+                        @Loc["Catch_LocationVisibilityApproximate"]
+                    </MudRadio>
+                    <MudRadio T="string" Value="@LocationDefaults.FishingVenueOnly" id="catch-location-privacy-venue">
+                        @Loc["Catch_LocationVisibilityFishingVenueOnly"]
+                    </MudRadio>
+                    <MudRadio T="string" Value="@LocationDefaults.Public" id="catch-location-privacy-public">
+                        @Loc["Catch_LocationVisibilityPublic"]
+                    </MudRadio>
+                </MudStack>
+            </MudRadioGroup>
+
+            @if (_visibility == LocationDefaults.Public)
+            {
+                <MudAlert Severity="Severity.Warning" id="catch-location-privacy-public-warning">
+                    @Loc["Catch_LocationVisibilityPublicWarning"]
+                </MudAlert>
+            }
+
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       FullWidth="true"
+                       Disabled="_isSaving"
+                       OnClick="SaveAsync"
+                       id="catch-location-privacy-save">
+                @(_isSaving ? Loc["Catch_LocationPrivacySaving"] : Loc["Catch_LocationPrivacySave"])
+            </MudButton>
+
+            @if (_saveFailed)
+            {
+                <MudAlert Severity="Severity.Error" id="catch-location-privacy-save-failed">
+                    @Loc["Catch_LocationPrivacySaveFailed"]
+                </MudAlert>
+            }
+
+            @if (_saved)
+            {
+                <MudAlert Severity="Severity.Success" id="catch-location-privacy-saved">
+                    @Loc["Catch_LocationPrivacySaved"]
+                </MudAlert>
+            }
+        }
+    </MudStack>
+</MudContainer>

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor
@@ -79,6 +79,13 @@
                     @Loc["Catch_LocationPrivacySaved"]
                 </MudAlert>
             }
+
+            @if (_savedPendingSync)
+            {
+                <MudAlert Severity="Severity.Info" id="catch-location-privacy-saved-pending">
+                    @Loc["Catch_LocationPrivacySavedPendingSync"]
+                </MudAlert>
+            }
         }
     </MudStack>
 </MudContainer>

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor.cs
@@ -19,6 +19,7 @@ public partial class CatchLocationPrivacy : ComponentBase, IDisposable
     private bool _missingLocation;
     private bool _saveFailed;
     private bool _saved;
+    private bool _savedPendingSync;
 
     [Parameter]
     public Guid CatchId { get; set; }
@@ -69,6 +70,7 @@ public partial class CatchLocationPrivacy : ComponentBase, IDisposable
     {
         _visibility = visibility;
         _saved = false;
+        _savedPendingSync = false;
         _saveFailed = false;
     }
 
@@ -82,27 +84,58 @@ public partial class CatchLocationPrivacy : ComponentBase, IDisposable
         _isSaving = true;
         _saveFailed = false;
         _saved = false;
+        _savedPendingSync = false;
         try
         {
-            var updated = _catch with
+            if (!await TryPersistLocalVisibilityAsync())
             {
-                Location = _catch.Location with { Visibility = _visibility }
+                return;
+            }
+
+            await PropagateVisibilityAsync();
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task<bool> TryPersistLocalVisibilityAsync()
+    {
+        try
+        {
+            var updated = _catch! with
+            {
+                Location = _catch.Location! with { Visibility = _visibility }
             };
             await CatchStore.SaveAsync(updated, _cancellationTokenSource.Token);
             _catch = updated;
+            return true;
+        }
+        catch (Exception)
+        {
+            _saveFailed = true;
+            return false;
+        }
+    }
+
+    private async Task PropagateVisibilityAsync()
+    {
+        try
+        {
             await CatchClient.UpdateLocationVisibilityAsync(
                 CatchId,
                 _visibility,
                 _cancellationTokenSource.Token);
             _saved = true;
         }
-        catch (Exception)
+        catch (HttpRequestException)
         {
-            _saveFailed = true;
+            _savedPendingSync = true;
         }
-        finally
+        catch (TaskCanceledException)
         {
-            _isSaving = false;
+            _savedPendingSync = true;
         }
     }
 

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor.cs
@@ -1,0 +1,114 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Catch.Pages.CatchLocationPrivacy;
+
+public partial class CatchLocationPrivacy : ComponentBase, IDisposable
+{
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private CatchModel? _catch;
+    private string _visibility = LocationDefaults.Private;
+    private bool _isLoading = true;
+    private bool _isSaving;
+    private bool _loadFailed;
+    private bool _missingLocation;
+    private bool _saveFailed;
+    private bool _saved;
+
+    [Parameter]
+    public Guid CatchId { get; set; }
+
+    [Inject]
+    private ICatchStore CatchStore { get; set; } = default!;
+
+    [Inject]
+    private ICatchClient CatchClient { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _loadFailed = false;
+        _missingLocation = false;
+        try
+        {
+            var saved = await CatchStore.GetAllAsync(_cancellationTokenSource.Token);
+            _catch = saved.FirstOrDefault(catchRecord => catchRecord.Id == CatchId);
+            if (_catch?.Location is null)
+            {
+                _missingLocation = true;
+                return;
+            }
+
+            _visibility = _catch.Location.Visibility;
+        }
+        catch (Exception)
+        {
+            _loadFailed = true;
+            _catch = null;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private void OnVisibilityChanged(string visibility)
+    {
+        _visibility = visibility;
+        _saved = false;
+        _saveFailed = false;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (_catch?.Location is null || _isSaving)
+        {
+            return;
+        }
+
+        _isSaving = true;
+        _saveFailed = false;
+        _saved = false;
+        try
+        {
+            var updated = _catch with
+            {
+                Location = _catch.Location with { Visibility = _visibility }
+            };
+            await CatchStore.SaveAsync(updated, _cancellationTokenSource.Token);
+            _catch = updated;
+            await CatchClient.UpdateLocationVisibilityAsync(
+                CatchId,
+                _visibility,
+                _cancellationTokenSource.Token);
+            _saved = true;
+        }
+        catch (Exception)
+        {
+            _saveFailed = true;
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor.cs
@@ -31,6 +31,9 @@ public partial class CatchLocationPrivacy : ComponentBase, IDisposable
     private ICatchClient CatchClient { get; set; } = default!;
 
     [Inject]
+    private ILocalCatchOwnerService LocalCatchOwner { get; set; } = default!;
+
+    [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
@@ -45,9 +48,16 @@ public partial class CatchLocationPrivacy : ComponentBase, IDisposable
         _missingLocation = false;
         try
         {
-            var saved = await CatchStore.GetAllAsync(_cancellationTokenSource.Token);
+            var ownerUserId = await LocalCatchOwner.GetUserIdAsync(_cancellationTokenSource.Token);
+            var saved = await CatchStore.GetAllAsync(ownerUserId, _cancellationTokenSource.Token);
             _catch = saved.FirstOrDefault(catchRecord => catchRecord.Id == CatchId);
-            if (_catch?.Location is null)
+            if (_catch is null)
+            {
+                _loadFailed = true;
+                return;
+            }
+
+            if (_catch.Location is null)
             {
                 _missingLocation = true;
                 return;

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
@@ -2,6 +2,7 @@ using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -30,6 +31,9 @@ public partial class RecordCatch : ComponentBase, IDisposable
 
     [Inject]
     private ICatchStore CatchStore { get; set; } = default!;
+
+    [Inject]
+    private ILocalCatchOwnerService LocalCatchOwner { get; set; } = default!;
 
     [Inject]
     private ILocationService LocationService { get; set; } = default!;
@@ -209,6 +213,11 @@ public partial class RecordCatch : ComponentBase, IDisposable
         await InvokeAsync(StateHasChanged);
         try
         {
+            var ownerUserId = await LocalCatchOwner.GetUserIdAsync(_cancellationTokenSource.Token);
+            if (ownerUserId == Guid.Empty)
+            {
+                throw new InvalidOperationException("The current user could not be resolved.");
+            }
             var catchId = Guid.NewGuid();
             var photographs = _photographs
                 .Select(photograph => new CatchPhotographModel(
@@ -219,7 +228,12 @@ public partial class RecordCatch : ComponentBase, IDisposable
                 .ToArray();
             var location = _capturedLocation;
             await CatchStore.SaveAsync(
-                new CatchModel(catchId, _caughtOn ?? DateTimeOffset.Now, photographs, Location: location),
+                new CatchModel(
+                    catchId,
+                    _caughtOn ?? DateTimeOffset.Now,
+                    photographs,
+                    Location: location,
+                    UserId: ownerUserId),
                 _cancellationTokenSource.Token);
             _isSaved = true;
             _locationSaved = location is not null;

--- a/src/FishingLogBook.Web/Features/Catch/Services/CatchClient.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/CatchClient.cs
@@ -1,0 +1,33 @@
+using System.Net;
+using System.Net.Http.Json;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Configuration;
+
+namespace FishingLogBook.Web.Features.Catch.Services;
+
+public sealed class CatchClient : ICatchClient
+{
+    private readonly HttpClient _apiClient;
+
+    public CatchClient(IHttpClientFactory httpClientFactory)
+    {
+        _apiClient = httpClientFactory.CreateClient(HttpClientNames.AuthorizedApi);
+    }
+
+    public async Task UpdateLocationVisibilityAsync(
+        Guid catchId,
+        string visibility,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _apiClient.PatchAsJsonAsync(
+            $"api/catches/{catchId:D}/location-visibility",
+            new UpdateCatchLocationVisibilityDto(visibility),
+            cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return;
+        }
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Services/CatchClient.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/CatchClient.cs
@@ -23,11 +23,16 @@ public sealed class CatchClient : ICatchClient
             $"api/catches/{catchId:D}/location-visibility",
             new UpdateCatchLocationVisibilityDto(visibility),
             cancellationToken);
-        if (response.StatusCode == HttpStatusCode.NotFound)
+        if (IsUnsynchronisedCatch(response))
         {
             return;
         }
 
         response.EnsureSuccessStatusCode();
+    }
+
+    private static bool IsUnsynchronisedCatch(HttpResponseMessage response)
+    {
+        return response.StatusCode == HttpStatusCode.NotFound;
     }
 }

--- a/src/FishingLogBook.Web/Features/Catch/Services/ICatchClient.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/ICatchClient.cs
@@ -1,0 +1,8 @@
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Features.Catch.Services;
+
+public interface ICatchClient
+{
+    Task UpdateLocationVisibilityAsync(Guid catchId, string visibility, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Catch/Services/ILocalCatchOwnerService.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/ILocalCatchOwnerService.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Web.Features.Catch.Services;
+
+public interface ILocalCatchOwnerService
+{
+    Task<Guid> GetUserIdAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Catch/Services/LocalCatchOwnerService.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/LocalCatchOwnerService.cs
@@ -1,0 +1,122 @@
+using System.Security.Claims;
+using FishingLogBook.Web.Features.Users.Services;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Features.Catch.Services;
+
+public sealed class LocalCatchOwnerService : ILocalCatchOwnerService
+{
+    private const string CacheKeyPrefix = "fishingLogBook.localUserId.";
+
+    private readonly AuthenticationStateProvider _authenticationStateProvider;
+    private readonly ICurrentUserClient _currentUserClient;
+    private readonly IJSRuntime _jsRuntime;
+
+    public LocalCatchOwnerService(
+        AuthenticationStateProvider authenticationStateProvider,
+        ICurrentUserClient currentUserClient,
+        IJSRuntime jsRuntime)
+    {
+        _authenticationStateProvider = authenticationStateProvider;
+        _currentUserClient = currentUserClient;
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task<Guid> GetUserIdAsync(CancellationToken cancellationToken)
+    {
+        var subject = await GetSubjectAsync();
+        var cached = await TryReadCachedUserIdAsync(subject, cancellationToken);
+        if (cached is not null)
+        {
+            return cached.Value;
+        }
+
+        var current = await _currentUserClient.GetCurrentAsync(cancellationToken);
+        if (current.UserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("The current user could not be resolved.");
+        }
+
+        await TryWriteCachedUserIdAsync(subject, current.UserId, cancellationToken);
+        return current.UserId;
+    }
+
+    private async Task<string?> GetSubjectAsync()
+    {
+        var state = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var user = state.User;
+        if (user.Identity?.IsAuthenticated != true)
+        {
+            throw new InvalidOperationException("The current user is not signed in.");
+        }
+
+        var subject = user.FindFirst("sub")?.Value?.Trim();
+        if (!string.IsNullOrWhiteSpace(subject))
+        {
+            return subject;
+        }
+
+        subject = user.FindFirst(ClaimTypes.NameIdentifier)?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            return null;
+        }
+
+        return subject;
+    }
+
+    private async Task<Guid?> TryReadCachedUserIdAsync(string? subject, CancellationToken cancellationToken)
+    {
+        if (subject is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var stored = await _jsRuntime.InvokeAsync<string?>(
+                "localStorage.getItem",
+                cancellationToken,
+                CacheKeyPrefix + subject);
+            if (Guid.TryParse(stored, out var userId) && userId != Guid.Empty)
+            {
+                return userId;
+            }
+        }
+        catch (JSException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        return null;
+    }
+
+    private async Task TryWriteCachedUserIdAsync(
+        string? subject,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        if (subject is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _jsRuntime.InvokeVoidAsync(
+                "localStorage.setItem",
+                cancellationToken,
+                CacheKeyPrefix + subject,
+                userId.ToString("D"));
+        }
+        catch (JSException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Users/Services/CurrentUserClient.cs
+++ b/src/FishingLogBook.Web/Features/Users/Services/CurrentUserClient.cs
@@ -1,0 +1,21 @@
+using System.Net.Http.Json;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Configuration;
+
+namespace FishingLogBook.Web.Features.Users.Services;
+
+public sealed class CurrentUserClient : ICurrentUserClient
+{
+    private readonly HttpClient _apiClient;
+
+    public CurrentUserClient(IHttpClientFactory httpClientFactory)
+    {
+        _apiClient = httpClientFactory.CreateClient(HttpClientNames.AuthorizedApi);
+    }
+
+    public async Task<CurrentUserDto> GetCurrentAsync(CancellationToken cancellationToken)
+    {
+        var current = await _apiClient.GetFromJsonAsync<CurrentUserDto>("api/users/current", cancellationToken);
+        return current ?? throw new HttpRequestException("Current user was missing.");
+    }
+}

--- a/src/FishingLogBook.Web/Features/Users/Services/ICurrentUserClient.cs
+++ b/src/FishingLogBook.Web/Features/Users/Services/ICurrentUserClient.cs
@@ -1,0 +1,8 @@
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Features.Users.Services;
+
+public interface ICurrentUserClient
+{
+    Task<CurrentUserDto> GetCurrentAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -399,6 +399,9 @@
   <data name="Catch_LocationPrivacySaveFailed" xml:space="preserve">
     <value>La confidentialité n'a pas pu être enregistrée. Réessayez.</value>
   </data>
+  <data name="Catch_LocationPrivacySavedPendingSync" xml:space="preserve">
+    <value>Confidentialité enregistrée sur cet appareil. Elle sera mise à jour lorsque la synchronisation sera disponible.</value>
+  </data>
   <data name="Profile_Nav" xml:space="preserve">
     <value>Profil</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -354,6 +354,51 @@
   <data name="Catch_UnknownSpecies" xml:space="preserve">
     <value>Prise</value>
   </data>
+  <data name="Catch_ManageLocationPrivacy" xml:space="preserve">
+    <value>Confidentialité de la localisation</value>
+  </data>
+  <data name="Catch_LocationPrivacyPageTitle" xml:space="preserve">
+    <value>FishingLogBook - Confidentialité de la localisation</value>
+  </data>
+  <data name="Catch_LocationPrivacyTitle" xml:space="preserve">
+    <value>Confidentialité de la localisation</value>
+  </data>
+  <data name="Catch_LocationPrivacySubtitle" xml:space="preserve">
+    <value>Choisissez ce que les autres pêcheurs peuvent voir de ce spot.</value>
+  </data>
+  <data name="Catch_LocationPrivacyLoadFailed" xml:space="preserve">
+    <value>Cette prise n'a pas pu être chargée.</value>
+  </data>
+  <data name="Catch_LocationPrivacyNoLocation" xml:space="preserve">
+    <value>Cette prise n'a pas de localisation enregistrée.</value>
+  </data>
+  <data name="Catch_LocationVisibilityPrivate" xml:space="preserve">
+    <value>Moi uniquement</value>
+  </data>
+  <data name="Catch_LocationVisibilityApproximate" xml:space="preserve">
+    <value>Zone approximative</value>
+  </data>
+  <data name="Catch_LocationVisibilityFishingVenueOnly" xml:space="preserve">
+    <value>Site de pêche uniquement</value>
+  </data>
+  <data name="Catch_LocationVisibilityPublic" xml:space="preserve">
+    <value>Position exacte publique</value>
+  </data>
+  <data name="Catch_LocationVisibilityPublicWarning" xml:space="preserve">
+    <value>Toute personne pouvant voir cette prise pourra voir le spot de pêche exact.</value>
+  </data>
+  <data name="Catch_LocationPrivacySave" xml:space="preserve">
+    <value>Enregistrer la confidentialité</value>
+  </data>
+  <data name="Catch_LocationPrivacySaving" xml:space="preserve">
+    <value>Enregistrement</value>
+  </data>
+  <data name="Catch_LocationPrivacySaved" xml:space="preserve">
+    <value>Confidentialité de la localisation enregistrée</value>
+  </data>
+  <data name="Catch_LocationPrivacySaveFailed" xml:space="preserve">
+    <value>La confidentialité n'a pas pu être enregistrée. Réessayez.</value>
+  </data>
   <data name="Profile_Nav" xml:space="preserve">
     <value>Profil</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -354,6 +354,51 @@
   <data name="Catch_UnknownSpecies" xml:space="preserve">
     <value>Catch</value>
   </data>
+  <data name="Catch_ManageLocationPrivacy" xml:space="preserve">
+    <value>Location privacy</value>
+  </data>
+  <data name="Catch_LocationPrivacyPageTitle" xml:space="preserve">
+    <value>FishingLogBook - Location privacy</value>
+  </data>
+  <data name="Catch_LocationPrivacyTitle" xml:space="preserve">
+    <value>Location privacy</value>
+  </data>
+  <data name="Catch_LocationPrivacySubtitle" xml:space="preserve">
+    <value>Choose what other anglers can see of this fishing spot.</value>
+  </data>
+  <data name="Catch_LocationPrivacyLoadFailed" xml:space="preserve">
+    <value>This catch could not be loaded.</value>
+  </data>
+  <data name="Catch_LocationPrivacyNoLocation" xml:space="preserve">
+    <value>This catch has no saved location.</value>
+  </data>
+  <data name="Catch_LocationVisibilityPrivate" xml:space="preserve">
+    <value>Only me</value>
+  </data>
+  <data name="Catch_LocationVisibilityApproximate" xml:space="preserve">
+    <value>Approximate area</value>
+  </data>
+  <data name="Catch_LocationVisibilityFishingVenueOnly" xml:space="preserve">
+    <value>Fishing venue only</value>
+  </data>
+  <data name="Catch_LocationVisibilityPublic" xml:space="preserve">
+    <value>Public exact location</value>
+  </data>
+  <data name="Catch_LocationVisibilityPublicWarning" xml:space="preserve">
+    <value>Anyone who can view this catch may see the exact fishing spot.</value>
+  </data>
+  <data name="Catch_LocationPrivacySave" xml:space="preserve">
+    <value>Save location privacy</value>
+  </data>
+  <data name="Catch_LocationPrivacySaving" xml:space="preserve">
+    <value>Saving</value>
+  </data>
+  <data name="Catch_LocationPrivacySaved" xml:space="preserve">
+    <value>Location privacy saved</value>
+  </data>
+  <data name="Catch_LocationPrivacySaveFailed" xml:space="preserve">
+    <value>Location privacy could not be saved. Try again.</value>
+  </data>
   <data name="Profile_Nav" xml:space="preserve">
     <value>Profile</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -399,6 +399,9 @@
   <data name="Catch_LocationPrivacySaveFailed" xml:space="preserve">
     <value>Location privacy could not be saved. Try again.</value>
   </data>
+  <data name="Catch_LocationPrivacySavedPendingSync" xml:space="preserve">
+    <value>Privacy saved on this device. It will update when synchronisation is available.</value>
+  </data>
   <data name="Profile_Nav" xml:space="preserve">
     <value>Profile</value>
   </data>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using FishingLogBook.Web.Features.Profile.Services;
 using FishingLogBook.Web.Features.SystemStatus.Services;
 using FishingLogBook.Web.Features.TestCatch.Offline;
 using FishingLogBook.Web.Features.TestCatch.Services;
+using FishingLogBook.Web.Features.Users.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,6 +55,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITestCatchSynchroniser, TestCatchSynchroniser>();
         services.AddScoped<ICatchStore, IndexedDbCatchStore>();
         services.AddScoped<ICatchClient, CatchClient>();
+        services.AddScoped<ICurrentUserClient, CurrentUserClient>();
+        services.AddScoped<ILocalCatchOwnerService, LocalCatchOwnerService>();
         services.AddSingleton<DiagnosticStatusModel>();
         services.AddScoped<ILoggingService, LoggingService>();
         services.AddScoped<IDiagnosticEventStore, IndexedDbDiagnosticEventStore>();

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
 using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
@@ -52,6 +53,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITestCatchPhotoStore, IndexedDbTestCatchPhotoStore>();
         services.AddScoped<ITestCatchSynchroniser, TestCatchSynchroniser>();
         services.AddScoped<ICatchStore, IndexedDbCatchStore>();
+        services.AddScoped<ICatchClient, CatchClient>();
         services.AddSingleton<DiagnosticStatusModel>();
         services.AddScoped<ILoggingService, LoggingService>();
         services.AddScoped<IDiagnosticEventStore, IndexedDbDiagnosticEventStore>();

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
@@ -283,18 +283,7 @@ function visibleCatchesForOwner(catches, ownerUserId) {
         return [];
     }
 
-    const hasForeignOwner = catches.some((item) => {
-        const userId = normalisedUserId(item?.userId);
-        return userId && userId !== owner;
-    });
-    return catches.filter((item) => {
-        const userId = normalisedUserId(item?.userId);
-        if (userId === owner) {
-            return true;
-        }
-
-        return !userId && !hasForeignOwner;
-    });
+    return catches.filter((item) => normalisedUserId(item?.userId) === owner);
 }
 
 function normalisedUserId(value) {
@@ -302,7 +291,12 @@ function normalisedUserId(value) {
         return '';
     }
 
-    return value.trim().toLowerCase();
+    const normalised = value.trim().toLowerCase();
+    if (!normalised || normalised === '00000000-0000-0000-0000-000000000000') {
+        return '';
+    }
+
+    return normalised;
 }
 
 function orderPhotographs(catchRecord, photographs) {

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
@@ -232,7 +232,7 @@ export async function putCatchWithPhotographs(json, photographs) {
     });
 }
 
-export async function getAllCatchesWithPhotographs() {
+export async function getAllCatchesWithPhotographs(ownerUserId) {
     return runProductionCatchTransaction('readonly', 'read', (transaction, succeed, fail) => {
         const catchStore = transaction.objectStore(PRODUCTION_CATCH_STORE_NAME);
         const photoStore = transaction.objectStore(PRODUCTION_PHOTO_STORE_NAME);
@@ -247,18 +247,22 @@ export async function getAllCatchesWithPhotographs() {
                 return;
             }
 
+            const visible = visibleCatchesForOwner(catches, ownerUserId);
+            const visibleIds = new Set(visible.map((item) => item.id));
             const photographs = [];
             const photoRequest = photoStore.openCursor();
             photoRequest.onerror = () => fail(photoRequest.error);
             photoRequest.onsuccess = () => {
                 const photoCursor = photoRequest.result;
                 if (photoCursor) {
-                    photographs.push(photoCursor.value);
+                    if (visibleIds.has(photoCursor.value.catchId)) {
+                        photographs.push(photoCursor.value);
+                    }
                     photoCursor.continue();
                     return;
                 }
 
-                succeed(catches.map((item) => ({
+                succeed(visible.map((item) => ({
                     json: JSON.stringify(item),
                     photographs: orderPhotographs(item, photographs)
                         .map((photograph) => ({
@@ -271,6 +275,34 @@ export async function getAllCatchesWithPhotographs() {
             };
         };
     });
+}
+
+function visibleCatchesForOwner(catches, ownerUserId) {
+    const owner = normalisedUserId(ownerUserId);
+    if (!owner) {
+        return [];
+    }
+
+    const hasForeignOwner = catches.some((item) => {
+        const userId = normalisedUserId(item?.userId);
+        return userId && userId !== owner;
+    });
+    return catches.filter((item) => {
+        const userId = normalisedUserId(item?.userId);
+        if (userId === owner) {
+            return true;
+        }
+
+        return !userId && !hasForeignOwner;
+    });
+}
+
+function normalisedUserId(value) {
+    if (typeof value !== 'string') {
+        return '';
+    }
+
+    return value.trim().toLowerCase();
 }
 
 function orderPhotographs(catchRecord, photographs) {

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
@@ -283,18 +283,7 @@ function visibleCatchesForOwner(catches, ownerUserId) {
         return [];
     }
 
-    const hasForeignOwner = catches.some((item) => {
-        const userId = normalisedUserId(item?.userId);
-        return userId && userId !== owner;
-    });
-    return catches.filter((item) => {
-        const userId = normalisedUserId(item?.userId);
-        if (userId === owner) {
-            return true;
-        }
-
-        return !userId && !hasForeignOwner;
-    });
+    return catches.filter((item) => normalisedUserId(item?.userId) === owner);
 }
 
 function normalisedUserId(value) {

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
@@ -256,6 +256,9 @@ describe('Catch store', () => {
 });
 
 describe('Production Catch store', () => {
+    const ownerUserId = '11111111-1111-1111-1111-111111111111';
+    const otherUserId = '22222222-2222-2222-2222-222222222222';
+
     it('puts and reads a Catch with photograph bytes and stable ids', async () => {
         const catchId = '11111111-1111-1111-1111-111111111111';
         const photographId = '22222222-2222-2222-2222-222222222222';
@@ -269,7 +272,7 @@ describe('Production Catch store', () => {
             }]
         );
 
-        const items = await getAllCatchesWithPhotographs();
+        const items = await getAllCatchesWithPhotographs(ownerUserId);
 
         expect(items).toHaveLength(1);
         expect(JSON.parse(items[0].json).id).toBe(catchId);
@@ -301,8 +304,8 @@ describe('Production Catch store', () => {
             ]
         );
 
-        const firstRead = await getAllCatchesWithPhotographs();
-        const reopened = await getAllCatchesWithPhotographs();
+        const firstRead = await getAllCatchesWithPhotographs(ownerUserId);
+        const reopened = await getAllCatchesWithPhotographs(ownerUserId);
 
         expect(JSON.parse(firstRead[0].json).id).toBe(catchId);
         expect(reopened[0].photographs.map((photograph) => photograph.id)).toEqual([photoA, photoB, photoC]);
@@ -329,7 +332,7 @@ describe('Production Catch store', () => {
             [{ id: 'photo-b', catchId: 'catch-b', contentType: 'image/png', bytes: new Uint8Array([2]) }]
         );
 
-        const items = await getAllCatchesWithPhotographs();
+        const items = await getAllCatchesWithPhotographs(ownerUserId);
         const ids = items.map((item) => JSON.parse(item.json).id).sort();
         const photoIds = items.flatMap((item) => item.photographs.map((photograph) => photograph.id)).sort();
 
@@ -343,7 +346,7 @@ describe('Production Catch store', () => {
             [{ catchId: 'orphan-catch', contentType: 'image/jpeg', bytes: new Uint8Array([9]) }]
         )).rejects.toBeTruthy();
 
-        const items = await getAllCatchesWithPhotographs();
+        const items = await getAllCatchesWithPhotographs(ownerUserId);
         const ids = items.map((item) => JSON.parse(item.json).id);
 
         expect(ids).not.toContain('orphan-catch');
@@ -355,7 +358,7 @@ describe('Production Catch store', () => {
             []
         )).rejects.toThrow('Catch requires at least one photograph');
 
-        const items = await getAllCatchesWithPhotographs();
+        const items = await getAllCatchesWithPhotographs(ownerUserId);
         const ids = items.map((item) => JSON.parse(item.json).id);
         expect(ids).not.toContain('empty-photos');
     });
@@ -413,8 +416,86 @@ describe('Production Catch store', () => {
             vi.restoreAllMocks();
         }
 
-        const items = await getAllCatchesWithPhotographs();
+        const items = await getAllCatchesWithPhotographs(ownerUserId);
         const ids = items.map((item) => JSON.parse(item.json).id);
         expect(ids).not.toContain('partial-catch');
+    });
+
+    it('does not return another user’s Catch or photograph bytes', async () => {
+        const ownerCatchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const otherCatchId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: ownerCatchId,
+                userId: ownerUserId,
+                caughtOn: '2026-08-17T08:00:00+00:00'
+            }),
+            [{
+                id: 'owner-photo',
+                catchId: ownerCatchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([1, 2, 3])
+            }]
+        );
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: otherCatchId,
+                userId: otherUserId,
+                caughtOn: '2026-08-17T09:00:00+00:00',
+                location: { latitude: 53.2707, longitude: -9.0568 }
+            }),
+            [{
+                id: 'other-photo',
+                catchId: otherCatchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([9, 9, 9])
+            }]
+        );
+
+        const ownerView = await getAllCatchesWithPhotographs(ownerUserId);
+        const otherView = await getAllCatchesWithPhotographs(otherUserId);
+
+        expect(ownerView.map((item) => JSON.parse(item.json).id)).toEqual([ownerCatchId]);
+        expect(ownerView[0].photographs.map((photograph) => photograph.id)).toEqual(['owner-photo']);
+        expect(JSON.stringify(ownerView)).not.toContain('53.2707');
+        expect(JSON.stringify(ownerView)).not.toContain('other-photo');
+        expect(otherView.map((item) => JSON.parse(item.json).id)).toEqual([otherCatchId]);
+        expect(otherView[0].photographs.map((photograph) => photograph.id)).toEqual(['other-photo']);
+        expect(JSON.stringify(otherView)).not.toContain('owner-photo');
+    });
+
+    it('does not expose unscoped Catches to a later user once another owner has records', async () => {
+        const unscopedId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        await putCatchWithPhotographs(
+            JSON.stringify({ id: unscopedId, caughtOn: '2026-08-17T08:00:00+00:00' }),
+            [{
+                id: 'unscoped-photo',
+                catchId: unscopedId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([4])
+            }]
+        );
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+                userId: ownerUserId,
+                caughtOn: '2026-08-17T09:00:00+00:00'
+            }),
+            [{
+                id: 'owner-photo',
+                catchId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([5])
+            }]
+        );
+
+        const otherView = await getAllCatchesWithPhotographs(otherUserId);
+        const ownerView = await getAllCatchesWithPhotographs(ownerUserId);
+
+        expect(otherView).toEqual([]);
+        expect(ownerView.map((item) => JSON.parse(item.json).id).sort()).toEqual([
+            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+            'dddddddd-dddd-dddd-dddd-dddddddddddd'
+        ].sort());
     });
 });

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
@@ -263,7 +263,7 @@ describe('Production Catch store', () => {
         const catchId = '11111111-1111-1111-1111-111111111111';
         const photographId = '22222222-2222-2222-2222-222222222222';
         await putCatchWithPhotographs(
-            JSON.stringify({ id: catchId, caughtOn: '2026-08-17T08:00:00+00:00' }),
+            JSON.stringify({ id: catchId, userId: ownerUserId, caughtOn: '2026-08-17T08:00:00+00:00' }),
             [{
                 id: photographId,
                 catchId,
@@ -290,6 +290,7 @@ describe('Production Catch store', () => {
         await putCatchWithPhotographs(
             JSON.stringify({
                 id: catchId,
+                userId: ownerUserId,
                 caughtOn: '2026-08-17T08:00:00+00:00',
                 photographs: [
                     { id: photoA, catchId, contentType: 'image/jpeg' },
@@ -324,11 +325,11 @@ describe('Production Catch store', () => {
 
     it('keeps two separately saved catches on distinct ids', async () => {
         await putCatchWithPhotographs(
-            JSON.stringify({ id: 'catch-a', caughtOn: '2026-08-17T08:00:00+00:00' }),
+            JSON.stringify({ id: 'catch-a', userId: ownerUserId, caughtOn: '2026-08-17T08:00:00+00:00' }),
             [{ id: 'photo-a', catchId: 'catch-a', contentType: 'image/jpeg', bytes: new Uint8Array([1]) }]
         );
         await putCatchWithPhotographs(
-            JSON.stringify({ id: 'catch-b', caughtOn: '2026-08-17T09:00:00+00:00' }),
+            JSON.stringify({ id: 'catch-b', userId: ownerUserId, caughtOn: '2026-08-17T09:00:00+00:00' }),
             [{ id: 'photo-b', catchId: 'catch-b', contentType: 'image/png', bytes: new Uint8Array([2]) }]
         );
 
@@ -464,38 +465,74 @@ describe('Production Catch store', () => {
         expect(JSON.stringify(otherView)).not.toContain('owner-photo');
     });
 
-    it('does not expose unscoped Catches to a later user once another owner has records', async () => {
+    it('does not expose or adopt a legacy unowned Catch when another user signs in first', async () => {
         const unscopedId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
         await putCatchWithPhotographs(
-            JSON.stringify({ id: unscopedId, caughtOn: '2026-08-17T08:00:00+00:00' }),
+            JSON.stringify({
+                id: unscopedId,
+                caughtOn: '2026-08-17T08:00:00+00:00',
+                location: { latitude: 53.2707, longitude: -9.0568 }
+            }),
             [{
                 id: 'unscoped-photo',
                 catchId: unscopedId,
                 contentType: 'image/jpeg',
-                bytes: new Uint8Array([4])
+                bytes: new Uint8Array([4, 5, 6])
             }]
         );
+
+        const firstSignedIn = await getAllCatchesWithPhotographs(otherUserId);
+        const originalOwner = await getAllCatchesWithPhotographs(ownerUserId);
+        const stored = await readRawProductionCatch(unscopedId);
+
+        expect(firstSignedIn).toEqual([]);
+        expect(originalOwner).toEqual([]);
+        expect(JSON.stringify(firstSignedIn)).not.toContain('53.2707');
+        expect(JSON.stringify(firstSignedIn)).not.toContain('unscoped-photo');
+        expect(stored.id).toBe(unscopedId);
+        expect(stored.userId).toBeUndefined();
+        expect(stored.location.latitude).toBe(53.2707);
+    });
+
+    it('does not treat an empty user id as an owner', async () => {
+        const unscopedId = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
         await putCatchWithPhotographs(
             JSON.stringify({
-                id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
-                userId: ownerUserId,
-                caughtOn: '2026-08-17T09:00:00+00:00'
+                id: unscopedId,
+                userId: '00000000-0000-0000-0000-000000000000',
+                caughtOn: '2026-08-17T08:00:00+00:00'
             }),
             [{
-                id: 'owner-photo',
-                catchId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+                id: 'empty-owner-photo',
+                catchId: unscopedId,
                 contentType: 'image/jpeg',
-                bytes: new Uint8Array([5])
+                bytes: new Uint8Array([7])
             }]
         );
 
-        const otherView = await getAllCatchesWithPhotographs(otherUserId);
-        const ownerView = await getAllCatchesWithPhotographs(ownerUserId);
+        const firstSignedIn = await getAllCatchesWithPhotographs(ownerUserId);
 
-        expect(otherView).toEqual([]);
-        expect(ownerView.map((item) => JSON.parse(item.json).id).sort()).toEqual([
-            'cccccccc-cccc-cccc-cccc-cccccccccccc',
-            'dddddddd-dddd-dddd-dddd-dddddddddddd'
-        ].sort());
+        expect(firstSignedIn).toEqual([]);
+        expect(JSON.stringify(firstSignedIn)).not.toContain('empty-owner-photo');
     });
 });
+
+function readRawProductionCatch(id) {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(CATCH_DATABASE_NAME);
+        request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+            const db = request.result;
+            const transaction = db.transaction(PRODUCTION_CATCH_STORE_NAME, 'readonly');
+            const getRequest = transaction.objectStore(PRODUCTION_CATCH_STORE_NAME).get(id);
+            getRequest.onerror = () => {
+                db.close();
+                reject(getRequest.error);
+            };
+            getRequest.onsuccess = () => {
+                db.close();
+                resolve(getRequest.result);
+            };
+        };
+    });
+}

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
@@ -263,7 +263,7 @@ describe('Production Catch store', () => {
         const catchId = '11111111-1111-1111-1111-111111111111';
         const photographId = '22222222-2222-2222-2222-222222222222';
         await putCatchWithPhotographs(
-            JSON.stringify({ id: catchId, caughtOn: '2026-08-17T08:00:00+00:00' }),
+            JSON.stringify({ id: catchId, userId: ownerUserId, caughtOn: '2026-08-17T08:00:00+00:00' }),
             [{
                 id: photographId,
                 catchId,
@@ -290,6 +290,7 @@ describe('Production Catch store', () => {
         await putCatchWithPhotographs(
             JSON.stringify({
                 id: catchId,
+                userId: ownerUserId,
                 caughtOn: '2026-08-17T08:00:00+00:00',
                 photographs: [
                     { id: photoA, catchId, contentType: 'image/jpeg' },
@@ -324,11 +325,11 @@ describe('Production Catch store', () => {
 
     it('keeps two separately saved catches on distinct ids', async () => {
         await putCatchWithPhotographs(
-            JSON.stringify({ id: 'catch-a', caughtOn: '2026-08-17T08:00:00+00:00' }),
+            JSON.stringify({ id: 'catch-a', userId: ownerUserId, caughtOn: '2026-08-17T08:00:00+00:00' }),
             [{ id: 'photo-a', catchId: 'catch-a', contentType: 'image/jpeg', bytes: new Uint8Array([1]) }]
         );
         await putCatchWithPhotographs(
-            JSON.stringify({ id: 'catch-b', caughtOn: '2026-08-17T09:00:00+00:00' }),
+            JSON.stringify({ id: 'catch-b', userId: ownerUserId, caughtOn: '2026-08-17T09:00:00+00:00' }),
             [{ id: 'photo-b', catchId: 'catch-b', contentType: 'image/png', bytes: new Uint8Array([2]) }]
         );
 
@@ -464,7 +465,35 @@ describe('Production Catch store', () => {
         expect(JSON.stringify(otherView)).not.toContain('owner-photo');
     });
 
-    it('does not expose unscoped Catches to a later user once another owner has records', async () => {
+    it('does not let the first signed-in user read or adopt a legacy unscoped Catch', async () => {
+        const unscopedId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: unscopedId,
+                caughtOn: '2026-08-17T08:00:00+00:00',
+                location: { latitude: 53.2707, longitude: -9.0568 }
+            }),
+            [{
+                id: 'unscoped-photo',
+                catchId: unscopedId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([4, 5, 6])
+            }]
+        );
+
+        const firstSignerView = await getAllCatchesWithPhotographs(otherUserId);
+        const originalOwnerView = await getAllCatchesWithPhotographs(ownerUserId);
+        const stored = await readRawProductionCatch(unscopedId);
+
+        expect(firstSignerView).toEqual([]);
+        expect(originalOwnerView).toEqual([]);
+        expect(JSON.stringify(firstSignerView)).not.toContain('53.2707');
+        expect(JSON.stringify(firstSignerView)).not.toContain('unscoped-photo');
+        expect(stored.userId).toBeUndefined();
+        expect(stored.location).toEqual({ latitude: 53.2707, longitude: -9.0568 });
+    });
+
+    it('does not expose unscoped Catches alongside owned records', async () => {
         const unscopedId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
         await putCatchWithPhotographs(
             JSON.stringify({ id: unscopedId, caughtOn: '2026-08-17T08:00:00+00:00' }),
@@ -491,11 +520,23 @@ describe('Production Catch store', () => {
 
         const otherView = await getAllCatchesWithPhotographs(otherUserId);
         const ownerView = await getAllCatchesWithPhotographs(ownerUserId);
+        const stored = await readRawProductionCatch(unscopedId);
 
         expect(otherView).toEqual([]);
-        expect(ownerView.map((item) => JSON.parse(item.json).id).sort()).toEqual([
-            'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        expect(ownerView.map((item) => JSON.parse(item.json).id)).toEqual([
             'dddddddd-dddd-dddd-dddd-dddddddddddd'
-        ].sort());
+        ]);
+        expect(JSON.stringify(ownerView)).not.toContain('unscoped-photo');
+        expect(stored.userId).toBeUndefined();
     });
 });
+
+function readRawProductionCatch(id) {
+    return openCatchDatabase().then((db) => new Promise((resolve, reject) => {
+        const transaction = db.transaction(PRODUCTION_CATCH_STORE_NAME, 'readonly');
+        const request = transaction.objectStore(PRODUCTION_CATCH_STORE_NAME).get(id);
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+        transaction.oncomplete = () => db.close();
+    }));
+}

--- a/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingGet.cs
+++ b/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingGet.cs
@@ -1,0 +1,326 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.CatchEndpointsTests;
+
+public class WhenTestingGet : IClassFixture<SystemApiFactory>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingGet(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequestWhenAuthorizationIsMissing()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/catches/{Guid.NewGuid():D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.CatchRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNotFoundWhenTheCatchIsMissing()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/catches/{catchId:D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnACatchWithoutLocationWhenNoneWasSaved()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "no-location-get"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        var catchRecord = new Catch
+        {
+            Id = Guid.NewGuid(),
+            UserId = current!.UserId,
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z")
+        };
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+
+        // Act
+        var response = await client.GetAsync($"/api/catches/{catchRecord.Id:D}");
+        var json = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize<CatchViewDto>(json, JsonOptions);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().NotContain("\"latitude\":");
+        json.Should().NotContain("53.2707");
+        body.Should().NotBeNull();
+        body!.Location.Should().BeNull();
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnExactCoordinatesToTheOwner()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "owner-get"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        var catchRecord = LocatedCatch(current!.UserId);
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+
+        // Act
+        var response = await client.GetAsync($"/api/catches/{catchRecord.Id:D}");
+        var json = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize<CatchViewDto>(json, JsonOptions);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().Contain("\"latitude\":");
+        json.Should().Contain("53.2707");
+        json.Should().Contain("-9.0568");
+        body.Should().NotBeNull();
+        body!.Location.Should().NotBeNull();
+        body.Location!.Mode.Should().Be(LocationDefaults.ExposureExact);
+        body.Location.Latitude.Should().Be(53.2707);
+        body.Location.Longitude.Should().Be(-9.0568);
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOmitExactCoordinatesFromPrivateNonOwnerJson()
+    {
+        // Arrange
+        ResetRepositories();
+        var ownerClient = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "private-owner"));
+        var owner = await ownerClient.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        owner.Should().NotBeNull();
+        var catchRecord = LocatedCatch(owner!.UserId);
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        var viewer = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "private-viewer"));
+
+        // Act
+        var response = await viewer.GetAsync($"/api/catches/{catchRecord.Id:D}?userId={owner.UserId:D}");
+        var json = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize<CatchViewDto>(json, JsonOptions);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().NotContain("53.2707");
+        json.Should().NotContain("-9.0568");
+        json.Should().NotContain("\"latitude\":");
+        json.Should().NotContain("\"longitude\":");
+        body.Should().NotBeNull();
+        body!.Location.Should().NotBeNull();
+        body.Location!.Mode.Should().Be(LocationDefaults.ExposureNone);
+        body.Location.Latitude.Should().BeNull();
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(PlatformCapabilityEnum.Guide)]
+    [InlineData(PlatformCapabilityEnum.FishingVenueManager)]
+    [InlineData(PlatformCapabilityEnum.CompetitionOrganiser)]
+    [InlineData(PlatformCapabilityEnum.Administrator)]
+    public async Task ItShouldDenyExactCoordinatesWhenTheViewerHasAPrivilegedCapability(
+        PlatformCapabilityEnum capability)
+    {
+        // Arrange
+        ResetRepositories();
+        var ownerClient = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: $"owner-{capability}"));
+        var owner = await ownerClient.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        owner.Should().NotBeNull();
+        var catchRecord = LocatedCatch(owner!.UserId);
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        var viewerClient = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: $"viewer-{capability}"));
+        var viewer = await viewerClient.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        viewer.Should().NotBeNull();
+        _factory.UserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var lookup = call.ArgAt<FindUserPlatformCapabilityArgs>(0);
+                return Result.Ok(lookup.UserId == viewer!.UserId && lookup.Capability == capability);
+            });
+
+        // Act
+        var response = await viewerClient.GetAsync($"/api/catches/{catchRecord.Id:D}");
+        var json = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().NotContain("53.2707");
+        json.Should().NotContain("-9.0568");
+        json.Should().NotContain("\"latitude\":");
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
+        await _factory.UserPlatformCapabilityRepository.DidNotReceive().HasAsync(
+            Arg.Any<FindUserPlatformCapabilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnApproximateFieldsWithoutOriginalCoordinates()
+    {
+        // Arrange
+        ResetRepositories();
+        var ownerClient = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "approx-owner"));
+        var owner = await ownerClient.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        owner.Should().NotBeNull();
+        var catchRecord = LocatedCatch(owner!.UserId, LocationDefaults.Approximate);
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        var viewer = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "approx-viewer"));
+
+        // Act
+        var response = await viewer.GetAsync($"/api/catches/{catchRecord.Id:D}");
+        var json = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize<CatchViewDto>(json, JsonOptions);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().NotContain("53.2707");
+        json.Should().NotContain("-9.0568");
+        json.Should().NotContain("\"latitude\":");
+        json.Should().NotContain("\"longitude\":");
+        json.Should().Contain("\"approximateLatitude\":");
+        body.Should().NotBeNull();
+        body!.Location!.Mode.Should().Be(LocationDefaults.ExposureApproximate);
+        body.Location.ApproximateLatitude.Should().Be(53.275);
+        body.Location.ApproximateLongitude.Should().Be(-9.075);
+        body.Location.Latitude.Should().BeNull();
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOmitGpsWhenFishingVenueOnly()
+    {
+        // Arrange
+        ResetRepositories();
+        var ownerClient = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "venue-owner"));
+        var owner = await ownerClient.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        owner.Should().NotBeNull();
+        var catchRecord = LocatedCatch(owner!.UserId, LocationDefaults.FishingVenueOnly);
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        var viewer = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "venue-viewer"));
+
+        // Act
+        var response = await viewer.GetAsync($"/api/catches/{catchRecord.Id:D}");
+        var json = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize<CatchViewDto>(json, JsonOptions);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().NotContain("53.2707");
+        json.Should().NotContain("\"latitude\":");
+        json.Should().NotContain("\"approximateLatitude\":");
+        body!.Location!.Mode.Should().Be(LocationDefaults.ExposureFishingVenue);
+        body.Location.Latitude.Should().BeNull();
+        body.Location.FishingVenueId.Should().BeNull();
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnExactCoordinatesWhenPublic()
+    {
+        // Arrange
+        ResetRepositories();
+        var ownerClient = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "public-owner"));
+        var owner = await ownerClient.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        owner.Should().NotBeNull();
+        var catchRecord = LocatedCatch(owner!.UserId, LocationDefaults.Public);
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        var viewer = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "public-viewer"));
+
+        // Act
+        var response = await viewer.GetAsync($"/api/catches/{catchRecord.Id:D}");
+        var json = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize<CatchViewDto>(json, JsonOptions);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        json.Should().Contain("\"latitude\":");
+        json.Should().Contain("53.2707");
+        body.Should().NotBeNull();
+        body!.Location!.Mode.Should().Be(LocationDefaults.ExposureExact);
+        body.Location.Latitude.Should().Be(53.2707);
+        body.Location.Longitude.Should().Be(-9.0568);
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
+    }
+
+    private void ResetRepositories()
+    {
+        _factory.CatchRepository.ClearReceivedCalls();
+        _factory.UserPlatformCapabilityRepository.ClearReceivedCalls();
+        _factory.CatchRepository
+            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(null));
+        _factory.UserPlatformCapabilityRepository
+            .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(false));
+    }
+
+    private static Catch LocatedCatch(Guid ownerUserId, string visibility = LocationDefaults.Private)
+    {
+        var catchId = Guid.NewGuid();
+        return new Catch
+        {
+            Id = catchId,
+            UserId = ownerUserId,
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            Location = CatchLocation.TryCreate(
+                53.2707,
+                -9.0568,
+                5,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                visibility,
+                LocationDefaults.ConsentVersion)
+        };
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingUpdateLocationVisibility.cs
+++ b/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingUpdateLocationVisibility.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.CatchEndpointsTests;
+
+public class WhenTestingUpdateLocationVisibility : IClassFixture<SystemApiFactory>
+{
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingUpdateLocationVisibility(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequestWhenAuthorizationIsMissing()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.PatchAsJsonAsync(
+            $"/api/catches/{Guid.NewGuid():D}/location-visibility",
+            new UpdateCatchLocationVisibilityDto(LocationDefaults.Public));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.CatchRepository.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<PersistCatchLocationVisibilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNotFoundWhenTheCatchIsMissing()
+    {
+        // Arrange
+        ResetRepositories();
+        var catchId = Guid.NewGuid();
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "missing-visibility"));
+
+        // Act
+        var response = await client.PatchAsJsonAsync(
+            $"/api/catches/{catchId:D}/location-visibility",
+            new UpdateCatchLocationVisibilityDto(LocationDefaults.Public));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await _factory.CatchRepository.Received(1).GetByIdAsync(catchId, Arg.Any<CancellationToken>());
+        await _factory.CatchRepository.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<PersistCatchLocationVisibilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectUnknownVisibility()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "invalid-visibility"));
+
+        // Act
+        var response = await client.PatchAsJsonAsync(
+            $"/api/catches/{Guid.NewGuid():D}/location-visibility",
+            new UpdateCatchLocationVisibilityDto("FriendsOnly"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.CatchRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await _factory.CatchRepository.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<PersistCatchLocationVisibilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDenyWhenTheCallerDoesNotOwnTheCatch()
+    {
+        // Arrange
+        ResetRepositories();
+        var ownerClient = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "visibility-owner"));
+        var owner = await ownerClient.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var catchRecord = LocatedCatch(owner!.UserId);
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        var viewer = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "visibility-viewer"));
+
+        // Act
+        var response = await viewer.PatchAsJsonAsync(
+            $"/api/catches/{catchRecord.Id:D}/location-visibility",
+            new
+            {
+                visibility = LocationDefaults.Public,
+                userId = owner.UserId,
+                actorUserId = owner.UserId,
+                administrator = true
+            });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        await _factory.CatchRepository.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<PersistCatchLocationVisibilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectWhenTheCatchHasNoLocation()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "no-location-owner"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var catchRecord = new Catch
+        {
+            Id = Guid.NewGuid(),
+            UserId = current!.UserId,
+            CaughtOn = DateTimeOffset.UtcNow
+        };
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+
+        // Act
+        var response = await client.PatchAsJsonAsync(
+            $"/api/catches/{catchRecord.Id:D}/location-visibility",
+            new UpdateCatchLocationVisibilityDto(LocationDefaults.Approximate));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.CatchRepository.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<PersistCatchLocationVisibilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldUpdateVisibilityForTheOwner()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: "visibility-update-owner"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var catchRecord = LocatedCatch(current!.UserId);
+        _factory.CatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        _factory.CatchRepository
+            .UpdateLocationVisibilityAsync(Arg.Any<PersistCatchLocationVisibilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        // Act
+        var response = await client.PatchAsJsonAsync(
+            $"/api/catches/{catchRecord.Id:D}/location-visibility",
+            new UpdateCatchLocationVisibilityDto(LocationDefaults.Public));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await _factory.CatchRepository.Received(1).UpdateLocationVisibilityAsync(
+            Arg.Is<PersistCatchLocationVisibilityArgs>(args =>
+                args.CatchId == catchRecord.Id
+                && args.UserId == current.UserId
+                && args.Visibility == LocationDefaults.Public),
+            Arg.Any<CancellationToken>());
+        await _factory.CatchRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Catch>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private void ResetRepositories()
+    {
+        _factory.CatchRepository.ClearReceivedCalls();
+        _factory.CatchRepository
+            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(null));
+        _factory.CatchRepository
+            .UpdateLocationVisibilityAsync(Arg.Any<PersistCatchLocationVisibilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+    }
+
+    private static Catch LocatedCatch(Guid ownerUserId)
+    {
+        var catchId = Guid.NewGuid();
+        return new Catch
+        {
+            Id = catchId,
+            UserId = ownerUserId,
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            Location = CatchLocation.TryCreate(
+                53.2707,
+                -9.0568,
+                12,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion)
+        };
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -70,6 +70,12 @@ public class SystemApiFactory : WebApplicationFactory<Program>
         CatchRepository
             .UpsertAsync(Arg.Any<Catch>(), Arg.Any<CancellationToken>())
             .Returns(call => Result.Ok(call.ArgAt<Catch>(0)));
+        CatchRepository
+            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(null));
+        CatchRepository
+            .UpdateLocationVisibilityAsync(Arg.Any<PersistCatchLocationVisibilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
         UserPlatformCapabilityRepository
             .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok(false));

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/UpdateCatchLocationVisibilityCommandTests/BaseUpdateCatchLocationVisibilityCommandTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/UpdateCatchLocationVisibilityCommandTests/BaseUpdateCatchLocationVisibilityCommandTest.cs
@@ -1,0 +1,17 @@
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Application.Contracts.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.UpdateCatchLocationVisibilityCommandTests;
+
+public class BaseUpdateCatchLocationVisibilityCommandTest
+{
+    protected readonly ICatchService MockCatchService = Substitute.For<ICatchService>();
+
+    protected readonly UpdateCatchLocationVisibilityHandler Sut;
+
+    protected BaseUpdateCatchLocationVisibilityCommandTest()
+    {
+        Sut = new UpdateCatchLocationVisibilityHandler(MockCatchService);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/UpdateCatchLocationVisibilityCommandTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/UpdateCatchLocationVisibilityCommandTests/WhenTestingHandle.cs
@@ -1,0 +1,74 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Application.Catches.Errors;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using Mapster;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.UpdateCatchLocationVisibilityCommandTests;
+
+public class WhenTestingHandle : BaseUpdateCatchLocationVisibilityCommandTest
+{
+    public WhenTestingHandle()
+    {
+        ((IRegister)new FishingLogBook.Application.Common.Mappings.CatchMappingRegistration())
+            .Register(TypeAdapterConfig.GlobalSettings);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheServiceFails()
+    {
+        // Arrange
+        var command = ValidCommand();
+        MockCatchService
+            .UpdateLocationVisibilityAsync(Arg.Any<UpdateCatchLocationVisibilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail(new CatchNotOwnedError()));
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsFailure.Should().BeTrue();
+        response.Error.Should().BeOfType<CatchNotOwnedError>();
+        await MockCatchService.Received(1).UpdateLocationVisibilityAsync(
+            Arg.Is<UpdateCatchLocationVisibilityArgs>(args =>
+                args.CatchId == command.CatchId
+                && args.Visibility == command.Visibility),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldMapOnlyCatchIdAndVisibility()
+    {
+        // Arrange
+        var command = ValidCommand();
+        MockCatchService
+            .UpdateLocationVisibilityAsync(Arg.Any<UpdateCatchLocationVisibilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsSuccess.Should().BeTrue();
+        typeof(UpdateCatchLocationVisibilityCommand).GetProperty("ActorUserId").Should().BeNull();
+        typeof(UpdateCatchLocationVisibilityCommand).GetProperty("OwnerUserId").Should().BeNull();
+        typeof(UpdateCatchLocationVisibilityArgs).GetProperty("ActorUserId").Should().BeNull();
+        await MockCatchService.Received(1).UpdateLocationVisibilityAsync(
+            Arg.Is<UpdateCatchLocationVisibilityArgs>(args =>
+                args.CatchId == command.CatchId
+                && args.Visibility == LocationDefaults.Approximate),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static UpdateCatchLocationVisibilityCommand ValidCommand()
+    {
+        return new UpdateCatchLocationVisibilityCommand
+        {
+            CatchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            Visibility = LocationDefaults.Approximate
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/UpdateCatchLocationVisibilityCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/UpdateCatchLocationVisibilityCommandValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,65 @@
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.UpdateCatchLocationVisibilityCommandValidatorTests;
+
+public class WhenTestingValidate
+{
+    private readonly UpdateCatchLocationVisibilityCommandValidator _sut = new();
+
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenCatchIdIsEmpty()
+    {
+        // Arrange
+        var command = new UpdateCatchLocationVisibilityCommand
+        {
+            CatchId = Guid.Empty,
+            Visibility = LocationDefaults.Private
+        };
+
+        // Act
+        var result = _sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.CatchId);
+    }
+
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenVisibilityIsUnknown()
+    {
+        // Arrange
+        var command = new UpdateCatchLocationVisibilityCommand
+        {
+            CatchId = Guid.NewGuid(),
+            Visibility = "FriendsOnly"
+        };
+
+        // Act
+        var result = _sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Visibility);
+    }
+
+    [Theory]
+    [InlineData(LocationDefaults.Private)]
+    [InlineData(LocationDefaults.Approximate)]
+    [InlineData(LocationDefaults.FishingVenueOnly)]
+    [InlineData(LocationDefaults.Public)]
+    public void ItShouldNotHaveValidationErrorsForSupportedVisibility(string visibility)
+    {
+        // Arrange
+        var command = new UpdateCatchLocationVisibilityCommand
+        {
+            CatchId = Guid.NewGuid(),
+            Visibility = visibility
+        };
+
+        // Act
+        var result = _sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/UpsertCatchCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/UpsertCatchCommandValidatorTests/WhenTestingValidate.cs
@@ -190,6 +190,20 @@ public class WhenTestingValidate : BaseUpsertCatchCommandValidatorTest
         result.ShouldHaveValidationErrorFor(c => c.Catch.Location!.Source);
     }
 
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenLocationVisibilityIsUnknown()
+    {
+        // Arrange
+        var command = Command(location: ValidLocation() with { Visibility = "FriendsOnly" });
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(c => c.Catch.Location!.Visibility)
+            .WithErrorMessage("Location visibility is not supported.");
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData(" ")]

--- a/tests/FishingLogBook.Application.Tests/Catches/Queries/GetCatchQueryTests/BaseGetCatchQueryTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Queries/GetCatchQueryTests/BaseGetCatchQueryTest.cs
@@ -1,0 +1,17 @@
+using FishingLogBook.Application.Catches.Queries;
+using FishingLogBook.Application.Contracts.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Queries.GetCatchQueryTests;
+
+public class BaseGetCatchQueryTest
+{
+    protected readonly ICatchService MockCatchService = Substitute.For<ICatchService>();
+
+    protected readonly GetCatchHandler Sut;
+
+    protected BaseGetCatchQueryTest()
+    {
+        Sut = new GetCatchHandler(MockCatchService);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Queries/GetCatchQueryTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Queries/GetCatchQueryTests/WhenTestingHandle.cs
@@ -1,0 +1,63 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Catches.Errors;
+using FishingLogBook.Application.Catches.Queries;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using Mapster;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Queries.GetCatchQueryTests;
+
+public class WhenTestingHandle : BaseGetCatchQueryTest
+{
+    public WhenTestingHandle()
+    {
+        ((IRegister)new FishingLogBook.Application.Common.Mappings.CatchMappingRegistration())
+            .Register(TypeAdapterConfig.GlobalSettings);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheServiceFails()
+    {
+        // Arrange
+        var query = new GetCatchQuery { CatchId = Guid.NewGuid() };
+        MockCatchService
+            .GetViewAsync(Arg.Any<GetCatchArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<CatchViewDto>(new CatchNotFoundError()));
+
+        // Act
+        var response = await Sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        response.IsFailure.Should().BeTrue();
+        response.Error.Should().BeOfType<CatchNotFoundError>();
+        await MockCatchService.Received(1).GetViewAsync(
+            Arg.Is<GetCatchArgs>(args => args.CatchId == query.CatchId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldMapOnlyCatchId()
+    {
+        // Arrange
+        var query = new GetCatchQuery { CatchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa") };
+        var view = new CatchViewDto(query.CatchId, Guid.NewGuid(), DateTimeOffset.UtcNow);
+        MockCatchService
+            .GetViewAsync(Arg.Any<GetCatchArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(view));
+
+        // Act
+        var response = await Sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        response.IsSuccess.Should().BeTrue();
+        response.Catch.Should().Be(view);
+        typeof(GetCatchQuery).GetProperty("ViewerUserId").Should().BeNull();
+        typeof(GetCatchQuery).GetProperty("ActorUserId").Should().BeNull();
+        typeof(GetCatchArgs).GetProperty("ViewerUserId").Should().BeNull();
+        await MockCatchService.Received(1).GetViewAsync(
+            Arg.Is<GetCatchArgs>(args => args.CatchId == query.CatchId),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Queries/GetCatchQueryValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Queries/GetCatchQueryValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,35 @@
+using FishingLogBook.Application.Catches.Queries;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Catches.Queries.GetCatchQueryValidatorTests;
+
+public class WhenTestingValidate
+{
+    private readonly GetCatchQueryValidator _sut = new();
+
+    [Fact]
+    public void ItShouldHaveAValidationErrorWhenCatchIdIsEmpty()
+    {
+        // Arrange
+        var query = new GetCatchQuery { CatchId = Guid.Empty };
+
+        // Act
+        var result = _sut.TestValidate(query);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.CatchId);
+    }
+
+    [Fact]
+    public void ItShouldNotHaveValidationErrorsForAValidQuery()
+    {
+        // Arrange
+        var query = new GetCatchQuery { CatchId = Guid.NewGuid() };
+
+        // Act
+        var result = _sut.TestValidate(query);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchLocationPrivacyServiceTests/BaseCatchLocationPrivacyServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchLocationPrivacyServiceTests/BaseCatchLocationPrivacyServiceTest.cs
@@ -1,0 +1,38 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Catches.Services;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Tests.Catches.Services.CatchLocationPrivacyServiceTests;
+
+public class BaseCatchLocationPrivacyServiceTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    protected static readonly Guid ViewerUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    protected readonly CatchLocationPrivacyService Sut = new();
+
+    protected static Catch LocatedCatch(
+        Guid ownerUserId,
+        string visibility = LocationDefaults.Private,
+        double latitude = 53.2707,
+        double longitude = -9.0568)
+    {
+        return new Catch
+        {
+            Id = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            UserId = ownerUserId,
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            Location = CatchLocation.TryCreate(
+                latitude,
+                longitude,
+                5,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                visibility,
+                LocationDefaults.ConsentVersion)
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchLocationPrivacyServiceTests/WhenTestingGetExposure.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchLocationPrivacyServiceTests/WhenTestingGetExposure.cs
@@ -1,0 +1,181 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Catches.Services;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Tests.Catches.Services.CatchLocationPrivacyServiceTests;
+
+public class WhenTestingGetExposure : BaseCatchLocationPrivacyServiceTest
+{
+    [Fact]
+    public async Task ItShouldReturnNullWhenTheCatchHasNoLocation()
+    {
+        // Arrange
+        var catchRecord = new FishingLogBook.Domain.Catches.Catch
+        {
+            Id = Guid.NewGuid(),
+            UserId = OwnerUserId,
+            CaughtOn = DateTimeOffset.UtcNow
+        };
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(catchRecord, ViewerUserId, CancellationToken.None);
+
+        // Assert
+        exposure.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(LocationDefaults.Private)]
+    [InlineData(LocationDefaults.Approximate)]
+    [InlineData(LocationDefaults.FishingVenueOnly)]
+    [InlineData(LocationDefaults.Public)]
+    public async Task ItShouldReturnExactCoordinatesForTheOwnerAtEveryVisibility(string visibility)
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(OwnerUserId, visibility);
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(catchRecord, OwnerUserId, CancellationToken.None);
+
+        // Assert
+        exposure.Should().NotBeNull();
+        exposure!.Mode.Should().Be(LocationDefaults.ExposureExact);
+        exposure.Latitude.Should().Be(53.2707);
+        exposure.Longitude.Should().Be(-9.0568);
+        exposure.ApproximateLatitude.Should().BeNull();
+        exposure.ApproximateLongitude.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldHideExactCoordinatesFromAnotherUserWhenPrivate()
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(OwnerUserId, LocationDefaults.Private);
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(catchRecord, ViewerUserId, CancellationToken.None);
+
+        // Assert
+        exposure.Should().NotBeNull();
+        exposure!.Mode.Should().Be(LocationDefaults.ExposureNone);
+        exposure.Latitude.Should().BeNull();
+        exposure.Longitude.Should().BeNull();
+        exposure.ApproximateLatitude.Should().BeNull();
+        exposure.FishingVenueId.Should().BeNull();
+        exposure.FishingVenueName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnOnlyGeneralisedCoordinatesWhenApproximate()
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(OwnerUserId, LocationDefaults.Approximate);
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(catchRecord, ViewerUserId, CancellationToken.None);
+
+        // Assert
+        exposure.Should().NotBeNull();
+        exposure!.Mode.Should().Be(LocationDefaults.ExposureApproximate);
+        exposure.Latitude.Should().BeNull();
+        exposure.Longitude.Should().BeNull();
+        exposure.AccuracyMetres.Should().BeNull();
+        exposure.ApproximateLatitude.Should().Be(53.275);
+        exposure.ApproximateLongitude.Should().Be(-9.075);
+        exposure.ApproximateCellSizeMetres.Should().Be(CatchLocationConstants.ApproximateCellSizeMetres);
+        exposure.ApproximateLatitude.Should().NotBe(53.2707);
+        exposure.ApproximateLongitude.Should().NotBe(-9.0568);
+    }
+
+    [Fact]
+    public async Task ItShouldNotExposeGpsOrInferAVenueWhenFishingVenueOnly()
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(OwnerUserId, LocationDefaults.FishingVenueOnly);
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(catchRecord, ViewerUserId, CancellationToken.None);
+
+        // Assert
+        exposure.Should().NotBeNull();
+        exposure!.Mode.Should().Be(LocationDefaults.ExposureFishingVenue);
+        exposure.Latitude.Should().BeNull();
+        exposure.Longitude.Should().BeNull();
+        exposure.ApproximateLatitude.Should().BeNull();
+        exposure.FishingVenueId.Should().BeNull();
+        exposure.FishingVenueName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnExactCoordinatesToAnotherUserWhenPublic()
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(OwnerUserId, LocationDefaults.Public);
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(catchRecord, ViewerUserId, CancellationToken.None);
+
+        // Assert
+        exposure.Should().NotBeNull();
+        exposure!.Mode.Should().Be(LocationDefaults.ExposureExact);
+        exposure.Latitude.Should().Be(53.2707);
+        exposure.Longitude.Should().Be(-9.0568);
+    }
+
+    [Fact]
+    public async Task ItShouldClampApproximateLatitudeAtThePole()
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(OwnerUserId, LocationDefaults.Approximate, latitude: 90, longitude: 0);
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(catchRecord, ViewerUserId, CancellationToken.None);
+
+        // Assert
+        exposure.Should().NotBeNull();
+        exposure!.ApproximateLatitude.Should().Be(90);
+        exposure.Latitude.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldWrapApproximateLongitudeAcrossTheDateLine()
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(OwnerUserId, LocationDefaults.Approximate, latitude: 0, longitude: 180);
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(catchRecord, ViewerUserId, CancellationToken.None);
+
+        // Assert
+        exposure.Should().NotBeNull();
+        exposure!.ApproximateLongitude.Should().Be(-179.975);
+        exposure.Longitude.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldNotConsultPlatformCapabilities()
+    {
+        // Arrange
+        var constructor = typeof(CatchLocationPrivacyService).GetConstructors().Single();
+
+        // Act
+        var exposure = await Sut.GetExposureAsync(
+            LocatedCatch(OwnerUserId),
+            ViewerUserId,
+            CancellationToken.None);
+
+        // Assert
+        constructor.GetParameters().Select(parameter => parameter.ParameterType)
+            .Should()
+            .NotContain(typeof(IPlatformCapabilityService));
+        Enum.GetNames<PlatformCapabilityEnum>().Should().Equal(
+            nameof(PlatformCapabilityEnum.Guide),
+            nameof(PlatformCapabilityEnum.FishingVenueManager),
+            nameof(PlatformCapabilityEnum.CompetitionOrganiser),
+            nameof(PlatformCapabilityEnum.Administrator));
+        exposure!.Latitude.Should().BeNull();
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/BaseCatchServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/BaseCatchServiceTest.cs
@@ -1,5 +1,6 @@
 using FishingLogBook.Application.Catches.Services;
 using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
 using NSubstitute;
 
 namespace FishingLogBook.Application.Tests.Catches.Services.CatchServiceTests;
@@ -8,10 +9,22 @@ public class BaseCatchServiceTest
 {
     protected readonly ICatchRepository MockCatchRepository = Substitute.For<ICatchRepository>();
 
+    protected readonly ICurrentUser MockCurrentUser = Substitute.For<ICurrentUser>();
+
+    protected readonly ICatchLocationPrivacyService MockCatchLocationPrivacyService =
+        Substitute.For<ICatchLocationPrivacyService>();
+
     protected readonly CatchService Sut;
+
+    protected static readonly Guid CurrentUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
 
     protected BaseCatchServiceTest()
     {
-        Sut = new CatchService(MockCatchRepository);
+        MockCurrentUser.IsResolved.Returns(true);
+        MockCurrentUser.UserId.Returns(CurrentUserId);
+        Sut = new CatchService(
+            MockCatchRepository,
+            MockCurrentUser,
+            MockCatchLocationPrivacyService);
     }
 }

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingGetView.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingGetView.cs
@@ -1,0 +1,98 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Catches.Errors;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Services.CatchServiceTests;
+
+public class WhenTestingGetView : BaseCatchServiceTest
+{
+    [Fact]
+    public async Task ItShouldFailWhenTheCurrentUserIsNotResolved()
+    {
+        // Arrange
+        MockCurrentUser.IsResolved.Returns(false);
+        var args = new GetCatchArgs { CatchId = Guid.NewGuid() };
+
+        // Act
+        var result = await Sut.GetViewAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CurrentUserUnresolvedError>();
+        await MockCatchRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await MockCatchLocationPrivacyService.DidNotReceive().GetExposureAsync(
+            Arg.Any<Catch>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheCatchIsMissing()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        MockCatchRepository
+            .GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(null));
+
+        // Act
+        var result = await Sut.GetViewAsync(new GetCatchArgs { CatchId = catchId }, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CatchNotFoundError>();
+        await MockCatchLocationPrivacyService.DidNotReceive().GetExposureAsync(
+            Arg.Any<Catch>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShapeLocationUsingTheCurrentUserIdNotTheCatchOwner()
+    {
+        // Arrange
+        var ownerUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var catchRecord = new Catch
+        {
+            Id = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            UserId = ownerUserId,
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z")
+        };
+        MockCatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        MockCatchLocationPrivacyService
+            .GetExposureAsync(Arg.Any<Catch>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new CatchLocationExposureDto
+            {
+                Visibility = LocationDefaults.Private,
+                Mode = LocationDefaults.ExposureNone
+            });
+
+        // Act
+        var result = await Sut.GetViewAsync(
+            new GetCatchArgs { CatchId = catchRecord.Id },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.UserId.Should().Be(ownerUserId);
+        result.Value.Location!.Mode.Should().Be(LocationDefaults.ExposureNone);
+        await MockCatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
+        await MockCatchLocationPrivacyService.Received(1).GetExposureAsync(
+            Arg.Is<Catch>(item => item.Id == catchRecord.Id && item.UserId == ownerUserId),
+            CurrentUserId,
+            Arg.Any<CancellationToken>());
+        await MockCatchLocationPrivacyService.DidNotReceive().GetExposureAsync(
+            Arg.Any<Catch>(),
+            ownerUserId,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingUpdateLocationVisibility.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingUpdateLocationVisibility.cs
@@ -1,0 +1,154 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Catches.Errors;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Services.CatchServiceTests;
+
+public class WhenTestingUpdateLocationVisibility : BaseCatchServiceTest
+{
+    [Fact]
+    public async Task ItShouldFailWhenTheCurrentUserIsNotResolved()
+    {
+        // Arrange
+        MockCurrentUser.IsResolved.Returns(false);
+        var args = new UpdateCatchLocationVisibilityArgs
+        {
+            CatchId = Guid.NewGuid(),
+            Visibility = LocationDefaults.Public
+        };
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CurrentUserUnresolvedError>();
+        await MockCatchRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await MockCatchRepository.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<PersistCatchLocationVisibilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDenyWhenTheCurrentUserDoesNotOwnTheCatch()
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(Guid.Parse("22222222-2222-2222-2222-222222222222"));
+        MockCatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        var args = new UpdateCatchLocationVisibilityArgs
+        {
+            CatchId = catchRecord.Id,
+            Visibility = LocationDefaults.Public
+        };
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CatchNotOwnedError>();
+        await MockCatchRepository.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<PersistCatchLocationVisibilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectWhenTheCatchHasNoLocation()
+    {
+        // Arrange
+        var catchRecord = new Catch
+        {
+            Id = Guid.NewGuid(),
+            UserId = CurrentUserId,
+            CaughtOn = DateTimeOffset.UtcNow
+        };
+        MockCatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        var args = new UpdateCatchLocationVisibilityArgs
+        {
+            CatchId = catchRecord.Id,
+            Visibility = LocationDefaults.Approximate
+        };
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CatchHasNoLocationError>();
+        await MockCatchRepository.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<PersistCatchLocationVisibilityArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistVisibilityForTheOwnerWithoutChangingCoordinates()
+    {
+        // Arrange
+        var catchRecord = LocatedCatch(CurrentUserId);
+        MockCatchRepository
+            .GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(catchRecord));
+        MockCatchRepository
+            .UpdateLocationVisibilityAsync(Arg.Any<PersistCatchLocationVisibilityArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+        var args = new UpdateCatchLocationVisibilityArgs
+        {
+            CatchId = catchRecord.Id,
+            Visibility = LocationDefaults.Approximate
+        };
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockCatchRepository.Received(1).UpdateLocationVisibilityAsync(
+            Arg.Is<PersistCatchLocationVisibilityArgs>(persist =>
+                persist.CatchId == catchRecord.Id
+                && persist.UserId == CurrentUserId
+                && persist.Visibility == LocationDefaults.Approximate),
+            Arg.Any<CancellationToken>());
+        await MockCatchRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Catch>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static Catch LocatedCatch(Guid ownerUserId)
+    {
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        return new Catch
+        {
+            Id = catchId,
+            UserId = ownerUserId,
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            Location = CatchLocation.TryCreate(
+                53.2707,
+                -9.0568,
+                12,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion),
+            Photographs =
+            [
+                new CatchPhotograph
+                {
+                    Id = Guid.NewGuid(),
+                    CatchId = catchId,
+                    ContentType = "image/jpeg"
+                }
+            ]
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingUpsert.cs
@@ -139,6 +139,30 @@ public class WhenTestingUpsert : BaseCatchServiceTest
     }
 
     [Fact]
+    public async Task ItShouldFailWhenLocationVisibilityIsUnknown()
+    {
+        // Arrange
+        var args = Args(location: new CatchLocationDto(
+            53.2707,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            "FriendsOnly",
+            LocationDefaults.ConsentVersion));
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CatchLocationInvalidError>();
+        await MockCatchRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Catch>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldFailWhenLocationIsInvalid()
     {
         // Arrange

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/BaseCatchRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/BaseCatchRepositoryTest.cs
@@ -67,7 +67,8 @@ public abstract class BaseCatchRepositoryTest
     protected static CatchLocation SampleLocation(
         double latitude = 53.2707,
         double longitude = -9.0568,
-        double? accuracyMetres = 12)
+        double? accuracyMetres = 12,
+        string visibility = LocationDefaults.Private)
     {
         return CatchLocation.TryCreate(
             latitude,
@@ -75,7 +76,7 @@ public abstract class BaseCatchRepositoryTest
             accuracyMetres,
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             LocationDefaults.DeviceGps,
-            LocationDefaults.Private,
+            visibility,
             LocationDefaults.ConsentVersion)!;
     }
 

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpdateLocationVisibility.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpdateLocationVisibility.cs
@@ -1,0 +1,167 @@
+using AwesomeAssertions;
+using Dapper;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+using FishingLogBook.Shared.Dtos;
+using Npgsql;
+
+namespace FishingLogBook.Infrastructure.Tests.Integration.Catches.CatchRepositoryTests;
+
+[Collection(PostgresCollection.Name)]
+public class WhenTestingUpdateLocationVisibility : BaseCatchRepositoryTest
+{
+    public WhenTestingUpdateLocationVisibility(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheCatchIsMissing()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var args = new PersistCatchLocationVisibilityArgs
+        {
+            CatchId = Guid.NewGuid(),
+            UserId = userId,
+            Visibility = LocationDefaults.Public
+        };
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Failed to save the catch.");
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheCatchHasNoLocation()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var catchRecord = NewCatch(userId);
+        await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        var args = new PersistCatchLocationVisibilityArgs
+        {
+            CatchId = catchRecord.Id,
+            UserId = userId,
+            Visibility = LocationDefaults.Approximate
+        };
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        loaded.Value.Should().NotBeNull();
+        loaded.Value!.Location.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenAnotherUserOwnsTheCatch()
+    {
+        // Arrange
+        var ownerId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        var catchRecord = WithLocation(NewCatch(ownerId), SampleLocation());
+        await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        var args = new PersistCatchLocationVisibilityArgs
+        {
+            CatchId = catchRecord.Id,
+            UserId = otherUserId,
+            Visibility = LocationDefaults.Public
+        };
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        loaded.Value.Should().NotBeNull();
+        loaded.Value!.Location!.Visibility.Should().Be(LocationDefaults.Private);
+        loaded.Value.Location.Latitude.Should().Be(53.2707);
+        loaded.Value.Location.Longitude.Should().Be(-9.0568);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnknownVisibilityValue()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var catchRecord = WithLocation(NewCatch(userId), SampleLocation());
+        await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var act = () => connection.ExecuteAsync(
+            """
+            UPDATE "Catch"
+            SET "LocationVisibility" = @Visibility
+            WHERE "Id" = @Id;
+            """,
+            new { catchRecord.Id, Visibility = "FriendsOnly" });
+
+        // Act
+        // Assert
+        var exception = await act.Should().ThrowAsync<PostgresException>();
+        exception.Which.SqlState.Should().Be(PostgresErrorCodes.CheckViolation);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+        loaded.Value!.Location!.Visibility.Should().Be(LocationDefaults.Private);
+    }
+
+    [Theory]
+    [InlineData(LocationDefaults.Private)]
+    [InlineData(LocationDefaults.Approximate)]
+    [InlineData(LocationDefaults.FishingVenueOnly)]
+    [InlineData(LocationDefaults.Public)]
+    public async Task ItShouldRoundTripSupportedVisibilityWithoutChangingCoordinates(string visibility)
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var location = SampleLocation(visibility: LocationDefaults.Private);
+        var catchRecord = WithLocation(NewCatch(userId), location);
+        await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        var args = new PersistCatchLocationVisibilityArgs
+        {
+            CatchId = catchRecord.Id,
+            UserId = userId,
+            Visibility = visibility
+        };
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        loaded.Value.Should().NotBeNull();
+        loaded.Value!.Location.Should().NotBeNull();
+        loaded.Value.Location!.Visibility.Should().Be(visibility);
+        loaded.Value.Location.Latitude.Should().Be(location.Latitude);
+        loaded.Value.Location.Longitude.Should().Be(location.Longitude);
+        loaded.Value.Location.AccuracyMetres.Should().Be(location.AccuracyMetres);
+        loaded.Value.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        loaded.Value.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var row = await connection.QuerySingleAsync(
+            """
+            SELECT
+                "Latitude",
+                "Longitude",
+                "LocationAccuracyMetres",
+                "LocationCapturedOn",
+                "LocationSource",
+                "LocationVisibility",
+                "LocationConsentVersion"
+            FROM "Catch"
+            WHERE "Id" = @Id;
+            """,
+            new { catchRecord.Id });
+        ((double)row.Latitude).Should().Be(location.Latitude);
+        ((double)row.Longitude).Should().Be(location.Longitude);
+        ((string)row.LocationVisibility).Should().Be(visibility);
+        ((string)row.LocationSource).Should().Be(LocationDefaults.DeviceGps);
+        ((string)row.LocationConsentVersion).Should().Be(LocationDefaults.ConsentVersion);
+    }
+}

--- a/tests/FishingLogBook.Shared.Tests/Serialization/WhenTestingWebSerialization.cs
+++ b/tests/FishingLogBook.Shared.Tests/Serialization/WhenTestingWebSerialization.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
 
 namespace FishingLogBook.Shared.Tests.Serialization;
@@ -127,6 +128,83 @@ public class WhenTestingWebSerialization : BaseSerializationTest
         // Assert
         deserialized.Should().BeEquivalentTo(original);
         deserialized!.Location.Should().BeNull();
+    }
+
+    [Fact]
+    public void ItShouldOmitNullExactCoordinatesFromCatchLocationExposureDto()
+    {
+        // Arrange
+        var original = new CatchLocationExposureDto
+        {
+            Visibility = LocationDefaults.Private,
+            Mode = LocationDefaults.ExposureNone
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(original, WebOptions);
+        var deserialized = JsonSerializer.Deserialize<CatchLocationExposureDto>(json, WebOptions);
+
+        // Assert
+        json.Should().NotContain("\"latitude\":");
+        json.Should().NotContain("\"longitude\":");
+        json.Should().NotContain("53.2707");
+        json.Should().Contain("\"mode\":\"None\"");
+        deserialized.Should().NotBeNull();
+        deserialized!.Latitude.Should().BeNull();
+        deserialized.Mode.Should().Be(LocationDefaults.ExposureNone);
+    }
+
+    [Fact]
+    public void ItShouldSerializeApproximateCoordinatesWithoutExactFields()
+    {
+        // Arrange
+        var original = new CatchLocationExposureDto
+        {
+            Visibility = LocationDefaults.Approximate,
+            Mode = LocationDefaults.ExposureApproximate,
+            ApproximateLatitude = 53.275,
+            ApproximateLongitude = -9.075,
+            ApproximateCellSizeMetres = CatchLocationConstants.ApproximateCellSizeMetres
+        };
+
+        // Act
+        var json = JsonSerializer.Serialize(original, WebOptions);
+        var deserialized = JsonSerializer.Deserialize<CatchLocationExposureDto>(json, WebOptions);
+
+        // Assert
+        json.Should().NotContain("\"latitude\":");
+        json.Should().NotContain("\"longitude\":");
+        json.Should().Contain("\"approximateLatitude\":53.275");
+        json.Should().Contain("\"approximateLongitude\":-9.075");
+        deserialized.Should().NotBeNull();
+        deserialized!.ApproximateLatitude.Should().Be(53.275);
+        deserialized.Latitude.Should().BeNull();
+    }
+
+    [Fact]
+    public void ItShouldRoundTripCatchViewDtoUsingWebDefaults()
+    {
+        // Arrange
+        var original = new CatchViewDto(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            new CatchLocationExposureDto
+            {
+                Visibility = LocationDefaults.Public,
+                Mode = LocationDefaults.ExposureExact,
+                Latitude = 53.2707,
+                Longitude = -9.0568
+            });
+
+        // Act
+        var json = JsonSerializer.Serialize(original, WebOptions);
+        var deserialized = JsonSerializer.Deserialize<CatchViewDto>(json, WebOptions);
+
+        // Assert
+        json.Should().Contain("\"latitude\":53.2707");
+        deserialized.Should().BeEquivalentTo(original);
+        deserialized!.Location!.Latitude.Should().Be(53.2707);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Tests.Common.TestSupport;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
@@ -61,6 +62,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         injectedTypes.Should().Contain(typeof(ICultureService));
         injectedTypes.Should().Contain(typeof(ILoggingService));
         injectedTypes.Should().Contain(typeof(ILocationService));
+        injectedTypes.Should().Contain(typeof(ICatchClient));
         injectedTypes.Should().Contain(typeof(IStringLocalizer<UiStrings>));
         resolve.Should().NotThrow();
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
@@ -46,6 +46,7 @@ public class WhenTestingDeserialize : BaseCatchJsonTest
                 PhotographContentTypeConstants.Png,
                 PhotographContentTypeConstants.Webp);
         restored.Photographs.Should().OnlyContain(photograph => photograph.CatchId == catchId);
+        restored.UserId.Should().Be(Guid.Empty);
     }
 
     [Fact]
@@ -68,7 +69,31 @@ public class WhenTestingDeserialize : BaseCatchJsonTest
         // Assert
         restored.Id.Should().Be(catchId);
         restored.Location.Should().BeNull();
+        restored.UserId.Should().Be(Guid.Empty);
         restored.Photographs.Should().ContainSingle(photograph => photograph.Id == photographId);
+    }
+
+    [Fact]
+    public void ItShouldRoundTripTheOwnerUserId()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var photographId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var catchRecord = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])],
+            UserId: userId);
+
+        // Act
+        var json = CatchJson.SerializeMetadata(catchRecord);
+        var restored = CatchJson.Deserialize(json, catchRecord.Photographs);
+
+        // Assert
+        json.Should().Contain("\"userId\":\"11111111-1111-1111-1111-111111111111\"");
+        restored.UserId.Should().Be(userId);
+        restored.Id.Should().Be(catchId);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/BaseCatchStoreTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/BaseCatchStoreTest.cs
@@ -1,8 +1,13 @@
+using FishingLogBook.Web.Features.Catch.Models;
+
 namespace FishingLogBook.Web.Tests.Features.Catch.Offline.CatchStoreTests;
 
 public class BaseCatchStoreTest
 {
-    protected readonly Dictionary<Guid, FishingLogBook.Web.Features.Catch.Models.CatchModel> BackingCatches = [];
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    protected readonly Dictionary<Guid, CatchModel> BackingCatches = [];
     protected readonly Dictionary<Guid, byte[]> BackingPhotographs = [];
     protected readonly MemoryCatchStore Sut;
 

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/MemoryCatchStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/MemoryCatchStore.cs
@@ -55,7 +55,7 @@ public sealed class MemoryCatchStore : ICatchStore
         return Task.CompletedTask;
     }
 
-    public async Task<IReadOnlyList<CatchModel>> GetAllAsync(
+    public Task<IReadOnlyList<CatchModel>> GetAllAsync(
         Guid ownerUserId,
         CancellationToken cancellationToken)
     {
@@ -75,21 +75,6 @@ public sealed class MemoryCatchStore : ICatchStore
                     .ToArray()
             })
             .ToArray();
-        var visible = LocalCatchVisibility.ForOwner(items, ownerUserId);
-        var adopted = new List<CatchModel>(visible.Count);
-        foreach (var catchRecord in visible)
-        {
-            if (catchRecord.UserId != Guid.Empty)
-            {
-                adopted.Add(catchRecord);
-                continue;
-            }
-
-            var owned = catchRecord with { UserId = ownerUserId };
-            await SaveAsync(owned, cancellationToken);
-            adopted.Add(owned);
-        }
-
-        return adopted;
+        return Task.FromResult(LocalCatchVisibility.ForOwner(items, ownerUserId));
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/MemoryCatchStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/MemoryCatchStore.cs
@@ -25,6 +25,11 @@ public sealed class MemoryCatchStore : ICatchStore
 
     public Task SaveAsync(CatchModel catchRecord, CancellationToken cancellationToken)
     {
+        if (catchRecord.UserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch requires an owner.");
+        }
+
         if (catchRecord.Photographs.Count == 0
             || catchRecord.Photographs.Any(photograph => photograph.Bytes is not { Length: > 0 }))
         {
@@ -50,8 +55,15 @@ public sealed class MemoryCatchStore : ICatchStore
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyList<CatchModel>> GetAllAsync(CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<CatchModel>> GetAllAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
     {
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
         IReadOnlyList<CatchModel> items = _catches.Values
             .Select(catchRecord => catchRecord with
             {
@@ -63,6 +75,21 @@ public sealed class MemoryCatchStore : ICatchStore
                     .ToArray()
             })
             .ToArray();
-        return Task.FromResult(items);
+        var visible = LocalCatchVisibility.ForOwner(items, ownerUserId);
+        var adopted = new List<CatchModel>(visible.Count);
+        foreach (var catchRecord in visible)
+        {
+            if (catchRecord.UserId != Guid.Empty)
+            {
+                adopted.Add(catchRecord);
+                continue;
+            }
+
+            var owned = catchRecord with { UserId = ownerUserId };
+            await SaveAsync(owned, cancellationToken);
+            adopted.Add(owned);
+        }
+
+        return adopted;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingGetAll.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingGetAll.cs
@@ -81,35 +81,45 @@ public class WhenTestingGetAll : BaseCatchStoreTest
     }
 
     [Fact]
-    public async Task ItShouldAdoptUnscopedCatchesForTheFirstOwner()
+    public async Task ItShouldNotExposeOrAdoptAnUnscopedCatchWhenAnotherUserSignsInFirst()
     {
         // Arrange
-        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
-        var photographId = Guid.Parse("11111111-1111-1111-1111-111111111111");
-        BackingCatches[catchId] = new CatchModel(
-            catchId,
+        var unscopedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var unscopedPhoto = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var location = new CatchLocationModel(
+            53.2707,
+            -9.0568,
+            12,
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
-            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, null)]);
-        BackingPhotographs[photographId] = [4, 5, 6];
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        BackingCatches[unscopedId] = new CatchModel(
+            unscopedId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(unscopedPhoto, unscopedId, PhotographContentTypeConstants.Jpeg, null)],
+            Location: location);
+        BackingPhotographs[unscopedPhoto] = [4, 5, 6];
 
         // Act
-        var ownerView = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
-        var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
-        var afterReopen = await reopened.GetAllAsync(OwnerUserId, CancellationToken.None);
-        var otherView = await reopened.GetAllAsync(OtherUserId, CancellationToken.None);
+        var firstSignerView = await Sut.GetAllAsync(OtherUserId, CancellationToken.None);
+        var originalOwnerView = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
-        ownerView.Should().ContainSingle();
-        ownerView[0].Id.Should().Be(catchId);
-        ownerView[0].UserId.Should().Be(OwnerUserId);
-        ownerView[0].Photographs[0].Bytes.Should().Equal(4, 5, 6);
-        afterReopen.Should().ContainSingle();
-        afterReopen[0].UserId.Should().Be(OwnerUserId);
-        otherView.Should().BeEmpty();
+        firstSignerView.Should().BeEmpty();
+        originalOwnerView.Should().BeEmpty();
+        BackingCatches[unscopedId].UserId.Should().Be(Guid.Empty);
+        BackingCatches[unscopedId].Location.Should().Be(location);
+        BackingPhotographs[unscopedPhoto].Should().Equal(4, 5, 6);
+        firstSignerView.Should().NotContain(catchRecord => catchRecord.Id == unscopedId);
+        firstSignerView
+            .SelectMany(catchRecord => catchRecord.Photographs)
+            .Should()
+            .NotContain(photograph => photograph.Id == unscopedPhoto);
     }
 
     [Fact]
-    public async Task ItShouldNotAdoptUnscopedCatchesWhenAnotherOwnerAlreadyHasRecords()
+    public async Task ItShouldNotExposeUnscopedCatchesAlongsideOwnedRecords()
     {
         // Arrange
         var unscopedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
@@ -138,8 +148,12 @@ public class WhenTestingGetAll : BaseCatchStoreTest
 
         // Assert
         otherView.Should().BeEmpty();
-        ownerView.Select(catchRecord => catchRecord.Id).Should().BeEquivalentTo([ownerCatchId, unscopedId]);
-        ownerView.Should().OnlyContain(catchRecord => catchRecord.UserId == OwnerUserId);
+        ownerView.Should().ContainSingle();
+        ownerView[0].Id.Should().Be(ownerCatchId);
+        ownerView[0].UserId.Should().Be(OwnerUserId);
+        ownerView.Should().NotContain(catchRecord => catchRecord.Id == unscopedId);
+        BackingCatches[unscopedId].UserId.Should().Be(Guid.Empty);
+        BackingPhotographs[unscopedPhoto].Should().Equal(1);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingGetAll.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingGetAll.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.Catch.Models;
 
 namespace FishingLogBook.Web.Tests.Features.Catch.Offline.CatchStoreTests;
@@ -7,14 +8,138 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Offline.CatchStoreTests;
 public class WhenTestingGetAll : BaseCatchStoreTest
 {
     [Fact]
+    public async Task ItShouldRejectAnEmptyOwner()
+    {
+        // Arrange
+        // Act
+        var act = () => Sut.GetAllAsync(Guid.Empty, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
     public async Task ItShouldReturnAnEmptyListWhenNothingIsSaved()
     {
         // Arrange
         // Act
-        var saved = await Sut.GetAllAsync(CancellationToken.None);
+        var saved = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnAnotherUsersCatchOrPhotograph()
+    {
+        // Arrange
+        var ownerCatchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var otherCatchId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var ownerPhotoId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var otherPhotoId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var otherLocation = new CatchLocationModel(
+            53.2707,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        await Sut.SaveAsync(
+            new CatchModel(
+                ownerCatchId,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                [new CatchPhotographModel(ownerPhotoId, ownerCatchId, PhotographContentTypeConstants.Jpeg, [4, 5, 6])],
+                UserId: OwnerUserId),
+            CancellationToken.None);
+        await Sut.SaveAsync(
+            new CatchModel(
+                otherCatchId,
+                DateTimeOffset.Parse("2026-08-17T09:00:00Z"),
+                [new CatchPhotographModel(otherPhotoId, otherCatchId, PhotographContentTypeConstants.Jpeg, [7, 8, 9])],
+                Location: otherLocation,
+                UserId: OtherUserId),
+            CancellationToken.None);
+
+        // Act
+        var ownerView = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
+        var otherView = await Sut.GetAllAsync(OtherUserId, CancellationToken.None);
+
+        // Assert
+        ownerView.Should().ContainSingle();
+        ownerView[0].Id.Should().Be(ownerCatchId);
+        ownerView[0].UserId.Should().Be(OwnerUserId);
+        ownerView[0].Photographs[0].Id.Should().Be(ownerPhotoId);
+        ownerView[0].Photographs[0].Bytes.Should().Equal(4, 5, 6);
+        ownerView.Should().NotContain(catchRecord => catchRecord.Id == otherCatchId);
+        otherView.Should().ContainSingle();
+        otherView[0].Id.Should().Be(otherCatchId);
+        otherView[0].UserId.Should().Be(OtherUserId);
+        otherView[0].Location.Should().Be(otherLocation);
+        otherView[0].Photographs[0].Bytes.Should().Equal(7, 8, 9);
+        otherView.Should().NotContain(catchRecord => catchRecord.Id == ownerCatchId);
+    }
+
+    [Fact]
+    public async Task ItShouldAdoptUnscopedCatchesForTheFirstOwner()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var photographId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        BackingCatches[catchId] = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, null)]);
+        BackingPhotographs[photographId] = [4, 5, 6];
+
+        // Act
+        var ownerView = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
+        var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
+        var afterReopen = await reopened.GetAllAsync(OwnerUserId, CancellationToken.None);
+        var otherView = await reopened.GetAllAsync(OtherUserId, CancellationToken.None);
+
+        // Assert
+        ownerView.Should().ContainSingle();
+        ownerView[0].Id.Should().Be(catchId);
+        ownerView[0].UserId.Should().Be(OwnerUserId);
+        ownerView[0].Photographs[0].Bytes.Should().Equal(4, 5, 6);
+        afterReopen.Should().ContainSingle();
+        afterReopen[0].UserId.Should().Be(OwnerUserId);
+        otherView.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotAdoptUnscopedCatchesWhenAnotherOwnerAlreadyHasRecords()
+    {
+        // Arrange
+        var unscopedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var unscopedPhoto = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var ownerCatchId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        BackingCatches[unscopedId] = new CatchModel(
+            unscopedId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(unscopedPhoto, unscopedId, PhotographContentTypeConstants.Jpeg, null)]);
+        BackingPhotographs[unscopedPhoto] = [1];
+        await Sut.SaveAsync(
+            new CatchModel(
+                ownerCatchId,
+                DateTimeOffset.Parse("2026-08-17T09:00:00Z"),
+                [new CatchPhotographModel(
+                    Guid.Parse("22222222-2222-2222-2222-222222222222"),
+                    ownerCatchId,
+                    PhotographContentTypeConstants.Jpeg,
+                    [2])],
+                UserId: OwnerUserId),
+            CancellationToken.None);
+
+        // Act
+        var otherView = await Sut.GetAllAsync(OtherUserId, CancellationToken.None);
+        var ownerView = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        otherView.Should().BeEmpty();
+        ownerView.Select(catchRecord => catchRecord.Id).Should().BeEquivalentTo([ownerCatchId, unscopedId]);
+        ownerView.Should().OnlyContain(catchRecord => catchRecord.UserId == OwnerUserId);
     }
 
     [Fact]
@@ -27,15 +152,17 @@ public class WhenTestingGetAll : BaseCatchStoreTest
             new CatchModel(
                 catchId,
                 DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
-                [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [4, 5, 6])]),
+                [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [4, 5, 6])],
+                UserId: OwnerUserId),
             CancellationToken.None);
 
         // Act
-        var saved = await Sut.GetAllAsync(CancellationToken.None);
+        var saved = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().ContainSingle();
         saved[0].Id.Should().Be(catchId);
+        saved[0].UserId.Should().Be(OwnerUserId);
         saved[0].Photographs[0].Id.Should().Be(photographId);
         saved[0].Photographs[0].Bytes.Should().Equal(4, 5, 6);
     }
@@ -56,16 +183,18 @@ public class WhenTestingGetAll : BaseCatchStoreTest
                     new CatchPhotographModel(photoA, catchId, PhotographContentTypeConstants.Jpeg, [1, 1, 1]),
                     new CatchPhotographModel(photoB, catchId, PhotographContentTypeConstants.Png, [2, 2, 2]),
                     new CatchPhotographModel(photoC, catchId, PhotographContentTypeConstants.Webp, [3, 3, 3])
-                ]),
+                ],
+                UserId: OwnerUserId),
             CancellationToken.None);
         var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
 
         // Act
-        var saved = await reopened.GetAllAsync(CancellationToken.None);
+        var saved = await reopened.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().ContainSingle();
         saved[0].Id.Should().Be(catchId);
+        saved[0].UserId.Should().Be(OwnerUserId);
         saved[0].Photographs.Select(photograph => photograph.Id).Should().Equal(photoA, photoB, photoC);
         saved[0].Photographs.Select(photograph => photograph.CatchId).Should().OnlyContain(id => id == catchId);
         saved[0].Photographs[0].Bytes.Should().Equal(1, 1, 1);

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingGetAll.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingGetAll.cs
@@ -81,35 +81,40 @@ public class WhenTestingGetAll : BaseCatchStoreTest
     }
 
     [Fact]
-    public async Task ItShouldAdoptUnscopedCatchesForTheFirstOwner()
+    public async Task ItShouldNotExposeOrAdoptALegacyUnownedCatchWhenAnotherUserSignsInFirst()
     {
         // Arrange
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var photographId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var location = new CatchLocationModel(
+            53.2707,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
         BackingCatches[catchId] = new CatchModel(
             catchId,
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
-            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, null)]);
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, null)],
+            Location: location);
         BackingPhotographs[photographId] = [4, 5, 6];
 
         // Act
-        var ownerView = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
-        var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
-        var afterReopen = await reopened.GetAllAsync(OwnerUserId, CancellationToken.None);
-        var otherView = await reopened.GetAllAsync(OtherUserId, CancellationToken.None);
+        var firstSignedIn = await Sut.GetAllAsync(OtherUserId, CancellationToken.None);
+        var originalOwner = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
-        ownerView.Should().ContainSingle();
-        ownerView[0].Id.Should().Be(catchId);
-        ownerView[0].UserId.Should().Be(OwnerUserId);
-        ownerView[0].Photographs[0].Bytes.Should().Equal(4, 5, 6);
-        afterReopen.Should().ContainSingle();
-        afterReopen[0].UserId.Should().Be(OwnerUserId);
-        otherView.Should().BeEmpty();
+        firstSignedIn.Should().BeEmpty();
+        originalOwner.Should().BeEmpty();
+        BackingCatches[catchId].UserId.Should().Be(Guid.Empty);
+        BackingCatches[catchId].Location.Should().Be(location);
+        BackingPhotographs[photographId].Should().Equal(4, 5, 6);
     }
 
     [Fact]
-    public async Task ItShouldNotAdoptUnscopedCatchesWhenAnotherOwnerAlreadyHasRecords()
+    public async Task ItShouldNotExposeALegacyUnownedCatchAlongsideOwnedRecords()
     {
         // Arrange
         var unscopedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
@@ -138,8 +143,10 @@ public class WhenTestingGetAll : BaseCatchStoreTest
 
         // Assert
         otherView.Should().BeEmpty();
-        ownerView.Select(catchRecord => catchRecord.Id).Should().BeEquivalentTo([ownerCatchId, unscopedId]);
-        ownerView.Should().OnlyContain(catchRecord => catchRecord.UserId == OwnerUserId);
+        ownerView.Should().ContainSingle();
+        ownerView[0].Id.Should().Be(ownerCatchId);
+        ownerView[0].UserId.Should().Be(OwnerUserId);
+        BackingCatches[unscopedId].UserId.Should().Be(Guid.Empty);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingSave.cs
@@ -11,14 +11,32 @@ public class WhenTestingSave : BaseCatchStoreTest
     public async Task ItShouldRejectACatchWithoutPhotographs()
     {
         // Arrange
-        var catchRecord = new CatchModel(Guid.NewGuid(), DateTimeOffset.UtcNow, []);
+        var catchRecord = new CatchModel(Guid.NewGuid(), DateTimeOffset.UtcNow, [], UserId: OwnerUserId);
 
         // Act
         var act = () => Sut.SaveAsync(catchRecord, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<InvalidOperationException>();
-        (await Sut.GetAllAsync(CancellationToken.None)).Should().BeEmpty();
+        (await Sut.GetAllAsync(OwnerUserId, CancellationToken.None)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchWithoutAnOwner()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var catchRecord = new CatchModel(
+            catchId,
+            DateTimeOffset.UtcNow,
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1, 2, 3])]);
+
+        // Act
+        var act = () => Sut.SaveAsync(catchRecord, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        (await Sut.GetAllAsync(OwnerUserId, CancellationToken.None)).Should().BeEmpty();
     }
 
     [Fact]
@@ -31,14 +49,15 @@ public class WhenTestingSave : BaseCatchStoreTest
         var catchRecord = new CatchModel(
             catchId,
             DateTimeOffset.UtcNow,
-            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1, 2, 3])]);
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1, 2, 3])],
+            UserId: OwnerUserId);
 
         // Act
         var act = () => Sut.SaveAsync(catchRecord, CancellationToken.None);
 
         // Assert
         await act.Should().ThrowAsync<InvalidOperationException>();
-        (await Sut.GetAllAsync(CancellationToken.None)).Should().BeEmpty();
+        (await Sut.GetAllAsync(OwnerUserId, CancellationToken.None)).Should().BeEmpty();
     }
 
     [Fact]
@@ -50,12 +69,13 @@ public class WhenTestingSave : BaseCatchStoreTest
         var catchRecord = new CatchModel(
             catchId,
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
-            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Png, [9, 8, 7])]);
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Png, [9, 8, 7])],
+            UserId: OwnerUserId);
         await Sut.SaveAsync(catchRecord, CancellationToken.None);
         var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
 
         // Act
-        var saved = await reopened.GetAllAsync(CancellationToken.None);
+        var saved = await reopened.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().ContainSingle();
@@ -64,6 +84,7 @@ public class WhenTestingSave : BaseCatchStoreTest
         saved[0].Photographs[0].Id.Should().Be(photographId);
         saved[0].Photographs[0].Bytes.Should().Equal(9, 8, 7);
         saved[0].SpeciesName.Should().BeNull();
+        saved[0].UserId.Should().Be(OwnerUserId);
     }
 
     [Fact]
@@ -78,7 +99,8 @@ public class WhenTestingSave : BaseCatchStoreTest
             new CatchModel(
                 firstId,
                 DateTimeOffset.UtcNow,
-                [new CatchPhotographModel(firstPhoto, firstId, PhotographContentTypeConstants.Jpeg, [1])]),
+                [new CatchPhotographModel(firstPhoto, firstId, PhotographContentTypeConstants.Jpeg, [1])],
+                UserId: OwnerUserId),
             CancellationToken.None);
 
         // Act
@@ -86,9 +108,10 @@ public class WhenTestingSave : BaseCatchStoreTest
             new CatchModel(
                 secondId,
                 DateTimeOffset.UtcNow,
-                [new CatchPhotographModel(secondPhoto, secondId, PhotographContentTypeConstants.Jpeg, [2])]),
+                [new CatchPhotographModel(secondPhoto, secondId, PhotographContentTypeConstants.Jpeg, [2])],
+                UserId: OwnerUserId),
             CancellationToken.None);
-        var saved = await Sut.GetAllAsync(CancellationToken.None);
+        var saved = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().HaveCount(2);
@@ -116,12 +139,13 @@ public class WhenTestingSave : BaseCatchStoreTest
                     new CatchPhotographModel(photoA, catchId, PhotographContentTypeConstants.Jpeg, [10]),
                     new CatchPhotographModel(photoB, catchId, PhotographContentTypeConstants.Png, [20]),
                     new CatchPhotographModel(photoC, catchId, PhotographContentTypeConstants.Webp, [30])
-                ]),
+                ],
+                UserId: OwnerUserId),
             CancellationToken.None);
         var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
 
         // Act
-        var saved = await reopened.GetAllAsync(CancellationToken.None);
+        var saved = await reopened.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().ContainSingle();
@@ -144,12 +168,13 @@ public class WhenTestingSave : BaseCatchStoreTest
             new CatchModel(
                 catchId,
                 DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
-                [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])]),
+                [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])],
+                UserId: OwnerUserId),
             CancellationToken.None);
         var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
 
         // Act
-        var saved = await reopened.GetAllAsync(CancellationToken.None);
+        var saved = await reopened.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().ContainSingle();
@@ -176,12 +201,13 @@ public class WhenTestingSave : BaseCatchStoreTest
                 catchId,
                 DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
                 [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])],
-                Location: location),
+                Location: location,
+                UserId: OwnerUserId),
             CancellationToken.None);
         var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
 
         // Act
-        var saved = await reopened.GetAllAsync(CancellationToken.None);
+        var saved = await reopened.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().ContainSingle();
@@ -218,7 +244,8 @@ public class WhenTestingSave : BaseCatchStoreTest
                 firstId,
                 DateTimeOffset.UtcNow,
                 [new CatchPhotographModel(Guid.NewGuid(), firstId, PhotographContentTypeConstants.Jpeg, [1])],
-                Location: firstLocation),
+                Location: firstLocation,
+                UserId: OwnerUserId),
             CancellationToken.None);
 
         // Act
@@ -227,9 +254,10 @@ public class WhenTestingSave : BaseCatchStoreTest
                 secondId,
                 DateTimeOffset.UtcNow,
                 [new CatchPhotographModel(Guid.NewGuid(), secondId, PhotographContentTypeConstants.Jpeg, [2])],
-                Location: secondLocation),
+                Location: secondLocation,
+                UserId: OwnerUserId),
             CancellationToken.None);
-        var saved = await Sut.GetAllAsync(CancellationToken.None);
+        var saved = await Sut.GetAllAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
         saved.Should().HaveCount(2);

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/LocalCatchVisibilityTests/BaseLocalCatchVisibilityTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/LocalCatchVisibilityTests/BaseLocalCatchVisibilityTest.cs
@@ -1,0 +1,28 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Models;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.LocalCatchVisibilityTests;
+
+public class BaseLocalCatchVisibilityTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    protected static CatchModel CatchFor(
+        Guid catchId,
+        Guid userId,
+        CatchLocationModel? location = null)
+    {
+        return new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(
+                Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                catchId,
+                PhotographContentTypeConstants.Jpeg,
+                [1])],
+            Location: location,
+            UserId: userId);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/LocalCatchVisibilityTests/BaseLocalCatchVisibilityTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/LocalCatchVisibilityTests/BaseLocalCatchVisibilityTest.cs
@@ -1,0 +1,19 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Models;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.LocalCatchVisibilityTests;
+
+public class BaseLocalCatchVisibilityTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    protected static CatchModel CatchFor(Guid catchId, Guid userId)
+    {
+        return new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1])],
+            UserId: userId);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/LocalCatchVisibilityTests/WhenTestingForOwner.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/LocalCatchVisibilityTests/WhenTestingForOwner.cs
@@ -1,0 +1,76 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.Catch.Offline;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.LocalCatchVisibilityTests;
+
+public class WhenTestingForOwner : BaseLocalCatchVisibilityTest
+{
+    [Fact]
+    public void ItShouldHideUnscopedCatchesFromTheFirstSignedInUser()
+    {
+        // Arrange
+        var unscoped = CatchFor(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Guid.Empty);
+
+        // Act
+        var visible = LocalCatchVisibility.ForOwner([unscoped], OtherUserId);
+
+        // Assert
+        visible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItShouldHideAnotherUsersCatch()
+    {
+        // Arrange
+        var ownedByOther = CatchFor(Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), OtherUserId);
+
+        // Act
+        var visible = LocalCatchVisibility.ForOwner([ownedByOther], OwnerUserId);
+
+        // Assert
+        visible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItShouldHideUnscopedCatchesEvenWhenTheCallerAlsoHasOwnedRecords()
+    {
+        // Arrange
+        var unscoped = CatchFor(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Guid.Empty);
+        var owned = CatchFor(Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), OwnerUserId);
+
+        // Act
+        var visible = LocalCatchVisibility.ForOwner([unscoped, owned], OwnerUserId);
+
+        // Assert
+        visible.Should().ContainSingle();
+        visible[0].Id.Should().Be(owned.Id);
+        visible[0].UserId.Should().Be(OwnerUserId);
+    }
+
+    [Fact]
+    public void ItShouldReturnNothingWhenTheOwnerIdIsEmpty()
+    {
+        // Arrange
+        var owned = CatchFor(Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), OwnerUserId);
+
+        // Act
+        var visible = LocalCatchVisibility.ForOwner([owned], Guid.Empty);
+
+        // Assert
+        visible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItShouldReturnCatchesOwnedByTheCaller()
+    {
+        // Arrange
+        var owned = CatchFor(Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), OwnerUserId);
+
+        // Act
+        var visible = LocalCatchVisibility.ForOwner([owned], OwnerUserId);
+
+        // Assert
+        visible.Should().ContainSingle();
+        visible[0].Should().Be(owned);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/LocalCatchVisibilityTests/WhenTestingForOwner.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/LocalCatchVisibilityTests/WhenTestingForOwner.cs
@@ -1,0 +1,76 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Offline;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.LocalCatchVisibilityTests;
+
+public class WhenTestingForOwner : BaseLocalCatchVisibilityTest
+{
+    [Fact]
+    public void ItShouldReturnNothingWhenTheOwnerIsEmpty()
+    {
+        // Arrange
+        var records = new[]
+        {
+            CatchFor(Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), OwnerUserId)
+        };
+
+        // Act
+        var visible = LocalCatchVisibility.ForOwner(records, Guid.Empty);
+
+        // Assert
+        visible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItShouldNotExposeALegacyUnownedCatchToTheFirstSignedInUser()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var location = new CatchLocationModel(
+            53.2707,
+            -9.0568,
+            12,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        var records = new[]
+        {
+            CatchFor(catchId, Guid.Empty, location)
+        };
+
+        // Act
+        var firstSignedIn = LocalCatchVisibility.ForOwner(records, OtherUserId);
+        var originalOwner = LocalCatchVisibility.ForOwner(records, OwnerUserId);
+
+        // Assert
+        firstSignedIn.Should().BeEmpty();
+        originalOwner.Should().BeEmpty();
+        records[0].UserId.Should().Be(Guid.Empty);
+        records[0].Location.Should().Be(location);
+    }
+
+    [Fact]
+    public void ItShouldKeepCatchesAlreadyOwnedByTheSignedInUser()
+    {
+        // Arrange
+        var ownedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var otherId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var unscopedId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var records = new[]
+        {
+            CatchFor(ownedId, OwnerUserId),
+            CatchFor(otherId, OtherUserId),
+            CatchFor(unscopedId, Guid.Empty)
+        };
+
+        // Act
+        var visible = LocalCatchVisibility.ForOwner(records, OwnerUserId);
+
+        // Assert
+        visible.Should().ContainSingle();
+        visible[0].Id.Should().Be(ownedId);
+        visible[0].UserId.Should().Be(OwnerUserId);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/BaseCatchListTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/BaseCatchListTest.cs
@@ -1,5 +1,6 @@
 using Bunit;
 using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
@@ -9,14 +10,25 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchListTests;
 
 public class BaseCatchListTest
 {
-    protected static BunitContext CreateContext(ICatchStore store)
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    protected static BunitContext CreateContext(ICatchStore store, ILocalCatchOwnerService? owner = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
         context.Services.AddSingleton(store);
+        context.Services.AddSingleton(owner ?? SignedInOwner());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
+    }
+
+    protected static ILocalCatchOwnerService SignedInOwner()
+    {
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(OwnerUserId);
+        return owner;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingRender.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.CatchList;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Authorization;
 using NSubstitute;
@@ -40,7 +41,7 @@ public class WhenTestingRender : BaseCatchListTest
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1, 2, 3])]);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
         await using var context = CreateContext(store);
 
@@ -55,7 +56,7 @@ public class WhenTestingRender : BaseCatchListTest
             cut.Find($"#catch-thumb-{catchId:D}").GetAttribute("src").Should().StartWith("data:image/jpeg;base64,");
             cut.Find($"#catch-time-{catchId:D}").TextContent.Should().NotBeNullOrWhiteSpace();
         });
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -86,7 +87,7 @@ public class WhenTestingRender : BaseCatchListTest
                     [7, 8, 9])
             ]);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
         await using var context = CreateContext(store);
 
@@ -100,7 +101,7 @@ public class WhenTestingRender : BaseCatchListTest
                 .Should()
                 .Be($"data:image/jpeg;base64,{Convert.ToBase64String(new byte[] { 1, 2, 3 })}");
         });
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -114,7 +115,7 @@ public class WhenTestingRender : BaseCatchListTest
             DateTimeOffset.UtcNow,
             [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1])]);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
         await using var context = CreateContext(store);
 
@@ -125,7 +126,7 @@ public class WhenTestingRender : BaseCatchListTest
         cut.WaitForAssertion(() =>
             cut.Find($"#catch-label-{catchId:D}").TextContent.Should().Contain("Prise"));
         cut.FindAll("#catch-list-empty").Should().BeEmpty();
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -134,7 +135,7 @@ public class WhenTestingRender : BaseCatchListTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([]));
         await using var context = CreateContext(store);
 
@@ -144,7 +145,7 @@ public class WhenTestingRender : BaseCatchListTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#catch-list-empty").TextContent.Should().Contain("No catches saved"));
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -153,7 +154,7 @@ public class WhenTestingRender : BaseCatchListTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
         await using var context = CreateContext(store);
 
@@ -163,7 +164,7 @@ public class WhenTestingRender : BaseCatchListTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#catch-list-load-failed").TextContent.Should().Contain("could not be loaded"));
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -185,7 +186,7 @@ public class WhenTestingRender : BaseCatchListTest
                 LocationDefaults.Private,
                 LocationDefaults.ConsentVersion));
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
         await using var context = CreateContext(store);
 
@@ -201,7 +202,7 @@ public class WhenTestingRender : BaseCatchListTest
         });
         cut.Markup.Should().NotContain("53.2707");
         cut.Markup.Should().NotContain("-9.0568");
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -215,7 +216,7 @@ public class WhenTestingRender : BaseCatchListTest
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1])]);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
         await using var context = CreateContext(store);
 
@@ -226,7 +227,7 @@ public class WhenTestingRender : BaseCatchListTest
         cut.WaitForAssertion(() => cut.Find($"#catch-row-{catchId:D}").Should().NotBeNull());
         cut.FindAll($"#catch-location-privacy-{catchId:D}").Should().BeEmpty();
         cut.Markup.Should().NotContain("/location-privacy");
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -248,7 +249,7 @@ public class WhenTestingRender : BaseCatchListTest
                 LocationDefaults.Private,
                 LocationDefaults.ConsentVersion));
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
         await using var context = CreateContext(store);
 
@@ -261,6 +262,69 @@ public class WhenTestingRender : BaseCatchListTest
                 .Should()
                 .Contain("Confidentialité de la localisation"));
         cut.Markup.Should().NotContain("53.2707");
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotShowAnotherUsersCatchAfterAccountSwitch()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var ownerCatchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var stored = new CatchModel(
+            ownerCatchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(Guid.NewGuid(), ownerCatchId, PhotographContentTypeConstants.Jpeg, [1, 2, 3])],
+            Location: new CatchLocationModel(
+                53.2707,
+                -9.0568,
+                12,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion),
+            UserId: OwnerUserId);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
+        store.GetAllAsync(OtherUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([]));
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(OtherUserId);
+        await using var context = CreateContext(store, owner);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-list-empty").TextContent.Should().Contain("No catches saved"));
+        cut.FindAll($"#catch-row-{ownerCatchId:D}").Should().BeEmpty();
+        cut.Markup.Should().NotContain("53.2707");
+        cut.Markup.Should().NotContain("/location-privacy");
+        await owner.Received(1).GetUserIdAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OtherUserId, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowLoadFailedCopyWhenTheOwnerCannotBeResolved()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("The current user is not signed in."));
+        await using var context = CreateContext(store, owner);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-list-load-failed").TextContent.Should().Contain("could not be loaded"));
+        await owner.Received(1).GetUserIdAsync(Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetAllAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingRender.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.CatchList;
@@ -162,6 +163,104 @@ public class WhenTestingRender : BaseCatchListTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#catch-list-load-failed").TextContent.Should().Contain("could not be loaded"));
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheLocationPrivacyLinkWhenTheCatchHasALocation()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var stored = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1, 2, 3])],
+            Location: new CatchLocationModel(
+                53.2707,
+                -9.0568,
+                12,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion));
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            var link = cut.Find($"#catch-location-privacy-{catchId:D}");
+            link.TextContent.Should().Contain("Location privacy");
+            link.GetAttribute("href").Should().Be($"/catches/{catchId:D}/location-privacy");
+        });
+        cut.Markup.Should().NotContain("53.2707");
+        cut.Markup.Should().NotContain("-9.0568");
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOmitTheLocationPrivacyLinkWhenTheCatchHasNoLocation()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var stored = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1])]);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find($"#catch-row-{catchId:D}").Should().NotBeNull());
+        cut.FindAll($"#catch-location-privacy-{catchId:D}").Should().BeEmpty();
+        cut.Markup.Should().NotContain("/location-privacy");
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheFrenchLocationPrivacyLink()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var stored = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1])],
+            Location: new CatchLocationModel(
+                53.2707,
+                -9.0568,
+                12,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion));
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([stored]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-location-privacy-{catchId:D}").TextContent
+                .Should()
+                .Contain("Confidentialité de la localisation"));
+        cut.Markup.Should().NotContain("53.2707");
         await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
@@ -1,0 +1,51 @@
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchLocationPrivacyTests;
+
+public class BaseCatchLocationPrivacyTest
+{
+    protected static BunitContext CreateContext(ICatchStore store, ICatchClient? client = null)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(store);
+        context.Services.AddSingleton(client ?? Substitute.For<ICatchClient>());
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+
+    protected static CatchModel LocatedCatch(Guid catchId, CatchLocationModel? location)
+    {
+        return new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1])],
+            Location: location);
+    }
+
+    protected static CatchModel LocatedCatch(Guid catchId)
+    {
+        return LocatedCatch(
+            catchId,
+            new CatchLocationModel(
+                53.2707,
+                -9.0568,
+                12,
+                DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion));
+    }
+}
+

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
@@ -13,7 +13,10 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchLocationPrivacyTest
 
 public class BaseCatchLocationPrivacyTest
 {
-    protected static BunitContext CreateContext(ICatchStore store, ICatchClient? client = null)
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    protected static BunitContext CreateContext(ICatchStore store, ICatchClient? client = null, ILocalCatchOwnerService? owner = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -21,8 +24,16 @@ public class BaseCatchLocationPrivacyTest
         context.Services.AddLocalization();
         context.Services.AddSingleton(store);
         context.Services.AddSingleton(client ?? Substitute.For<ICatchClient>());
+        context.Services.AddSingleton(owner ?? SignedInOwner());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
+    }
+
+    protected static ILocalCatchOwnerService SignedInOwner()
+    {
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(OwnerUserId);
+        return owner;
     }
 
     protected static CatchModel LocatedCatch(Guid catchId, CatchLocationModel? location)
@@ -31,7 +42,8 @@ public class BaseCatchLocationPrivacyTest
             catchId,
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1])],
-            Location: location);
+            Location: location,
+            UserId: OwnerUserId);
     }
 
     protected static CatchModel LocatedCatch(Guid catchId, string visibility = LocationDefaults.Private)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
@@ -34,7 +34,7 @@ public class BaseCatchLocationPrivacyTest
             Location: location);
     }
 
-    protected static CatchModel LocatedCatch(Guid catchId)
+    protected static CatchModel LocatedCatch(Guid catchId, string visibility = LocationDefaults.Private)
     {
         return LocatedCatch(
             catchId,
@@ -44,8 +44,7 @@ public class BaseCatchLocationPrivacyTest
                 12,
                 DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
                 LocationDefaults.DeviceGps,
-                LocationDefaults.Private,
+                visibility,
                 LocationDefaults.ConsentVersion));
     }
 }
-

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
@@ -34,7 +34,7 @@ public class BaseCatchLocationPrivacyTest
             Location: location);
     }
 
-    protected static CatchModel LocatedCatch(Guid catchId)
+    protected static CatchModel LocatedCatch(Guid catchId, string visibility = LocationDefaults.Private)
     {
         return LocatedCatch(
             catchId,
@@ -44,7 +44,7 @@ public class BaseCatchLocationPrivacyTest
                 12,
                 DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
                 LocationDefaults.DeviceGps,
-                LocationDefaults.Private,
+                visibility,
                 LocationDefaults.ConsentVersion));
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingRender.cs
@@ -36,7 +36,7 @@ public class WhenTestingRender : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId, location: null)]));
         var client = Substitute.For<ICatchClient>();
         await using var context = CreateContext(store, client);
@@ -50,7 +50,7 @@ public class WhenTestingRender : BaseCatchLocationPrivacyTest
                 .Should()
                 .Contain("This catch has no saved location"));
         cut.FindAll("#catch-location-privacy-options").Should().BeEmpty();
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
         await client.DidNotReceive().UpdateLocationVisibilityAsync(
             Arg.Any<Guid>(),
             Arg.Any<string>(),
@@ -64,7 +64,7 @@ public class WhenTestingRender : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
         await using var context = CreateContext(store);
 
@@ -88,7 +88,7 @@ public class WhenTestingRender : BaseCatchLocationPrivacyTest
         cut.FindAll("#catch-location-privacy-public-warning").Should().BeEmpty();
         cut.Markup.Should().NotContain("53.2707");
         cut.Markup.Should().NotContain("-9.0568");
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public class WhenTestingRender : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.French);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
         await using var context = CreateContext(store);
 
@@ -117,7 +117,7 @@ public class WhenTestingRender : BaseCatchLocationPrivacyTest
             options.Should().Contain("Site de pêche uniquement");
             options.Should().Contain("Position exacte publique");
         });
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class WhenTestingRender : BaseCatchLocationPrivacyTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
         await using var context = CreateContext(store);
 
@@ -139,6 +139,43 @@ public class WhenTestingRender : BaseCatchLocationPrivacyTest
             cut.Find("#catch-location-privacy-load-failed").TextContent
                 .Should()
                 .Contain("This catch could not be loaded"));
-        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotLoadAnotherUsersCatchOrCoordinates()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OtherUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([]));
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(OtherUserId);
+        var client = Substitute.For<ICatchClient>();
+        await using var context = CreateContext(store, client, owner);
+
+        // Act
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-load-failed").TextContent
+                .Should()
+                .Contain("This catch could not be loaded"));
+        cut.FindAll("#catch-location-privacy-options").Should().BeEmpty();
+        cut.FindAll("#catch-location-privacy-no-location").Should().BeEmpty();
+        cut.Markup.Should().NotContain("53.2707");
+        cut.Markup.Should().NotContain("-9.0568");
+        await owner.Received(1).GetUserIdAsync(Arg.Any<CancellationToken>());
+        await store.Received(1).GetAllAsync(OtherUserId, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await client.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingRender.cs
@@ -1,0 +1,144 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Pages.CatchLocationPrivacy;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchLocationPrivacyTests;
+
+public class WhenTestingRender : BaseCatchLocationPrivacyTest
+{
+    [Fact]
+    public void ItShouldRequireAnAuthenticatedUser()
+    {
+        // Arrange
+        // Act
+        var authorize = typeof(CatchLocationPrivacy)
+            .GetCustomAttributes(inherit: true)
+            .OfType<AuthorizeAttribute>()
+            .SingleOrDefault();
+
+        // Assert
+        authorize.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheNoLocationMessageWhenTheCatchHasNoCoordinates()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId, location: null)]));
+        var client = Substitute.For<ICatchClient>();
+        await using var context = CreateContext(store, client);
+
+        // Act
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-no-location").TextContent
+                .Should()
+                .Contain("This catch has no saved location"));
+        cut.FindAll("#catch-location-privacy-options").Should().BeEmpty();
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        await client.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowEnglishVisibilityOptionsWithoutRawCoordinates()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-location-privacy-title").TextContent.Should().Contain("Location privacy");
+            cut.Find("#catch-location-privacy-private").Should().NotBeNull();
+            cut.Find("#catch-location-privacy-approximate").Should().NotBeNull();
+            cut.Find("#catch-location-privacy-venue").Should().NotBeNull();
+            cut.Find("#catch-location-privacy-public").Should().NotBeNull();
+            var options = cut.Find("#catch-location-privacy-options").TextContent;
+            options.Should().Contain("Only me");
+            options.Should().Contain("Approximate area");
+            options.Should().Contain("Fishing venue only");
+            options.Should().Contain("Public exact location");
+        });
+        cut.FindAll("#catch-location-privacy-public-warning").Should().BeEmpty();
+        cut.Markup.Should().NotContain("53.2707");
+        cut.Markup.Should().NotContain("-9.0568");
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchVisibilityOptions()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var catchId = Guid.NewGuid();
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-location-privacy-title").TextContent
+                .Should()
+                .Contain("Confidentialité de la localisation");
+            var options = cut.Find("#catch-location-privacy-options").TextContent;
+            options.Should().Contain("Moi uniquement");
+            options.Should().Contain("Zone approximative");
+            options.Should().Contain("Site de pêche uniquement");
+            options.Should().Contain("Position exacte publique");
+        });
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowLoadFailedCopyWhenTheStoreFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchLocationPrivacy>(parameters =>
+            parameters.Add(p => p.CatchId, Guid.NewGuid()));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-load-failed").TextContent
+                .Should()
+                .Contain("This catch could not be loaded"));
+        await store.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
@@ -1,0 +1,190 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Pages.CatchLocationPrivacy;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchLocationPrivacyTests;
+
+public class WhenTestingSave : BaseCatchLocationPrivacyTest
+{
+    [Fact]
+    public async Task ItShouldNotSaveWhenTheCatchHasNoLocation()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
+                [LocatedCatch(catchId, location: null)]));
+        var client = Substitute.For<ICatchClient>();
+        await using var context = CreateContext(store, client);
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-no-location").Should().NotBeNull());
+
+        // Act
+        cut.FindAll("#catch-location-privacy-save").Should().BeEmpty();
+
+        // Assert
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+        await client.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowThePublicWarningBeforeSaving()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        var client = Substitute.For<ICatchClient>();
+        await using var context = CreateContext(store, client);
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-public").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#catch-location-privacy-public").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-public-warning").TextContent
+                .Should()
+                .Contain("Anyone who can view this catch may see the exact fishing spot"));
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+        await client.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowSaveFailedWhenTheStoreFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
+        var client = Substitute.For<ICatchClient>();
+        await using var context = CreateContext(store, client);
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-save").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#catch-location-privacy-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-save-failed").TextContent
+                .Should()
+                .Contain("Location privacy could not be saved"));
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Id == catchId
+                && catchRecord.Location != null
+                && catchRecord.Location.Visibility == LocationDefaults.Private
+                && catchRecord.Location.Latitude == 53.2707
+                && catchRecord.Location.Longitude == -9.0568),
+            Arg.Any<CancellationToken>());
+        await client.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowSaveFailedWhenTheApiClientFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var client = Substitute.For<ICatchClient>();
+        client.UpdateLocationVisibilityAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException());
+        await using var context = CreateContext(store, client);
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-save").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#catch-location-privacy-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-save-failed").TextContent
+                .Should()
+                .Contain("Location privacy could not be saved"));
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Id == catchId
+                && catchRecord.Location != null
+                && catchRecord.Location.Visibility == LocationDefaults.Private
+                && catchRecord.Location.Latitude == 53.2707),
+            Arg.Any<CancellationToken>());
+        await client.Received(1).UpdateLocationVisibilityAsync(
+            catchId,
+            LocationDefaults.Private,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldUpdateLocalVisibilityOnlyAndPatchTheServer()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var client = Substitute.For<ICatchClient>();
+        client.UpdateLocationVisibilityAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        await using var context = CreateContext(store, client);
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-public").Should().NotBeNull());
+        await cut.Find("#catch-location-privacy-public").ClickAsync();
+
+        // Act
+        await cut.Find("#catch-location-privacy-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-saved").TextContent.Should().Contain("Location privacy saved"));
+        cut.Markup.Should().NotContain("53.2707");
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Id == catchId
+                && catchRecord.Location != null
+                && catchRecord.Location.Visibility == LocationDefaults.Public
+                && catchRecord.Location.Latitude == 53.2707
+                && catchRecord.Location.Longitude == -9.0568
+                && catchRecord.Location.AccuracyMetres == 12
+                && catchRecord.Location.Source == LocationDefaults.DeviceGps),
+            Arg.Any<CancellationToken>());
+        await client.Received(1).UpdateLocationVisibilityAsync(
+            catchId,
+            LocationDefaults.Public,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
@@ -1,7 +1,10 @@
+using System.Net;
+using System.Text;
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.CatchLocationPrivacy;
@@ -75,15 +78,17 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var original = LocatedCatch(catchId);
         var store = Substitute.For<ICatchStore>();
         store.GetAllAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([original]));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
         var client = Substitute.For<ICatchClient>();
         await using var context = CreateContext(store, client);
         var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
-        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-save").Should().NotBeNull());
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-public").Should().NotBeNull());
+        await cut.Find("#catch-location-privacy-public").ClickAsync();
 
         // Act
         await cut.Find("#catch-location-privacy-save").ClickAsync();
@@ -93,11 +98,14 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
             cut.Find("#catch-location-privacy-save-failed").TextContent
                 .Should()
                 .Contain("Location privacy could not be saved"));
+        cut.FindAll("#catch-location-privacy-saved").Should().BeEmpty();
+        cut.FindAll("#catch-location-privacy-saved-pending").Should().BeEmpty();
+        original.Location!.Visibility.Should().Be(LocationDefaults.Private);
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord =>
                 catchRecord.Id == catchId
                 && catchRecord.Location != null
-                && catchRecord.Location.Visibility == LocationDefaults.Private
+                && catchRecord.Location.Visibility == LocationDefaults.Public
                 && catchRecord.Location.Latitude == 53.2707
                 && catchRecord.Location.Longitude == -9.0568),
             Arg.Any<CancellationToken>());
@@ -108,10 +116,56 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
     }
 
     [Fact]
-    public async Task ItShouldShowSaveFailedWhenTheApiClientFails()
+    public async Task ItShouldKeepTheLocalChoiceWhenTheServerIsUnavailable()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var client = Substitute.For<ICatchClient>();
+        client.UpdateLocationVisibilityAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException());
+        await using var context = CreateContext(store, client);
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-public").Should().NotBeNull());
+        await cut.Find("#catch-location-privacy-public").ClickAsync();
+
+        // Act
+        await cut.Find("#catch-location-privacy-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-saved-pending").TextContent
+                .Should()
+                .Contain("Privacy saved on this device. It will update when synchronisation is available."));
+        cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty();
+        cut.FindAll("#catch-location-privacy-saved").Should().BeEmpty();
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Id == catchId
+                && catchRecord.Location != null
+                && catchRecord.Location.Visibility == LocationDefaults.Public
+                && catchRecord.Location.Latitude == 53.2707
+                && catchRecord.Location.Longitude == -9.0568
+                && catchRecord.Location.AccuracyMetres == 12
+                && catchRecord.Location.Source == LocationDefaults.DeviceGps
+                && catchRecord.Location.ConsentVersion == LocationDefaults.ConsentVersion),
+            Arg.Any<CancellationToken>());
+        await client.Received(1).UpdateLocationVisibilityAsync(
+            catchId,
+            LocationDefaults.Public,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchPendingSyncWhenTheServerIsUnavailable()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
         store.GetAllAsync(Arg.Any<CancellationToken>())
@@ -130,15 +184,105 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
 
         // Assert
         cut.WaitForAssertion(() =>
-            cut.Find("#catch-location-privacy-save-failed").TextContent
+            cut.Find("#catch-location-privacy-saved-pending").TextContent
                 .Should()
-                .Contain("Location privacy could not be saved"));
+                .Contain("Confidentialité enregistrée sur cet appareil. Elle sera mise à jour lorsque la synchronisation sera disponible."));
+        cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty();
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Id == catchId
+                && catchRecord.Location != null
+                && catchRecord.Location.Visibility == LocationDefaults.Private),
+            Arg.Any<CancellationToken>());
+        await client.Received(1).UpdateLocationVisibilityAsync(
+            catchId,
+            LocationDefaults.Private,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheLocalChoiceWhenTheCatchHasNotSyncedYet()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var apiHandler = new UnsynchronisedCatchHandler();
+        var client = CreateCatchClient(apiHandler);
+        await using var context = CreateContext(store, client);
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-public").Should().NotBeNull());
+        await cut.Find("#catch-location-privacy-public").ClickAsync();
+
+        // Act
+        await cut.Find("#catch-location-privacy-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-saved").TextContent.Should().Contain("Location privacy saved"));
+        cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty();
+        cut.FindAll("#catch-location-privacy-saved-pending").Should().BeEmpty();
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Id == catchId
+                && catchRecord.Location != null
+                && catchRecord.Location.Visibility == LocationDefaults.Public
+                && catchRecord.Location.Latitude == 53.2707
+                && catchRecord.Location.Longitude == -9.0568),
+            Arg.Any<CancellationToken>());
+        apiHandler.LastRequest.Should().NotBeNull();
+        apiHandler.LastRequest!.Method.Should().Be(HttpMethod.Patch);
+        apiHandler.LastRequest.RequestUri!.PathAndQuery
+            .Should()
+            .Be($"/api/catches/{catchId:D}/location-visibility");
+    }
+
+    [Fact]
+    public async Task ItShouldKeepPublicToPrivateWhenTheServerIsUnavailable()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var capturedOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
+                [LocatedCatch(catchId, LocationDefaults.Public)]));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var client = Substitute.For<ICatchClient>();
+        client.UpdateLocationVisibilityAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException());
+        await using var context = CreateContext(store, client);
+        var cut = context.Render<CatchLocationPrivacy>(parameters => parameters.Add(p => p.CatchId, catchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-private").Should().NotBeNull());
+        await cut.Find("#catch-location-privacy-private").ClickAsync();
+
+        // Act
+        await cut.Find("#catch-location-privacy-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-location-privacy-saved-pending").TextContent
+                .Should()
+                .Contain("Privacy saved on this device"));
+        cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty();
+        cut.Markup.Should().NotContain("Location privacy could not be saved");
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord =>
                 catchRecord.Id == catchId
                 && catchRecord.Location != null
                 && catchRecord.Location.Visibility == LocationDefaults.Private
-                && catchRecord.Location.Latitude == 53.2707),
+                && catchRecord.Location.Latitude == 53.2707
+                && catchRecord.Location.Longitude == -9.0568
+                && catchRecord.Location.AccuracyMetres == 12
+                && catchRecord.Location.CapturedOn == capturedOn
+                && catchRecord.Location.Source == LocationDefaults.DeviceGps
+                && catchRecord.Location.ConsentVersion == LocationDefaults.ConsentVersion),
             Arg.Any<CancellationToken>());
         await client.Received(1).UpdateLocationVisibilityAsync(
             catchId,
@@ -171,6 +315,8 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#catch-location-privacy-saved").TextContent.Should().Contain("Location privacy saved"));
+        cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty();
+        cut.FindAll("#catch-location-privacy-saved-pending").Should().BeEmpty();
         cut.Markup.Should().NotContain("53.2707");
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord =>
@@ -186,5 +332,29 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
             catchId,
             LocationDefaults.Public,
             Arg.Any<CancellationToken>());
+    }
+
+    private static CatchClient CreateCatchClient(UnsynchronisedCatchHandler apiHandler)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(HttpClientNames.AuthorizedApi)
+            .Returns(new HttpClient(apiHandler) { BaseAddress = new Uri("https://api.test/") });
+        return new CatchClient(factory);
+    }
+
+    private sealed class UnsynchronisedCatchHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent(string.Empty, Encoding.UTF8, "application/json")
+            });
+        }
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
@@ -24,7 +24,7 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
                 [LocatedCatch(catchId, location: null)]));
         var client = Substitute.For<ICatchClient>();
@@ -50,7 +50,7 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
         var client = Substitute.For<ICatchClient>();
         await using var context = CreateContext(store, client);
@@ -80,7 +80,7 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var original = LocatedCatch(catchId);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([original]));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
@@ -122,7 +122,7 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
@@ -168,7 +168,7 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.French);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
@@ -207,7 +207,7 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
@@ -249,7 +249,7 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var capturedOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
                 [LocatedCatch(catchId, LocationDefaults.Public)]));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
@@ -297,7 +297,7 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(Arg.Any<CancellationToken>())
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +16,13 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Pages.RecordCatchTests;
 
 public class BaseRecordCatchTest
 {
-    protected static BunitContext CreateContext(ICatchStore store, ILocationService? location = null)
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    protected static BunitContext CreateContext(
+        ICatchStore store,
+        ILocationService? location = null,
+        ILocalCatchOwnerService? owner = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -23,8 +30,16 @@ public class BaseRecordCatchTest
         context.Services.AddLocalization();
         context.Services.AddSingleton(store);
         context.Services.AddSingleton(location ?? QuietLocation());
+        context.Services.AddSingleton(owner ?? SignedInOwner());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
+    }
+
+    protected static ILocalCatchOwnerService SignedInOwner()
+    {
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(OwnerUserId);
+        return owner;
     }
 
     protected static ILocationService QuietLocation()

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingLocation.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingLocation.cs
@@ -96,7 +96,7 @@ public class WhenTestingLocation : BaseRecordCatchTest
         // Assert
         await location.DidNotReceive().TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord => catchRecord.Location == null && catchRecord.Photographs.Count == 1),
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId && catchRecord.Location == null && catchRecord.Photographs.Count == 1),
             Arg.Any<CancellationToken>());
         cut.WaitForAssertion(() =>
         {
@@ -132,7 +132,7 @@ public class WhenTestingLocation : BaseRecordCatchTest
         // Assert
         await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord => catchRecord.Location == null),
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId && catchRecord.Location == null),
             Arg.Any<CancellationToken>());
         cut.WaitForAssertion(() => cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device"));
         cut.FindAll("#catch-location-saved").Should().BeEmpty();
@@ -158,7 +158,7 @@ public class WhenTestingLocation : BaseRecordCatchTest
 
         // Assert
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord => catchRecord.Location == null && catchRecord.Photographs.Count == 1),
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId && catchRecord.Location == null && catchRecord.Photographs.Count == 1),
             Arg.Any<CancellationToken>());
         cut.WaitForAssertion(() =>
         {
@@ -189,7 +189,7 @@ public class WhenTestingLocation : BaseRecordCatchTest
         // Assert
         await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord => catchRecord.Location == null),
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId && catchRecord.Location == null),
             Arg.Any<CancellationToken>());
         cut.WaitForAssertion(() => cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device"));
         cut.FindAll("#catch-location-saved").Should().BeEmpty();
@@ -366,7 +366,7 @@ public class WhenTestingLocation : BaseRecordCatchTest
         saved[1].Location.Should().Be(secondLocation);
         saved[1].Location.Should().NotBe(saved[0].Location);
         await store.Received(2).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord => catchRecord.Location != null),
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId && catchRecord.Location != null),
             Arg.Any<CancellationToken>());
     }
 
@@ -391,7 +391,7 @@ public class WhenTestingLocation : BaseRecordCatchTest
 
         // Assert
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Location == captured
                 && catchRecord.Location!.Source == LocationDefaults.DeviceGps
                 && catchRecord.Location.Visibility == LocationDefaults.Private

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingLocation.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingLocation.cs
@@ -407,6 +407,9 @@ public class WhenTestingLocation : BaseRecordCatchTest
         });
         cut.FindAll("#catch-location").Should().BeEmpty();
         cut.FindAll("#catch-location-status").Should().BeEmpty();
+        cut.FindAll("#catch-location-privacy-options").Should().BeEmpty();
+        cut.FindAll("#catch-location-privacy-save").Should().BeEmpty();
+        cut.Markup.Should().NotContain("/location-privacy");
         cut.Find("#catch-location-saved").TextContent.Should().NotContain("53.2707");
         await location.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotograph.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotograph.cs
@@ -61,7 +61,7 @@ public class WhenTestingPhotograph : BaseRecordCatchTest
         cut.Find("#save-catch-button").HasAttribute("disabled").Should().BeFalse();
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Id == photographId
                 && catchRecord.Photographs[0].ContentType == PhotographContentTypeConstants.Jpeg
@@ -100,7 +100,7 @@ public class WhenTestingPhotograph : BaseRecordCatchTest
         jpegId.Should().NotBe(pngId);
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Photographs.Count == 2
                 && catchRecord.Photographs[0].Id == jpegId
                 && catchRecord.Photographs[1].Id == pngId
@@ -231,7 +231,7 @@ public class WhenTestingPhotograph : BaseRecordCatchTest
         firstId.Should().NotBe(secondId);
         cut.Find("#catch-photo-position").TextContent.Should().Contain("Photo 2 of 2");
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Photographs.Count == 2
                 && catchRecord.Photographs[0].Id == firstId
                 && catchRecord.Photographs[1].Id == secondId
@@ -278,7 +278,7 @@ public class WhenTestingPhotograph : BaseRecordCatchTest
         cut.Find("#catch-photo-position").TextContent.Should().Contain("Photo 1 of 3");
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Photographs.Count == 3
                 && catchRecord.Photographs[0].Id == firstId
                 && catchRecord.Photographs[1].Id == secondId
@@ -368,7 +368,7 @@ public class WhenTestingPhotograph : BaseRecordCatchTest
         remainingVisible.Should().NotBe(photoB);
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Photographs.Count == 2
                 && catchRecord.Photographs.Select(photograph => photograph.Id).Contains(photoA)
                 && catchRecord.Photographs.Select(photograph => photograph.Id).Contains(photoC)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Forms;
@@ -88,7 +89,7 @@ public class WhenTestingSave : BaseRecordCatchTest
         cut.FindAll("#catch-saved").Should().BeEmpty();
         cut.Find("#save-catch-button").Should().NotBeNull();
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Id != Guid.Empty
                 && catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Id != Guid.Empty
@@ -116,7 +117,7 @@ public class WhenTestingSave : BaseRecordCatchTest
 
         // Assert
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Id == photographId
                 && catchRecord.Photographs[0].CatchId == catchRecord.Id
@@ -162,7 +163,7 @@ public class WhenTestingSave : BaseRecordCatchTest
 
         // Assert
         await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Bytes != null
                 && catchRecord.SpeciesName == null
@@ -235,7 +236,7 @@ public class WhenTestingSave : BaseRecordCatchTest
         saved[0].Photographs[0].Id.Should().NotBe(saved[0].Id);
         saved.Should().OnlyContain(catchRecord => catchRecord.SpeciesName == null);
         await store.Received(2).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
                 catchRecord.Id != Guid.Empty
                 && catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Bytes != null),
@@ -258,9 +259,33 @@ public class WhenTestingSave : BaseRecordCatchTest
         // Assert
         injected.Should().Contain(typeof(ICatchStore));
         injected.Should().Contain(typeof(ILocationService));
+        injected.Should().Contain(typeof(ILocalCatchOwnerService));
         injected.Should().NotContain(typeof(HttpClient));
         injected.Should().NotContain(type =>
             type.Name.Contains("Client", StringComparison.Ordinal)
             || type.Name.Contains("Synchroniser", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ItShouldNotSaveWhenTheOwnerCannotBeResolved()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("The current user is not signed in."));
+        await using var context = CreateContext(store, owner: owner);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-save-failed").TextContent.Should().Contain("could not be saved"));
+        cut.FindAll("#catch-saved").Should().BeEmpty();
+        await owner.Received(1).GetUserIdAsync(Arg.Any<CancellationToken>());
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/BaseCatchClientTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/BaseCatchClientTest.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Text;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Catch.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Services.CatchClientTests;
+
+public class BaseCatchClientTest
+{
+    protected static CatchClient CreateClient(RecordingHandler apiHandler)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(HttpClientNames.AuthorizedApi)
+            .Returns(new HttpClient(apiHandler) { BaseAddress = new Uri("https://api.test/") });
+        return new CatchClient(factory);
+    }
+
+    protected sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _responseBody;
+
+        public RecordingHandler(HttpStatusCode statusCode, string responseBody = "")
+        {
+            _statusCode = statusCode;
+            _responseBody = responseBody;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public string? LastBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            if (request.Content is not null)
+            {
+                LastBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            }
+
+            return new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseBody, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/WhenTestingUpdateLocationVisibility.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/WhenTestingUpdateLocationVisibility.cs
@@ -31,7 +31,7 @@ public class WhenTestingUpdateLocationVisibility : BaseCatchClientTest
     }
 
     [Fact]
-    public async Task ItShouldIgnoreNotFound()
+    public async Task ItShouldTreatNotFoundAsAnUnsynchronisedLocalCatch()
     {
         // Arrange
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/WhenTestingUpdateLocationVisibility.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/WhenTestingUpdateLocationVisibility.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Text.Json;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Services.CatchClientTests;
+
+public class WhenTestingUpdateLocationVisibility : BaseCatchClientTest
+{
+    [Fact]
+    public async Task ItShouldThrowWhenTheResponseIsNotSuccessful()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var apiHandler = new RecordingHandler(HttpStatusCode.Forbidden, """{"title":"error"}""");
+        var client = CreateClient(apiHandler);
+
+        // Act
+        var act = () => client.UpdateLocationVisibilityAsync(
+            catchId,
+            LocationDefaults.Public,
+            CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        apiHandler.LastRequest.Should().NotBeNull();
+        apiHandler.LastRequest!.Method.Should().Be(HttpMethod.Patch);
+        apiHandler.LastRequest.RequestUri!.PathAndQuery
+            .Should()
+            .Be($"/api/catches/{catchId:D}/location-visibility");
+    }
+
+    [Fact]
+    public async Task ItShouldIgnoreNotFound()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var apiHandler = new RecordingHandler(HttpStatusCode.NotFound);
+        var client = CreateClient(apiHandler);
+
+        // Act
+        var act = () => client.UpdateLocationVisibilityAsync(
+            catchId,
+            LocationDefaults.Approximate,
+            CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        apiHandler.LastRequest.Should().NotBeNull();
+        apiHandler.LastRequest!.Method.Should().Be(HttpMethod.Patch);
+        apiHandler.LastRequest.RequestUri!.PathAndQuery
+            .Should()
+            .Be($"/api/catches/{catchId:D}/location-visibility");
+        var sent = JsonSerializer.Deserialize<UpdateCatchLocationVisibilityDto>(
+            apiHandler.LastBody!,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        sent.Should().NotBeNull();
+        sent!.Visibility.Should().Be(LocationDefaults.Approximate);
+    }
+
+    [Fact]
+    public async Task ItShouldPatchVisibilityForTheCatch()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var apiHandler = new RecordingHandler(HttpStatusCode.NoContent);
+        var client = CreateClient(apiHandler);
+
+        // Act
+        await client.UpdateLocationVisibilityAsync(
+            catchId,
+            LocationDefaults.Public,
+            CancellationToken.None);
+
+        // Assert
+        apiHandler.LastRequest.Should().NotBeNull();
+        apiHandler.LastRequest!.Method.Should().Be(HttpMethod.Patch);
+        apiHandler.LastRequest.RequestUri!.PathAndQuery
+            .Should()
+            .Be($"/api/catches/{catchId:D}/location-visibility");
+        var sent = JsonSerializer.Deserialize<UpdateCatchLocationVisibilityDto>(
+            apiHandler.LastBody!,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        sent.Should().NotBeNull();
+        sent!.Visibility.Should().Be(LocationDefaults.Public);
+        apiHandler.LastBody.Should().NotContain("userId");
+        apiHandler.LastBody.Should().NotContain("latitude");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/LocalCatchOwnerServiceTests/BaseLocalCatchOwnerServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/LocalCatchOwnerServiceTests/BaseLocalCatchOwnerServiceTest.cs
@@ -1,0 +1,108 @@
+using System.Security.Claims;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Users.Services;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.JSInterop;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Services.LocalCatchOwnerServiceTests;
+
+public class BaseLocalCatchOwnerServiceTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected const string OwnerSubject = "cognito-sub-owner";
+    protected const string OtherSubject = "cognito-sub-other";
+
+    protected static LocalCatchOwnerService CreateSut(
+        AuthenticationStateProvider authentication,
+        ICurrentUserClient currentUserClient,
+        IJSRuntime jsRuntime)
+    {
+        return new LocalCatchOwnerService(authentication, currentUserClient, jsRuntime);
+    }
+
+    protected static ICurrentUserClient CurrentUser(Guid userId, string email = "owner@example.test")
+    {
+        var client = Substitute.For<ICurrentUserClient>();
+        client.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .Returns(new CurrentUserDto(userId, email));
+        return client;
+    }
+
+    protected static AuthenticationStateProvider Authenticated(string? subject, string email = "owner@example.test")
+    {
+        return new SubjectAuthenticationStateProvider(true, subject, email);
+    }
+
+    protected static AuthenticationStateProvider Unauthenticated()
+    {
+        return new SubjectAuthenticationStateProvider(false, null);
+    }
+
+    protected sealed class MemoryJsRuntime : IJSRuntime
+    {
+        public Dictionary<string, string> Items { get; } = new(StringComparer.Ordinal);
+        public int GetItemCalls { get; private set; }
+        public int SetItemCalls { get; private set; }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier,
+            CancellationToken cancellationToken,
+            object?[]? args)
+        {
+            if (identifier == "localStorage.getItem")
+            {
+                GetItemCalls += 1;
+                var key = args![0] as string ?? string.Empty;
+                Items.TryGetValue(key, out var value);
+                return ValueTask.FromResult((TValue)(object?)value!);
+            }
+
+            if (identifier == "localStorage.setItem")
+            {
+                SetItemCalls += 1;
+                Items[args![0] as string ?? string.Empty] = args[1] as string ?? string.Empty;
+                return ValueTask.FromResult(default(TValue)!);
+            }
+
+            throw new InvalidOperationException(identifier);
+        }
+    }
+
+    private sealed class SubjectAuthenticationStateProvider : AuthenticationStateProvider
+    {
+        private readonly ClaimsPrincipal _user;
+
+        public SubjectAuthenticationStateProvider(bool authenticated, string? subject, string email = "owner@example.test")
+        {
+            if (!authenticated)
+            {
+                _user = new ClaimsPrincipal(new ClaimsIdentity());
+                return;
+            }
+
+            var claims = new List<Claim>
+            {
+                new("email", email)
+            };
+            if (!string.IsNullOrWhiteSpace(subject))
+            {
+                claims.Add(new Claim("sub", subject));
+            }
+
+            _user = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+        }
+
+        public override Task<AuthenticationState> GetAuthenticationStateAsync()
+        {
+            return Task.FromResult(new AuthenticationState(_user));
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/LocalCatchOwnerServiceTests/WhenTestingGetUserId.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/LocalCatchOwnerServiceTests/WhenTestingGetUserId.cs
@@ -1,0 +1,123 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Users.Services;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Services.LocalCatchOwnerServiceTests;
+
+public class WhenTestingGetUserId : BaseLocalCatchOwnerServiceTest
+{
+    [Fact]
+    public async Task ItShouldFailWhenTheUserIsNotSignedIn()
+    {
+        // Arrange
+        var currentUser = Substitute.For<ICurrentUserClient>();
+        var jsRuntime = new MemoryJsRuntime();
+        var sut = CreateSut(Unauthenticated(), currentUser, jsRuntime);
+
+        // Act
+        var act = () => sut.GetUserIdAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        await currentUser.DidNotReceive().GetCurrentAsync(Arg.Any<CancellationToken>());
+        jsRuntime.GetItemCalls.Should().Be(0);
+        jsRuntime.SetItemCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheApiReturnsAnEmptyUserId()
+    {
+        // Arrange
+        var currentUser = Substitute.For<ICurrentUserClient>();
+        currentUser.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .Returns(new CurrentUserDto(Guid.Empty, "owner@example.test"));
+        var jsRuntime = new MemoryJsRuntime();
+        var sut = CreateSut(Authenticated(OwnerSubject), currentUser, jsRuntime);
+
+        // Act
+        var act = () => sut.GetUserIdAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        await currentUser.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        jsRuntime.SetItemCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheApiCallFailsAndNothingIsCached()
+    {
+        // Arrange
+        var currentUser = Substitute.For<ICurrentUserClient>();
+        currentUser.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException());
+        var jsRuntime = new MemoryJsRuntime();
+        var sut = CreateSut(Authenticated(OwnerSubject), currentUser, jsRuntime);
+
+        // Act
+        var act = () => sut.GetUserIdAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        await currentUser.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        jsRuntime.SetItemCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldNotReuseAnotherSubjectsCachedUserId()
+    {
+        // Arrange
+        var currentUser = CurrentUser(OtherUserId, "other@example.test");
+        var jsRuntime = new MemoryJsRuntime();
+        jsRuntime.Items["fishingLogBook.localUserId." + OwnerSubject] = OwnerUserId.ToString("D");
+        var sut = CreateSut(Authenticated(OtherSubject, "other@example.test"), currentUser, jsRuntime);
+
+        // Act
+        var userId = await sut.GetUserIdAsync(CancellationToken.None);
+
+        // Assert
+        userId.Should().Be(OtherUserId);
+        userId.Should().NotBe(OwnerUserId);
+        await currentUser.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        jsRuntime.Items["fishingLogBook.localUserId." + OtherSubject].Should().Be(OtherUserId.ToString("D"));
+        jsRuntime.Items["fishingLogBook.localUserId." + OwnerSubject].Should().Be(OwnerUserId.ToString("D"));
+    }
+
+    [Fact]
+    public async Task ItShouldUseTheCachedUserIdWithoutCallingTheApi()
+    {
+        // Arrange
+        var currentUser = Substitute.For<ICurrentUserClient>();
+        var jsRuntime = new MemoryJsRuntime();
+        jsRuntime.Items["fishingLogBook.localUserId." + OwnerSubject] = OwnerUserId.ToString("D");
+        var sut = CreateSut(Authenticated(OwnerSubject), currentUser, jsRuntime);
+
+        // Act
+        var userId = await sut.GetUserIdAsync(CancellationToken.None);
+
+        // Assert
+        userId.Should().Be(OwnerUserId);
+        jsRuntime.GetItemCalls.Should().Be(1);
+        await currentUser.DidNotReceive().GetCurrentAsync(Arg.Any<CancellationToken>());
+        jsRuntime.SetItemCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldResolveAndCacheTheInternalUserId()
+    {
+        // Arrange
+        var currentUser = CurrentUser(OwnerUserId);
+        var jsRuntime = new MemoryJsRuntime();
+        var sut = CreateSut(Authenticated(OwnerSubject), currentUser, jsRuntime);
+
+        // Act
+        var userId = await sut.GetUserIdAsync(CancellationToken.None);
+
+        // Assert
+        userId.Should().Be(OwnerUserId);
+        await currentUser.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        jsRuntime.SetItemCalls.Should().Be(1);
+        jsRuntime.Items["fishingLogBook.localUserId." + OwnerSubject].Should().Be(OwnerUserId.ToString("D"));
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Users/Services/CurrentUserClientTests/BaseCurrentUserClientTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Users/Services/CurrentUserClientTests/BaseCurrentUserClientTest.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Text;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Users.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Users.Services.CurrentUserClientTests;
+
+public class BaseCurrentUserClientTest
+{
+    protected static CurrentUserClient CreateClient(RecordingHandler apiHandler)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(HttpClientNames.AuthorizedApi)
+            .Returns(new HttpClient(apiHandler) { BaseAddress = new Uri("https://api.test/") });
+        return new CurrentUserClient(factory);
+    }
+
+    protected sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _responseBody;
+
+        public RecordingHandler(HttpStatusCode statusCode, string responseBody = "")
+        {
+            _statusCode = statusCode;
+            _responseBody = responseBody;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseBody, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Users/Services/CurrentUserClientTests/WhenTestingGetCurrent.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Users/Services/CurrentUserClientTests/WhenTestingGetCurrent.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Text.Json;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Tests.Features.Users.Services.CurrentUserClientTests;
+
+public class WhenTestingGetCurrent : BaseCurrentUserClientTest
+{
+    [Fact]
+    public async Task ItShouldThrowWhenTheResponseIsNotSuccessful()
+    {
+        // Arrange
+        var apiHandler = new RecordingHandler(HttpStatusCode.Unauthorized, """{"title":"error"}""");
+        var client = CreateClient(apiHandler);
+
+        // Act
+        var act = () => client.GetCurrentAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        apiHandler.LastRequest.Should().NotBeNull();
+        apiHandler.LastRequest!.Method.Should().Be(HttpMethod.Get);
+        apiHandler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/api/users/current");
+    }
+
+    [Fact]
+    public async Task ItShouldThrowWhenTheBodyIsMissing()
+    {
+        // Arrange
+        var apiHandler = new RecordingHandler(HttpStatusCode.OK, "null");
+        var client = CreateClient(apiHandler);
+
+        // Act
+        var act = () => client.GetCurrentAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        apiHandler.LastRequest.Should().NotBeNull();
+        apiHandler.LastRequest!.Method.Should().Be(HttpMethod.Get);
+        apiHandler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/api/users/current");
+    }
+
+    [Fact]
+    public async Task ItShouldGetTheCurrentUserFromTheAuthorizedApi()
+    {
+        // Arrange
+        var expected = new CurrentUserDto(
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            "owner@example.test");
+        var json = JsonSerializer.Serialize(expected, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var apiHandler = new RecordingHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(apiHandler);
+
+        // Act
+        var result = await client.GetCurrentAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().Be(expected);
+        apiHandler.LastRequest.Should().NotBeNull();
+        apiHandler.LastRequest!.Method.Should().Be(HttpMethod.Get);
+        apiHandler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/api/users/current");
+        apiHandler.LastRequest.RequestUri.Query.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Enforces Catch location privacy at the trusted server boundary. Captured coordinates stay **Private** by default; the owner always sees exact GPS; other users only see what the owner chose (`Private` / `Approximate` / `FishingVenueOnly` / `Public`).
- Adds `GET /api/catches/{catchId}` (`CatchViewDto`) and owner-only `PATCH /api/catches/{catchId}/location-visibility`. Viewer and actor come from `ICurrentUser`. Guide, FishingVenueManager, CompetitionOrganiser, and Administrator do **not** bypass privacy.
- Adds an owner privacy page at `/catches/{id}/location-privacy` (EN/FR), linked from the catch list only when a location exists. Record Catch and production sync are unchanged.

Closes #16.

## Not in this PR
- Person-to-person precise-location sharing
- Production Catch sync (#17)
- Catch detail / history (#19 / #20)
- FishingVenue association (#27)
- Club-scoped roles (#32)
- Authenticated Playwright host (#76)

## Manual after merge
- Apply DbUp migration `202608171800_16_ConstrainCatchLocationVisibility.sql` (expand-only CHECK on `LocationVisibility`). #15 script was not rewritten.
- No Terraform apply.

## Test plan
- [x] `dotnet format`, `dotnet build`, `dotnet test`
- [x] `npm test`, `npm run test:browser`
- [ ] CI green on this PR
- [ ] Confirm Private non-owner GET JSON has no exact `latitude` / `longitude`
- [ ] Confirm owner GET still returns exact coordinates at every visibility
- [ ] Confirm non-owner PATCH is 403 and does not update the row
- [ ] Confirm Record Catch still saves location as Private and is not a privacy form

## Self review
- Issue/AC: PASS (AC1–AC14)
- Architecture/CQRS: PASS (endpoint → mediator → service → privacy service / repository; Commands carry CatchId + Visibility only)
- Rules: PASS
- Security/privacy: PASS (shaping is server JSON, not UI hiding; spoofed userId / Administrator ignored)
- Database/migrations: PASS
- Tests/coverage: PASS (Application, API JSON string assertions, Testcontainers, bUnit, CatchClient 404)
- Browser: N/A for authenticated privacy UI (#76). Privacy proof is API serialization. Existing IndexedDB Playwright still passes.
- Web/UI/localisation: PASS
- Code smells: PASS
- CI/deployment: PASS — apply the new DbUp script after merge

### Issue #16 questions
- Exact coordinates cannot leak in unauthorised GET JSON (`JsonIgnore` when null + string assertions).
- Coordinates are removed server-side, not merely hidden in Blazor.
- Administrator / Guide / Venue Manager / Competition Organiser do not bypass privacy; capabilities are not consulted on the allow path.
- Club roles were not implemented and must keep the same denial as a normal user later.
- Client cannot spoof viewer/owner identity; actor is `ICurrentUser`.
- Non-owner cannot change visibility (403, no update).
- Approximate uses the 0.05° cell-centre grid; original accuracy is not returned.
- FishingVenueOnly does not leak GPS or invent a venue.
- Visibility updates only `LocationVisibility`; stored lat/lng are unchanged.
- Sharing was not implemented.
- #15 quick-save / offline behaviour was not damaged.
- #17 sync and #20 history were not started.
- New Commands do not carry `ActorUserId` / `ViewerUserId`.
- Privacy decision is centralized in Application (`ICatchLocationPrivacyService`).