### PR TITLE
FLB#17 | synchronise production catches without weakening offline saves

### DIFF
--- a/.claude/rules/csharp.md
+++ b/.claude/rules/csharp.md
@@ -64,7 +64,8 @@ see **`database.md`**.
 - Inject interfaces from `Application/Contracts`, never concrete types from another layer.
   API endpoints inject `IMediator`, not repositories or handlers (see **`cqrs.md`**).
 - Use `ILogger<T>` for logging. Use `async`/`await` and pass `CancellationToken` through
-  database/API/service methods.
+  database/API/service methods. Every server-side `catch` must log the caught
+  exception — see **`exception-logging.md`**.
 - Prefer readable explicit code. Avoid unnecessary abstractions. Do **not** create a
   repository interface for every class unless it provides genuine value (testability,
   crossing a layer boundary).

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -129,7 +129,8 @@ null). They still must not drop the source column.
   concatenation for values.
 - Return **FluentResults** `Result`, `Result<T>` — not exceptions for expected failures
   (not found, constraint, connectivity wrapped as `Fail`). Do not leak Npgsql/Dapper
-  types across the boundary.
+  types across the boundary. When a `catch` converts an exception into `Result.Fail`,
+  log the original exception with `ILogger` first — see **`exception-logging.md`**.
 - SQL transactions (begin/commit/rollback) and unique-constraint recovery live here,
   not in CQRS handlers. Handlers orchestrate; they do not hold `NpgsqlTransaction`.
 - Filter/query/lookup methods accept `*Args` types from `Application/Args/`.

--- a/.claude/rules/exception-logging.md
+++ b/.claude/rules/exception-logging.md
@@ -1,0 +1,94 @@
+---
+paths:
+  - "src/FishingLogBook.Api/**/*.cs"
+  - "src/FishingLogBook.Application/**/*.cs"
+  - "src/FishingLogBook.Domain/**/*.cs"
+  - "src/FishingLogBook.Infrastructure/**/*.cs"
+  - "src/FishingLogBook.DependencyInjection/**/*.cs"
+  - "src/FishingLogBook.Db.Migrations/**/*.cs"
+  - "src/FishingLogBook.Db.Migrations.App/**/*.cs"
+---
+
+# Server-side exception logging
+
+Every `catch` block in production **server-side** code must log the caught exception.
+
+This applies to all server-side layers and integrations:
+
+- `FishingLogBook.Api`
+- `FishingLogBook.Application`
+- `FishingLogBook.Domain` where catch blocks exist
+- `FishingLogBook.Infrastructure`
+- repositories and other database access
+- external HTTP/API clients
+- authentication integrations
+- object storage / R2
+- synchronisation/orchestration
+- background processing
+- DbUp migrations and the migration runner
+
+Silent catch blocks are not permitted.
+
+Blazor WebAssembly (`FishingLogBook.Web`) is not covered by this rule. Client
+diagnostics stay on the existing Web logging/diagnostic path.
+
+## When an exception is caught
+
+If an exception is caught and then:
+
+- converted to a `Result`
+- converted to a typed error
+- translated into an HTTP response
+- suppressed
+- retried
+- handled locally
+
+the **original exception object** must be logged at an appropriate level.
+
+## Levels
+
+Unexpected technical exceptions:
+
+```csharp
+_logger.LogError(exception, "Failed to save the catch {CatchId}.", catchId);
+```
+
+Expected or recoverable exceptional conditions (unique-key recovery, known
+constraint conflict, invalid caller argument mapped to 400):
+
+```csharp
+_logger.LogWarning(exception, "User identity already exists; recovering the existing user.");
+```
+
+Pass the exception as the first argument to `ILogger` so stack trace, inner
+exception, and exception type are retained. Do not log `exception.ToString()`
+or `exception.Message` as a substitute for the exception object.
+
+Safe, generic messages may still be returned to callers and API clients.
+
+Never expose raw exception details to API clients.
+
+## Cleanup-and-rethrow
+
+A `catch` that only rolls back a transaction (or similar cleanup) and rethrows
+the same exception may omit a log **if** a later `catch` in the same method
+logs that exception before translating or swallowing it. Do not log the same
+exception twice.
+
+Request-abort `OperationCanceledException` that is immediately rethrown may be
+logged at `LogDebug` so the catch is not silent without treating disconnects as
+errors.
+
+## What not to log
+
+Never log:
+
+- access or refresh tokens
+- photograph bytes or base64
+- precise GPS coordinates
+- complete Catch payloads
+- secrets, connection strings, or unnecessary PII
+
+Safe correlation fields such as CatchId, PhotographId, and UserId are allowed
+in the log message template. Do not add coordinates, emails, or raw request
+bodies to those templates.

--- a/.claude/rules/github-operations.md
+++ b/.claude/rules/github-operations.md
@@ -2,10 +2,12 @@
 
 Perform Git and GitHub operations directly in the parent agent.
 
-- Use the GitLens/GitKraken MCP tools directly for local status, checkout, add, commit,
-  fetch and push operations.
-- Use the project GitHub MCP tools directly for issues, pull requests, reviews, review
-  threads, comments, titles and body updates.
+- Use the GitLens/GitKraken MCP tools only for local status, checkout, add, commit and
+  history operations.
+- Use the project GitHub MCP directly for remote branches, file pushes, issues, pull
+  requests, reviews, review threads, comments, titles and body updates.
+- Do not use GitLens/GitKraken `git_push`; it invokes the repository's configured Git
+  transport and may incorrectly require SSH credentials.
 - Discover the exact MCP tool schema before invoking it.
 - Do not delegate Git or GitHub reads or writes to subagents.
 - Do not use `gh`, shell Git write commands, SSH, or browser automation when the

--- a/.cursor/rules/read-claude-rules.mdc
+++ b/.cursor/rules/read-claude-rules.mdc
@@ -13,6 +13,7 @@ Before planning, coding, testing, committing, or touching infrastructure, read t
 | Planning or implementing a GitHub issue | `.claude/rules/product-workflow.md` |
 | After implementation and tests, before declaring complete or PR-ready | `.claude/rules/self-review.md` |
 | C# (API, Application, Domain, Infrastructure, Shared) | `.claude/rules/csharp.md` |
+| Server-side `catch` / exception logging | `.claude/rules/exception-logging.md` |
 | CQRS / application services | `.claude/rules/cqrs.md` |
 | Blazor WASM / MudBlazor / PWA | `.claude/rules/blazor.md` |
 | Tests (including `WhenTesting` naming) | `.claude/rules/testing-csharp.md` and `.claude/rules/testing-blazor.md` |

--- a/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
+++ b/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
@@ -111,6 +111,13 @@ public static class AuthenticationExtensions
 
     private sealed class AuthConfigStartupValidator : IValidateOptions<AuthConfig>
     {
+        private readonly ILogger<AuthConfigStartupValidator> _logger;
+
+        public AuthConfigStartupValidator(ILogger<AuthConfigStartupValidator> logger)
+        {
+            _logger = logger;
+        }
+
         public ValidateOptionsResult Validate(string? name, AuthConfig options)
         {
             try
@@ -120,6 +127,7 @@ public static class AuthenticationExtensions
             }
             catch (InvalidOperationException exception)
             {
+                _logger.LogError(exception, "Authentication configuration is invalid.");
                 return ValidateOptionsResult.Fail(exception.Message);
             }
         }

--- a/src/FishingLogBook.Api/Endpoints/CatchEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/CatchEndpoints.cs
@@ -41,6 +41,26 @@ public static class CatchEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status503ServiceUnavailable);
 
+        endpoints.MapPost("/api/catches/{catchId:guid}/photographs/upload-url", CreatePhotographUploadAsync)
+            .WithName("CreateCatchPhotographUpload")
+            .WithTags("Catches")
+            .RequireAuthorization()
+            .Produces<PhotographUploadDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        endpoints.MapPost("/api/catches/{catchId:guid}/photographs", RecordPhotographAsync)
+            .WithName("RecordCatchPhotograph")
+            .WithTags("Catches")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
         return endpoints;
     }
 
@@ -159,6 +179,96 @@ public static class CatchEndpoints
         }
 
         if (response.Error is CatchHasNoLocationError)
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> CreatePhotographUploadAsync(
+        Guid catchId,
+        PhotographUploadRequestDto request,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new CreateCatchPhotographUploadCommand
+            {
+                CatchId = catchId,
+                Request = request
+            },
+            cancellationToken);
+        if (response.ValidationErrors is { Count: > 0 })
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.Error is CatchPhotographNotFoundError)
+        {
+            return Results.NotFound();
+        }
+
+        if (response.Error is CatchObjectStorageNotConfiguredError)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.Ok(response.Upload);
+    }
+
+    private static async Task<IResult> RecordPhotographAsync(
+        Guid catchId,
+        RecordPhotographDto photograph,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new RecordCatchPhotographCommand
+            {
+                CatchId = catchId,
+                Photograph = photograph
+            },
+            cancellationToken);
+        if (response.ValidationErrors is { Count: > 0 })
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.Error is CatchPhotographNotFoundError)
+        {
+            return Results.NotFound();
+        }
+
+        if (response.Error is CatchPhotographObjectKeyMismatchError)
         {
             return Results.BadRequest(response);
         }

--- a/src/FishingLogBook.Api/Endpoints/TestCatchEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/TestCatchEndpoints.cs
@@ -94,6 +94,7 @@ public static class TestCatchEndpoints
         Guid id,
         RecordPhotographDto request,
         TestCatchService testCatchService,
+        ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
         if (id == Guid.Empty ||
@@ -109,8 +110,10 @@ public static class TestCatchEndpoints
             var recorded = await testCatchService.RecordPhotographAsync(id, request, cancellationToken);
             return recorded ? Results.NoContent() : Results.NotFound();
         }
-        catch (ArgumentException)
+        catch (ArgumentException exception)
         {
+            loggerFactory.CreateLogger("TestCatchPhotographEndpoint")
+                .LogWarning(exception, "Catch photograph could not be recorded.");
             return Results.BadRequest();
         }
     }

--- a/src/FishingLogBook.Api/FishingLogBook.Api.http
+++ b/src/FishingLogBook.Api/FishingLogBook.Api.http
@@ -115,3 +115,28 @@ Authorization: Bearer <access-token>
 }
 
 ###
+
+POST {{FishingLogBook.Api_HostAddress}}/api/catches/00000000-0000-0000-0000-000000000000/photographs/upload-url
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <access-token>
+
+{
+  "photographId": "11111111-1111-1111-1111-111111111111",
+  "contentType": "image/jpeg"
+}
+
+###
+
+POST {{FishingLogBook.Api_HostAddress}}/api/catches/00000000-0000-0000-0000-000000000000/photographs
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <access-token>
+
+{
+  "photographId": "11111111-1111-1111-1111-111111111111",
+  "objectKey": "catches/22222222-2222-2222-2222-222222222222/00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111",
+  "contentType": "image/jpeg"
+}
+
+###

--- a/src/FishingLogBook.Api/Middleware/CurrentUserMiddleware.cs
+++ b/src/FishingLogBook.Api/Middleware/CurrentUserMiddleware.cs
@@ -52,8 +52,9 @@ public sealed class CurrentUserMiddleware
                 return;
             }
         }
-        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (context.RequestAborted.IsCancellationRequested)
         {
+            _logger.LogDebug(exception, "Current user resolution was cancelled.");
             throw;
         }
         catch (Exception exception)

--- a/src/FishingLogBook.Application/Args/CreateCatchPhotographUploadArgs.cs
+++ b/src/FishingLogBook.Application/Args/CreateCatchPhotographUploadArgs.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Args;
+
+public sealed class CreateCatchPhotographUploadArgs
+{
+    public Guid CatchId { get; init; }
+
+    public PhotographUploadRequestDto Request { get; init; } = new(Guid.Empty, string.Empty);
+}

--- a/src/FishingLogBook.Application/Args/GetCatchPhotographArgs.cs
+++ b/src/FishingLogBook.Application/Args/GetCatchPhotographArgs.cs
@@ -1,0 +1,10 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class GetCatchPhotographArgs
+{
+    public Guid UserId { get; init; }
+
+    public Guid CatchId { get; init; }
+
+    public Guid PhotographId { get; init; }
+}

--- a/src/FishingLogBook.Application/Args/RecordCatchPhotographArgs.cs
+++ b/src/FishingLogBook.Application/Args/RecordCatchPhotographArgs.cs
@@ -1,0 +1,12 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class RecordCatchPhotographArgs
+{
+    public Guid CatchId { get; init; }
+
+    public Guid PhotographId { get; init; }
+
+    public string ObjectKey { get; init; } = string.Empty;
+
+    public string ContentType { get; init; } = string.Empty;
+}

--- a/src/FishingLogBook.Application/Catches/Commands/CreateCatchPhotographUploadCommand.cs
+++ b/src/FishingLogBook.Application/Catches/Commands/CreateCatchPhotographUploadCommand.cs
@@ -1,0 +1,73 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Catches.Errors;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace FishingLogBook.Application.Catches.Commands;
+
+public sealed class CreateCatchPhotographUploadCommand : IRequest<CreateCatchPhotographUploadResponse>
+{
+    public Guid CatchId { get; init; }
+
+    public PhotographUploadRequestDto Request { get; init; } = new(Guid.Empty, string.Empty);
+}
+
+public sealed class CreateCatchPhotographUploadResponse : ValidatedResponse
+{
+    public PhotographUploadDto? Upload { get; init; }
+}
+
+public sealed class CreateCatchPhotographUploadHandler
+    : IRequestHandler<CreateCatchPhotographUploadCommand, CreateCatchPhotographUploadResponse>
+{
+    private readonly ICatchPhotographService _catchPhotographService;
+
+    public CreateCatchPhotographUploadHandler(ICatchPhotographService catchPhotographService)
+    {
+        _catchPhotographService = catchPhotographService;
+    }
+
+    public async Task<CreateCatchPhotographUploadResponse> Handle(
+        CreateCatchPhotographUploadCommand command,
+        CancellationToken cancellationToken)
+    {
+        if (!_catchPhotographService.IsObjectStorageConfigured)
+        {
+            return ValidatedResponse.FromError<CreateCatchPhotographUploadResponse>(
+                new CatchObjectStorageNotConfiguredError());
+        }
+
+        var result = await _catchPhotographService.CreateUploadAsync(
+            command.Adapt<CreateCatchPhotographUploadArgs>(),
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<CreateCatchPhotographUploadResponse>(result.Errors[0]);
+        }
+
+        return new CreateCatchPhotographUploadResponse
+        {
+            Upload = result.Value
+        };
+    }
+}
+
+public sealed class CreateCatchPhotographUploadCommandValidator
+    : AbstractValidator<CreateCatchPhotographUploadCommand>
+{
+    public CreateCatchPhotographUploadCommandValidator()
+    {
+        RuleFor(command => command.CatchId)
+            .NotEmpty();
+        RuleFor(command => command.Request.PhotographId)
+            .NotEmpty();
+        RuleFor(command => command.Request.ContentType)
+            .Must(PhotographContentTypeConstants.IsAllowed)
+            .WithMessage("Photograph content type must be image/jpeg, image/png, or image/webp.");
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Commands/RecordCatchPhotographCommand.cs
+++ b/src/FishingLogBook.Application/Catches/Commands/RecordCatchPhotographCommand.cs
@@ -1,0 +1,62 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using Mapster;
+using MediatR;
+
+namespace FishingLogBook.Application.Catches.Commands;
+
+public sealed class RecordCatchPhotographCommand : IRequest<RecordCatchPhotographResponse>
+{
+    public Guid CatchId { get; init; }
+
+    public RecordPhotographDto Photograph { get; init; } =
+        new(Guid.Empty, string.Empty, string.Empty);
+}
+
+public sealed class RecordCatchPhotographResponse : ValidatedResponse
+{
+}
+
+public sealed class RecordCatchPhotographHandler
+    : IRequestHandler<RecordCatchPhotographCommand, RecordCatchPhotographResponse>
+{
+    private readonly ICatchPhotographService _catchPhotographService;
+
+    public RecordCatchPhotographHandler(ICatchPhotographService catchPhotographService)
+    {
+        _catchPhotographService = catchPhotographService;
+    }
+
+    public async Task<RecordCatchPhotographResponse> Handle(
+        RecordCatchPhotographCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _catchPhotographService.RecordAsync(
+            command.Adapt<RecordCatchPhotographArgs>(),
+            cancellationToken);
+        return result.IsFailed
+            ? ValidatedResponse.FromError<RecordCatchPhotographResponse>(result.Errors[0])
+            : new RecordCatchPhotographResponse();
+    }
+}
+
+public sealed class RecordCatchPhotographCommandValidator
+    : AbstractValidator<RecordCatchPhotographCommand>
+{
+    public RecordCatchPhotographCommandValidator()
+    {
+        RuleFor(command => command.CatchId)
+            .NotEmpty();
+        RuleFor(command => command.Photograph.PhotographId)
+            .NotEmpty();
+        RuleFor(command => command.Photograph.ObjectKey)
+            .Must(value => !string.IsNullOrWhiteSpace(value));
+        RuleFor(command => command.Photograph.ContentType)
+            .Must(PhotographContentTypeConstants.IsAllowed)
+            .WithMessage("Photograph content type must be image/jpeg, image/png, or image/webp.");
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Errors/CatchObjectStorageNotConfiguredError.cs
+++ b/src/FishingLogBook.Application/Catches/Errors/CatchObjectStorageNotConfiguredError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Catches.Errors;
+
+public sealed class CatchObjectStorageNotConfiguredError : Error
+{
+    public CatchObjectStorageNotConfiguredError()
+        : base("Object storage is not configured.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Errors/CatchPhotographNotFoundError.cs
+++ b/src/FishingLogBook.Application/Catches/Errors/CatchPhotographNotFoundError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Catches.Errors;
+
+public sealed class CatchPhotographNotFoundError : Error
+{
+    public CatchPhotographNotFoundError()
+        : base("The catch photograph was not found.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Errors/CatchPhotographObjectKeyMismatchError.cs
+++ b/src/FishingLogBook.Application/Catches/Errors/CatchPhotographObjectKeyMismatchError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Catches.Errors;
+
+public sealed class CatchPhotographObjectKeyMismatchError : Error
+{
+    public CatchPhotographObjectKeyMismatchError()
+        : base("The photograph object key does not match the catch.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Catches/Services/CatchPhotographService.cs
+++ b/src/FishingLogBook.Application/Catches/Services/CatchPhotographService.cs
@@ -1,0 +1,127 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Catches.Errors;
+using FishingLogBook.Application.Contracts;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.Catches.Services;
+
+public sealed class CatchPhotographService : ICatchPhotographService
+{
+    private static readonly TimeSpan UploadLifetime = TimeSpan.FromMinutes(15);
+
+    private readonly ICatchRepository _catchRepository;
+    private readonly IObjectStorage _objectStorage;
+    private readonly ICurrentUser _currentUser;
+
+    public CatchPhotographService(
+        ICatchRepository catchRepository,
+        IObjectStorage objectStorage,
+        ICurrentUser currentUser)
+    {
+        _catchRepository = catchRepository;
+        _objectStorage = objectStorage;
+        _currentUser = currentUser;
+    }
+
+    public bool IsObjectStorageConfigured
+    {
+        get
+        {
+            return _objectStorage.IsConfigured;
+        }
+    }
+
+    public async Task<Result<PhotographUploadDto>> CreateUploadAsync(
+        CreateCatchPhotographUploadArgs args,
+        CancellationToken cancellationToken)
+    {
+        var photograph = await LoadOwnedPhotographAsync(
+            args.CatchId,
+            args.Request.PhotographId,
+            cancellationToken);
+        if (photograph.IsFailed)
+        {
+            return Result.Fail<PhotographUploadDto>(photograph.Errors);
+        }
+
+        if (!string.Equals(
+                photograph.Value.ContentType,
+                args.Request.ContentType,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Result.Fail<PhotographUploadDto>(new CatchPhotographNotFoundError());
+        }
+
+        var objectKey = ObjectKey(_currentUser.UserId, args.CatchId, args.Request.PhotographId);
+        var uploadUrl = await _objectStorage.CreateUploadUrlAsync(
+            objectKey,
+            args.Request.ContentType,
+            UploadLifetime,
+            cancellationToken);
+        return Result.Ok(new PhotographUploadDto(objectKey, uploadUrl.ToString()));
+    }
+
+    public async Task<Result> RecordAsync(
+        RecordCatchPhotographArgs args,
+        CancellationToken cancellationToken)
+    {
+        var photograph = await LoadOwnedPhotographAsync(
+            args.CatchId,
+            args.PhotographId,
+            cancellationToken);
+        if (photograph.IsFailed)
+        {
+            return photograph.ToResult();
+        }
+
+        if (!string.Equals(
+                photograph.Value.ContentType,
+                args.ContentType,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return Result.Fail(new CatchPhotographNotFoundError());
+        }
+
+        var expected = ObjectKey(_currentUser.UserId, args.CatchId, args.PhotographId);
+        return string.Equals(args.ObjectKey, expected, StringComparison.Ordinal)
+            ? Result.Ok()
+            : Result.Fail(new CatchPhotographObjectKeyMismatchError());
+    }
+
+    private async Task<Result<Domain.Catches.CatchPhotograph>> LoadOwnedPhotographAsync(
+        Guid catchId,
+        Guid photographId,
+        CancellationToken cancellationToken)
+    {
+        if (!_currentUser.IsResolved)
+        {
+            return Result.Fail<Domain.Catches.CatchPhotograph>(new CurrentUserUnresolvedError());
+        }
+
+        var loaded = await _catchRepository.GetPhotographAsync(
+            new GetCatchPhotographArgs
+            {
+                UserId = _currentUser.UserId,
+                CatchId = catchId,
+                PhotographId = photographId
+            },
+            cancellationToken);
+        if (loaded.IsFailed)
+        {
+            return Result.Fail<Domain.Catches.CatchPhotograph>(loaded.Errors);
+        }
+
+        return loaded.Value is null
+            ? Result.Fail<Domain.Catches.CatchPhotograph>(new CatchPhotographNotFoundError())
+            : Result.Ok(loaded.Value);
+    }
+
+    private static string ObjectKey(Guid userId, Guid catchId, Guid photographId)
+    {
+        return $"catches/{userId:D}/{catchId:D}/{photographId:D}";
+    }
+}

--- a/src/FishingLogBook.Application/Common/Mappings/CatchMappingRegistration.cs
+++ b/src/FishingLogBook.Application/Common/Mappings/CatchMappingRegistration.cs
@@ -16,6 +16,11 @@ public sealed class CatchMappingRegistration : IRegister
         config.NewConfig<GetCatchQuery, GetCatchArgs>();
         config.NewConfig<UpsertCatchCommand, UpsertCatchArgs>();
         config.NewConfig<UpdateCatchLocationVisibilityCommand, UpdateCatchLocationVisibilityArgs>();
+        config.NewConfig<CreateCatchPhotographUploadCommand, CreateCatchPhotographUploadArgs>();
+        config.NewConfig<RecordCatchPhotographCommand, RecordCatchPhotographArgs>()
+            .Map(destination => destination.PhotographId, source => source.Photograph.PhotographId)
+            .Map(destination => destination.ObjectKey, source => source.Photograph.ObjectKey)
+            .Map(destination => destination.ContentType, source => source.Photograph.ContentType);
         config.NewConfig<CatchPhotograph, CatchPhotographDto>()
             .MapWith(source => new CatchPhotographDto(source.Id, source.CatchId, source.ContentType));
         config.NewConfig<CatchLocation, CatchLocationDto>()

--- a/src/FishingLogBook.Application/Contracts/Repositories/ICatchRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/Repositories/ICatchRepository.cs
@@ -8,6 +8,10 @@ public interface ICatchRepository
 {
     Task<Result<Catch?>> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 
+    Task<Result<CatchPhotograph?>> GetPhotographAsync(
+        GetCatchPhotographArgs args,
+        CancellationToken cancellationToken);
+
     Task<Result<Catch>> UpsertAsync(Catch catchRecord, CancellationToken cancellationToken);
 
     Task<Result> UpdateLocationVisibilityAsync(

--- a/src/FishingLogBook.Application/Contracts/Services/ICatchPhotographService.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/ICatchPhotographService.cs
@@ -1,0 +1,18 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Services;
+
+public interface ICatchPhotographService
+{
+    bool IsObjectStorageConfigured { get; }
+
+    Task<Result<PhotographUploadDto>> CreateUploadAsync(
+        CreateCatchPhotographUploadArgs args,
+        CancellationToken cancellationToken);
+
+    Task<Result> RecordAsync(
+        RecordCatchPhotographArgs args,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserIdentityService, UserIdentityService>();
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<ICatchService, CatchService>();
+        services.AddScoped<ICatchPhotographService, CatchPhotographService>();
         services.AddScoped<ICatchLocationPrivacyService, CatchLocationPrivacyService>();
         services.AddScoped<IPlatformCapabilityService, PlatformCapabilityService>();
 

--- a/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Application.Contracts;
 using FishingLogBook.Application.Contracts.Repositories;
 using FishingLogBook.Domain.Catches;
 using FluentResults;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace FishingLogBook.Infrastructure.Persistence;
@@ -14,10 +15,12 @@ public sealed class CatchRepository : ICatchRepository
     private const string FailedMessage = "Failed to save the catch.";
 
     private readonly IDbConnectionFactory _connectionFactory;
+    private readonly ILogger<CatchRepository> _logger;
 
-    public CatchRepository(IDbConnectionFactory connectionFactory)
+    public CatchRepository(IDbConnectionFactory connectionFactory, ILogger<CatchRepository> logger)
     {
         _connectionFactory = connectionFactory;
+        _logger = logger;
     }
 
     public async Task<Result<Catch?>> GetByIdAsync(Guid id, CancellationToken cancellationToken)
@@ -27,8 +30,9 @@ public sealed class CatchRepository : ICatchRepository
             await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
             return Result.Ok(await LoadAsync(connection, transaction: null, id, cancellationToken));
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to load the catch {CatchId}.", id);
             return Result.Fail<Catch?>(FailedMessage);
         }
     }
@@ -55,8 +59,13 @@ public sealed class CatchRepository : ICatchRepository
                     cancellationToken: cancellationToken));
             return Result.Ok(photograph);
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(
+                exception,
+                "Failed to load catch photograph {PhotographId} for catch {CatchId}.",
+                args.PhotographId,
+                args.CatchId);
             return Result.Fail<CatchPhotograph?>(FailedMessage);
         }
     }
@@ -90,8 +99,9 @@ public sealed class CatchRepository : ICatchRepository
                 throw;
             }
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to save the catch {CatchId}.", catchRecord.Id);
             return Result.Fail<Catch>(FailedMessage);
         }
     }
@@ -123,8 +133,9 @@ public sealed class CatchRepository : ICatchRepository
                 ? Result.Ok()
                 : Result.Fail("Failed to save the catch.");
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to update catch location visibility {CatchId}.", args.CatchId);
             return Result.Fail("Failed to save the catch.");
         }
     }
@@ -265,11 +276,11 @@ public sealed class CatchRepository : ICatchRepository
         {
             catchRecord.Id,
             catchRecord.UserId,
-            catchRecord.CaughtOn,
+            CaughtOn = catchRecord.CaughtOn.ToUniversalTime(),
             Latitude = catchRecord.Location?.Latitude,
             Longitude = catchRecord.Location?.Longitude,
             LocationAccuracyMetres = catchRecord.Location?.AccuracyMetres,
-            LocationCapturedOn = catchRecord.Location?.CapturedOn,
+            LocationCapturedOn = catchRecord.Location?.CapturedOn.ToUniversalTime(),
             LocationSource = catchRecord.Location?.Source,
             LocationVisibility = catchRecord.Location?.Visibility,
             LocationConsentVersion = catchRecord.Location?.ConsentVersion

--- a/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
@@ -33,6 +33,34 @@ public sealed class CatchRepository : ICatchRepository
         }
     }
 
+    public async Task<Result<CatchPhotograph?>> GetPhotographAsync(
+        GetCatchPhotographArgs args,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            const string sql = """
+                SELECT p."Id", p."CatchId", p."ContentType"
+                FROM "CatchPhotograph" p
+                INNER JOIN "Catch" c ON c."Id" = p."CatchId"
+                WHERE p."Id" = @PhotographId
+                  AND p."CatchId" = @CatchId
+                  AND c."UserId" = @UserId;
+                """;
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            var photograph = await connection.QuerySingleOrDefaultAsync<CatchPhotograph>(
+                new CommandDefinition(
+                    sql,
+                    args,
+                    cancellationToken: cancellationToken));
+            return Result.Ok(photograph);
+        }
+        catch (Exception)
+        {
+            return Result.Fail<CatchPhotograph?>(FailedMessage);
+        }
+    }
+
     public async Task<Result<Catch>> UpsertAsync(Catch catchRecord, CancellationToken cancellationToken)
     {
         try

--- a/src/FishingLogBook.Infrastructure/Persistence/ProfileRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/ProfileRepository.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Application.Contracts.Repositories;
 using FishingLogBook.Application.Profiles.Errors;
 using FishingLogBook.Domain.Profiles;
 using FluentResults;
+using Microsoft.Extensions.Logging;
 
 namespace FishingLogBook.Infrastructure.Persistence;
 
@@ -20,10 +21,12 @@ public sealed class ProfileRepository : IProfileRepository
         """;
 
     private readonly IDbConnectionFactory _connectionFactory;
+    private readonly ILogger<ProfileRepository> _logger;
 
-    public ProfileRepository(IDbConnectionFactory connectionFactory)
+    public ProfileRepository(IDbConnectionFactory connectionFactory, ILogger<ProfileRepository> logger)
     {
         _connectionFactory = connectionFactory;
+        _logger = logger;
     }
 
     public async Task<Result<bool>> UserExistsAsync(Guid userId, CancellationToken cancellationToken)
@@ -38,8 +41,9 @@ public sealed class ProfileRepository : IProfileRepository
                 cancellationToken: cancellationToken));
             return Result.Ok(exists);
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to check whether user {UserId} exists.", userId);
             return Result.Fail<bool>(FailedMessage);
         }
     }
@@ -59,8 +63,9 @@ public sealed class ProfileRepository : IProfileRepository
                 cancellationToken: cancellationToken));
             return Result.Ok(profile);
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to load angler profile {UserId}.", userId);
             return Result.Fail<Profile?>(FailedMessage);
         }
     }
@@ -98,8 +103,9 @@ public sealed class ProfileRepository : IProfileRepository
             await connection.ExecuteAsync(new CommandDefinition(sql, profile, cancellationToken: cancellationToken));
             return await RequireByUserIdAsync(connection, profile.UserId, cancellationToken);
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to save angler profile {UserId}.", profile.UserId);
             return Result.Fail<Profile>(FailedMessage);
         }
     }
@@ -130,8 +136,9 @@ public sealed class ProfileRepository : IProfileRepository
 
             return await RequireByUserIdAsync(connection, args.UserId, cancellationToken);
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to update angler profile photograph {UserId}.", args.UserId);
             return Result.Fail<Profile>(FailedMessage);
         }
     }

--- a/src/FishingLogBook.Infrastructure/Persistence/UserIdentityRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/UserIdentityRepository.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Application.Args;
 using FishingLogBook.Application.Contracts.Repositories;
 using FishingLogBook.Domain.Users;
 using FluentResults;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace FishingLogBook.Infrastructure.Persistence;
@@ -12,10 +13,12 @@ public sealed class UserIdentityRepository : IUserIdentityRepository
     private const string ResolveFailedMessage = "Failed to resolve FishingLogBook user.";
 
     private readonly IDbConnectionFactory _connectionFactory;
+    private readonly ILogger<UserIdentityRepository> _logger;
 
-    public UserIdentityRepository(IDbConnectionFactory connectionFactory)
+    public UserIdentityRepository(IDbConnectionFactory connectionFactory, ILogger<UserIdentityRepository> logger)
     {
         _connectionFactory = connectionFactory;
+        _logger = logger;
     }
 
     public async Task<Result<Guid?>> FindUserIdAsync(
@@ -28,8 +31,9 @@ public sealed class UserIdentityRepository : IUserIdentityRepository
             var userId = await FindUserIdAsync(connection, args, transaction: null, cancellationToken);
             return Result.Ok(userId);
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to find FishingLogBook user identity.");
             return Result.Fail<Guid?>(ResolveFailedMessage);
         }
     }
@@ -52,11 +56,13 @@ public sealed class UserIdentityRepository : IUserIdentityRepository
             catch (PostgresException exception) when (exception.SqlState == PostgresErrorCodes.UniqueViolation)
             {
                 await transaction.RollbackAsync(cancellationToken);
+                _logger.LogWarning(exception, "User identity already exists; recovering the existing user.");
                 return await ExistingUserIdOrFailAsync(connection, user, identity, cancellationToken);
             }
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to create FishingLogBook user identity.");
             return Result.Fail<Guid>(ResolveFailedMessage);
         }
     }
@@ -69,8 +75,9 @@ public sealed class UserIdentityRepository : IUserIdentityRepository
             await UpdateEmailAsync(connection, user, transaction: null, cancellationToken);
             return Result.Ok();
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to update FishingLogBook user email.");
             return Result.Fail(ResolveFailedMessage);
         }
     }

--- a/src/FishingLogBook.Infrastructure/Persistence/UserPlatformCapabilityRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/UserPlatformCapabilityRepository.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Application.Contracts.Repositories;
 using FishingLogBook.Domain.Enums;
 using FishingLogBook.Domain.Users;
 using FluentResults;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace FishingLogBook.Infrastructure.Persistence;
@@ -13,10 +14,14 @@ public sealed class UserPlatformCapabilityRepository : IUserPlatformCapabilityRe
     private const string FailedMessage = "Failed to persist platform capability.";
 
     private readonly IDbConnectionFactory _connectionFactory;
+    private readonly ILogger<UserPlatformCapabilityRepository> _logger;
 
-    public UserPlatformCapabilityRepository(IDbConnectionFactory connectionFactory)
+    public UserPlatformCapabilityRepository(
+        IDbConnectionFactory connectionFactory,
+        ILogger<UserPlatformCapabilityRepository> logger)
     {
         _connectionFactory = connectionFactory;
+        _logger = logger;
     }
 
     public async Task<Result<bool>> HasAsync(
@@ -38,8 +43,9 @@ public sealed class UserPlatformCapabilityRepository : IUserPlatformCapabilityRe
                 cancellationToken: cancellationToken));
             return Result.Ok(exists);
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to check platform capability for user {UserId}.", args.UserId);
             return Result.Fail<bool>(FailedMessage);
         }
     }
@@ -63,8 +69,9 @@ public sealed class UserPlatformCapabilityRepository : IUserPlatformCapabilityRe
             return Result.Ok<IReadOnlyList<PlatformCapabilityEnum>>(
                 codes.Select(ParseCapability).ToArray());
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to load platform capabilities for user {UserId}.", args.UserId);
             return Result.Fail<IReadOnlyList<PlatformCapabilityEnum>>(FailedMessage);
         }
     }
@@ -87,10 +94,12 @@ public sealed class UserPlatformCapabilityRepository : IUserPlatformCapabilityRe
         }
         catch (PostgresException exception) when (exception.SqlState == PostgresErrorCodes.ForeignKeyViolation)
         {
+            _logger.LogWarning(exception, "Platform capability grant failed for user {UserId}.", association.UserId);
             return Result.Fail("Platform capability is invalid.");
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to grant platform capability for user {UserId}.", association.UserId);
             return Result.Fail(FailedMessage);
         }
     }
@@ -112,8 +121,9 @@ public sealed class UserPlatformCapabilityRepository : IUserPlatformCapabilityRe
                 cancellationToken: cancellationToken));
             return Result.Ok();
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            _logger.LogError(exception, "Failed to revoke platform capability for user {UserId}.", args.UserId);
             return Result.Fail(FailedMessage);
         }
     }

--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
@@ -40,6 +40,16 @@ public static class DiagnosticEventNames
     public const string SyncFailed = "SyncFailed";
     public const string SyncRetry = "SyncRetry";
 
+    public const string CatchSyncStarted = "CatchSyncStarted";
+    public const string CatchMetadataSyncSucceeded = "CatchMetadataSyncSucceeded";
+    public const string CatchMetadataSyncFailed = "CatchMetadataSyncFailed";
+    public const string PhotographUploadStarted = "PhotographUploadStarted";
+    public const string PhotographUploadSucceeded = "PhotographUploadSucceeded";
+    public const string PhotographUploadFailed = "PhotographUploadFailed";
+    public const string CatchSyncCompleted = "CatchSyncCompleted";
+    public const string CatchSyncFailed = "CatchSyncFailed";
+    public const string AuthenticationUnavailable = "AuthenticationUnavailable";
+
     public const string ServiceWorkerError = "ServiceWorkerError";
 
     public const string LocationPermissionDenied = "LocationPermissionDenied";

--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticMetadata.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticMetadata.cs
@@ -16,6 +16,8 @@ public static class DiagnosticMetadata
     public const string TimeoutMilliseconds = "timeoutMilliseconds";
     public const string ErrorType = "errorType";
     public const string Result = "result";
+    public const string CatchId = "catchId";
+    public const string PhotographId = "photographId";
 
     private static readonly HashSet<string> AllowedKeys = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -32,7 +34,9 @@ public static class DiagnosticMetadata
         UsageBytes,
         TimeoutMilliseconds,
         ErrorType,
-        Result
+        Result,
+        CatchId,
+        PhotographId
     };
 
     private static readonly string[] ForbiddenFragments =
@@ -81,6 +85,12 @@ public static class DiagnosticMetadata
         if (string.IsNullOrWhiteSpace(key) || !AllowedKeys.Contains(key))
         {
             return false;
+        }
+
+        if (string.Equals(key, CatchId, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(key, PhotographId, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
         }
 
         foreach (var fragment in ForbiddenFragments)

--- a/src/FishingLogBook.Web/BrowserTests/harness/index.html
+++ b/src/FishingLogBook.Web/BrowserTests/harness/index.html
@@ -7,7 +7,7 @@
 <body>
     <p id="status">loading</p>
     <script type="module">
-        import { getAllTestCatches, putTestCatch, putCatchWithPhotographs, getAllCatchesWithPhotographs } from '../../wwwroot/js/storage/catch-store.js';
+        import { getAllTestCatches, putTestCatch, putCatchWithPhotographs, getAllCatchesWithPhotographs, updateCatchMetadata } from '../../wwwroot/js/storage/catch-store.js';
         import { getTestCatchPhotograph, putTestCatchPhotograph } from '../../wwwroot/js/storage/photo-store.js';
         import { putDiagnosticEvent } from '../../wwwroot/js/storage/diagnostic-store.js';
 
@@ -142,6 +142,25 @@
                 return getAllCatchesWithPhotographs(ownerUserId);
             },
             async readProductionCatches() {
+                return getAllCatchesWithPhotographs(ownerUserId);
+            },
+            async transitionProductionCatchSyncState() {
+                const catchId = '11111111-1111-1111-1111-111111111111';
+                const photographId = '22222222-2222-2222-2222-222222222222';
+                await window.harness.putAndGetProductionCatch();
+                await updateCatchMetadata(JSON.stringify({
+                    id: catchId,
+                    userId: ownerUserId,
+                    caughtOn: '2026-08-17T08:00:00+00:00',
+                    syncStatus: 4,
+                    metadataSyncStatus: 3,
+                    photographs: [{
+                        id: photographId,
+                        catchId,
+                        contentType: 'image/jpeg',
+                        syncStatus: 4
+                    }]
+                }));
                 return getAllCatchesWithPhotographs(ownerUserId);
             },
             async putUnscopedProductionCatchThenReadAsFirstSigner() {

--- a/src/FishingLogBook.Web/BrowserTests/storage.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/storage.spec.js
@@ -73,6 +73,24 @@ test.describe('Production Catch IndexedDB', () => {
         expect(records[0].photographs[0].id).toBe('22222222-2222-2222-2222-222222222222');
     });
 
+    test('keeps sync transitions and photograph bytes after close and reload', async ({ page }) => {
+        await page.goto(`${harness}/index.html`);
+        await expect(page.locator('#status')).toHaveText('ready');
+        await page.evaluate(() => window.harness.transitionProductionCatchSyncState());
+
+        await page.reload();
+        await expect(page.locator('#status')).toHaveText('ready');
+
+        const records = await page.evaluate(() => window.harness.readProductionCatches());
+        const catchRecord = JSON.parse(records[0].json);
+        expect(catchRecord.syncStatus).toBe(4);
+        expect(catchRecord.metadataSyncStatus).toBe(3);
+        expect(catchRecord.photographs[0].syncStatus).toBe(4);
+        expect(records[0].photographs[0].bytesBase64).toBe(
+            btoa(String.fromCharCode(1, 2, 3))
+        );
+    });
+
     test('keeps three photographs and capture order after close and reload', async ({ page }) => {
         await page.goto(`${harness}/index.html`);
         await expect(page.locator('#status')).toHaveText('ready');

--- a/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
@@ -1,3 +1,5 @@
+using FishingLogBook.Web.Common;
+
 namespace FishingLogBook.Web.Features.Catch.Models;
 
 public sealed record CatchModel(
@@ -6,4 +8,6 @@ public sealed record CatchModel(
     IReadOnlyList<CatchPhotographModel> Photographs,
     string? SpeciesName = null,
     CatchLocationModel? Location = null,
-    Guid UserId = default);
+    Guid UserId = default,
+    SyncStatus SyncStatus = SyncStatus.SavedLocally,
+    SyncStatus MetadataSyncStatus = SyncStatus.SavedLocally);

--- a/src/FishingLogBook.Web/Features/Catch/Models/CatchPhotographModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Models/CatchPhotographModel.cs
@@ -1,7 +1,11 @@
+using FishingLogBook.Web.Common;
+
 namespace FishingLogBook.Web.Features.Catch.Models;
 
 public sealed record CatchPhotographModel(
     Guid Id,
     Guid CatchId,
     string ContentType,
-    byte[]? Bytes = null);
+    byte[]? Bytes = null,
+    SyncStatus SyncStatus = SyncStatus.SavedLocally,
+    string? ObjectKey = null);

--- a/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Catch.Models;
 
 namespace FishingLogBook.Web.Features.Catch.Offline;
@@ -23,10 +24,14 @@ internal static class CatchJson
                 .Select(photograph => new CatchPhotographMetadata(
                     photograph.Id,
                     photograph.CatchId,
-                    photograph.ContentType))
+                    photograph.ContentType,
+                    photograph.SyncStatus,
+                    photograph.ObjectKey))
                 .ToArray(),
             catchRecord.Location,
-            catchRecord.UserId);
+            catchRecord.UserId,
+            catchRecord.SyncStatus,
+            catchRecord.MetadataSyncStatus);
         return JsonSerializer.Serialize(metadata, Options);
     }
 
@@ -40,7 +45,9 @@ internal static class CatchJson
             OrderPhotographs(metadata.Photographs, photographs),
             metadata.SpeciesName,
             metadata.Location,
-            metadata.UserId);
+            metadata.UserId,
+            metadata.SyncStatus,
+            metadata.MetadataSyncStatus);
     }
 
     private static IReadOnlyList<CatchPhotographModel> OrderPhotographs(
@@ -53,7 +60,11 @@ internal static class CatchJson
         {
             if (byId.Remove(metadata.Id, out var photograph))
             {
-                ordered.Add(photograph);
+                ordered.Add(photograph with
+                {
+                    SyncStatus = metadata.SyncStatus,
+                    ObjectKey = metadata.ObjectKey
+                });
             }
         }
 
@@ -67,10 +78,14 @@ internal static class CatchJson
         string? SpeciesName,
         IReadOnlyList<CatchPhotographMetadata> Photographs,
         CatchLocationModel? Location = null,
-        Guid UserId = default);
+        Guid UserId = default,
+        SyncStatus SyncStatus = SyncStatus.SavedLocally,
+        SyncStatus MetadataSyncStatus = SyncStatus.SavedLocally);
 
     private sealed record CatchPhotographMetadata(
         Guid Id,
         Guid CatchId,
-        string ContentType);
+        string ContentType,
+        SyncStatus SyncStatus = SyncStatus.SavedLocally,
+        string? ObjectKey = null);
 }

--- a/src/FishingLogBook.Web/Features/Catch/Offline/CatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/CatchSynchroniser.cs
@@ -1,0 +1,653 @@
+using System.Collections.Concurrent;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+
+namespace FishingLogBook.Web.Features.Catch.Offline;
+
+public sealed class CatchSynchroniser : ICatchSynchroniser
+{
+    private readonly ConcurrentDictionary<Guid, byte> _inFlight = new();
+    private readonly ICatchStore _store;
+    private readonly ICatchClient _client;
+    private readonly INetworkService _networkService;
+    private readonly ILocalCatchOwnerService _localCatchOwner;
+    private readonly IDiagnosticLogger _diagnostics;
+    private readonly ILoggingService _logging;
+
+    public event EventHandler? StateChanged;
+
+    public CatchSynchroniser(
+        ICatchStore store,
+        ICatchClient client,
+        INetworkService networkService,
+        ILocalCatchOwnerService localCatchOwner,
+        IDiagnosticLogger diagnostics,
+        ILoggingService logging)
+    {
+        _store = store;
+        _client = client;
+        _networkService = networkService;
+        _localCatchOwner = localCatchOwner;
+        _diagnostics = diagnostics;
+        _logging = logging;
+    }
+
+    public async Task SynchronisePendingAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await SynchronisePendingCoreAsync(cancellationToken);
+        }
+        finally
+        {
+            StateChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public async Task RetryAsync(Guid catchId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RetryCoreAsync(catchId, cancellationToken);
+        }
+        finally
+        {
+            StateChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private async Task SynchronisePendingCoreAsync(CancellationToken cancellationToken)
+    {
+        var ownerUserId = await TryGetOwnerUserIdAsync(cancellationToken);
+        if (ownerUserId is null)
+        {
+            return;
+        }
+
+        var catches = await _store.GetAllAsync(ownerUserId.Value, cancellationToken);
+        catches = await RecoverInterruptedAsync(catches, cancellationToken);
+        var pending = catches.Where(NeedsSynchronisation).ToArray();
+        if (!await _networkService.IsOnlineAsync(cancellationToken))
+        {
+            foreach (var catchRecord in pending)
+            {
+                await _store.UpdateSyncStateAsync(ToWaiting(catchRecord), cancellationToken);
+            }
+
+            return;
+        }
+
+        foreach (var catchRecord in pending)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                await SynchroniseGuardedAsync(ownerUserId.Value, catchRecord.Id, cancellationToken);
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                await SafeLogAsync(
+                    DiagnosticLevel.Error,
+                    DiagnosticEventNames.CatchSyncFailed,
+                    "Catch synchronisation failed.",
+                    catchRecord.Id,
+                    photographId: null,
+                    exception,
+                    cancellationToken);
+            }
+        }
+    }
+
+    private async Task RetryCoreAsync(Guid catchId, CancellationToken cancellationToken)
+    {
+        var ownerUserId = await TryGetOwnerUserIdAsync(cancellationToken);
+        if (ownerUserId is null)
+        {
+            return;
+        }
+
+        var catchRecord = await _store.GetAsync(ownerUserId.Value, catchId, cancellationToken);
+        if (catchRecord is null || !NeedsSynchronisation(catchRecord))
+        {
+            return;
+        }
+
+        if (!await _networkService.IsOnlineAsync(cancellationToken))
+        {
+            await _store.UpdateSyncStateAsync(ToWaiting(catchRecord), cancellationToken);
+            return;
+        }
+
+        await SynchroniseGuardedAsync(ownerUserId.Value, catchId, cancellationToken);
+    }
+
+    private async Task SynchroniseGuardedAsync(
+        Guid ownerUserId,
+        Guid catchId,
+        CancellationToken cancellationToken)
+    {
+        if (!_inFlight.TryAdd(catchId, 0))
+        {
+            return;
+        }
+
+        try
+        {
+            await SynchroniseCatchAsync(ownerUserId, catchId, cancellationToken);
+        }
+        finally
+        {
+            _inFlight.TryRemove(catchId, out _);
+        }
+    }
+
+    private async Task SynchroniseCatchAsync(
+        Guid ownerUserId,
+        Guid catchId,
+        CancellationToken cancellationToken)
+    {
+        var catchRecord = await _store.GetAsync(ownerUserId, catchId, cancellationToken);
+        if (catchRecord is null)
+        {
+            return;
+        }
+
+        await SafeLogAsync(
+            DiagnosticLevel.Information,
+            DiagnosticEventNames.CatchSyncStarted,
+            "Catch synchronisation started.",
+            catchId,
+            photographId: null,
+            exception: null,
+            cancellationToken);
+        catchRecord = catchRecord with { SyncStatus = SyncStatus.Synchronising };
+        await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+
+        catchRecord = await SynchroniseMetadataAsync(catchRecord, cancellationToken);
+        if (catchRecord.MetadataSyncStatus != SyncStatus.Synchronised)
+        {
+            if (catchRecord.MetadataSyncStatus == SyncStatus.FailedToSynchronise)
+            {
+                await SafeLogAsync(
+                    DiagnosticLevel.Error,
+                    DiagnosticEventNames.CatchSyncFailed,
+                    "Catch synchronisation failed.",
+                    catchId,
+                    photographId: null,
+                    exception: null,
+                    cancellationToken);
+            }
+
+            return;
+        }
+
+        foreach (var photograph in catchRecord.Photographs.Where(NeedsPhotographSynchronisation).ToArray())
+        {
+            catchRecord = await SynchronisePhotographAsync(
+                catchRecord,
+                photograph.Id,
+                cancellationToken);
+        }
+
+        catchRecord = catchRecord with { SyncStatus = DeriveOverallStatus(catchRecord) };
+        await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+        await SafeLogAsync(
+            catchRecord.SyncStatus == SyncStatus.Synchronised
+                ? DiagnosticLevel.Information
+                : DiagnosticLevel.Error,
+            catchRecord.SyncStatus == SyncStatus.Synchronised
+                ? DiagnosticEventNames.CatchSyncCompleted
+                : DiagnosticEventNames.CatchSyncFailed,
+            catchRecord.SyncStatus == SyncStatus.Synchronised
+                ? "Catch synchronisation completed."
+                : "Catch synchronisation failed.",
+            catchId,
+            photographId: null,
+            exception: null,
+            cancellationToken);
+    }
+
+    private async Task<CatchModel> SynchroniseMetadataAsync(
+        CatchModel catchRecord,
+        CancellationToken cancellationToken)
+    {
+        if (catchRecord.MetadataSyncStatus == SyncStatus.Synchronised)
+        {
+            return catchRecord;
+        }
+
+        catchRecord = catchRecord with { MetadataSyncStatus = SyncStatus.Synchronising };
+        await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+        try
+        {
+            var sent = ToDto(catchRecord);
+            await _client.UpsertAsync(sent, cancellationToken);
+            var current = await _store.GetAsync(
+                catchRecord.UserId,
+                catchRecord.Id,
+                cancellationToken);
+            if (current is null)
+            {
+                return catchRecord;
+            }
+
+            if (!HasSameMetadata(current, sent))
+            {
+                current = current with
+                {
+                    SyncStatus = SyncStatus.WaitingToSynchronise,
+                    MetadataSyncStatus = SyncStatus.WaitingToSynchronise
+                };
+                await _store.UpdateSyncStateAsync(current, cancellationToken);
+                return current;
+            }
+
+            catchRecord = current with { MetadataSyncStatus = SyncStatus.Synchronised };
+            await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+            await SafeLogAsync(
+                DiagnosticLevel.Information,
+                DiagnosticEventNames.CatchMetadataSyncSucceeded,
+                "Catch metadata synchronisation succeeded.",
+                catchRecord.Id,
+                photographId: null,
+                exception: null,
+                cancellationToken);
+            return catchRecord;
+        }
+        catch (Exception exception) when (IsSynchronisationFailure(exception, cancellationToken))
+        {
+            catchRecord = catchRecord with
+            {
+                SyncStatus = SyncStatus.FailedToSynchronise,
+                MetadataSyncStatus = SyncStatus.FailedToSynchronise
+            };
+            await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+            await SafeLogAsync(
+                DiagnosticLevel.Error,
+                DiagnosticEventNames.CatchMetadataSyncFailed,
+                "Catch metadata synchronisation failed.",
+                catchRecord.Id,
+                photographId: null,
+                exception,
+                cancellationToken);
+            if (IsAuthenticationFailure(exception))
+            {
+                await SafeLogAsync(
+                    DiagnosticLevel.Warning,
+                    DiagnosticEventNames.AuthenticationUnavailable,
+                    "Authentication is unavailable for catch synchronisation.",
+                    catchRecord.Id,
+                    photographId: null,
+                    exception,
+                    cancellationToken);
+            }
+
+            return catchRecord;
+        }
+    }
+
+    private async Task<CatchModel> SynchronisePhotographAsync(
+        CatchModel catchRecord,
+        Guid photographId,
+        CancellationToken cancellationToken)
+    {
+        catchRecord = WithPhotographStatus(
+            catchRecord,
+            photographId,
+            SyncStatus.Synchronising,
+            objectKey: null);
+        await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+        await SafeLogAsync(
+            DiagnosticLevel.Information,
+            DiagnosticEventNames.PhotographUploadStarted,
+            "Catch photograph upload started.",
+            catchRecord.Id,
+            photographId,
+            exception: null,
+            cancellationToken);
+
+        var photograph = catchRecord.Photographs.Single(item => item.Id == photographId);
+        try
+        {
+            if (photograph.Bytes is not { Length: > 0 })
+            {
+                throw new InvalidOperationException("Catch photograph bytes are unavailable.");
+            }
+
+            var upload = await _client.CreatePhotographUploadAsync(
+                catchRecord.Id,
+                new PhotographUploadRequestDto(photograph.Id, photograph.ContentType),
+                cancellationToken);
+            await _client.UploadPhotographAsync(
+                upload.UploadUrl,
+                photograph.Bytes,
+                photograph.ContentType,
+                cancellationToken);
+            await _client.RecordPhotographAsync(
+                catchRecord.Id,
+                new RecordPhotographDto(
+                    photograph.Id,
+                    upload.ObjectKey,
+                    photograph.ContentType),
+                cancellationToken);
+            catchRecord = WithPhotographStatus(
+                catchRecord,
+                photographId,
+                SyncStatus.Synchronised,
+                upload.ObjectKey);
+            await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+            await SafeLogAsync(
+                DiagnosticLevel.Information,
+                DiagnosticEventNames.PhotographUploadSucceeded,
+                "Catch photograph upload succeeded.",
+                catchRecord.Id,
+                photographId,
+                exception: null,
+                cancellationToken);
+            return catchRecord;
+        }
+        catch (Exception exception) when (IsSynchronisationFailure(exception, cancellationToken))
+        {
+            catchRecord = WithPhotographStatus(
+                catchRecord,
+                photographId,
+                SyncStatus.FailedToSynchronise,
+                objectKey: null);
+            await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+            await SafeLogAsync(
+                DiagnosticLevel.Error,
+                DiagnosticEventNames.PhotographUploadFailed,
+                "Catch photograph upload failed.",
+                catchRecord.Id,
+                photographId,
+                exception,
+                cancellationToken);
+            if (IsAuthenticationFailure(exception))
+            {
+                await SafeLogAsync(
+                    DiagnosticLevel.Warning,
+                    DiagnosticEventNames.AuthenticationUnavailable,
+                    "Authentication is unavailable for catch synchronisation.",
+                    catchRecord.Id,
+                    photographId,
+                    exception,
+                    cancellationToken);
+            }
+
+            return catchRecord;
+        }
+    }
+
+    private async Task<IReadOnlyList<CatchModel>> RecoverInterruptedAsync(
+        IReadOnlyList<CatchModel> catches,
+        CancellationToken cancellationToken)
+    {
+        var recovered = new List<CatchModel>(catches.Count);
+        foreach (var catchRecord in catches)
+        {
+            var retryable = RecoverInterrupted(catchRecord);
+            recovered.Add(retryable);
+            if (retryable != catchRecord)
+            {
+                await _store.UpdateSyncStateAsync(retryable, cancellationToken);
+            }
+        }
+
+        return recovered;
+    }
+
+    private async Task<Guid?> TryGetOwnerUserIdAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _localCatchOwner.GetUserIdAsync(cancellationToken);
+        }
+        catch (Exception exception) when (exception is AccessTokenNotAvailableException
+                                          or InvalidOperationException
+                                          or HttpRequestException)
+        {
+            await SafeLogAsync(
+                DiagnosticLevel.Warning,
+                DiagnosticEventNames.AuthenticationUnavailable,
+                "Authentication is unavailable for catch synchronisation.",
+                catchId: null,
+                photographId: null,
+                exception,
+                cancellationToken);
+            return null;
+        }
+    }
+
+    private async Task SafeLogAsync(
+        DiagnosticLevel level,
+        string eventName,
+        string message,
+        Guid? catchId,
+        Guid? photographId,
+        Exception? exception,
+        CancellationToken cancellationToken)
+    {
+        var metadata = new Dictionary<string, string>();
+        if (catchId is not null)
+        {
+            metadata[DiagnosticMetadata.CatchId] = catchId.Value.ToString("D");
+        }
+
+        if (photographId is not null)
+        {
+            metadata[DiagnosticMetadata.PhotographId] = photographId.Value.ToString("D");
+        }
+
+        if (exception is not null)
+        {
+            metadata[DiagnosticMetadata.ErrorType] = exception.GetType().Name;
+        }
+
+        try
+        {
+            await _diagnostics.LogAsync(
+                level,
+                eventName,
+                message,
+                metadata,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception loggingException)
+        {
+            try
+            {
+                await _logging.LogErrorAsync(
+                    "catch synchronisation diagnostic",
+                    loggingException,
+                    CancellationToken.None);
+            }
+            catch (Exception)
+            {
+                // Diagnostics never control synchronisation state.
+            }
+        }
+    }
+
+    private static CatchModel RecoverInterrupted(CatchModel catchRecord)
+    {
+        var photographs = catchRecord.Photographs
+            .Select(photograph => photograph.SyncStatus == SyncStatus.Synchronising
+                ? photograph with { SyncStatus = SyncStatus.WaitingToSynchronise }
+                : photograph)
+            .ToArray();
+        return catchRecord with
+        {
+            SyncStatus = catchRecord.SyncStatus == SyncStatus.Synchronising
+                ? SyncStatus.WaitingToSynchronise
+                : catchRecord.SyncStatus,
+            MetadataSyncStatus = catchRecord.MetadataSyncStatus == SyncStatus.Synchronising
+                ? SyncStatus.WaitingToSynchronise
+                : catchRecord.MetadataSyncStatus,
+            Photographs = photographs
+        };
+    }
+
+    private static CatchModel ToWaiting(CatchModel catchRecord)
+    {
+        var photographs = catchRecord.Photographs
+            .Select(photograph => photograph.SyncStatus == SyncStatus.Synchronised
+                ? photograph
+                : photograph with { SyncStatus = SyncStatus.WaitingToSynchronise })
+            .ToArray();
+        return catchRecord with
+        {
+            SyncStatus = SyncStatus.WaitingToSynchronise,
+            MetadataSyncStatus = catchRecord.MetadataSyncStatus == SyncStatus.Synchronised
+                ? SyncStatus.Synchronised
+                : SyncStatus.WaitingToSynchronise,
+            Photographs = photographs
+        };
+    }
+
+    private static CatchModel WithPhotographStatus(
+        CatchModel catchRecord,
+        Guid photographId,
+        SyncStatus status,
+        string? objectKey)
+    {
+        return catchRecord with
+        {
+            Photographs = catchRecord.Photographs
+                .Select(photograph => photograph.Id == photographId
+                    ? photograph with
+                    {
+                        SyncStatus = status,
+                        ObjectKey = objectKey ?? photograph.ObjectKey
+                    }
+                    : photograph)
+                .ToArray()
+        };
+    }
+
+    private static SyncStatus DeriveOverallStatus(CatchModel catchRecord)
+    {
+        if (catchRecord.MetadataSyncStatus == SyncStatus.Synchronising
+            || catchRecord.Photographs.Any(
+                photograph => photograph.SyncStatus == SyncStatus.Synchronising))
+        {
+            return SyncStatus.Synchronising;
+        }
+
+        if (catchRecord.MetadataSyncStatus == SyncStatus.FailedToSynchronise
+            || catchRecord.Photographs.Any(
+                photograph => photograph.SyncStatus == SyncStatus.FailedToSynchronise))
+        {
+            return SyncStatus.FailedToSynchronise;
+        }
+
+        if (catchRecord.MetadataSyncStatus == SyncStatus.Synchronised
+            && catchRecord.Photographs.All(
+                photograph => photograph.SyncStatus == SyncStatus.Synchronised))
+        {
+            return SyncStatus.Synchronised;
+        }
+
+        return SyncStatus.WaitingToSynchronise;
+    }
+
+    private static CatchDto ToDto(CatchModel catchRecord)
+    {
+        return new CatchDto(
+            catchRecord.Id,
+            catchRecord.CaughtOn,
+            catchRecord.Photographs
+                .Select(photograph => new CatchPhotographDto(
+                    photograph.Id,
+                    photograph.CatchId,
+                    photograph.ContentType))
+                .ToArray(),
+            catchRecord.Location is null
+                ? null
+                : new CatchLocationDto(
+                    catchRecord.Location.Latitude,
+                    catchRecord.Location.Longitude,
+                    catchRecord.Location.AccuracyMetres,
+                    catchRecord.Location.CapturedOn,
+                    catchRecord.Location.Source,
+                    catchRecord.Location.Visibility,
+                    catchRecord.Location.ConsentVersion));
+    }
+
+    private static bool HasSameMetadata(CatchModel catchRecord, CatchDto sent)
+    {
+        if (catchRecord.Id != sent.Id
+            || catchRecord.CaughtOn != sent.CaughtOn
+            || catchRecord.Photographs.Count != sent.Photographs.Count)
+        {
+            return false;
+        }
+
+        var photographsMatch = catchRecord.Photographs.All(photograph =>
+            sent.Photographs.Any(dto =>
+                dto.Id == photograph.Id
+                && dto.CatchId == photograph.CatchId
+                && string.Equals(
+                    dto.ContentType,
+                    photograph.ContentType,
+                    StringComparison.OrdinalIgnoreCase)));
+        if (!photographsMatch)
+        {
+            return false;
+        }
+
+        if (catchRecord.Location is null || sent.Location is null)
+        {
+            return catchRecord.Location is null && sent.Location is null;
+        }
+
+        return catchRecord.Location.Latitude == sent.Location.Latitude
+            && catchRecord.Location.Longitude == sent.Location.Longitude
+            && catchRecord.Location.AccuracyMetres == sent.Location.AccuracyMetres
+            && catchRecord.Location.CapturedOn == sent.Location.CapturedOn
+            && string.Equals(
+                catchRecord.Location.Source,
+                sent.Location.Source,
+                StringComparison.Ordinal)
+            && string.Equals(
+                catchRecord.Location.Visibility,
+                sent.Location.Visibility,
+                StringComparison.Ordinal)
+            && string.Equals(
+                catchRecord.Location.ConsentVersion,
+                sent.Location.ConsentVersion,
+                StringComparison.Ordinal);
+    }
+
+    private static bool NeedsSynchronisation(CatchModel catchRecord)
+    {
+        return catchRecord.SyncStatus != SyncStatus.Synchronised;
+    }
+
+    private static bool NeedsPhotographSynchronisation(CatchPhotographModel photograph)
+    {
+        return photograph.SyncStatus != SyncStatus.Synchronised;
+    }
+
+    private static bool IsSynchronisationFailure(
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        return exception is not OperationCanceledException
+            || !cancellationToken.IsCancellationRequested;
+    }
+
+    private static bool IsAuthenticationFailure(Exception exception)
+    {
+        return exception is AccessTokenNotAvailableException
+            || exception is HttpRequestException
+            {
+                StatusCode: System.Net.HttpStatusCode.Unauthorized
+            };
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Offline/ICatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/ICatchStore.cs
@@ -7,4 +7,11 @@ public interface ICatchStore
     Task SaveAsync(CatchModel catchRecord, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<CatchModel>> GetAllAsync(Guid ownerUserId, CancellationToken cancellationToken);
+
+    Task<CatchModel?> GetAsync(
+        Guid ownerUserId,
+        Guid catchId,
+        CancellationToken cancellationToken);
+
+    Task UpdateSyncStateAsync(CatchModel catchRecord, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Features/Catch/Offline/ICatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/ICatchSynchroniser.cs
@@ -1,0 +1,10 @@
+namespace FishingLogBook.Web.Features.Catch.Offline;
+
+public interface ICatchSynchroniser
+{
+    event EventHandler? StateChanged;
+
+    Task SynchronisePendingAsync(CancellationToken cancellationToken);
+
+    Task RetryAsync(Guid catchId, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Catch/Offline/IndexedDbCatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/IndexedDbCatchStore.cs
@@ -104,6 +104,43 @@ public sealed class IndexedDbCatchStore : ICatchStore
         return LocalCatchVisibility.ForOwner(loaded, ownerUserId);
     }
 
+    public async Task<CatchModel?> GetAsync(
+        Guid ownerUserId,
+        Guid catchId,
+        CancellationToken cancellationToken)
+    {
+        var catches = await GetAllAsync(ownerUserId, cancellationToken);
+        return catches.SingleOrDefault(catchRecord => catchRecord.Id == catchId);
+    }
+
+    public async Task UpdateSyncStateAsync(
+        CatchModel catchRecord,
+        CancellationToken cancellationToken)
+    {
+        if (catchRecord.UserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch requires an owner.");
+        }
+
+        var json = CatchJson.SerializeMetadata(catchRecord);
+        await OfflineOperation.ExecuteAsync(
+            "write",
+            StoreName,
+            DiagnosticEventNames.OfflineDbWriteStarted,
+            DiagnosticEventNames.OfflineDbWriteCompleted,
+            DiagnosticEventNames.OfflineDbWriteFailed,
+            DiagnosticEventNames.OfflineDbWriteTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                await module.InvokeVoidAsync("updateCatchMetadata", token, json);
+            },
+            cancellationToken,
+            _logging);
+    }
+
     private static CatchModel ToModel(StoredCatchRecord record)
     {
         var photographs = record.Photographs

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
@@ -53,6 +53,34 @@
                                 <MudText Typo="Typo.caption" id="@($"catch-time-{catchRecord.Id:D}")">
                                     @catchRecord.CaughtOn.ToString("g")
                                 </MudText>
+                                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center"
+                                          id="@($"catch-sync-status-{catchRecord.Id:D}")">
+                                    <MudIcon Icon="@SyncStatusIcon(catchRecord.SyncStatus)"
+                                             Size="Size.Small" />
+                                    <MudText Typo="Typo.caption">
+                                        @Loc[SyncStatusKey(catchRecord.SyncStatus)]
+                                    </MudText>
+                                </MudStack>
+                                @if (catchRecord.SyncStatus == SyncStatus.FailedToSynchronise)
+                                {
+                                    <MudText Typo="Typo.caption"
+                                             id="@($"catch-sync-reassurance-{catchRecord.Id:D}")">
+                                        @Loc["Catch_SyncFailureReassurance"]
+                                    </MudText>
+                                }
+                                @if (catchRecord.SyncStatus is not SyncStatus.Synchronised
+                                     and not SyncStatus.Synchronising)
+                                {
+                                    <MudButton Variant="Variant.Outlined"
+                                               Color="Color.Primary"
+                                               Disabled="@_retrying.Contains(catchRecord.Id)"
+                                               OnClick="@(() => RetryAsync(catchRecord.Id))"
+                                               id="@($"catch-sync-retry-{catchRecord.Id:D}")">
+                                        @(catchRecord.SyncStatus == SyncStatus.FailedToSynchronise
+                                            ? Loc["Catch_SyncRetry"]
+                                            : Loc["Catch_SyncNow"])
+                                    </MudButton>
+                                }
                                 @if (catchRecord.Location is not null)
                                 {
                                     <MudButton Variant="Variant.Text"

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
@@ -1,3 +1,4 @@
+using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Services;
@@ -11,6 +12,7 @@ public partial class CatchList : ComponentBase, IDisposable
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private IReadOnlyList<CatchModel> _catches = [];
+    private readonly HashSet<Guid> _retrying = [];
     private bool _isLoading = true;
     private bool _loadFailed;
 
@@ -21,10 +23,14 @@ public partial class CatchList : ComponentBase, IDisposable
     private ILocalCatchOwnerService LocalCatchOwner { get; set; } = default!;
 
     [Inject]
+    private ICatchSynchroniser CatchSynchroniser { get; set; } = default!;
+
+    [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        CatchSynchroniser.StateChanged += OnSyncStateChanged;
         await LoadAsync();
     }
 
@@ -63,8 +69,62 @@ public partial class CatchList : ComponentBase, IDisposable
         return $"data:{photograph.ContentType};base64,{Convert.ToBase64String(photograph.Bytes!)}";
     }
 
+    private async Task RetryAsync(Guid catchId)
+    {
+        if (!_retrying.Add(catchId))
+        {
+            return;
+        }
+
+        try
+        {
+            await CatchSynchroniser.RetryAsync(catchId, _cancellationTokenSource.Token);
+            await LoadAsync();
+        }
+        finally
+        {
+            _retrying.Remove(catchId);
+        }
+    }
+
+    private void OnSyncStateChanged(object? sender, EventArgs args)
+    {
+        _ = InvokeAsync(RefreshAfterSynchronisationAsync);
+    }
+
+    private async Task RefreshAfterSynchronisationAsync()
+    {
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    private static string SyncStatusKey(SyncStatus syncStatus)
+    {
+        return syncStatus switch
+        {
+            SyncStatus.SavedLocally => "SyncStatus_SavedLocally",
+            SyncStatus.WaitingToSynchronise => "SyncStatus_WaitingToSynchronise",
+            SyncStatus.Synchronising => "SyncStatus_Synchronising",
+            SyncStatus.Synchronised => "SyncStatus_Synchronised",
+            SyncStatus.FailedToSynchronise => "SyncStatus_FailedToSynchronise",
+            _ => "SyncStatus_SavedLocally"
+        };
+    }
+
+    private static string SyncStatusIcon(SyncStatus syncStatus)
+    {
+        return syncStatus switch
+        {
+            SyncStatus.Synchronised => MudBlazor.Icons.Material.Filled.CheckCircle,
+            SyncStatus.FailedToSynchronise => MudBlazor.Icons.Material.Filled.SyncProblem,
+            SyncStatus.Synchronising => MudBlazor.Icons.Material.Filled.Sync,
+            _ => MudBlazor.Icons.Material.Filled.CloudQueue
+        };
+    }
+
     public void Dispose()
     {
+        CatchSynchroniser.StateChanged -= OnSyncStateChanged;
         _cancellationTokenSource.Cancel();
         _cancellationTokenSource.Dispose();
     }

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchLocationPrivacy/CatchLocationPrivacy.razor.cs
@@ -1,4 +1,5 @@
 using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Services;
@@ -116,7 +117,13 @@ public partial class CatchLocationPrivacy : ComponentBase, IDisposable
         {
             var updated = _catch! with
             {
-                Location = _catch.Location! with { Visibility = _visibility }
+                Location = _catch.Location! with { Visibility = _visibility },
+                SyncStatus = _catch.SyncStatus == SyncStatus.Synchronised
+                    ? SyncStatus.WaitingToSynchronise
+                    : _catch.SyncStatus,
+                MetadataSyncStatus = _catch.MetadataSyncStatus == SyncStatus.Synchronised
+                    ? SyncStatus.WaitingToSynchronise
+                    : _catch.MetadataSyncStatus
             };
             await CatchStore.SaveAsync(updated, _cancellationTokenSource.Token);
             _catch = updated;

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor
@@ -126,6 +126,9 @@
                 @if (_isSaved)
                 {
                     <MudAlert Severity="Severity.Success" id="catch-saved">@Loc["Catch_Saved"]</MudAlert>
+                    <MudText Typo="Typo.caption" id="catch-sync-saved-locally">
+                        @Loc["SyncStatus_SavedLocally"]
+                    </MudText>
                     @if (_locationSaved)
                     {
                         <MudText Typo="Typo.caption" id="catch-location-saved">@Loc["Catch_LocationSaved"]</MudText>

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
@@ -36,6 +36,9 @@ public partial class RecordCatch : ComponentBase, IDisposable
     private ILocalCatchOwnerService LocalCatchOwner { get; set; } = default!;
 
     [Inject]
+    private ICatchSynchroniser CatchSynchroniser { get; set; } = default!;
+
+    [Inject]
     private ILocationService LocationService { get; set; } = default!;
 
     [Inject]
@@ -211,6 +214,7 @@ public partial class RecordCatch : ComponentBase, IDisposable
         _isSaving = true;
         _saveFailed = false;
         await InvokeAsync(StateHasChanged);
+        var saved = false;
         try
         {
             var ownerUserId = await LocalCatchOwner.GetUserIdAsync(_cancellationTokenSource.Token);
@@ -237,6 +241,7 @@ public partial class RecordCatch : ComponentBase, IDisposable
                 _cancellationTokenSource.Token);
             _isSaved = true;
             _locationSaved = location is not null;
+            saved = true;
         }
         catch (Exception)
         {
@@ -245,6 +250,32 @@ public partial class RecordCatch : ComponentBase, IDisposable
         finally
         {
             _isSaving = false;
+        }
+
+        if (!saved)
+        {
+            return;
+        }
+
+        TryToSynchronisePending();
+    }
+
+    private void TryToSynchronisePending()
+    {
+        _ = SafeSynchronisePendingAsync();
+    }
+
+    private async Task SafeSynchronisePendingAsync()
+    {
+        try
+        {
+            await CatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception)
+        {
         }
     }
 

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -37,6 +38,9 @@ public partial class RecordCatch : ComponentBase, IDisposable
 
     [Inject]
     private ICatchSynchroniser CatchSynchroniser { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
 
     [Inject]
     private ILocationService LocationService { get; set; } = default!;
@@ -274,8 +278,12 @@ public partial class RecordCatch : ComponentBase, IDisposable
         catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
         }
-        catch (Exception)
+        catch (Exception exception)
         {
+            await Logging.LogErrorAsync(
+                "production catch synchronisation",
+                exception,
+                _cancellationTokenSource.Token);
         }
     }
 

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
@@ -131,7 +131,7 @@ public partial class RecordCatch : ComponentBase, IDisposable
         await stream.CopyToAsync(buffer, _cancellationTokenSource.Token);
         var bytes = buffer.ToArray();
         var contentType = file.ContentType;
-        _caughtOn ??= DateTimeOffset.Now;
+        _caughtOn ??= DateTimeOffset.UtcNow;
         _photographs.Add(new PendingPhotograph(
             Guid.NewGuid(),
             contentType,
@@ -230,7 +230,7 @@ public partial class RecordCatch : ComponentBase, IDisposable
             await CatchStore.SaveAsync(
                 new CatchModel(
                     catchId,
-                    _caughtOn ?? DateTimeOffset.Now,
+                    _caughtOn ?? DateTimeOffset.UtcNow,
                     photographs,
                     Location: location,
                     UserId: ownerUserId),

--- a/src/FishingLogBook.Web/Features/Catch/Services/CatchClient.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/CatchClient.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Configuration;
@@ -8,10 +9,59 @@ namespace FishingLogBook.Web.Features.Catch.Services;
 public sealed class CatchClient : ICatchClient
 {
     private readonly HttpClient _apiClient;
+    private readonly HttpClient _anonymousClient;
 
     public CatchClient(IHttpClientFactory httpClientFactory)
     {
         _apiClient = httpClientFactory.CreateClient(HttpClientNames.AuthorizedApi);
+        _anonymousClient = httpClientFactory.CreateClient(HttpClientNames.Anonymous);
+    }
+
+    public async Task UpsertAsync(CatchDto catchRecord, CancellationToken cancellationToken)
+    {
+        using var response = await _apiClient.PostAsJsonAsync(
+            "api/catches",
+            catchRecord,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task<PhotographUploadDto> CreatePhotographUploadAsync(
+        Guid catchId,
+        PhotographUploadRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _apiClient.PostAsJsonAsync(
+            $"api/catches/{catchId:D}/photographs/upload-url",
+            request,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var upload = await response.Content.ReadFromJsonAsync<PhotographUploadDto>(cancellationToken);
+        return upload ?? throw new HttpRequestException("Photograph upload URL was missing.");
+    }
+
+    public async Task UploadPhotographAsync(
+        string uploadUrl,
+        byte[] bytes,
+        string contentType,
+        CancellationToken cancellationToken)
+    {
+        using var content = new ByteArrayContent(bytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        using var response = await _anonymousClient.PutAsync(uploadUrl, content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task RecordPhotographAsync(
+        Guid catchId,
+        RecordPhotographDto request,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _apiClient.PostAsJsonAsync(
+            $"api/catches/{catchId:D}/photographs",
+            request,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
     }
 
     public async Task UpdateLocationVisibilityAsync(

--- a/src/FishingLogBook.Web/Features/Catch/Services/ICatchClient.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/ICatchClient.cs
@@ -4,5 +4,23 @@ namespace FishingLogBook.Web.Features.Catch.Services;
 
 public interface ICatchClient
 {
+    Task UpsertAsync(CatchDto catchRecord, CancellationToken cancellationToken);
+
+    Task<PhotographUploadDto> CreatePhotographUploadAsync(
+        Guid catchId,
+        PhotographUploadRequestDto request,
+        CancellationToken cancellationToken);
+
+    Task UploadPhotographAsync(
+        string uploadUrl,
+        byte[] bytes,
+        string contentType,
+        CancellationToken cancellationToken);
+
+    Task RecordPhotographAsync(
+        Guid catchId,
+        RecordPhotographDto request,
+        CancellationToken cancellationToken);
+
     Task UpdateLocationVisibilityAsync(Guid catchId, string visibility, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Features/TestCatch/Pages/TestCatchLog/TestCatchLog.razor
+++ b/src/FishingLogBook.Web/Features/TestCatch/Pages/TestCatchLog/TestCatchLog.razor
@@ -1,4 +1,3 @@
-@page "/test-catch"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @attribute [Authorize]

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor.cs
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor.cs
@@ -1,19 +1,74 @@
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.Extensions.Localization;
+using Microsoft.JSInterop;
 using MudBlazor;
 
 namespace FishingLogBook.Web.Layouts.MainLayout;
 
-public partial class MainLayout : LayoutComponentBase
+public partial class MainLayout : LayoutComponentBase, IDisposable
 {
     private readonly MudTheme _theme = new();
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
 
     private bool _isDarkMode;
     private bool _drawerOpen;
+    private DotNetObjectReference<MainLayout>? _dotNetReference;
 
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    [Inject]
+    private ICatchSynchroniser CatchSynchroniser { get; set; } = default!;
+
+    [Inject]
+    private IDiagnosticSynchroniser DiagnosticSynchroniser { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IJSRuntime JsRuntime { get; set; } = default!;
+
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        NavigationManager.LocationChanged += OnLocationChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        _dotNetReference = DotNetObjectReference.Create(this);
+        await JsRuntime.InvokeVoidAsync(
+            "fishingLogBookNetwork.onOnline",
+            _dotNetReference);
+        await JsRuntime.InvokeVoidAsync(
+            "fishingLogBookNetwork.onUsable",
+            _dotNetReference);
+        _ = SynchroniseAsync();
+    }
+
+    [JSInvokable]
+    public Task OnBrowserOnline()
+    {
+        return SynchroniseAsync();
+    }
+
+    [JSInvokable]
+    public Task OnBrowserUsable()
+    {
+        return SynchroniseAsync();
+    }
 
     private string ThemeToggleIcon
     {
@@ -39,5 +94,53 @@ public partial class MainLayout : LayoutComponentBase
     private void ToggleDrawer()
     {
         _drawerOpen = !_drawerOpen;
+    }
+
+    private async Task SynchroniseAsync()
+    {
+        try
+        {
+            await CatchSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "production catch synchronisation",
+                exception,
+                _cancellationTokenSource.Token);
+        }
+
+        try
+        {
+            await DiagnosticSynchroniser.SynchronisePendingAsync(_cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "diagnostic synchronisation",
+                exception,
+                _cancellationTokenSource.Token);
+        }
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        _ = SynchroniseAsync();
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+        _cancellationTokenSource.Cancel();
+        _dotNetReference?.Dispose();
+        _cancellationTokenSource.Dispose();
     }
 }

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -114,6 +114,15 @@
   <data name="SyncStatus_FailedToSynchronise" xml:space="preserve">
     <value>Échec de la synchronisation</value>
   </data>
+  <data name="Catch_SyncRetry" xml:space="preserve">
+    <value>Réessayer</value>
+  </data>
+  <data name="Catch_SyncNow" xml:space="preserve">
+    <value>Synchroniser maintenant</value>
+  </data>
+  <data name="Catch_SyncFailureReassurance" xml:space="preserve">
+    <value>Votre prise reste enregistrée sur cet appareil.</value>
+  </data>
   <data name="TestCatch_Retry" xml:space="preserve">
     <value>Réessayer la synchronisation</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -114,6 +114,15 @@
   <data name="SyncStatus_FailedToSynchronise" xml:space="preserve">
     <value>Failed to synchronise</value>
   </data>
+  <data name="Catch_SyncRetry" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+  <data name="Catch_SyncNow" xml:space="preserve">
+    <value>Synchronise now</value>
+  </data>
+  <data name="Catch_SyncFailureReassurance" xml:space="preserve">
+    <value>Your catch is still saved on this device.</value>
+  </data>
   <data name="TestCatch_Retry" xml:space="preserve">
     <value>Retry synchronisation</value>
   </data>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITestCatchPhotoStore, IndexedDbTestCatchPhotoStore>();
         services.AddScoped<ITestCatchSynchroniser, TestCatchSynchroniser>();
         services.AddScoped<ICatchStore, IndexedDbCatchStore>();
+        services.AddScoped<ICatchSynchroniser, CatchSynchroniser>();
         services.AddScoped<ICatchClient, CatchClient>();
         services.AddScoped<ICurrentUserClient, CurrentUserClient>();
         services.AddScoped<ILocalCatchOwnerService, LocalCatchOwnerService>();

--- a/src/FishingLogBook.Web/wwwroot/js/browser/network.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/network.js
@@ -5,6 +5,16 @@ export function createNetworkApi(targetWindow) {
             targetWindow.addEventListener('online', () => {
                 helper.invokeMethodAsync('OnBrowserOnline');
             });
+        },
+        onUsable: (helper) => {
+            targetWindow.addEventListener('pageshow', () => {
+                helper.invokeMethodAsync('OnBrowserUsable');
+            });
+            targetWindow.document?.addEventListener('visibilitychange', () => {
+                if (targetWindow.document.visibilityState === 'visible') {
+                    helper.invokeMethodAsync('OnBrowserUsable');
+                }
+            });
         }
     };
 }

--- a/src/FishingLogBook.Web/wwwroot/js/browser/network.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/network.test.js
@@ -34,6 +34,34 @@ describe('network', () => {
         expect(helper.invokeMethodAsync).toHaveBeenCalledWith('OnBrowserOnline');
     });
 
+    it('invokes the helper when the page resumes or becomes visible', () => {
+        const windowHandlers = {};
+        const documentHandlers = {};
+        const helper = { invokeMethodAsync: vi.fn() };
+        const targetWindow = {
+            navigator: { onLine: true },
+            document: {
+                visibilityState: 'hidden',
+                addEventListener(name, callback) {
+                    documentHandlers[name] = callback;
+                }
+            },
+            addEventListener(name, callback) {
+                windowHandlers[name] = callback;
+            }
+        };
+        const api = createNetworkApi(targetWindow);
+
+        api.onUsable(helper);
+        windowHandlers.pageshow();
+        targetWindow.document.visibilityState = 'visible';
+        documentHandlers.visibilitychange();
+
+        expect(helper.invokeMethodAsync).toHaveBeenCalledTimes(2);
+        expect(helper.invokeMethodAsync).toHaveBeenNthCalledWith(1, 'OnBrowserUsable');
+        expect(helper.invokeMethodAsync).toHaveBeenNthCalledWith(2, 'OnBrowserUsable');
+    });
+
     it('installs the network API on the window', () => {
         const targetWindow = {
             navigator: { onLine: true },

--- a/src/FishingLogBook.Web/wwwroot/js/offline-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/offline-store.js
@@ -2,7 +2,8 @@ export {
     putTestCatch,
     getAllTestCatches,
     putCatchWithPhotographs,
-    getAllCatchesWithPhotographs
+    getAllCatchesWithPhotographs,
+    updateCatchMetadata
 } from './storage/catch-store.js';
 export { putTestCatchPhotograph, getTestCatchPhotograph } from './storage/photo-store.js';
 export { getStorageEstimate } from './storage/indexed-db.js';

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
@@ -232,6 +232,49 @@ export async function putCatchWithPhotographs(json, photographs) {
     });
 }
 
+export async function updateCatchMetadata(json) {
+    const catchRecord = JSON.parse(json);
+    if (!catchRecord?.id || !normalisedUserId(catchRecord.userId)) {
+        throw new Error('Owned Catch id is required');
+    }
+
+    await runCatchTransaction(PRODUCTION_CATCH_STORE_NAME, 'readwrite', 'sync-state-write', (store, succeed, fail) => {
+        const existingRequest = store.get(catchRecord.id);
+        existingRequest.onerror = () => fail(existingRequest.error);
+        existingRequest.onsuccess = () => {
+            const existing = existingRequest.result;
+            if (!existing || normalisedUserId(existing.userId) !== normalisedUserId(catchRecord.userId)) {
+                fail(new Error('Owned Catch was not found'));
+                return;
+            }
+
+            const incomingPhotographs = new Map(
+                (catchRecord.photographs || []).map((photograph) => [photograph.id, photograph])
+            );
+            const photographs = (existing.photographs || []).map((photograph) => {
+                const incoming = incomingPhotographs.get(photograph.id);
+                if (!incoming) {
+                    return photograph;
+                }
+
+                return {
+                    ...photograph,
+                    syncStatus: incoming.syncStatus,
+                    objectKey: incoming.objectKey
+                };
+            });
+            const updateRequest = store.put({
+                ...existing,
+                syncStatus: catchRecord.syncStatus,
+                metadataSyncStatus: catchRecord.metadataSyncStatus,
+                photographs
+            });
+            updateRequest.onsuccess = () => succeed();
+            updateRequest.onerror = () => fail(updateRequest.error);
+        };
+    });
+}
+
 export async function getAllCatchesWithPhotographs(ownerUserId) {
     return runProductionCatchTransaction('readonly', 'read', (transaction, succeed, fail) => {
         const catchStore = transaction.objectStore(PRODUCTION_CATCH_STORE_NAME);

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
@@ -9,7 +9,8 @@ import {
     getAllTestCatches,
     openCatchDatabase,
     putCatchWithPhotographs,
-    putTestCatch
+    putTestCatch,
+    updateCatchMetadata
 } from './catch-store.js';
 import * as indexedDb from './indexed-db.js';
 
@@ -321,6 +322,138 @@ describe('Production Catch store', () => {
             btoa(String.fromCharCode(2, 2, 2)),
             btoa(String.fromCharCode(3, 3, 3))
         ]);
+    });
+
+    it('persists sync transitions across reopen without replacing photograph bytes', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const photographId = '11111111-1111-1111-1111-111111111111';
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId: ownerUserId,
+                syncStatus: 0,
+                metadataSyncStatus: 0,
+                photographs: [{
+                    id: photographId,
+                    catchId,
+                    contentType: 'image/jpeg',
+                    syncStatus: 0
+                }]
+            }),
+            [{
+                id: photographId,
+                catchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([1, 2, 3])
+            }]
+        );
+
+        await updateCatchMetadata(JSON.stringify({
+            id: catchId,
+            userId: ownerUserId,
+            syncStatus: 4,
+            metadataSyncStatus: 3,
+            photographs: [{
+                id: photographId,
+                catchId,
+                contentType: 'image/jpeg',
+                syncStatus: 3,
+                objectKey: `catches/${ownerUserId}/${catchId}/${photographId}`
+            }]
+        }));
+
+        const firstRead = await getAllCatchesWithPhotographs(ownerUserId);
+        const reopened = await getAllCatchesWithPhotographs(ownerUserId);
+        const metadata = JSON.parse(reopened[0].json);
+
+        expect(JSON.parse(firstRead[0].json).syncStatus).toBe(4);
+        expect(metadata.metadataSyncStatus).toBe(3);
+        expect(metadata.photographs[0].syncStatus).toBe(3);
+        expect(metadata.photographs[0].objectKey).toBe(
+            `catches/${ownerUserId}/${catchId}/${photographId}`
+        );
+        expect(reopened[0].photographs[0].bytesBase64).toBe(
+            btoa(String.fromCharCode(1, 2, 3))
+        );
+    });
+
+    it('does not let another user overwrite sync state', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        await putCatchWithPhotographs(
+            JSON.stringify({ id: catchId, userId: ownerUserId, syncStatus: 0 }),
+            [{
+                id: 'photo-1',
+                catchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([1])
+            }]
+        );
+
+        await expect(updateCatchMetadata(JSON.stringify({
+            id: catchId,
+            userId: otherUserId,
+            syncStatus: 3
+        }))).rejects.toThrow('Owned Catch was not found');
+
+        const ownerView = await getAllCatchesWithPhotographs(ownerUserId);
+        expect(JSON.parse(ownerView[0].json).syncStatus).toBe(0);
+        expect(ownerView[0].photographs[0].bytesBase64).toBe(
+            btoa(String.fromCharCode(1))
+        );
+    });
+
+    it('does not let a stale sync transition overwrite newer location privacy', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const photographId = '11111111-1111-1111-1111-111111111111';
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId: ownerUserId,
+                syncStatus: 1,
+                metadataSyncStatus: 1,
+                location: {
+                    latitude: 53.2707,
+                    longitude: -9.0568,
+                    visibility: 'Private'
+                },
+                photographs: [{
+                    id: photographId,
+                    catchId,
+                    contentType: 'image/jpeg',
+                    syncStatus: 1
+                }]
+            }),
+            [{
+                id: photographId,
+                catchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([1])
+            }]
+        );
+
+        await updateCatchMetadata(JSON.stringify({
+            id: catchId,
+            userId: ownerUserId,
+            syncStatus: 3,
+            metadataSyncStatus: 3,
+            location: {
+                latitude: 53.2707,
+                longitude: -9.0568,
+                visibility: 'Public'
+            },
+            photographs: [{
+                id: photographId,
+                catchId,
+                contentType: 'image/jpeg',
+                syncStatus: 3
+            }]
+        }));
+
+        const ownerView = await getAllCatchesWithPhotographs(ownerUserId);
+        const stored = JSON.parse(ownerView[0].json);
+        expect(stored.location.visibility).toBe('Private');
+        expect(stored.syncStatus).toBe(3);
+        expect(stored.photographs[0].syncStatus).toBe(3);
     });
 
     it('keeps two separately saved catches on distinct ids', async () => {

--- a/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingPhotograph.cs
+++ b/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingPhotograph.cs
@@ -1,0 +1,300 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.CatchEndpointsTests;
+
+public class WhenTestingPhotograph : IClassFixture<SystemApiFactory>
+{
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingPhotograph(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnauthenticatedUploadRequest()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateClient();
+        var catchId = Guid.NewGuid();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs/upload-url",
+            new PhotographUploadRequestDto(Guid.NewGuid(), "image/jpeg"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.CatchRepository.DidNotReceive().GetPhotographAsync(
+            Arg.Any<GetCatchPhotographArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnauthenticatedRecordRequest()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateClient();
+        var catchId = Guid.NewGuid();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs",
+            new RecordPhotographDto(Guid.NewGuid(), "object-key", "image/jpeg"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.CatchRepository.DidNotReceive().GetPhotographAsync(
+            Arg.Any<GetCatchPhotographArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnsupportedUploadContentType()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var catchId = Guid.NewGuid();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs/upload-url",
+            new PhotographUploadRequestDto(Guid.NewGuid(), "image/gif"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.CatchRepository.DidNotReceive().GetPhotographAsync(
+            Arg.Any<GetCatchPhotographArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnServiceUnavailableWhenPhotographLookupFails()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        _factory.CatchRepository.GetPhotographAsync(
+                Arg.Any<GetCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<CatchPhotograph?>("database unavailable"));
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs/upload-url",
+            new PhotographUploadRequestDto(photographId, "image/jpeg"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        await _factory.CatchRepository.Received(1).GetPhotographAsync(
+            Arg.Is<GetCatchPhotographArgs>(query =>
+                query.CatchId == catchId
+                && query.PhotographId == photographId),
+            Arg.Any<CancellationToken>());
+        await _factory.ObjectStorage.DidNotReceive().CreateUploadUrlAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnServiceUnavailableWhenObjectStorageIsNotConfigured()
+    {
+        // Arrange
+        Reset();
+        _factory.ObjectStorage.IsConfigured.Returns(false);
+        var client = _factory.CreateAuthenticatedClient();
+        var catchId = Guid.NewGuid();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs/upload-url",
+            new PhotographUploadRequestDto(Guid.NewGuid(), "image/jpeg"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        await _factory.CatchRepository.DidNotReceive().GetPhotographAsync(
+            Arg.Any<GetCatchPhotographArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDeriveAStableOwnerScopedObjectKey()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        _factory.CatchRepository.GetPhotographAsync(
+                Arg.Any<GetCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<CatchPhotograph?>(
+                new CatchPhotograph
+                {
+                    Id = photographId,
+                    CatchId = catchId,
+                    ContentType = "image/jpeg"
+                }));
+        var request = new PhotographUploadRequestDto(photographId, "image/jpeg");
+
+        // Act
+        var firstResponse = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs/upload-url",
+            request);
+        var secondResponse = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs/upload-url",
+            request);
+        var first = await firstResponse.Content.ReadFromJsonAsync<PhotographUploadDto>();
+        var second = await secondResponse.Content.ReadFromJsonAsync<PhotographUploadDto>();
+
+        // Assert
+        firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        secondResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        first!.ObjectKey.Should().Be(
+            $"catches/{current!.UserId:D}/{catchId:D}/{photographId:D}");
+        second!.ObjectKey.Should().Be(first.ObjectKey);
+        await _factory.CatchRepository.Received(2).GetPhotographAsync(
+            Arg.Is<GetCatchPhotographArgs>(query =>
+                query.UserId == current.UserId
+                && query.CatchId == catchId
+                && query.PhotographId == photographId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNotFoundForAPhotographOutsideTheCurrentOwner()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        _factory.CatchRepository.GetPhotographAsync(
+                Arg.Any<GetCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<CatchPhotograph?>(null));
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs/upload-url",
+            new PhotographUploadRequestDto(photographId, "image/jpeg"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await _factory.ObjectStorage.DidNotReceive().CreateUploadUrlAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAcceptRepeatedConfirmationWithoutCreatingAnotherRecord()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        _factory.CatchRepository.GetPhotographAsync(
+                Arg.Any<GetCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<CatchPhotograph?>(
+                new CatchPhotograph
+                {
+                    Id = photographId,
+                    CatchId = catchId,
+                    ContentType = "image/jpeg"
+                }));
+        var request = new RecordPhotographDto(
+            photographId,
+            $"catches/{current!.UserId:D}/{catchId:D}/{photographId:D}",
+            "image/jpeg");
+
+        // Act
+        var first = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs",
+            request);
+        var second = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs",
+            request);
+
+        // Assert
+        first.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        second.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await _factory.CatchRepository.Received(2).GetPhotographAsync(
+            Arg.Is<GetCatchPhotographArgs>(query =>
+                query.UserId == current.UserId
+                && query.CatchId == catchId
+                && query.PhotographId == photographId),
+            Arg.Any<CancellationToken>());
+        await _factory.CatchRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Catch>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAReplacementObjectKey()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        _factory.CatchRepository.GetPhotographAsync(
+                Arg.Any<GetCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<CatchPhotograph?>(
+                new CatchPhotograph
+                {
+                    Id = photographId,
+                    CatchId = catchId,
+                    ContentType = "image/jpeg"
+                }));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/catches/{catchId:D}/photographs",
+            new RecordPhotographDto(
+                photographId,
+                "catches/another-user/replacement",
+                "image/jpeg"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.CatchRepository.Received(1).GetPhotographAsync(
+            Arg.Is<GetCatchPhotographArgs>(query =>
+                query.CatchId == catchId
+                && query.PhotographId == photographId),
+            Arg.Any<CancellationToken>());
+    }
+
+    private void Reset()
+    {
+        _factory.CatchRepository.ClearReceivedCalls();
+        _factory.ObjectStorage.ClearReceivedCalls();
+        _factory.ObjectStorage.IsConfigured.Returns(true);
+        _factory.ObjectStorage.CreateUploadUrlAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new Uri("https://storage.test/upload"));
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingPhotograph.cs
+++ b/tests/FishingLogBook.Api.Tests/TestCatchEndpointsTests/WhenTestingPhotograph.cs
@@ -119,4 +119,37 @@ public class WhenTestingPhotograph : IClassFixture<SystemApiFactory>
             TimeSpan.FromMinutes(15),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task ItShouldRejectWhenThePhotographObjectKeyDoesNotMatch()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aabbccdd-eeff-0011-2233-445566778899");
+        var photographId = Guid.Parse("99887766-5544-3322-1100-ffeeddccbbaa");
+        var record = new TestCatchRecord
+        {
+            Id = catchId,
+            SpeciesName = "Roach",
+            CaughtOn = DateTimeOffset.Parse("2026-08-14T19:00:00Z")
+        };
+        _factory.TestCatchRepository
+            .GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(record);
+        _factory.TestCatchRepository.ClearReceivedCalls();
+        var client = _factory.CreateAuthenticatedClient();
+        var request = new RecordPhotographDto(photographId, "wrong-key", "image/jpeg");
+
+        // Act
+        var response = await client.PostAsJsonAsync($"/api/test-catches/{catchId:D}/photographs", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TestCatchRepository.Received(1).GetByIdAsync(catchId, Arg.Any<CancellationToken>());
+        await _factory.TestCatchRepository.DidNotReceive().UpsertPhotographAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/CreateCatchPhotographUploadCommandTests/BaseCreateCatchPhotographUploadCommandTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/CreateCatchPhotographUploadCommandTests/BaseCreateCatchPhotographUploadCommandTest.cs
@@ -1,0 +1,22 @@
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Application.Common.Mappings;
+using FishingLogBook.Application.Contracts.Services;
+using Mapster;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.CreateCatchPhotographUploadCommandTests;
+
+public class BaseCreateCatchPhotographUploadCommandTest
+{
+    protected readonly ICatchPhotographService MockCatchPhotographService =
+        Substitute.For<ICatchPhotographService>();
+    protected readonly CreateCatchPhotographUploadHandler Sut;
+
+    protected BaseCreateCatchPhotographUploadCommandTest()
+    {
+        ((IRegister)new CatchMappingRegistration()).Register(
+            TypeAdapterConfig.GlobalSettings);
+        MockCatchPhotographService.IsObjectStorageConfigured.Returns(true);
+        Sut = new CreateCatchPhotographUploadHandler(MockCatchPhotographService);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/CreateCatchPhotographUploadCommandTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/CreateCatchPhotographUploadCommandTests/WhenTestingHandle.cs
@@ -1,0 +1,86 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.CreateCatchPhotographUploadCommandTests;
+
+public class WhenTestingHandle : BaseCreateCatchPhotographUploadCommandTest
+{
+    [Fact]
+    public async Task ItShouldNotCallTheServiceWhenObjectStorageIsUnavailable()
+    {
+        // Arrange
+        MockCatchPhotographService.IsObjectStorageConfigured.Returns(false);
+        var command = Command();
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsFailure.Should().BeTrue();
+        await MockCatchPhotographService.DidNotReceive().CreateUploadAsync(
+            Arg.Any<CreateCatchPhotographUploadArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheServiceFailure()
+    {
+        // Arrange
+        var command = Command();
+        MockCatchPhotographService.CreateUploadAsync(
+                Arg.Any<CreateCatchPhotographUploadArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<PhotographUploadDto>("failed"));
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsFailure.Should().BeTrue();
+        response.ErrorMessage.Should().Be("failed");
+        await MockCatchPhotographService.Received(1).CreateUploadAsync(
+            Arg.Is<CreateCatchPhotographUploadArgs>(args =>
+                args.CatchId == command.CatchId
+                && args.Request == command.Request),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheUpload()
+    {
+        // Arrange
+        var command = Command();
+        var expected = new PhotographUploadDto("object-key", "https://storage.test/object");
+        MockCatchPhotographService.CreateUploadAsync(
+                Arg.Any<CreateCatchPhotographUploadArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(expected));
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsSuccess.Should().BeTrue();
+        response.Upload.Should().Be(expected);
+        await MockCatchPhotographService.Received(1).CreateUploadAsync(
+            Arg.Is<CreateCatchPhotographUploadArgs>(args =>
+                args.CatchId == command.CatchId
+                && args.Request == command.Request),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static CreateCatchPhotographUploadCommand Command()
+    {
+        return new CreateCatchPhotographUploadCommand
+        {
+            CatchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            Request = new PhotographUploadRequestDto(
+                Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                "image/jpeg")
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/CreateCatchPhotographUploadCommandValidatorTests/BaseCreateCatchPhotographUploadCommandValidatorTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/CreateCatchPhotographUploadCommandValidatorTests/BaseCreateCatchPhotographUploadCommandValidatorTest.cs
@@ -1,0 +1,8 @@
+using FishingLogBook.Application.Catches.Commands;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.CreateCatchPhotographUploadCommandValidatorTests;
+
+public class BaseCreateCatchPhotographUploadCommandValidatorTest
+{
+    protected readonly CreateCatchPhotographUploadCommandValidator Sut = new();
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/CreateCatchPhotographUploadCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/CreateCatchPhotographUploadCommandValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,63 @@
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.CreateCatchPhotographUploadCommandValidatorTests;
+
+public class WhenTestingValidate : BaseCreateCatchPhotographUploadCommandValidatorTest
+{
+    [Fact]
+    public void ItShouldRejectEmptyIds()
+    {
+        // Arrange
+        var command = new CreateCatchPhotographUploadCommand
+        {
+            Request = new PhotographUploadRequestDto(Guid.Empty, "image/jpeg")
+        };
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.CatchId);
+        result.ShouldHaveValidationErrorFor(item => item.Request.PhotographId);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnUnsupportedContentType()
+    {
+        // Arrange
+        var command = Command("image/gif");
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Request.ContentType);
+    }
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/png")]
+    [InlineData("image/webp")]
+    public void ItShouldAcceptSupportedContentTypes(string contentType)
+    {
+        // Arrange
+        var command = Command(contentType);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static CreateCatchPhotographUploadCommand Command(string contentType)
+    {
+        return new CreateCatchPhotographUploadCommand
+        {
+            CatchId = Guid.NewGuid(),
+            Request = new PhotographUploadRequestDto(Guid.NewGuid(), contentType)
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/RecordCatchPhotographCommandTests/BaseRecordCatchPhotographCommandTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/RecordCatchPhotographCommandTests/BaseRecordCatchPhotographCommandTest.cs
@@ -1,0 +1,21 @@
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Application.Common.Mappings;
+using FishingLogBook.Application.Contracts.Services;
+using Mapster;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.RecordCatchPhotographCommandTests;
+
+public class BaseRecordCatchPhotographCommandTest
+{
+    protected readonly ICatchPhotographService MockCatchPhotographService =
+        Substitute.For<ICatchPhotographService>();
+    protected readonly RecordCatchPhotographHandler Sut;
+
+    protected BaseRecordCatchPhotographCommandTest()
+    {
+        ((IRegister)new CatchMappingRegistration()).Register(
+            TypeAdapterConfig.GlobalSettings);
+        Sut = new RecordCatchPhotographHandler(MockCatchPhotographService);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/RecordCatchPhotographCommandTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/RecordCatchPhotographCommandTests/WhenTestingHandle.cs
@@ -1,0 +1,72 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.RecordCatchPhotographCommandTests;
+
+public class WhenTestingHandle : BaseRecordCatchPhotographCommandTest
+{
+    [Fact]
+    public async Task ItShouldReturnTheServiceFailure()
+    {
+        // Arrange
+        var command = Command();
+        MockCatchPhotographService.RecordAsync(
+                Arg.Any<RecordCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Fail("failed"));
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsFailure.Should().BeTrue();
+        response.ErrorMessage.Should().Be("failed");
+        await MockCatchPhotographService.Received(1).RecordAsync(
+            Arg.Is<RecordCatchPhotographArgs>(args =>
+                args.CatchId == command.CatchId
+                && args.PhotographId == command.Photograph.PhotographId
+                && args.ObjectKey == command.Photograph.ObjectKey
+                && args.ContentType == command.Photograph.ContentType),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRecordThePhotograph()
+    {
+        // Arrange
+        var command = Command();
+        MockCatchPhotographService.RecordAsync(
+                Arg.Any<RecordCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+
+        // Act
+        var response = await Sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        response.IsSuccess.Should().BeTrue();
+        await MockCatchPhotographService.Received(1).RecordAsync(
+            Arg.Is<RecordCatchPhotographArgs>(args =>
+                args.CatchId == command.CatchId
+                && args.PhotographId == command.Photograph.PhotographId
+                && args.ObjectKey == command.Photograph.ObjectKey
+                && args.ContentType == command.Photograph.ContentType),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static RecordCatchPhotographCommand Command()
+    {
+        return new RecordCatchPhotographCommand
+        {
+            CatchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            Photograph = new RecordPhotographDto(
+                Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                "object-key",
+                "image/jpeg")
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/RecordCatchPhotographCommandValidatorTests/BaseRecordCatchPhotographCommandValidatorTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/RecordCatchPhotographCommandValidatorTests/BaseRecordCatchPhotographCommandValidatorTest.cs
@@ -1,0 +1,8 @@
+using FishingLogBook.Application.Catches.Commands;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.RecordCatchPhotographCommandValidatorTests;
+
+public class BaseRecordCatchPhotographCommandValidatorTest
+{
+    protected readonly RecordCatchPhotographCommandValidator Sut = new();
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Commands/RecordCatchPhotographCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Commands/RecordCatchPhotographCommandValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,67 @@
+using FishingLogBook.Application.Catches.Commands;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Catches.Commands.RecordCatchPhotographCommandValidatorTests;
+
+public class WhenTestingValidate : BaseRecordCatchPhotographCommandValidatorTest
+{
+    [Fact]
+    public void ItShouldRejectEmptyRequiredValues()
+    {
+        // Arrange
+        var command = new RecordCatchPhotographCommand
+        {
+            Photograph = new RecordPhotographDto(Guid.Empty, string.Empty, "image/jpeg")
+        };
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.CatchId);
+        result.ShouldHaveValidationErrorFor(item => item.Photograph.PhotographId);
+        result.ShouldHaveValidationErrorFor(item => item.Photograph.ObjectKey);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnUnsupportedContentType()
+    {
+        // Arrange
+        var command = Command("image/gif");
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Photograph.ContentType);
+    }
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/png")]
+    [InlineData("image/webp")]
+    public void ItShouldAcceptSupportedContentTypes(string contentType)
+    {
+        // Arrange
+        var command = Command(contentType);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static RecordCatchPhotographCommand Command(string contentType)
+    {
+        return new RecordCatchPhotographCommand
+        {
+            CatchId = Guid.NewGuid(),
+            Photograph = new RecordPhotographDto(
+                Guid.NewGuid(),
+                "object-key",
+                contentType)
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchPhotographServiceTests/BaseCatchPhotographServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchPhotographServiceTests/BaseCatchPhotographServiceTest.cs
@@ -1,0 +1,57 @@
+using FishingLogBook.Application.Catches.Services;
+using FishingLogBook.Application.Contracts;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Domain.Catches;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Services.CatchPhotographServiceTests;
+
+public class BaseCatchPhotographServiceTest
+{
+    protected static readonly Guid UserId =
+        Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid CatchId =
+        Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid PhotographId =
+        Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    protected readonly ICatchRepository MockCatchRepository =
+        Substitute.For<ICatchRepository>();
+    protected readonly IObjectStorage MockObjectStorage =
+        Substitute.For<IObjectStorage>();
+    protected readonly ICurrentUser MockCurrentUser =
+        Substitute.For<ICurrentUser>();
+
+    protected BaseCatchPhotographServiceTest()
+    {
+        MockCurrentUser.IsResolved.Returns(true);
+        MockCurrentUser.UserId.Returns(UserId);
+        MockObjectStorage.IsConfigured.Returns(true);
+        MockObjectStorage.CreateUploadUrlAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new Uri("https://storage.test/upload"));
+        MockCatchRepository.GetPhotographAsync(
+                Arg.Any<Application.Args.GetCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<CatchPhotograph?>(
+                new CatchPhotograph
+                {
+                    Id = PhotographId,
+                    CatchId = CatchId,
+                    ContentType = "image/jpeg"
+                }));
+    }
+
+    protected CatchPhotographService CreateSut()
+    {
+        return new CatchPhotographService(
+            MockCatchRepository,
+            MockObjectStorage,
+            MockCurrentUser);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchPhotographServiceTests/WhenTestingCreateUpload.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchPhotographServiceTests/WhenTestingCreateUpload.cs
@@ -1,0 +1,82 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Catches.Errors;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Services.CatchPhotographServiceTests;
+
+public class WhenTestingCreateUpload : BaseCatchPhotographServiceTest
+{
+    [Fact]
+    public async Task ItShouldDeriveTheSameObjectKeyForRepeatedRequests()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var args = new CreateCatchPhotographUploadArgs
+        {
+            CatchId = CatchId,
+            Request = new PhotographUploadRequestDto(PhotographId, "image/jpeg")
+        };
+
+        // Act
+        var first = await sut.CreateUploadAsync(args, CancellationToken.None);
+        var second = await sut.CreateUploadAsync(args, CancellationToken.None);
+
+        // Assert
+        first.IsSuccess.Should().BeTrue();
+        second.IsSuccess.Should().BeTrue();
+        first.Value.ObjectKey.Should().Be(
+            $"catches/{UserId:D}/{CatchId:D}/{PhotographId:D}");
+        second.Value.ObjectKey.Should().Be(first.Value.ObjectKey);
+        await MockCatchRepository.Received(2).GetPhotographAsync(
+            Arg.Is<GetCatchPhotographArgs>(query =>
+                query.UserId == UserId
+                && query.CatchId == CatchId
+                && query.PhotographId == PhotographId),
+            Arg.Any<CancellationToken>());
+        await MockObjectStorage.Received(2).CreateUploadUrlAsync(
+            $"catches/{UserId:D}/{CatchId:D}/{PhotographId:D}",
+            "image/jpeg",
+            TimeSpan.FromMinutes(15),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAPhotographThatIsNotOwnedByTheCurrentUser()
+    {
+        // Arrange
+        MockCatchRepository.GetPhotographAsync(
+                Arg.Any<GetCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<CatchPhotograph?>(null));
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.CreateUploadAsync(
+            new CreateCatchPhotographUploadArgs
+            {
+                CatchId = CatchId,
+                Request = new PhotographUploadRequestDto(PhotographId, "image/jpeg")
+            },
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().BeOfType<CatchPhotographNotFoundError>();
+        await MockCatchRepository.Received(1).GetPhotographAsync(
+            Arg.Is<GetCatchPhotographArgs>(query =>
+                query.UserId == UserId
+                && query.CatchId == CatchId
+                && query.PhotographId == PhotographId),
+            Arg.Any<CancellationToken>());
+        await MockObjectStorage.DidNotReceive().CreateUploadUrlAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchPhotographServiceTests/WhenTestingRecord.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchPhotographServiceTests/WhenTestingRecord.cs
@@ -1,0 +1,66 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Catches.Errors;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Catches.Services.CatchPhotographServiceTests;
+
+public class WhenTestingRecord : BaseCatchPhotographServiceTest
+{
+    [Fact]
+    public async Task ItShouldAcceptTheDeterministicObjectKeyIdempotently()
+    {
+        // Arrange
+        var sut = CreateSut();
+        var args = new RecordCatchPhotographArgs
+        {
+            CatchId = CatchId,
+            PhotographId = PhotographId,
+            ContentType = "image/jpeg",
+            ObjectKey = $"catches/{UserId:D}/{CatchId:D}/{PhotographId:D}"
+        };
+
+        // Act
+        var first = await sut.RecordAsync(args, CancellationToken.None);
+        var second = await sut.RecordAsync(args, CancellationToken.None);
+
+        // Assert
+        first.IsSuccess.Should().BeTrue();
+        second.IsSuccess.Should().BeTrue();
+        await MockCatchRepository.Received(2).GetPhotographAsync(
+            Arg.Is<GetCatchPhotographArgs>(query =>
+                query.UserId == UserId
+                && query.CatchId == CatchId
+                && query.PhotographId == PhotographId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAClientSuppliedReplacementObjectKey()
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.RecordAsync(
+            new RecordCatchPhotographArgs
+            {
+                CatchId = CatchId,
+                PhotographId = PhotographId,
+                ContentType = "image/jpeg",
+                ObjectKey = "catches/another-user/replacement"
+            },
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().BeOfType<CatchPhotographObjectKeyMismatchError>();
+        await MockCatchRepository.Received(1).GetPhotographAsync(
+            Arg.Is<GetCatchPhotographArgs>(query =>
+                query.UserId == UserId
+                && query.CatchId == CatchId
+                && query.PhotographId == PhotographId),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/BaseCatchRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/BaseCatchRepositoryTest.cs
@@ -1,0 +1,47 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Infrastructure.Persistence;
+using FishingLogBook.Infrastructure.Tests.TestSupport;
+using FishingLogBook.Shared.Constants;
+using NSubstitute;
+using Npgsql;
+
+namespace FishingLogBook.Infrastructure.Tests.CatchRepositoryTests;
+
+public abstract class BaseCatchRepositoryTest
+{
+    protected readonly IDbConnectionFactory MockConnectionFactory = Substitute.For<IDbConnectionFactory>();
+    protected readonly RecordingLogger<CatchRepository> Logger = new();
+    protected readonly CatchRepository Sut;
+
+    protected BaseCatchRepositoryTest()
+    {
+        Sut = new CatchRepository(MockConnectionFactory, Logger);
+    }
+
+    protected void FailOpenConnection(Exception exception)
+    {
+        MockConnectionFactory.CreateOpenConnectionAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException<NpgsqlConnection>(exception));
+    }
+
+    protected static Catch NewCatch()
+    {
+        var catchId = Guid.NewGuid();
+        return new Catch
+        {
+            Id = catchId,
+            UserId = Guid.NewGuid(),
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            Photographs =
+            [
+                new CatchPhotograph
+                {
+                    Id = Guid.NewGuid(),
+                    CatchId = catchId,
+                    ContentType = PhotographContentTypeConstants.Jpeg
+                }
+            ]
+        };
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/WhenTestingGetById.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/WhenTestingGetById.cs
@@ -1,0 +1,30 @@
+using AwesomeAssertions;
+using FishingLogBook.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace FishingLogBook.Infrastructure.Tests.CatchRepositoryTests;
+
+public class WhenTestingGetById : BaseCatchRepositoryTest
+{
+    [Fact]
+    public async Task ItShouldLogTheExceptionWhenTheDatabaseReadFails()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var exception = new InvalidOperationException("database unavailable");
+        FailOpenConnection(exception);
+
+        // Act
+        var result = await Sut.GetByIdAsync(catchId, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Failed to save the catch.");
+        Logger.Records.Should().ContainSingle();
+        Logger.Records[0].Level.Should().Be(LogLevel.Error);
+        Logger.Records[0].Exception.Should().BeSameAs(exception);
+        Logger.Records[0].Message.Should().Contain(catchId.ToString("D"));
+        await MockConnectionFactory.Received(1).CreateOpenConnectionAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/WhenTestingGetPhotograph.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/WhenTestingGetPhotograph.cs
@@ -1,0 +1,37 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace FishingLogBook.Infrastructure.Tests.CatchRepositoryTests;
+
+public class WhenTestingGetPhotograph : BaseCatchRepositoryTest
+{
+    [Fact]
+    public async Task ItShouldLogTheExceptionWhenTheDatabaseReadFails()
+    {
+        // Arrange
+        var args = new GetCatchPhotographArgs
+        {
+            UserId = Guid.NewGuid(),
+            CatchId = Guid.NewGuid(),
+            PhotographId = Guid.NewGuid()
+        };
+        var exception = new InvalidOperationException("database unavailable");
+        FailOpenConnection(exception);
+
+        // Act
+        var result = await Sut.GetPhotographAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Failed to save the catch.");
+        Logger.Records.Should().ContainSingle();
+        Logger.Records[0].Level.Should().Be(LogLevel.Error);
+        Logger.Records[0].Exception.Should().BeSameAs(exception);
+        Logger.Records[0].Message.Should().Contain(args.PhotographId.ToString("D"));
+        Logger.Records[0].Message.Should().Contain(args.CatchId.ToString("D"));
+        await MockConnectionFactory.Received(1).CreateOpenConnectionAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/WhenTestingUpdateLocationVisibility.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/WhenTestingUpdateLocationVisibility.cs
@@ -1,0 +1,38 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Infrastructure.Persistence;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace FishingLogBook.Infrastructure.Tests.CatchRepositoryTests;
+
+public class WhenTestingUpdateLocationVisibility : BaseCatchRepositoryTest
+{
+    [Fact]
+    public async Task ItShouldLogTheExceptionWhenTheDatabaseWriteFails()
+    {
+        // Arrange
+        var args = new PersistCatchLocationVisibilityArgs
+        {
+            CatchId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Visibility = LocationDefaults.Private
+        };
+        var exception = new InvalidOperationException("database unavailable");
+        FailOpenConnection(exception);
+
+        // Act
+        var result = await Sut.UpdateLocationVisibilityAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Failed to save the catch.");
+        Logger.Records.Should().ContainSingle();
+        Logger.Records[0].Level.Should().Be(LogLevel.Error);
+        Logger.Records[0].Exception.Should().BeSameAs(exception);
+        Logger.Records[0].Message.Should().Contain(args.CatchId.ToString("D"));
+        await MockConnectionFactory.Received(1).CreateOpenConnectionAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/WhenTestingUpsert.cs
@@ -1,0 +1,31 @@
+using AwesomeAssertions;
+using FishingLogBook.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace FishingLogBook.Infrastructure.Tests.CatchRepositoryTests;
+
+public class WhenTestingUpsert : BaseCatchRepositoryTest
+{
+    [Fact]
+    public async Task ItShouldLogTheExceptionWhenTheDatabaseWriteFails()
+    {
+        // Arrange
+        var catchRecord = NewCatch();
+        var exception = new InvalidOperationException(
+            "Cannot write DateTimeOffset with Offset=04:00:00 to PostgreSQL type 'timestamp with time zone', only offset 0 (UTC) is supported. (Parameter 'value')");
+        FailOpenConnection(exception);
+
+        // Act
+        var result = await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Failed to save the catch.");
+        Logger.Records.Should().ContainSingle();
+        Logger.Records[0].Level.Should().Be(LogLevel.Error);
+        Logger.Records[0].Exception.Should().BeSameAs(exception);
+        Logger.Records[0].Message.Should().Contain(catchRecord.Id.ToString("D"));
+        await MockConnectionFactory.Received(1).CreateOpenConnectionAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/BaseUserPlatformCapabilityRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/BaseUserPlatformCapabilityRepositoryTest.cs
@@ -4,7 +4,9 @@ using FishingLogBook.Domain.Enums;
 using FishingLogBook.Domain.Users;
 using FishingLogBook.Infrastructure.Persistence;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+using FishingLogBook.Infrastructure.Tests.TestSupport;
 using FishingLogBook.Tests.Common.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace FishingLogBook.Infrastructure.Tests.Integration.Capabilities.UserPlatformCapabilityRepositoryTests;
 
@@ -12,14 +14,15 @@ namespace FishingLogBook.Infrastructure.Tests.Integration.Capabilities.UserPlatf
 public abstract class BaseUserPlatformCapabilityRepositoryTest
 {
     protected readonly UserPlatformCapabilityRepository Sut;
+    protected readonly RecordingLogger<UserPlatformCapabilityRepository> Logger = new();
     protected readonly UserIdentityRepository Users;
     protected readonly NpgsqlConnectionFactory ConnectionFactory;
 
     protected BaseUserPlatformCapabilityRepositoryTest(PostgresFixture fixture)
     {
         ConnectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
-        Sut = new UserPlatformCapabilityRepository(ConnectionFactory);
-        Users = new UserIdentityRepository(ConnectionFactory);
+        Sut = new UserPlatformCapabilityRepository(ConnectionFactory, Logger);
+        Users = new UserIdentityRepository(ConnectionFactory, NullLogger<UserIdentityRepository>.Instance);
     }
 
     protected async Task<Guid> CreateUserAsync()

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingGrant.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Capabilities/UserPlatformCapabilityRepositoryTests/WhenTestingGrant.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Dapper;
 using FishingLogBook.Domain.Enums;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace FishingLogBook.Infrastructure.Tests.Integration.Capabilities.UserPlatformCapabilityRepositoryTests;
@@ -28,6 +29,9 @@ public class WhenTestingGrant : BaseUserPlatformCapabilityRepositoryTest
         result.IsFailed.Should().BeTrue();
         result.Errors[0].Message.Should().Be("Platform capability is invalid.");
         (await CountForUserAsync(missingUserId)).Should().Be(0);
+        Logger.Records.Should().ContainSingle();
+        Logger.Records[0].Level.Should().Be(LogLevel.Warning);
+        Logger.Records[0].Exception.Should().BeOfType<PostgresException>();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/BaseCatchRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/BaseCatchRepositoryTest.cs
@@ -1,9 +1,11 @@
 using FishingLogBook.Domain.Catches;
 using FishingLogBook.Infrastructure.Persistence;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+using FishingLogBook.Infrastructure.Tests.TestSupport;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Tests.Common.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace FishingLogBook.Infrastructure.Tests.Integration.Catches.CatchRepositoryTests;
 
@@ -11,14 +13,15 @@ namespace FishingLogBook.Infrastructure.Tests.Integration.Catches.CatchRepositor
 public abstract class BaseCatchRepositoryTest
 {
     protected readonly CatchRepository Sut;
+    protected readonly RecordingLogger<CatchRepository> Logger = new();
     protected readonly UserIdentityRepository Users;
     protected readonly NpgsqlConnectionFactory ConnectionFactory;
 
     protected BaseCatchRepositoryTest(PostgresFixture fixture)
     {
         ConnectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
-        Sut = new CatchRepository(ConnectionFactory);
-        Users = new UserIdentityRepository(ConnectionFactory);
+        Sut = new CatchRepository(ConnectionFactory, Logger);
+        Users = new UserIdentityRepository(ConnectionFactory, NullLogger<UserIdentityRepository>.Instance);
     }
 
     protected async Task<Guid> CreateUserAsync()

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingGetPhotograph.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingGetPhotograph.cs
@@ -1,0 +1,67 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+
+namespace FishingLogBook.Infrastructure.Tests.Integration.Catches.CatchRepositoryTests;
+
+public class WhenTestingGetPhotograph : BaseCatchRepositoryTest
+{
+    public WhenTestingGetPhotograph(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldReturnThePhotographForItsOwner()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var catchRecord = NewCatch(ownerUserId);
+        var photograph = catchRecord.Photographs.Single();
+        var saved = await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        saved.IsSuccess.Should().BeTrue();
+
+        // Act
+        var result = await Sut.GetPhotographAsync(
+            new GetCatchPhotographArgs
+            {
+                UserId = ownerUserId,
+                CatchId = catchRecord.Id,
+                PhotographId = photograph.Id
+            },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Id.Should().Be(photograph.Id);
+        result.Value.CatchId.Should().Be(catchRecord.Id);
+        result.Value.ContentType.Should().Be(photograph.ContentType);
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnThePhotographForAnotherUser()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        var catchRecord = NewCatch(ownerUserId);
+        var photograph = catchRecord.Photographs.Single();
+        var saved = await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        saved.IsSuccess.Should().BeTrue();
+
+        // Act
+        var result = await Sut.GetPhotographAsync(
+            new GetCatchPhotographArgs
+            {
+                UserId = otherUserId,
+                CatchId = catchRecord.Id,
+                PhotographId = photograph.Id
+            },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpsert.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Domain.Catches;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace FishingLogBook.Infrastructure.Tests.Integration.Catches.CatchRepositoryTests;
@@ -81,6 +82,51 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
         loaded.Value.CaughtOn.Should().Be(updated.CaughtOn);
         loaded.Value.Photographs[0].Id.Should().Be(original.Photographs[0].Id);
         loaded.Value.Location.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldPersistACatchWhenTimestampsHaveANonUtcOffset()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var catchId = Guid.NewGuid();
+        var caughtOn = new DateTimeOffset(2026, 8, 17, 23, 24, 33, TimeSpan.FromHours(4));
+        var capturedOn = new DateTimeOffset(2026, 8, 17, 23, 24, 34, TimeSpan.FromHours(4));
+        var catchRecord = WithLocation(
+            new Catch
+            {
+                Id = catchId,
+                UserId = userId,
+                CaughtOn = caughtOn,
+                Photographs =
+                [
+                    new CatchPhotograph
+                    {
+                        Id = Guid.NewGuid(),
+                        CatchId = catchId,
+                        ContentType = PhotographContentTypeConstants.Jpeg
+                    }
+                ]
+            },
+            CatchLocation.TryCreate(
+                53.2707,
+                -9.0568,
+                12,
+                capturedOn,
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion)!);
+
+        // Act
+        var result = await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CaughtOn.Should().Be(caughtOn.ToUniversalTime());
+        result.Value.CaughtOn.Offset.Should().Be(TimeSpan.Zero);
+        result.Value.Location.Should().NotBeNull();
+        result.Value.Location!.CapturedOn.Should().Be(capturedOn.ToUniversalTime());
+        result.Value.Location.CapturedOn.Offset.Should().Be(TimeSpan.Zero);
     }
 
     [Fact]
@@ -334,6 +380,10 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
         result.IsFailed.Should().BeTrue();
         result.Errors[0].Message.Should().Be("Failed to save the catch.");
         loaded.Value.Should().BeNull();
+        Logger.Records.Should().ContainSingle();
+        Logger.Records[0].Level.Should().Be(LogLevel.Error);
+        Logger.Records[0].Exception.Should().NotBeNull();
+        Logger.Records[0].Message.Should().Contain(catchRecord.Id.ToString("D"));
     }
 
     [Fact]

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Profiles/ProfileRepositoryTests/BaseProfileRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Profiles/ProfileRepositoryTests/BaseProfileRepositoryTest.cs
@@ -1,7 +1,9 @@
 using FishingLogBook.Domain.Profiles;
 using FishingLogBook.Infrastructure.Persistence;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+using FishingLogBook.Infrastructure.Tests.TestSupport;
 using FishingLogBook.Tests.Common.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace FishingLogBook.Infrastructure.Tests.Integration.Profiles.ProfileRepositoryTests;
 
@@ -9,14 +11,15 @@ namespace FishingLogBook.Infrastructure.Tests.Integration.Profiles.ProfileReposi
 public abstract class BaseProfileRepositoryTest
 {
     protected readonly ProfileRepository Sut;
+    protected readonly RecordingLogger<ProfileRepository> Logger = new();
     protected readonly UserIdentityRepository Users;
     protected readonly NpgsqlConnectionFactory ConnectionFactory;
 
     protected BaseProfileRepositoryTest(PostgresFixture fixture)
     {
         ConnectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
-        Sut = new ProfileRepository(ConnectionFactory);
-        Users = new UserIdentityRepository(ConnectionFactory);
+        Sut = new ProfileRepository(ConnectionFactory, Logger);
+        Users = new UserIdentityRepository(ConnectionFactory, NullLogger<UserIdentityRepository>.Instance);
     }
 
     protected async Task<Guid> CreateUserAsync()

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Users/UserIdentityRepositoryTests/BaseUserIdentityRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Users/UserIdentityRepositoryTests/BaseUserIdentityRepositoryTest.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Application.Args;
 using FishingLogBook.Domain.Users;
 using FishingLogBook.Infrastructure.Persistence;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
+using FishingLogBook.Infrastructure.Tests.TestSupport;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Tests.Common.Builders;
 
@@ -11,12 +12,13 @@ namespace FishingLogBook.Infrastructure.Tests.Integration.Users.UserIdentityRepo
 public abstract class BaseUserIdentityRepositoryTest
 {
     protected readonly UserIdentityRepository Sut;
+    protected readonly RecordingLogger<UserIdentityRepository> Logger = new();
     protected readonly NpgsqlConnectionFactory ConnectionFactory;
 
     protected BaseUserIdentityRepositoryTest(PostgresFixture fixture)
     {
         ConnectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
-        Sut = new UserIdentityRepository(ConnectionFactory);
+        Sut = new UserIdentityRepository(ConnectionFactory, Logger);
     }
 
     protected static string NewSubject()

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Users/UserIdentityRepositoryTests/WhenTestingCreate.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Users/UserIdentityRepositoryTests/WhenTestingCreate.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Application.Args;
 using FishingLogBook.Application.Users.Services;
 using FishingLogBook.Infrastructure.Tests.Integration.TestSupport;
 using FishingLogBook.Shared.Constants;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 
@@ -87,6 +88,9 @@ public class WhenTestingCreate : BaseUserIdentityRepositoryTest
         (await CountUsersAsync()).Should().Be(usersAfterFirst);
         (await CountIdentitiesAsync()).Should().Be(identitiesAfterFirst);
         (await CountUsersWithoutIdentityAsync()).Should().Be(0);
+        Logger.Records.Should().ContainSingle();
+        Logger.Records[0].Level.Should().Be(LogLevel.Warning);
+        Logger.Records[0].Exception.Should().BeOfType<PostgresException>();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Infrastructure.Tests/TestSupport/RecordingLogger.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/TestSupport/RecordingLogger.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Logging;
+
+namespace FishingLogBook.Infrastructure.Tests.TestSupport;
+
+public sealed class RecordingLogger<T> : ILogger<T>
+{
+    public List<RecordedLog> Records { get; } = [];
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+    {
+        return NullScope.Instance;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return true;
+    }
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Records.Add(new RecordedLog(logLevel, exception, formatter(state, exception)));
+    }
+
+    public sealed record RecordedLog(LogLevel Level, Exception? Exception, string Message);
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/FishingLogBook.Shared.Tests/Diagnostics/DiagnosticMetadataTests/BaseDiagnosticMetadataTest.cs
+++ b/tests/FishingLogBook.Shared.Tests/Diagnostics/DiagnosticMetadataTests/BaseDiagnosticMetadataTest.cs
@@ -1,0 +1,5 @@
+namespace FishingLogBook.Shared.Tests.Diagnostics.DiagnosticMetadataTests;
+
+public class BaseDiagnosticMetadataTest
+{
+}

--- a/tests/FishingLogBook.Shared.Tests/Diagnostics/DiagnosticMetadataTests/WhenTestingFilter.cs
+++ b/tests/FishingLogBook.Shared.Tests/Diagnostics/DiagnosticMetadataTests/WhenTestingFilter.cs
@@ -1,0 +1,35 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Diagnostics;
+
+namespace FishingLogBook.Shared.Tests.Diagnostics.DiagnosticMetadataTests;
+
+public class WhenTestingFilter : BaseDiagnosticMetadataTest
+{
+    [Fact]
+    public void ItShouldKeepOnlySafeCatchCorrelationIds()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid().ToString("D");
+        var photographId = Guid.NewGuid().ToString("D");
+        IReadOnlyDictionary<string, string> metadata =
+            new Dictionary<string, string>
+            {
+                [DiagnosticMetadata.CatchId] = catchId,
+                [DiagnosticMetadata.PhotographId] = photographId,
+                ["photographBytes"] = "base64",
+                ["latitude"] = "53.2707",
+                ["token"] = "secret"
+            };
+
+        // Act
+        var result = DiagnosticMetadata.Filter(metadata);
+
+        // Assert
+        result.Should().BeEquivalentTo(
+            new Dictionary<string, string>
+            {
+                [DiagnosticMetadata.CatchId] = catchId,
+                [DiagnosticMetadata.PhotographId] = photographId
+            });
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Tests.Common.TestSupport;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
+using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Models;
 using FishingLogBook.Web.Features.Diagnostics.Services;
@@ -63,6 +64,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         injectedTypes.Should().Contain(typeof(ILoggingService));
         injectedTypes.Should().Contain(typeof(ILocationService));
         injectedTypes.Should().Contain(typeof(ICatchClient));
+        injectedTypes.Should().Contain(typeof(ICatchSynchroniser));
         injectedTypes.Should().Contain(typeof(IStringLocalizer<UiStrings>));
         resolve.Should().NotThrow();
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/MemoryCatchStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/MemoryCatchStore.cs
@@ -77,4 +77,44 @@ public sealed class MemoryCatchStore : ICatchStore
             .ToArray();
         return Task.FromResult(LocalCatchVisibility.ForOwner(items, ownerUserId));
     }
+
+    public async Task<CatchModel?> GetAsync(
+        Guid ownerUserId,
+        Guid catchId,
+        CancellationToken cancellationToken)
+    {
+        var catches = await GetAllAsync(ownerUserId, cancellationToken);
+        return catches.SingleOrDefault(catchRecord => catchRecord.Id == catchId);
+    }
+
+    public Task UpdateSyncStateAsync(
+        CatchModel catchRecord,
+        CancellationToken cancellationToken)
+    {
+        if (!_catches.TryGetValue(catchRecord.Id, out var existing)
+            || existing.UserId != catchRecord.UserId)
+        {
+            throw new InvalidOperationException("Owned Catch was not found.");
+        }
+
+        var incomingPhotographs = catchRecord.Photographs.ToDictionary(
+            photograph => photograph.Id);
+        _catches[catchRecord.Id] = existing with
+        {
+            SyncStatus = catchRecord.SyncStatus,
+            MetadataSyncStatus = catchRecord.MetadataSyncStatus,
+            Photographs = existing.Photographs
+                .Select(photograph => incomingPhotographs.TryGetValue(
+                    photograph.Id,
+                    out var incoming)
+                    ? photograph with
+                    {
+                        SyncStatus = incoming.SyncStatus,
+                        ObjectKey = incoming.ObjectKey
+                    }
+                    : photograph)
+                .ToArray()
+        };
+        return Task.CompletedTask;
+    }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/BaseCatchSynchroniserTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/BaseCatchSynchroniserTest.cs
@@ -1,0 +1,122 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Tests.Features.Catch.Offline.CatchStoreTests;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.CatchSynchroniserTests;
+
+public class BaseCatchSynchroniserTest
+{
+    protected static readonly Guid OwnerUserId =
+        Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId =
+        Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected static readonly Guid CatchId =
+        Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid PhotographAId =
+        Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+    protected static readonly Guid PhotographBId =
+        Guid.Parse("bbbbbbbb-2222-2222-2222-222222222222");
+    protected static readonly Guid PhotographCId =
+        Guid.Parse("cccccccc-3333-3333-3333-333333333333");
+
+    protected readonly ICatchClient MockCatchClient = Substitute.For<ICatchClient>();
+    protected readonly INetworkService MockNetworkService = Substitute.For<INetworkService>();
+    protected readonly ILocalCatchOwnerService MockLocalCatchOwner =
+        Substitute.For<ILocalCatchOwnerService>();
+    protected readonly IDiagnosticLogger MockDiagnostics = Substitute.For<IDiagnosticLogger>();
+    protected readonly ILoggingService MockLogging = Substitute.For<ILoggingService>();
+
+    protected BaseCatchSynchroniserTest()
+    {
+        MockLocalCatchOwner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .Returns(OwnerUserId);
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>())
+            .Returns(true);
+        MockCatchClient.CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var catchId = call.ArgAt<Guid>(0);
+                var request = call.ArgAt<PhotographUploadRequestDto>(1);
+                var objectKey =
+                    $"catches/{OwnerUserId:D}/{catchId:D}/{request.PhotographId:D}";
+                return new PhotographUploadDto(
+                    objectKey,
+                    $"https://storage.test/{request.PhotographId:D}");
+            });
+    }
+
+    protected CatchSynchroniser CreateSut(MemoryCatchStore store)
+    {
+        return new CatchSynchroniser(
+            store,
+            MockCatchClient,
+            MockNetworkService,
+            MockLocalCatchOwner,
+            MockDiagnostics,
+            MockLogging);
+    }
+
+    protected static CatchModel CreateCatch(
+        Guid? catchId = null,
+        Guid? userId = null,
+        SyncStatus catchStatus = SyncStatus.SavedLocally,
+        SyncStatus metadataStatus = SyncStatus.SavedLocally,
+        IReadOnlyList<CatchPhotographModel>? photographs = null)
+    {
+        var id = catchId ?? CatchId;
+        return new CatchModel(
+            id,
+            DateTimeOffset.Parse("2026-08-17T12:00:00Z"),
+            photographs ??
+            [
+                CreatePhotograph(PhotographAId, id),
+                CreatePhotograph(PhotographBId, id),
+                CreatePhotograph(PhotographCId, id)
+            ],
+            "Pike",
+            new CatchLocationModel(
+                53.2707,
+                -9.0568,
+                7,
+                DateTimeOffset.Parse("2026-08-17T11:59:00Z"),
+                "DeviceGps",
+                "Private",
+                "1"),
+            userId ?? OwnerUserId,
+            catchStatus,
+            metadataStatus);
+    }
+
+    protected static CatchPhotographModel CreatePhotograph(
+        Guid photographId,
+        Guid catchId,
+        SyncStatus status = SyncStatus.SavedLocally)
+    {
+        return new CatchPhotographModel(
+            photographId,
+            catchId,
+            "image/jpeg",
+            [1, 2, 3],
+            status);
+    }
+
+    protected static async Task<MemoryCatchStore> CreateStoreAsync(params CatchModel[] catches)
+    {
+        var store = new MemoryCatchStore();
+        foreach (var catchRecord in catches)
+        {
+            await store.SaveAsync(catchRecord, CancellationToken.None);
+        }
+
+        return store;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/WhenTestingRetry.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/WhenTestingRetry.cs
@@ -1,0 +1,70 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.CatchSynchroniserTests;
+
+public class WhenTestingRetry : BaseCatchSynchroniserTest
+{
+    [Fact]
+    public async Task ItShouldNotRetryAnotherUsersCatch()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateCatch(userId: OwnerUserId));
+        MockLocalCatchOwner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .Returns(OtherUserId);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.RetryAsync(CatchId, CancellationToken.None);
+
+        // Assert
+        await MockCatchClient.DidNotReceive()
+            .UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive()
+            .CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRetryOnlyTheOutstandingPhotograph()
+    {
+        // Arrange
+        var catchRecord = CreateCatch(
+            catchStatus: SyncStatus.FailedToSynchronise,
+            metadataStatus: SyncStatus.Synchronised,
+            photographs:
+            [
+                CreatePhotograph(PhotographAId, CatchId, SyncStatus.Synchronised),
+                CreatePhotograph(PhotographBId, CatchId, SyncStatus.FailedToSynchronise),
+                CreatePhotograph(PhotographCId, CatchId, SyncStatus.Synchronised)
+            ]);
+        var store = await CreateStoreAsync(catchRecord);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.RetryAsync(CatchId, CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved.Location.Should().Be(catchRecord.Location);
+        saved.Photographs.Should().OnlyContain(
+            photograph => photograph.SyncStatus == SyncStatus.Synchronised);
+        await MockCatchClient.DidNotReceive()
+            .UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await MockCatchClient.Received(1).CreatePhotographUploadAsync(
+            CatchId,
+            Arg.Is<PhotographUploadRequestDto>(request =>
+                request.PhotographId == PhotographBId),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.Received(1).RecordPhotographAsync(
+            CatchId,
+            Arg.Is<RecordPhotographDto>(request =>
+                request.PhotographId == PhotographBId),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
@@ -1,0 +1,403 @@
+using System.Net;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.CatchSynchroniserTests;
+
+public class WhenTestingSynchronisePending : BaseCatchSynchroniserTest
+{
+    [Fact]
+    public async Task ItShouldNotCallTheServerWhenOffline()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateCatch());
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var sut = CreateSut(store);
+        var stateChanged = 0;
+        sut.StateChanged += (_, _) => stateChanged++;
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.SyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+        saved.MetadataSyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+        saved.Photographs.Should().OnlyContain(
+            photograph => photograph.SyncStatus == SyncStatus.WaitingToSynchronise);
+        stateChanged.Should().Be(1);
+        await MockCatchClient.DidNotReceive()
+            .UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive()
+            .CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPreserveAllLocalDataWhenMetadataFails()
+    {
+        // Arrange
+        var expected = CreateCatch();
+        var store = await CreateStoreAsync(expected);
+        MockCatchClient.UpsertAsync(
+                Arg.Any<CatchDto>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("unavailable"));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        saved.MetadataSyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        saved.Location.Should().Be(expected.Location);
+        saved.Photographs.Should().HaveCount(3);
+        saved.Photographs.Should().OnlyContain(
+            photograph => photograph.Bytes != null && photograph.Bytes.Length == 3);
+        await MockCatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(dto =>
+                dto.Id == CatchId
+                && dto.Location != null
+                && dto.Location.Latitude == 53.2707
+                && dto.Location.Longitude == -9.0568
+                && dto.Location.Visibility == "Private"),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<PhotographUploadRequestDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepSuccessfulPhotographsAndFailTheOverallCatchWhenOneUploadFails()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateCatch());
+        MockCatchClient.UploadPhotographAsync(
+                $"https://storage.test/{PhotographBId:D}",
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("storage unavailable"));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        saved.MetadataSyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved.Photographs.Single(item => item.Id == PhotographAId)
+            .SyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved.Photographs.Single(item => item.Id == PhotographBId)
+            .SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        saved.Photographs.Single(item => item.Id == PhotographCId)
+            .SyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved.Location!.Visibility.Should().Be("Private");
+        saved.Location.Latitude.Should().Be(53.2707);
+        saved.Photographs.Should().OnlyContain(
+            photograph => photograph.Bytes != null && photograph.Bytes.Length == 3);
+        await MockCatchClient.Received(3).CreatePhotographUploadAsync(
+            CatchId,
+            Arg.Is<PhotographUploadRequestDto>(request =>
+                request.PhotographId == PhotographAId
+                || request.PhotographId == PhotographBId
+                || request.PhotographId == PhotographCId),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.Received(2).RecordPhotographAsync(
+            CatchId,
+            Arg.Is<RecordPhotographDto>(request =>
+                request.PhotographId == PhotographAId
+                || request.PhotographId == PhotographCId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRecoverStaleSynchronisingState()
+    {
+        // Arrange
+        var stale = CreateCatch(
+            catchStatus: SyncStatus.Synchronising,
+            metadataStatus: SyncStatus.Synchronising,
+            photographs:
+            [
+                CreatePhotograph(PhotographAId, CatchId, SyncStatus.Synchronising)
+            ]);
+        var store = await CreateStoreAsync(stale);
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.SyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+        saved.MetadataSyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+        saved.Photographs.Should().ContainSingle()
+            .Which.SyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+        await MockCatchClient.DidNotReceive()
+            .UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotSynchroniseUserACatchWhileUserBIsSignedIn()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateCatch(userId: OwnerUserId));
+        MockLocalCatchOwner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .Returns(OtherUserId);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+
+        // Assert
+        await MockLocalCatchOwner.Received(1)
+            .GetUserIdAsync(Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive()
+            .UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive()
+            .CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPreserveLocalDataWhenAuthenticationIsUnavailable()
+    {
+        // Arrange
+        var expected = CreateCatch();
+        var store = await CreateStoreAsync(expected);
+        MockLocalCatchOwner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("not signed in"));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved.Should().BeEquivalentTo(expected);
+        await MockCatchClient.DidNotReceive()
+            .UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await MockDiagnostics.Received(1).LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.AuthenticationUnavailable,
+            "Authentication is unavailable for catch synchronisation.",
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPreserveLocalDataWhenTheAccessTokenHasExpired()
+    {
+        // Arrange
+        var expected = CreateCatch();
+        var store = await CreateStoreAsync(expected);
+        MockCatchClient.UpsertAsync(
+                Arg.Any<CatchDto>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException(
+                "unauthorized",
+                null,
+                HttpStatusCode.Unauthorized));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        saved.Location.Should().Be(expected.Location);
+        saved.Photographs.Should().HaveCount(3);
+        await MockCatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(dto => dto.Id == CatchId),
+            Arg.Any<CancellationToken>());
+        await MockDiagnostics.Received(1).LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.AuthenticationUnavailable,
+            "Authentication is unavailable for catch synchronisation.",
+            Arg.Is<IReadOnlyDictionary<string, string>>(metadata =>
+                metadata[DiagnosticMetadata.CatchId] == CatchId.ToString("D")),
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldContinueWithOtherCatchesWhenOneFails()
+    {
+        // Arrange
+        var catchBId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var catchCId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var catchA = CreateCatch(
+            photographs: [CreatePhotograph(PhotographAId, CatchId)]);
+        var catchB = CreateCatch(
+            catchBId,
+            photographs: [CreatePhotograph(PhotographBId, catchBId)]);
+        var catchC = CreateCatch(
+            catchCId,
+            photographs: [CreatePhotograph(PhotographCId, catchCId)]);
+        var store = await CreateStoreAsync(catchA, catchB, catchC);
+        MockCatchClient.UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                if (call.Arg<CatchDto>().Id == catchBId)
+                {
+                    throw new HttpRequestException("metadata failed");
+                }
+
+                return Task.CompletedTask;
+            });
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAllAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        saved.Single(item => item.Id == CatchId).SyncStatus
+            .Should().Be(SyncStatus.Synchronised);
+        saved.Single(item => item.Id == catchBId).SyncStatus
+            .Should().Be(SyncStatus.FailedToSynchronise);
+        saved.Single(item => item.Id == catchCId).SyncStatus
+            .Should().Be(SyncStatus.Synchronised);
+        await MockCatchClient.Received(3).UpsertAsync(
+            Arg.Is<CatchDto>(dto =>
+                dto.Id == CatchId || dto.Id == catchBId || dto.Id == catchCId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPreventConcurrentAttemptsForTheSameCatch()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(
+            CreateCatch(photographs: [CreatePhotograph(PhotographAId, CatchId)]));
+        var metadataStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseMetadata = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockCatchClient.UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                metadataStarted.SetResult();
+                await releaseMetadata.Task;
+            });
+        var sut = CreateSut(store);
+
+        // Act
+        var first = sut.SynchronisePendingAsync(CancellationToken.None);
+        await metadataStarted.Task;
+        var second = sut.SynchronisePendingAsync(CancellationToken.None);
+        releaseMetadata.SetResult();
+        await Task.WhenAll(first, second);
+
+        // Assert
+        await MockCatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(dto => dto.Id == CatchId),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.Received(1).CreatePhotographUploadAsync(
+            CatchId,
+            Arg.Is<PhotographUploadRequestDto>(request =>
+                request.PhotographId == PhotographAId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotOverwriteANewerPrivacyChoiceMadeDuringMetadataSync()
+    {
+        // Arrange
+        var original = CreateCatch() with
+        {
+            Location = CreateCatch().Location! with { Visibility = "Public" }
+        };
+        var store = await CreateStoreAsync(original);
+        MockCatchClient.UpsertAsync(
+                Arg.Any<CatchDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                var current = await store.GetAsync(
+                    OwnerUserId,
+                    CatchId,
+                    CancellationToken.None);
+                await store.SaveAsync(
+                    current! with
+                    {
+                        Location = current.Location! with { Visibility = "Private" },
+                        SyncStatus = SyncStatus.WaitingToSynchronise,
+                        MetadataSyncStatus = SyncStatus.WaitingToSynchronise
+                    },
+                    CancellationToken.None);
+            });
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.Location!.Visibility.Should().Be("Private");
+        saved.SyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+        saved.MetadataSyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+        await MockCatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(dto =>
+                dto.Id == CatchId
+                && dto.Location != null
+                && dto.Location.Visibility == "Public"),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<PhotographUploadRequestDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSynchroniseMetadataAndEveryPhotograph()
+    {
+        // Arrange
+        var expected = CreateCatch();
+        var store = await CreateStoreAsync(expected);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved.MetadataSyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved.Photographs.Should().OnlyContain(
+            photograph => photograph.SyncStatus == SyncStatus.Synchronised);
+        saved.Photographs.Should().OnlyContain(
+            photograph => photograph.Bytes != null && photograph.Bytes.Length == 3);
+        saved.Location.Should().Be(expected.Location);
+        await MockCatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(dto =>
+                dto.Id == CatchId
+                && dto.UserId == Guid.Empty
+                && dto.Photographs.Count == 3
+                && dto.Location != null
+                && dto.Location.Latitude == expected.Location!.Latitude
+                && dto.Location.Longitude == expected.Location.Longitude
+                && dto.Location.Visibility == expected.Location.Visibility),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.Received(3).UploadPhotographAsync(
+            Arg.Is<string>(url => url.StartsWith("https://storage.test/")),
+            Arg.Is<byte[]>(bytes => bytes.SequenceEqual(new byte[] { 1, 2, 3 })),
+            "image/jpeg",
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/BaseCatchListTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/BaseCatchListTest.cs
@@ -13,7 +13,10 @@ public class BaseCatchListTest
     protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
-    protected static BunitContext CreateContext(ICatchStore store, ILocalCatchOwnerService? owner = null)
+    protected static BunitContext CreateContext(
+        ICatchStore store,
+        ILocalCatchOwnerService? owner = null,
+        ICatchSynchroniser? synchroniser = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -21,6 +24,7 @@ public class BaseCatchListTest
         context.Services.AddLocalization();
         context.Services.AddSingleton(store);
         context.Services.AddSingleton(owner ?? SignedInOwner());
+        context.Services.AddSingleton(synchroniser ?? Substitute.For<ICatchSynchroniser>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingSyncStatus.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingSyncStatus.cs
@@ -1,0 +1,157 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Pages.CatchList;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchListTests;
+
+public class WhenTestingSyncStatus : BaseCatchListTest
+{
+    [Fact]
+    public async Task ItShouldShowTheFailedStatusAndRetryTheExactCatch()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var catchRecord = CatchWithStatus(catchId, SyncStatus.FailedToSynchronise);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<CatchModel>>([catchRecord]);
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        await using var context = CreateContext(store, synchroniser: synchroniser);
+
+        // Act
+        var cut = context.Render<CatchList>();
+        await cut.Find($"#catch-sync-retry-{catchId:D}").ClickAsync(new());
+
+        // Assert
+        cut.Find($"#catch-sync-status-{catchId:D}").TextContent
+            .Should().Contain("Failed to synchronise");
+        cut.Find($"#catch-sync-reassurance-{catchId:D}").TextContent
+            .Should().Contain("Your catch is still saved on this device.");
+        await synchroniser.Received(1).RetryAsync(
+            catchId,
+            Arg.Any<CancellationToken>());
+        await store.Received(2).GetAllAsync(
+            OwnerUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheSynchronisedStatus()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<CatchModel>>(
+                [CatchWithStatus(catchId, SyncStatus.Synchronised)]);
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.Find($"#catch-sync-status-{catchId:D}").TextContent
+            .Should().Contain("Synchronised");
+        cut.FindAll($"#catch-sync-retry-{catchId:D}").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldOfferManualSynchronisationForALocallySavedCatch()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var catchRecord = CatchWithStatus(catchId, SyncStatus.SavedLocally);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<CatchModel>>([catchRecord]);
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var cut = context.Render<CatchList>();
+
+        // Act
+        await cut.Find($"#catch-sync-retry-{catchId:D}").ClickAsync(new());
+
+        // Assert
+        cut.Find($"#catch-sync-retry-{catchId:D}").TextContent
+            .Should().Contain("Synchronise now");
+        await synchroniser.Received(1).RetryAsync(
+            catchId,
+            Arg.Any<CancellationToken>());
+        await store.Received(2).GetAllAsync(
+            OwnerUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchSyncActions()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var catchId = Guid.NewGuid();
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<CatchModel>>(
+                [CatchWithStatus(catchId, SyncStatus.FailedToSynchronise)]);
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.Find($"#catch-sync-retry-{catchId:D}").TextContent
+            .Should().Contain("Réessayer");
+        cut.Find($"#catch-sync-reassurance-{catchId:D}").TextContent
+            .Should().Contain("Votre prise reste enregistrée sur cet appareil.");
+    }
+
+    [Fact]
+    public async Task ItShouldRefreshWhenBackgroundSynchronisationChangesState()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(
+                _ => [CatchWithStatus(catchId, SyncStatus.SavedLocally)],
+                _ => [CatchWithStatus(catchId, SyncStatus.Synchronised)]);
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var cut = context.Render<CatchList>();
+
+        // Act
+        synchroniser.StateChanged += Raise.Event<EventHandler>(
+            synchroniser,
+            EventArgs.Empty);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-sync-status-{catchId:D}").TextContent
+                .Should().Contain("Synchronised"));
+        await store.Received(2).GetAllAsync(
+            OwnerUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    private static CatchModel CatchWithStatus(Guid catchId, SyncStatus status)
+    {
+        return new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T12:00:00Z"),
+            [
+                new CatchPhotographModel(
+                    Guid.NewGuid(),
+                    catchId,
+                    "image/jpeg",
+                    [1, 2, 3],
+                    status)
+            ],
+            UserId: OwnerUserId,
+            SyncStatus: status,
+            MetadataSyncStatus: status);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
@@ -4,6 +4,7 @@ using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
@@ -251,7 +252,19 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
         var store = Substitute.For<ICatchStore>();
         store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
-                [LocatedCatch(catchId, LocationDefaults.Public)]));
+                [
+                    LocatedCatch(catchId, LocationDefaults.Public) with
+                    {
+                        SyncStatus = SyncStatus.Synchronised,
+                        MetadataSyncStatus = SyncStatus.Synchronised,
+                        Photographs = LocatedCatch(catchId).Photographs
+                            .Select(photograph => photograph with
+                            {
+                                SyncStatus = SyncStatus.Synchronised
+                            })
+                            .ToArray()
+                    }
+                ]));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var client = Substitute.For<ICatchClient>();
@@ -282,7 +295,11 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
                 && catchRecord.Location.AccuracyMetres == 12
                 && catchRecord.Location.CapturedOn == capturedOn
                 && catchRecord.Location.Source == LocationDefaults.DeviceGps
-                && catchRecord.Location.ConsentVersion == LocationDefaults.ConsentVersion),
+                && catchRecord.Location.ConsentVersion == LocationDefaults.ConsentVersion
+                && catchRecord.SyncStatus == SyncStatus.WaitingToSynchronise
+                && catchRecord.MetadataSyncStatus == SyncStatus.WaitingToSynchronise
+                && catchRecord.Photographs.All(
+                    photograph => photograph.SyncStatus == SyncStatus.Synchronised)),
             Arg.Any<CancellationToken>());
         await client.Received(1).UpdateLocationVisibilityAsync(
             catchId,

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
@@ -22,7 +22,8 @@ public class BaseRecordCatchTest
     protected static BunitContext CreateContext(
         ICatchStore store,
         ILocationService? location = null,
-        ILocalCatchOwnerService? owner = null)
+        ILocalCatchOwnerService? owner = null,
+        ICatchSynchroniser? synchroniser = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -31,8 +32,19 @@ public class BaseRecordCatchTest
         context.Services.AddSingleton(store);
         context.Services.AddSingleton(location ?? QuietLocation());
         context.Services.AddSingleton(owner ?? SignedInOwner());
+        context.Services.AddSingleton(synchroniser ?? QuietSynchroniser());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
+    }
+
+    protected static ICatchSynchroniser QuietSynchroniser()
+    {
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        synchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        synchroniser.RetryAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return synchroniser;
     }
 
     protected static ILocalCatchOwnerService SignedInOwner()

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
@@ -6,6 +6,7 @@ using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
 using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +24,8 @@ public class BaseRecordCatchTest
         ICatchStore store,
         ILocationService? location = null,
         ILocalCatchOwnerService? owner = null,
-        ICatchSynchroniser? synchroniser = null)
+        ICatchSynchroniser? synchroniser = null,
+        ILoggingService? logging = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -33,8 +35,19 @@ public class BaseRecordCatchTest
         context.Services.AddSingleton(location ?? QuietLocation());
         context.Services.AddSingleton(owner ?? SignedInOwner());
         context.Services.AddSingleton(synchroniser ?? QuietSynchroniser());
+        context.Services.AddSingleton(logging ?? QuietLogging());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
+    }
+
+    protected static ILoggingService QuietLogging()
+    {
+        var logging = Substitute.For<ILoggingService>();
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return logging;
     }
 
     protected static ICatchSynchroniser QuietSynchroniser()

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Web.Browser.Location;
+using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
@@ -35,7 +36,8 @@ public class WhenTestingSave : BaseRecordCatchTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
-        await using var context = CreateContext(store);
+        var synchroniser = QuietSynchroniser();
+        await using var context = CreateContext(store, synchroniser: synchroniser);
 
         // Act
         var cut = context.Render<RecordCatch>();
@@ -51,6 +53,7 @@ public class WhenTestingSave : BaseRecordCatchTest
         cut.FindAll("#catch-location-status").Should().BeEmpty();
         cut.FindAll("#test-catch-location-explainer").Should().BeEmpty();
         await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -58,7 +61,8 @@ public class WhenTestingSave : BaseRecordCatchTest
     {
         // Arrange
         var store = Substitute.For<ICatchStore>();
-        await using var context = CreateContext(store);
+        var synchroniser = QuietSynchroniser();
+        await using var context = CreateContext(store, synchroniser: synchroniser);
         var cut = context.Render<RecordCatch>();
 
         // Act
@@ -66,6 +70,7 @@ public class WhenTestingSave : BaseRecordCatchTest
 
         // Assert
         await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -76,7 +81,8 @@ public class WhenTestingSave : BaseRecordCatchTest
         var store = Substitute.For<ICatchStore>();
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Photograph persistence failed."));
-        await using var context = CreateContext(store);
+        var synchroniser = QuietSynchroniser();
+        await using var context = CreateContext(store, synchroniser: synchroniser);
         var cut = context.Render<RecordCatch>();
         cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
 
@@ -97,6 +103,7 @@ public class WhenTestingSave : BaseRecordCatchTest
                 && catchRecord.CaughtOn.Offset == TimeSpan.Zero
                 && catchRecord.Location == null),
             Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -107,7 +114,8 @@ public class WhenTestingSave : BaseRecordCatchTest
         var store = Substitute.For<ICatchStore>();
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
-        await using var context = CreateContext(store);
+        var synchroniser = QuietSynchroniser();
+        await using var context = CreateContext(store, synchroniser: synchroniser);
         var cut = context.Render<RecordCatch>();
         cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
         var photographId = VisiblePhotographId(cut);
@@ -145,6 +153,8 @@ public class WhenTestingSave : BaseRecordCatchTest
         cut.FindAll("#catch-location-status").Should().BeEmpty();
         cut.FindAll("#catch-location").Should().BeEmpty();
         cut.FindComponents<InputFile>().Should().BeEmpty();
+        await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().RetryAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -221,7 +231,8 @@ public class WhenTestingSave : BaseRecordCatchTest
                 saved.Add(call.ArgAt<CatchModel>(0));
                 return Task.CompletedTask;
             });
-        await using var context = CreateContext(store);
+        var synchroniser = QuietSynchroniser();
+        await using var context = CreateContext(store, synchroniser: synchroniser);
         var cut = context.Render<RecordCatch>();
 
         // Act
@@ -244,6 +255,8 @@ public class WhenTestingSave : BaseRecordCatchTest
                 && catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Bytes != null),
             Arg.Any<CancellationToken>());
+        await synchroniser.Received(2).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().RetryAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -263,10 +276,9 @@ public class WhenTestingSave : BaseRecordCatchTest
         injected.Should().Contain(typeof(ICatchStore));
         injected.Should().Contain(typeof(ILocationService));
         injected.Should().Contain(typeof(ILocalCatchOwnerService));
+        injected.Should().Contain(typeof(ICatchSynchroniser));
         injected.Should().NotContain(typeof(HttpClient));
-        injected.Should().NotContain(type =>
-            type.Name.Contains("Client", StringComparison.Ordinal)
-            || type.Name.Contains("Synchroniser", StringComparison.Ordinal));
+        injected.Should().NotContain(type => type.Name.Contains("Client", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -278,7 +290,8 @@ public class WhenTestingSave : BaseRecordCatchTest
         var owner = Substitute.For<ILocalCatchOwnerService>();
         owner.GetUserIdAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("The current user is not signed in."));
-        await using var context = CreateContext(store, owner: owner);
+        var synchroniser = QuietSynchroniser();
+        await using var context = CreateContext(store, owner: owner, synchroniser: synchroniser);
         var cut = context.Render<RecordCatch>();
         cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
 
@@ -290,5 +303,115 @@ public class WhenTestingSave : BaseRecordCatchTest
         cut.FindAll("#catch-saved").Should().BeEmpty();
         await owner.Received(1).GetUserIdAsync(Arg.Any<CancellationToken>());
         await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepLocalSaveSuccessWhenSyncFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        synchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("The API is unavailable."));
+        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device");
+            cut.FindAll("#catch-save-failed").Should().BeEmpty();
+        });
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
+                catchRecord.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+        await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepLocalSaveSuccessWhenSyncHangs()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        synchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
+            .Returns(Hang());
+        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device");
+            cut.FindAll("#catch-save-failed").Should().BeEmpty();
+            cut.FindAll("#save-catch-button").Should().BeEmpty();
+        });
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId),
+            Arg.Any<CancellationToken>());
+        await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldTriggerProductionSyncAfterLocalSaveCompletes()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var order = new List<string>();
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                await Task.Yield();
+                order.Add("save");
+            });
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        synchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                order.Add("sync");
+                return Task.CompletedTask;
+            });
+        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device");
+            cut.FindAll("#catch-save-failed").Should().BeEmpty();
+            order.Should().Equal("save", "sync");
+        });
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
+                catchRecord.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+        await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().RetryAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    private static Task Hang()
+    {
+        return new TaskCompletionSource().Task;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
@@ -6,6 +6,7 @@ using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
 using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Forms;
@@ -277,6 +278,7 @@ public class WhenTestingSave : BaseRecordCatchTest
         injected.Should().Contain(typeof(ILocationService));
         injected.Should().Contain(typeof(ILocalCatchOwnerService));
         injected.Should().Contain(typeof(ICatchSynchroniser));
+        injected.Should().Contain(typeof(ILoggingService));
         injected.Should().NotContain(typeof(HttpClient));
         injected.Should().NotContain(type => type.Name.Contains("Client", StringComparison.Ordinal));
     }
@@ -317,7 +319,8 @@ public class WhenTestingSave : BaseRecordCatchTest
         var synchroniser = Substitute.For<ICatchSynchroniser>();
         synchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("The API is unavailable."));
-        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, synchroniser: synchroniser, logging: logging);
         var cut = context.Render<RecordCatch>();
         cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
 
@@ -335,6 +338,60 @@ public class WhenTestingSave : BaseRecordCatchTest
                 catchRecord.SyncStatus == SyncStatus.SavedLocally),
             Arg.Any<CancellationToken>());
         await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "production catch synchronisation",
+            Arg.Is<Exception>(exception =>
+                exception is HttpRequestException
+                && exception.Message == "The API is unavailable."),
+            Arg.Any<CancellationToken>());
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLogUnexpectedSyncExceptionsWithoutFailingLocalSave()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        synchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("IndexedDB getAll failed."));
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, synchroniser: synchroniser, logging: logging);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-saved").TextContent.Should().Contain("Catch saved on this device");
+            cut.FindAll("#catch-save-failed").Should().BeEmpty();
+            cut.FindAll("#save-catch-button").Should().BeEmpty();
+        });
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
+                catchRecord.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+        await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "production catch synchronisation",
+            Arg.Is<Exception>(exception =>
+                exception is InvalidOperationException
+                && exception.Message == "IndexedDB getAll failed."),
+            Arg.Any<CancellationToken>());
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().RetryAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -388,7 +445,8 @@ public class WhenTestingSave : BaseRecordCatchTest
                 order.Add("sync");
                 return Task.CompletedTask;
             });
-        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, synchroniser: synchroniser, logging: logging);
         var cut = context.Render<RecordCatch>();
         cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
 
@@ -408,6 +466,14 @@ public class WhenTestingSave : BaseRecordCatchTest
             Arg.Any<CancellationToken>());
         await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
         await synchroniser.DidNotReceive().RetryAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Any<string>(),
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 
     private static Task Hang()

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
@@ -94,6 +94,7 @@ public class WhenTestingSave : BaseRecordCatchTest
                 && catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Id != Guid.Empty
                 && catchRecord.SpeciesName == null
+                && catchRecord.CaughtOn.Offset == TimeSpan.Zero
                 && catchRecord.Location == null),
             Arg.Any<CancellationToken>());
     }
@@ -123,6 +124,7 @@ public class WhenTestingSave : BaseRecordCatchTest
                 && catchRecord.Photographs[0].CatchId == catchRecord.Id
                 && catchRecord.SpeciesName == null
                 && catchRecord.CaughtOn != default
+                && catchRecord.CaughtOn.Offset == TimeSpan.Zero
                 && catchRecord.Location == null),
             Arg.Any<CancellationToken>());
         cut.WaitForAssertion(() =>
@@ -167,7 +169,8 @@ public class WhenTestingSave : BaseRecordCatchTest
                 catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Bytes != null
                 && catchRecord.SpeciesName == null
-                && catchRecord.CaughtOn != default),
+                && catchRecord.CaughtOn != default
+                && catchRecord.CaughtOn.Offset == TimeSpan.Zero),
             Arg.Any<CancellationToken>());
         cut.WaitForAssertion(() =>
         {

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/BaseCatchClientTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/BaseCatchClientTest.cs
@@ -9,11 +9,15 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Services.CatchClientTests;
 
 public class BaseCatchClientTest
 {
-    protected static CatchClient CreateClient(RecordingHandler apiHandler)
+    protected static CatchClient CreateClient(
+        RecordingHandler apiHandler,
+        RecordingHandler? anonymousHandler = null)
     {
         var factory = Substitute.For<IHttpClientFactory>();
         factory.CreateClient(HttpClientNames.AuthorizedApi)
             .Returns(new HttpClient(apiHandler) { BaseAddress = new Uri("https://api.test/") });
+        factory.CreateClient(HttpClientNames.Anonymous)
+            .Returns(new HttpClient(anonymousHandler ?? new RecordingHandler(HttpStatusCode.OK)));
         return new CatchClient(factory);
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/WhenTestingSynchronisation.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/CatchClientTests/WhenTestingSynchronisation.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Text.Json;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Services.CatchClientTests;
+
+public class WhenTestingSynchronisation : BaseCatchClientTest
+{
+    [Fact]
+    public async Task ItShouldPostCatchMetadata()
+    {
+        // Arrange
+        var handler = new RecordingHandler(HttpStatusCode.OK);
+        var client = CreateClient(handler);
+        var catchId = Guid.NewGuid();
+        var dto = new CatchDto(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T12:00:00Z"),
+            [new CatchPhotographDto(Guid.NewGuid(), catchId, "image/jpeg")]);
+
+        // Act
+        await client.UpsertAsync(dto, CancellationToken.None);
+
+        // Assert
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/api/catches");
+        var sent = JsonSerializer.Deserialize<CatchDto>(
+            handler.LastBody!,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        sent.Should().BeEquivalentTo(dto);
+    }
+
+    [Fact]
+    public async Task ItShouldUploadPhotographBytesWithoutApiAuthorization()
+    {
+        // Arrange
+        var apiHandler = new RecordingHandler(HttpStatusCode.OK);
+        var storageHandler = new RecordingHandler(HttpStatusCode.OK);
+        var client = CreateClient(apiHandler, storageHandler);
+
+        // Act
+        await client.UploadPhotographAsync(
+            "https://storage.test/object",
+            [1, 2, 3],
+            "image/jpeg",
+            CancellationToken.None);
+
+        // Assert
+        storageHandler.LastRequest!.Method.Should().Be(HttpMethod.Put);
+        storageHandler.LastRequest.RequestUri.Should().Be(new Uri("https://storage.test/object"));
+        storageHandler.LastRequest.Headers.Authorization.Should().BeNull();
+        storageHandler.LastRequest.Content!.Headers.ContentType!.MediaType.Should().Be("image/jpeg");
+        apiHandler.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldUseTheProductionPhotographEndpoints()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        var photographId = Guid.NewGuid();
+        var upload = new PhotographUploadDto("object-key", "https://storage.test/object");
+        var uploadHandler = new RecordingHandler(
+            HttpStatusCode.OK,
+            JsonSerializer.Serialize(upload));
+        var client = CreateClient(uploadHandler);
+
+        // Act
+        var actual = await client.CreatePhotographUploadAsync(
+            catchId,
+            new PhotographUploadRequestDto(photographId, "image/jpeg"),
+            CancellationToken.None);
+
+        // Assert
+        actual.Should().Be(upload);
+        uploadHandler.LastRequest!.RequestUri!.PathAndQuery.Should().Be(
+            $"/api/catches/{catchId:D}/photographs/upload-url");
+    }
+
+    [Fact]
+    public async Task ItShouldRecordPhotographMetadata()
+    {
+        // Arrange
+        var handler = new RecordingHandler(HttpStatusCode.NoContent);
+        var client = CreateClient(handler);
+        var catchId = Guid.NewGuid();
+        var request = new RecordPhotographDto(
+            Guid.NewGuid(),
+            "object-key",
+            "image/jpeg");
+
+        // Act
+        await client.RecordPhotographAsync(
+            catchId,
+            request,
+            CancellationToken.None);
+
+        // Assert
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be(
+            $"/api/catches/{catchId:D}/photographs");
+        var sent = JsonSerializer.Deserialize<RecordPhotographDto>(
+            handler.LastBody!,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        sent.Should().Be(request);
+    }
+
+    [Fact]
+    public async Task ItShouldThrowWhenMetadataUpsertFails()
+    {
+        // Arrange
+        var handler = new RecordingHandler(HttpStatusCode.ServiceUnavailable);
+        var client = CreateClient(handler);
+        var catchId = Guid.NewGuid();
+        var dto = new CatchDto(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T12:00:00Z"),
+            [new CatchPhotographDto(Guid.NewGuid(), catchId, "image/jpeg")]);
+
+        // Act
+        var action = () => client.UpsertAsync(dto, CancellationToken.None);
+
+        // Assert
+        await action.Should().ThrowAsync<HttpRequestException>();
+        handler.LastRequest!.RequestUri!.PathAndQuery.Should().Be("/api/catches");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
@@ -1,6 +1,8 @@
 using Bunit;
 using Bunit.TestDoubles;
 using FishingLogBook.Web.Features.Authentication.Services;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
@@ -10,7 +12,10 @@ namespace FishingLogBook.Web.Tests.Layouts.MainLayoutTests;
 
 public class BaseMainLayoutTest
 {
-    protected static BunitContext CreateContext(bool isAuthenticated = false)
+    protected static BunitContext CreateContext(
+        bool isAuthenticated = false,
+        ICatchSynchroniser? catchSynchroniser = null,
+        IDiagnosticSynchroniser? diagnosticSynchroniser = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -28,6 +33,11 @@ public class BaseMainLayoutTest
         }
 
         context.Services.AddSingleton(Substitute.For<ICultureService>());
+        context.Services.AddSingleton(
+            catchSynchroniser ?? Substitute.For<ICatchSynchroniser>());
+        context.Services.AddSingleton(
+            diagnosticSynchroniser ?? Substitute.For<IDiagnosticSynchroniser>());
+        context.Services.AddSingleton(Substitute.For<ILoggingService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
     }

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
@@ -1,0 +1,37 @@
+using Bunit;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Layouts.MainLayout;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Layouts.MainLayoutTests;
+
+public class WhenTestingSynchronisation : BaseMainLayoutTest
+{
+    [Fact]
+    public async Task ItShouldSynchroniseOnStartupAndNavigationReentry()
+    {
+        // Arrange
+        var catchSynchroniser = Substitute.For<ICatchSynchroniser>();
+        var diagnosticSynchroniser = Substitute.For<IDiagnosticSynchroniser>();
+        await using var context = CreateContext(
+            isAuthenticated: true,
+            catchSynchroniser,
+            diagnosticSynchroniser);
+        context.Render<MainLayout>();
+        await Task.Yield();
+
+        // Act
+        context.Services.GetRequiredService<NavigationManager>()
+            .NavigateTo("/catches");
+        await Task.Yield();
+
+        // Assert
+        await catchSynchroniser.Received(2).SynchronisePendingAsync(
+            Arg.Any<CancellationToken>());
+        await diagnosticSynchroniser.Received(2).SynchronisePendingAsync(
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- Makes production Catch the active synchronised path: local IndexedDB save stays offline-first, then metadata and photographs sync afterwards using the existing Catch API, deterministic R2 object keys, and owner identity from `ICurrentUser`.
- Persists Catch and photograph sync state, recovers stale `Synchronising` after restart, retries outstanding work only, and shows compact status plus Retry on `/catches` (EN/FR).
- Fixes the live sync 503: Npgsql cannot write `DateTimeOffset` with a non-UTC offset, so Catch timestamps are normalised to UTC at persistence. Server-side catch blocks now log the original exception instead of swallowing it.

Closes #17.

## TestCatch inventory
| Area | Decision |
|---|---|
| Metadata upsert / idempotent CatchId | REFACTOR / GENERALISE into production `CatchClient` + `CatchSynchroniser` |
| Photograph upload URL + R2 PUT + record | REFACTOR / GENERALISE; object key is deterministic `catches/{userId}/{catchId}/{photographId}` |
| In-flight per-catch guard, retry, startup/reconnect | REFACTOR / GENERALISE; MainLayout `online` / `pageshow` / visibility triggers |
| IndexedDB sync fields | REUSE production Catch store; merge sync metadata without overwriting newer local location/privacy |
| Ownership | REUSE #16: local UserId scopes which Catches may sync; server ownership is `ICurrentUser` only |
| Diagnostics | REUSE bounded client diagnostic logger and a small #17 event set only; do not promote verbose TestCatch tracing |
| `/test-catch` route | REMOVE from user-facing navigation; TestCatch proof code/tests kept until production coverage exists |

## Not in this PR
- Catch editing (#19)
- Catch history/filtering (#20)
- FishingVenue association (#27)
- Multi-device conflict UI
- Authenticated Playwright host (#76)
- True iOS background sync while the PWA is terminated

## Test plan
- [x] Targeted repository/upsert tests for non-UTC `CaughtOn` / `CapturedOn`
- [x] Targeted RecordCatch save tests (`CaughtOn` offset is UTC)
- [x] Targeted exception-logging tests (Catch upsert, identity unique recovery, capability FK, TestCatch photograph mismatch)
- [ ] CI green on this PR
- [ ] Record a Catch on a non-UTC machine, confirm local save, then confirm metadata sync is 200 not 503
- [ ] Confirm Failed still shows Retry and the Catch remains on the device
- [ ] Confirm a User A Catch does not sync while User B is signed in

## Self review
- Issue/AC: PASS for the implemented sync path (AC1–AC19 in code/tests). Manual UTC+4 sync originally failed with 503; that is fixed in this branch.
- Architecture/CQRS: PASS (PWA synchroniser → Catch client → existing Catch endpoints → mediator → service → repository). No parallel SyncCatch endpoint.
- Offline-first: PASS — Record Catch still finishes at IndexedDB; sync is later/best-effort.
- Idempotency: PASS — stable CatchId / PhotographId; deterministic object keys; upsert on conflict.
- Security/privacy: PASS — server UserId from `ICurrentUser`; #16 viewer shaping unchanged; exact owner coordinates still persist for the owner.
- Diagnostics: PASS — small event set; sync state is not driven by diagnostics; catch blocks log exceptions server-side without returning them to clients.
- Tests: PASS for added unit/API/Testcontainers/bUnit coverage. Browser IndexedDB close/reopen is covered where the existing harness can without production test auth.
- Extra scope: server-side exception-logging rule is included because silent repository catches hid the UTC sync failure. Web client catch blocks are not in this rule.
- CI/deployment: no new DbUp migration. Restart API after pull so UTC normalisation and logging are loaded.
