### PR TITLE
FLB#18 | persist angler and recorder without weakening catch ownership

### DIFF
--- a/src/FishingLogBook.Application/Catches/Services/CatchService.cs
+++ b/src/FishingLogBook.Application/Catches/Services/CatchService.cs
@@ -51,6 +51,8 @@ public sealed class CatchService : ICatchService
         {
             Id = args.Catch.Id,
             UserId = args.UserId,
+            AnglerUserId = args.UserId,
+            RecordedByUserId = args.UserId,
             CaughtOn = args.Catch.CaughtOn,
             Location = location,
             Photographs = photographs
@@ -88,7 +90,11 @@ public sealed class CatchService : ICatchService
             loaded.Value.Id,
             loaded.Value.UserId,
             loaded.Value.CaughtOn,
-            exposure));
+            exposure)
+        {
+            AnglerUserId = loaded.Value.AnglerUserId,
+            RecordedByUserId = loaded.Value.RecordedByUserId
+        });
     }
 
     public async Task<Result> UpdateLocationVisibilityAsync(

--- a/src/FishingLogBook.Application/Common/Mappings/CatchMappingRegistration.cs
+++ b/src/FishingLogBook.Application/Common/Mappings/CatchMappingRegistration.cs
@@ -53,7 +53,9 @@ public sealed class CatchMappingRegistration : IRegister
                         source.Location.Visibility,
                         source.Location.ConsentVersion))
             {
-                UserId = source.UserId
+                UserId = source.UserId,
+                AnglerUserId = source.AnglerUserId,
+                RecordedByUserId = source.RecordedByUserId
             });
     }
 }

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608181200_18_AddCatchProvenance.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608181200_18_AddCatchProvenance.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "Catch"
+    ADD COLUMN IF NOT EXISTS "AnglerUserId" uuid NULL,
+    ADD COLUMN IF NOT EXISTS "RecordedByUserId" uuid NULL;
+
+ALTER TABLE "Catch"
+    DROP CONSTRAINT IF EXISTS "FkCatchAnglerUser";
+
+ALTER TABLE "Catch"
+    ADD CONSTRAINT "FkCatchAnglerUser" FOREIGN KEY ("AnglerUserId") REFERENCES "User" ("Id");
+
+ALTER TABLE "Catch"
+    DROP CONSTRAINT IF EXISTS "FkCatchRecordedByUser";
+
+ALTER TABLE "Catch"
+    ADD CONSTRAINT "FkCatchRecordedByUser" FOREIGN KEY ("RecordedByUserId") REFERENCES "User" ("Id");
+
+UPDATE "Catch"
+SET "AnglerUserId" = "UserId"
+WHERE "AnglerUserId" IS NULL;
+
+UPDATE "Catch"
+SET "RecordedByUserId" = "UserId"
+WHERE "RecordedByUserId" IS NULL;

--- a/src/FishingLogBook.Domain/Catches/Catch.cs
+++ b/src/FishingLogBook.Domain/Catches/Catch.cs
@@ -6,6 +6,10 @@ public sealed class Catch
 
     public Guid UserId { get; init; }
 
+    public Guid AnglerUserId { get; init; }
+
+    public Guid RecordedByUserId { get; init; }
+
     public DateTimeOffset CaughtOn { get; init; }
 
     public CatchLocation? Location { get; init; }

--- a/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/CatchRepository.cs
@@ -150,6 +150,8 @@ public sealed class CatchRepository : ICatchRepository
             INSERT INTO "Catch" (
                 "Id",
                 "UserId",
+                "AnglerUserId",
+                "RecordedByUserId",
                 "CaughtOn",
                 "Latitude",
                 "Longitude",
@@ -161,6 +163,8 @@ public sealed class CatchRepository : ICatchRepository
             VALUES (
                 @Id,
                 @UserId,
+                @AnglerUserId,
+                @RecordedByUserId,
                 @CaughtOn,
                 @Latitude,
                 @Longitude,
@@ -227,6 +231,8 @@ public sealed class CatchRepository : ICatchRepository
             SELECT
                 "Id",
                 "UserId",
+                COALESCE("AnglerUserId", "UserId") AS "AnglerUserId",
+                COALESCE("RecordedByUserId", "UserId") AS "RecordedByUserId",
                 "CaughtOn",
                 "Latitude",
                 "Longitude",
@@ -264,6 +270,8 @@ public sealed class CatchRepository : ICatchRepository
         {
             Id = catchRow.Id,
             UserId = catchRow.UserId,
+            AnglerUserId = catchRow.AnglerUserId,
+            RecordedByUserId = catchRow.RecordedByUserId,
             CaughtOn = catchRow.CaughtOn,
             Location = ToLocation(catchRow),
             Photographs = photographs.ToArray()
@@ -276,6 +284,8 @@ public sealed class CatchRepository : ICatchRepository
         {
             catchRecord.Id,
             catchRecord.UserId,
+            catchRecord.AnglerUserId,
+            catchRecord.RecordedByUserId,
             CaughtOn = catchRecord.CaughtOn.ToUniversalTime(),
             Latitude = catchRecord.Location?.Latitude,
             Longitude = catchRecord.Location?.Longitude,
@@ -309,6 +319,10 @@ public sealed class CatchRepository : ICatchRepository
         public Guid Id { get; init; }
 
         public Guid UserId { get; init; }
+
+        public Guid AnglerUserId { get; init; }
+
+        public Guid RecordedByUserId { get; init; }
 
         public DateTimeOffset CaughtOn { get; init; }
 

--- a/src/FishingLogBook.Shared/Dtos/CatchDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/CatchDto.cs
@@ -7,4 +7,8 @@ public sealed record CatchDto(
     CatchLocationDto? Location = null)
 {
     public Guid UserId { get; init; }
+
+    public Guid AnglerUserId { get; init; }
+
+    public Guid RecordedByUserId { get; init; }
 }

--- a/src/FishingLogBook.Shared/Dtos/CatchViewDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/CatchViewDto.cs
@@ -4,4 +4,9 @@ public sealed record CatchViewDto(
     Guid Id,
     Guid UserId,
     DateTimeOffset CaughtOn,
-    CatchLocationExposureDto? Location = null);
+    CatchLocationExposureDto? Location = null)
+{
+    public Guid AnglerUserId { get; init; }
+
+    public Guid RecordedByUserId { get; init; }
+}

--- a/src/FishingLogBook.Web/BrowserTests/harness/index.html
+++ b/src/FishingLogBook.Web/BrowserTests/harness/index.html
@@ -62,6 +62,54 @@
                 );
                 return getAllCatchesWithPhotographs(ownerUserId);
             },
+            async putAndGetProductionCatchWithProvenance() {
+                const catchId = '11111111-1111-1111-1111-111111111111';
+                const photographId = '22222222-2222-2222-2222-222222222222';
+                await putCatchWithPhotographs(
+                    JSON.stringify({
+                        id: catchId,
+                        userId: ownerUserId,
+                        anglerUserId: ownerUserId,
+                        recordedByUserId: ownerUserId,
+                        caughtOn: '2026-08-17T08:00:00+00:00',
+                        photographs: [{
+                            id: photographId,
+                            catchId,
+                            contentType: 'image/jpeg'
+                        }]
+                    }),
+                    [{
+                        id: photographId,
+                        catchId,
+                        contentType: 'image/jpeg',
+                        bytes: new Uint8Array([1, 2, 3])
+                    }]
+                );
+                return getAllCatchesWithPhotographs(ownerUserId);
+            },
+            async putLegacyProductionCatchWithoutProvenance() {
+                const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+                const photographId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+                await putCatchWithPhotographs(
+                    JSON.stringify({
+                        id: catchId,
+                        userId: ownerUserId,
+                        caughtOn: '2026-08-17T08:00:00+00:00',
+                        photographs: [{
+                            id: photographId,
+                            catchId,
+                            contentType: 'image/jpeg'
+                        }]
+                    }),
+                    [{
+                        id: photographId,
+                        catchId,
+                        contentType: 'image/jpeg',
+                        bytes: new Uint8Array([4, 5, 6])
+                    }]
+                );
+                return getAllCatchesWithPhotographs(ownerUserId);
+            },
             async putAndGetProductionCatchWithThreePhotographs() {
                 const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
                 const photoA = '11111111-1111-1111-1111-111111111111';

--- a/src/FishingLogBook.Web/BrowserTests/storage.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/storage.spec.js
@@ -73,6 +73,39 @@ test.describe('Production Catch IndexedDB', () => {
         expect(records[0].photographs[0].id).toBe('22222222-2222-2222-2222-222222222222');
     });
 
+    test('keeps owner and provenance ids after close and reload', async ({ page }) => {
+        await page.goto(`${harness}/index.html`);
+        await expect(page.locator('#status')).toHaveText('ready');
+        await page.evaluate(() => window.harness.putAndGetProductionCatchWithProvenance());
+
+        await page.reload();
+        await expect(page.locator('#status')).toHaveText('ready');
+
+        const records = await page.evaluate(() => window.harness.readProductionCatches());
+        const catchRecord = JSON.parse(records[0].json);
+        expect(catchRecord.userId).toBe('11111111-1111-1111-1111-111111111111');
+        expect(catchRecord.anglerUserId).toBe('11111111-1111-1111-1111-111111111111');
+        expect(catchRecord.recordedByUserId).toBe('11111111-1111-1111-1111-111111111111');
+        expect(catchRecord.anglerUserId).toBe(catchRecord.userId);
+        expect(catchRecord.recordedByUserId).toBe(catchRecord.userId);
+    });
+
+    test('still reads a Catch stored without provenance properties', async ({ page }) => {
+        await page.goto(`${harness}/index.html`);
+        await expect(page.locator('#status')).toHaveText('ready');
+        await page.evaluate(() => window.harness.putLegacyProductionCatchWithoutProvenance());
+
+        await page.reload();
+        await expect(page.locator('#status')).toHaveText('ready');
+
+        const records = await page.evaluate(() => window.harness.readProductionCatches());
+        const catchRecord = JSON.parse(records[0].json);
+        expect(catchRecord.id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+        expect(catchRecord.userId).toBe('11111111-1111-1111-1111-111111111111');
+        expect(catchRecord.anglerUserId).toBeUndefined();
+        expect(catchRecord.recordedByUserId).toBeUndefined();
+    });
+
     test('keeps sync transitions and photograph bytes after close and reload', async ({ page }) => {
         await page.goto(`${harness}/index.html`);
         await expect(page.locator('#status')).toHaveText('ready');

--- a/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
@@ -10,4 +10,6 @@ public sealed record CatchModel(
     CatchLocationModel? Location = null,
     Guid UserId = default,
     SyncStatus SyncStatus = SyncStatus.SavedLocally,
-    SyncStatus MetadataSyncStatus = SyncStatus.SavedLocally);
+    SyncStatus MetadataSyncStatus = SyncStatus.SavedLocally,
+    Guid AnglerUserId = default,
+    Guid RecordedByUserId = default);

--- a/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
@@ -31,7 +31,9 @@ internal static class CatchJson
             catchRecord.Location,
             catchRecord.UserId,
             catchRecord.SyncStatus,
-            catchRecord.MetadataSyncStatus);
+            catchRecord.MetadataSyncStatus,
+            catchRecord.AnglerUserId,
+            catchRecord.RecordedByUserId);
         return JsonSerializer.Serialize(metadata, Options);
     }
 
@@ -47,7 +49,9 @@ internal static class CatchJson
             metadata.Location,
             metadata.UserId,
             metadata.SyncStatus,
-            metadata.MetadataSyncStatus);
+            metadata.MetadataSyncStatus,
+            metadata.AnglerUserId == Guid.Empty ? metadata.UserId : metadata.AnglerUserId,
+            metadata.RecordedByUserId == Guid.Empty ? metadata.UserId : metadata.RecordedByUserId);
     }
 
     private static IReadOnlyList<CatchPhotographModel> OrderPhotographs(
@@ -80,7 +84,9 @@ internal static class CatchJson
         CatchLocationModel? Location = null,
         Guid UserId = default,
         SyncStatus SyncStatus = SyncStatus.SavedLocally,
-        SyncStatus MetadataSyncStatus = SyncStatus.SavedLocally);
+        SyncStatus MetadataSyncStatus = SyncStatus.SavedLocally,
+        Guid AnglerUserId = default,
+        Guid RecordedByUserId = default);
 
     private sealed record CatchPhotographMetadata(
         Guid Id,

--- a/src/FishingLogBook.Web/Features/Catch/Offline/CatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/CatchSynchroniser.cs
@@ -576,13 +576,21 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
                     catchRecord.Location.CapturedOn,
                     catchRecord.Location.Source,
                     catchRecord.Location.Visibility,
-                    catchRecord.Location.ConsentVersion));
+                    catchRecord.Location.ConsentVersion))
+        {
+            UserId = catchRecord.UserId,
+            AnglerUserId = catchRecord.AnglerUserId,
+            RecordedByUserId = catchRecord.RecordedByUserId
+        };
     }
 
     private static bool HasSameMetadata(CatchModel catchRecord, CatchDto sent)
     {
         if (catchRecord.Id != sent.Id
             || catchRecord.CaughtOn != sent.CaughtOn
+            || catchRecord.UserId != sent.UserId
+            || catchRecord.AnglerUserId != sent.AnglerUserId
+            || catchRecord.RecordedByUserId != sent.RecordedByUserId
             || catchRecord.Photographs.Count != sent.Photographs.Count)
         {
             return false;

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
@@ -53,6 +53,12 @@
                                 <MudText Typo="Typo.caption" id="@($"catch-time-{catchRecord.Id:D}")">
                                     @catchRecord.CaughtOn.ToString("g")
                                 </MudText>
+                                <MudText Typo="Typo.caption" id="@($"catch-angler-{catchRecord.Id:D}")">
+                                    @Loc["Catch_AnglerYou"]
+                                </MudText>
+                                <MudText Typo="Typo.caption" id="@($"catch-recorded-by-{catchRecord.Id:D}")">
+                                    @Loc["Catch_RecordedByYou"]
+                                </MudText>
                                 <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center"
                                           id="@($"catch-sync-status-{catchRecord.Id:D}")">
                                     <MudIcon Icon="@SyncStatusIcon(catchRecord.SyncStatus)"

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
@@ -241,7 +241,9 @@ public partial class RecordCatch : ComponentBase, IDisposable
                     _caughtOn ?? DateTimeOffset.UtcNow,
                     photographs,
                     Location: location,
-                    UserId: ownerUserId),
+                    UserId: ownerUserId,
+                    AnglerUserId: ownerUserId,
+                    RecordedByUserId: ownerUserId),
                 _cancellationTokenSource.Token);
             _isSaved = true;
             _locationSaved = location is not null;

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -363,6 +363,12 @@
   <data name="Catch_UnknownSpecies" xml:space="preserve">
     <value>Prise</value>
   </data>
+  <data name="Catch_AnglerYou" xml:space="preserve">
+    <value>Pêcheur : Vous</value>
+  </data>
+  <data name="Catch_RecordedByYou" xml:space="preserve">
+    <value>Enregistré par : Vous</value>
+  </data>
   <data name="Catch_ManageLocationPrivacy" xml:space="preserve">
     <value>Confidentialité de la localisation</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -363,6 +363,12 @@
   <data name="Catch_UnknownSpecies" xml:space="preserve">
     <value>Catch</value>
   </data>
+  <data name="Catch_AnglerYou" xml:space="preserve">
+    <value>Angler: You</value>
+  </data>
+  <data name="Catch_RecordedByYou" xml:space="preserve">
+    <value>Recorded by: You</value>
+  </data>
   <data name="Catch_ManageLocationPrivacy" xml:space="preserve">
     <value>Location privacy</value>
   </data>

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
@@ -283,6 +283,60 @@ describe('Production Catch store', () => {
         expect(items[0].photographs[0].bytesBase64).toBe(btoa(String.fromCharCode(1, 2, 3)));
     });
 
+    it('keeps owner and provenance ids after reopen', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId: ownerUserId,
+                anglerUserId: ownerUserId,
+                recordedByUserId: ownerUserId,
+                caughtOn: '2026-08-17T08:00:00+00:00'
+            }),
+            [{
+                id: 'provenance-photo',
+                catchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([1])
+            }]
+        );
+
+        const firstRead = await getAllCatchesWithPhotographs(ownerUserId);
+        const reopened = await getAllCatchesWithPhotographs(ownerUserId);
+        const catchRecord = JSON.parse(reopened[0].json);
+
+        expect(JSON.parse(firstRead[0].json).anglerUserId).toBe(ownerUserId);
+        expect(catchRecord.userId).toBe(ownerUserId);
+        expect(catchRecord.anglerUserId).toBe(ownerUserId);
+        expect(catchRecord.recordedByUserId).toBe(ownerUserId);
+        expect(catchRecord.anglerUserId).toBe(catchRecord.userId);
+        expect(catchRecord.recordedByUserId).toBe(catchRecord.userId);
+    });
+
+    it('still reads a Catch stored without provenance properties', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId: ownerUserId,
+                caughtOn: '2026-08-17T08:00:00+00:00'
+            }),
+            [{
+                id: 'legacy-photo',
+                catchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([1])
+            }]
+        );
+
+        const reopened = await getAllCatchesWithPhotographs(ownerUserId);
+        const catchRecord = JSON.parse(reopened[0].json);
+
+        expect(catchRecord.userId).toBe(ownerUserId);
+        expect(catchRecord.anglerUserId).toBeUndefined();
+        expect(catchRecord.recordedByUserId).toBeUndefined();
+    });
+
     it('reads three photographs in metadata order after reopen', async () => {
         const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
         const photoA = '11111111-1111-1111-1111-111111111111';

--- a/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingGet.cs
+++ b/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingGet.cs
@@ -68,6 +68,8 @@ public class WhenTestingGet : IClassFixture<SystemApiFactory>
         {
             Id = Guid.NewGuid(),
             UserId = current!.UserId,
+            AnglerUserId = current.UserId,
+            RecordedByUserId = current.UserId,
             CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z")
         };
         _factory.CatchRepository
@@ -84,7 +86,10 @@ public class WhenTestingGet : IClassFixture<SystemApiFactory>
         json.Should().NotContain("\"latitude\":");
         json.Should().NotContain("53.2707");
         body.Should().NotBeNull();
-        body!.Location.Should().BeNull();
+        body!.UserId.Should().Be(current.UserId);
+        body.AnglerUserId.Should().Be(current.UserId);
+        body.RecordedByUserId.Should().Be(current.UserId);
+        body.Location.Should().BeNull();
         await _factory.CatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
     }
 
@@ -312,6 +317,8 @@ public class WhenTestingGet : IClassFixture<SystemApiFactory>
         {
             Id = catchId,
             UserId = ownerUserId,
+            AnglerUserId = ownerUserId,
+            RecordedByUserId = ownerUserId,
             CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             Location = CatchLocation.TryCreate(
                 53.2707,

--- a/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Api.Tests/CatchEndpointsTests/WhenTestingUpsert.cs
@@ -69,7 +69,9 @@ public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             [new CatchPhotographDto(photographId, catchId, PhotographContentTypeConstants.Jpeg)])
         {
-            UserId = clientOwner
+            UserId = clientOwner,
+            AnglerUserId = clientOwner,
+            RecordedByUserId = clientOwner
         };
         ResetCatchRepository();
         var client = _factory.CreateAuthenticatedClient();
@@ -84,12 +86,18 @@ public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         body.Should().NotBeNull();
         body!.UserId.Should().Be(current!.UserId);
+        body.AnglerUserId.Should().Be(current.UserId);
+        body.RecordedByUserId.Should().Be(current.UserId);
         body.UserId.Should().NotBe(clientOwner);
+        body.AnglerUserId.Should().NotBe(clientOwner);
+        body.RecordedByUserId.Should().NotBe(clientOwner);
         body.Id.Should().Be(catchId);
         body.Photographs.Should().ContainSingle(photograph => photograph.Id == photographId);
         await _factory.CatchRepository.Received(1).UpsertAsync(
             Arg.Is<Catch>(item =>
                 item.UserId == current.UserId
+                && item.AnglerUserId == current.UserId
+                && item.RecordedByUserId == current.UserId
                 && item.Id == catchId
                 && item.Photographs[0].Id == photographId),
             Arg.Any<CancellationToken>());

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingGetView.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingGetView.cs
@@ -63,6 +63,8 @@ public class WhenTestingGetView : BaseCatchServiceTest
         {
             Id = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
             UserId = ownerUserId,
+            AnglerUserId = ownerUserId,
+            RecordedByUserId = ownerUserId,
             CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z")
         };
         MockCatchRepository
@@ -84,6 +86,8 @@ public class WhenTestingGetView : BaseCatchServiceTest
         // Assert
         result.IsSuccess.Should().BeTrue();
         result.Value.UserId.Should().Be(ownerUserId);
+        result.Value.AnglerUserId.Should().Be(ownerUserId);
+        result.Value.RecordedByUserId.Should().Be(ownerUserId);
         result.Value.Location!.Mode.Should().Be(LocationDefaults.ExposureNone);
         await MockCatchRepository.Received(1).GetByIdAsync(catchRecord.Id, Arg.Any<CancellationToken>());
         await MockCatchLocationPrivacyService.Received(1).GetExposureAsync(

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingUpsert.cs
@@ -112,7 +112,9 @@ public class WhenTestingUpsert : BaseCatchServiceTest
                 DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
                 [new CatchPhotographDto(photographId, catchId, PhotographContentTypeConstants.Png)])
             {
-                UserId = clientUserId
+                UserId = clientUserId,
+                AnglerUserId = clientUserId,
+                RecordedByUserId = clientUserId
             }
         };
         MockCatchRepository
@@ -125,11 +127,17 @@ public class WhenTestingUpsert : BaseCatchServiceTest
         // Assert
         result.IsSuccess.Should().BeTrue();
         result.Value.UserId.Should().Be(authenticatedUserId);
+        result.Value.AnglerUserId.Should().Be(authenticatedUserId);
+        result.Value.RecordedByUserId.Should().Be(authenticatedUserId);
         result.Value.UserId.Should().NotBe(clientUserId);
+        result.Value.AnglerUserId.Should().NotBe(clientUserId);
+        result.Value.RecordedByUserId.Should().NotBe(clientUserId);
         result.Value.Photographs.Should().ContainSingle(photograph => photograph.Id == photographId);
         await MockCatchRepository.Received(1).UpsertAsync(
             Arg.Is<Catch>(item =>
                 item.UserId == authenticatedUserId
+                && item.AnglerUserId == authenticatedUserId
+                && item.RecordedByUserId == authenticatedUserId
                 && item.Id == catchId
                 && item.Photographs.Count == 1
                 && item.Photographs[0].Id == photographId
@@ -221,7 +229,9 @@ public class WhenTestingUpsert : BaseCatchServiceTest
                 && item.Location.CapturedOn == capturedOn
                 && item.Location.Source == LocationDefaults.DeviceGps
                 && item.Location.Visibility == LocationDefaults.Private
-                && item.Location.ConsentVersion == LocationDefaults.ConsentVersion),
+                && item.Location.ConsentVersion == LocationDefaults.ConsentVersion
+                && item.AnglerUserId == args.UserId
+                && item.RecordedByUserId == args.UserId),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/BaseCatchRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/CatchRepositoryTests/BaseCatchRepositoryTest.cs
@@ -3,8 +3,8 @@ using FishingLogBook.Domain.Catches;
 using FishingLogBook.Infrastructure.Persistence;
 using FishingLogBook.Infrastructure.Tests.TestSupport;
 using FishingLogBook.Shared.Constants;
-using NSubstitute;
 using Npgsql;
+using NSubstitute;
 
 namespace FishingLogBook.Infrastructure.Tests.CatchRepositoryTests;
 

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/BaseCatchRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/BaseCatchRepositoryTest.cs
@@ -62,6 +62,8 @@ public abstract class BaseCatchRepositoryTest
         {
             Id = id,
             UserId = userId,
+            AnglerUserId = userId,
+            RecordedByUserId = userId,
             CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             Photographs = photos
         };
@@ -89,6 +91,8 @@ public abstract class BaseCatchRepositoryTest
         {
             Id = catchRecord.Id,
             UserId = catchRecord.UserId,
+            AnglerUserId = catchRecord.AnglerUserId,
+            RecordedByUserId = catchRecord.RecordedByUserId,
             CaughtOn = catchRecord.CaughtOn,
             Location = location,
             Photographs = catchRecord.Photographs

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingGetById.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingGetById.cs
@@ -41,6 +41,8 @@ public class WhenTestingGetById : BaseCatchRepositoryTest
         result.Value.Should().NotBeNull();
         result.Value!.Id.Should().Be(catchRecord.Id);
         result.Value.UserId.Should().Be(userId);
+        result.Value.AnglerUserId.Should().Be(userId);
+        result.Value.RecordedByUserId.Should().Be(userId);
         result.Value.Photographs.Should().ContainSingle();
         result.Value.Photographs[0].Id.Should().Be(catchRecord.Photographs[0].Id);
         result.Value.Photographs[0].CatchId.Should().Be(catchRecord.Id);

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpdateLocationVisibility.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpdateLocationVisibility.cs
@@ -143,6 +143,9 @@ public class WhenTestingUpdateLocationVisibility : BaseCatchRepositoryTest
         loaded.Value.Location.AccuracyMetres.Should().Be(location.AccuracyMetres);
         loaded.Value.Location.Source.Should().Be(LocationDefaults.DeviceGps);
         loaded.Value.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+        loaded.Value.UserId.Should().Be(userId);
+        loaded.Value.AnglerUserId.Should().Be(userId);
+        loaded.Value.RecordedByUserId.Should().Be(userId);
         await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
         var row = await connection.QuerySingleAsync(
             """

--- a/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Integration/Catches/CatchRepositoryTests/WhenTestingUpsert.cs
@@ -49,6 +49,8 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
         result.IsSuccess.Should().BeTrue();
         result.Value.Id.Should().Be(catchId);
         result.Value.UserId.Should().Be(userId);
+        result.Value.AnglerUserId.Should().Be(userId);
+        result.Value.RecordedByUserId.Should().Be(userId);
         result.Value.Photographs.Should().HaveCount(2);
         result.Value.Photographs.Select(photograph => photograph.Id)
             .Should()
@@ -80,6 +82,8 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
         loaded.Value.Should().NotBeNull();
         loaded.Value!.Id.Should().Be(original.Id);
         loaded.Value.CaughtOn.Should().Be(updated.CaughtOn);
+        loaded.Value.AnglerUserId.Should().Be(userId);
+        loaded.Value.RecordedByUserId.Should().Be(userId);
         loaded.Value.Photographs[0].Id.Should().Be(original.Photographs[0].Id);
         loaded.Value.Location.Should().BeNull();
     }
@@ -97,6 +101,8 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
             {
                 Id = catchId,
                 UserId = userId,
+                AnglerUserId = userId,
+                RecordedByUserId = userId,
                 CaughtOn = caughtOn,
                 Photographs =
                 [
@@ -243,6 +249,8 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
         loaded.Value.Location.Longitude.Should().Be(location.Longitude);
         loaded.Value.Location.AccuracyMetres.Should().Be(location.AccuracyMetres);
         loaded.Value.Location.Visibility.Should().Be(LocationDefaults.Private);
+        loaded.Value.AnglerUserId.Should().Be(userId);
+        loaded.Value.RecordedByUserId.Should().Be(userId);
         loaded.Value.Photographs[0].Id.Should().Be(original.Photographs[0].Id);
     }
 
@@ -364,6 +372,8 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
         result.Errors[0].Should().BeOfType<CatchOwnershipConflictError>();
         loaded.Value.Should().NotBeNull();
         loaded.Value!.UserId.Should().Be(ownerId);
+        loaded.Value.AnglerUserId.Should().Be(ownerId);
+        loaded.Value.RecordedByUserId.Should().Be(ownerId);
     }
 
     [Fact]
@@ -439,5 +449,76 @@ public class WhenTestingUpsert : BaseCatchRepositoryTest
         // Assert
         result.IsFailed.Should().BeTrue();
         loaded.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepEstablishedProvenanceWhenTheSameCatchIsUpsertedAgain()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        var original = NewCatch(userId);
+        await Sut.UpsertAsync(original, CancellationToken.None);
+        var retried = new Catch
+        {
+            Id = original.Id,
+            UserId = userId,
+            AnglerUserId = otherUserId,
+            RecordedByUserId = otherUserId,
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T12:00:00Z"),
+            Photographs = original.Photographs
+        };
+
+        // Act
+        var result = await Sut.UpsertAsync(retried, CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(original.Id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AnglerUserId.Should().Be(userId);
+        result.Value.RecordedByUserId.Should().Be(userId);
+        loaded.Value.Should().NotBeNull();
+        loaded.Value!.UserId.Should().Be(userId);
+        loaded.Value.AnglerUserId.Should().Be(userId);
+        loaded.Value.RecordedByUserId.Should().Be(userId);
+        loaded.Value.CaughtOn.Should().Be(retried.CaughtOn);
+    }
+
+    [Fact]
+    public async Task ItShouldResolveMissingProvenanceColumnsToTheOwnerUserId()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var catchId = Guid.NewGuid();
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        await connection.ExecuteAsync(
+            """
+            INSERT INTO "Catch" ("Id", "UserId", "CaughtOn")
+            VALUES (@Id, @UserId, @CaughtOn);
+            """,
+            new
+            {
+                Id = catchId,
+                UserId = userId,
+                CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z")
+            });
+        await connection.ExecuteAsync(
+            """
+            UPDATE "Catch"
+            SET "AnglerUserId" = NULL,
+                "RecordedByUserId" = NULL
+            WHERE "Id" = @Id;
+            """,
+            new { Id = catchId });
+
+        // Act
+        var result = await Sut.GetByIdAsync(catchId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.UserId.Should().Be(userId);
+        result.Value.AnglerUserId.Should().Be(userId);
+        result.Value.RecordedByUserId.Should().Be(userId);
     }
 }

--- a/tests/FishingLogBook.Shared.Tests/Serialization/WhenTestingWebSerialization.cs
+++ b/tests/FishingLogBook.Shared.Tests/Serialization/WhenTestingWebSerialization.cs
@@ -96,7 +96,12 @@ public class WhenTestingWebSerialization : BaseSerializationTest
                 DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
                 LocationDefaults.DeviceGps,
                 LocationDefaults.Private,
-                LocationDefaults.ConsentVersion));
+                LocationDefaults.ConsentVersion))
+        {
+            UserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            AnglerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            RecordedByUserId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+        };
 
         // Act
         var json = JsonSerializer.Serialize(original, WebOptions);
@@ -195,7 +200,11 @@ public class WhenTestingWebSerialization : BaseSerializationTest
                 Mode = LocationDefaults.ExposureExact,
                 Latitude = 53.2707,
                 Longitude = -9.0568
-            });
+            })
+        {
+            AnglerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            RecordedByUserId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+        };
 
         // Act
         var json = JsonSerializer.Serialize(original, WebOptions);

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
@@ -47,6 +47,8 @@ public class WhenTestingDeserialize : BaseCatchJsonTest
                 PhotographContentTypeConstants.Webp);
         restored.Photographs.Should().OnlyContain(photograph => photograph.CatchId == catchId);
         restored.UserId.Should().Be(Guid.Empty);
+        restored.AnglerUserId.Should().Be(Guid.Empty);
+        restored.RecordedByUserId.Should().Be(Guid.Empty);
     }
 
     [Fact]
@@ -70,6 +72,8 @@ public class WhenTestingDeserialize : BaseCatchJsonTest
         restored.Id.Should().Be(catchId);
         restored.Location.Should().BeNull();
         restored.UserId.Should().Be(Guid.Empty);
+        restored.AnglerUserId.Should().Be(Guid.Empty);
+        restored.RecordedByUserId.Should().Be(Guid.Empty);
         restored.Photographs.Should().ContainSingle(photograph => photograph.Id == photographId);
     }
 
@@ -93,7 +97,60 @@ public class WhenTestingDeserialize : BaseCatchJsonTest
         // Assert
         json.Should().Contain("\"userId\":\"11111111-1111-1111-1111-111111111111\"");
         restored.UserId.Should().Be(userId);
+        restored.AnglerUserId.Should().Be(userId);
+        restored.RecordedByUserId.Should().Be(userId);
         restored.Id.Should().Be(catchId);
+    }
+
+    [Fact]
+    public void ItShouldRoundTripProvenanceUserIds()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var photographId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var catchRecord = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])],
+            UserId: userId,
+            AnglerUserId: userId,
+            RecordedByUserId: userId);
+
+        // Act
+        var json = CatchJson.SerializeMetadata(catchRecord);
+        var restored = CatchJson.Deserialize(json, catchRecord.Photographs);
+
+        // Assert
+        json.Should().Contain("\"anglerUserId\":\"11111111-1111-1111-1111-111111111111\"");
+        json.Should().Contain("\"recordedByUserId\":\"11111111-1111-1111-1111-111111111111\"");
+        restored.UserId.Should().Be(userId);
+        restored.AnglerUserId.Should().Be(userId);
+        restored.RecordedByUserId.Should().Be(userId);
+    }
+
+    [Fact]
+    public void ItShouldFallBackToTheOwnerWhenLegacyMetadataOmitsProvenance()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var photographId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var json = """
+            {"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","caughtOn":"2026-08-17T08:00:00+00:00","speciesName":null,"photographs":[{"id":"22222222-2222-2222-2222-222222222222","catchId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","contentType":"image/jpeg"}],"userId":"11111111-1111-1111-1111-111111111111"}
+            """;
+        var photographs = new[]
+        {
+            new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1])
+        };
+
+        // Act
+        var restored = CatchJson.Deserialize(json, photographs);
+
+        // Assert
+        restored.UserId.Should().Be(userId);
+        restored.AnglerUserId.Should().Be(userId);
+        restored.RecordedByUserId.Should().Be(userId);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
@@ -154,6 +154,57 @@ public class WhenTestingDeserialize : BaseCatchJsonTest
     }
 
     [Fact]
+    public void ItShouldFallBackToTheOwnerWhenBrowserStorageReturnsPre18Json()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var photographId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var json = """
+            {"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","userId":"11111111-1111-1111-1111-111111111111","caughtOn":"2026-08-17T08:00:00+00:00","photographs":[{"id":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","catchId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","contentType":"image/jpeg"}]}
+            """;
+        var photographs = new[]
+        {
+            new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [4, 5, 6])
+        };
+
+        // Act
+        var restored = CatchJson.Deserialize(json, photographs);
+
+        // Assert
+        restored.UserId.Should().Be(userId);
+        restored.AnglerUserId.Should().Be(userId);
+        restored.RecordedByUserId.Should().Be(userId);
+        restored.Photographs.Should().ContainSingle(photograph => photograph.Id == photographId);
+    }
+
+    [Fact]
+    public void ItShouldKeepProvenanceWhenBrowserStorageReturnsOwnedJson()
+    {
+        // Arrange
+        var catchId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var photographId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var json = """
+            {"id":"11111111-1111-1111-1111-111111111111","userId":"11111111-1111-1111-1111-111111111111","anglerUserId":"11111111-1111-1111-1111-111111111111","recordedByUserId":"11111111-1111-1111-1111-111111111111","caughtOn":"2026-08-17T08:00:00+00:00","photographs":[{"id":"22222222-2222-2222-2222-222222222222","catchId":"11111111-1111-1111-1111-111111111111","contentType":"image/jpeg"}]}
+            """;
+        var photographs = new[]
+        {
+            new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1, 2, 3])
+        };
+
+        // Act
+        var restored = CatchJson.Deserialize(json, photographs);
+
+        // Assert
+        restored.UserId.Should().Be(userId);
+        restored.AnglerUserId.Should().Be(userId);
+        restored.RecordedByUserId.Should().Be(userId);
+        restored.AnglerUserId.Should().Be(restored.UserId);
+        restored.RecordedByUserId.Should().Be(restored.UserId);
+    }
+
+    [Fact]
     public void ItShouldRoundTripANullLocation()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchStoreTests/WhenTestingSave.cs
@@ -70,7 +70,9 @@ public class WhenTestingSave : BaseCatchStoreTest
             catchId,
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Png, [9, 8, 7])],
-            UserId: OwnerUserId);
+            UserId: OwnerUserId,
+            AnglerUserId: OwnerUserId,
+            RecordedByUserId: OwnerUserId);
         await Sut.SaveAsync(catchRecord, CancellationToken.None);
         var reopened = new MemoryCatchStore(BackingCatches, BackingPhotographs);
 
@@ -85,6 +87,8 @@ public class WhenTestingSave : BaseCatchStoreTest
         saved[0].Photographs[0].Bytes.Should().Equal(9, 8, 7);
         saved[0].SpeciesName.Should().BeNull();
         saved[0].UserId.Should().Be(OwnerUserId);
+        saved[0].AnglerUserId.Should().Be(OwnerUserId);
+        saved[0].RecordedByUserId.Should().Be(OwnerUserId);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/BaseCatchSynchroniserTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/BaseCatchSynchroniserTest.cs
@@ -93,7 +93,9 @@ public class BaseCatchSynchroniserTest
                 "1"),
             userId ?? OwnerUserId,
             catchStatus,
-            metadataStatus);
+            metadataStatus,
+            AnglerUserId: userId ?? OwnerUserId,
+            RecordedByUserId: userId ?? OwnerUserId);
     }
 
     protected static CatchPhotographModel CreatePhotograph(

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/WhenTestingRetry.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/WhenTestingRetry.cs
@@ -54,6 +54,9 @@ public class WhenTestingRetry : BaseCatchSynchroniserTest
         saved.Location.Should().Be(catchRecord.Location);
         saved.Photographs.Should().OnlyContain(
             photograph => photograph.SyncStatus == SyncStatus.Synchronised);
+        saved.UserId.Should().Be(OwnerUserId);
+        saved.AnglerUserId.Should().Be(OwnerUserId);
+        saved.RecordedByUserId.Should().Be(OwnerUserId);
         await MockCatchClient.DidNotReceive()
             .UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
         await MockCatchClient.Received(1).CreatePhotographUploadAsync(

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
@@ -66,6 +66,9 @@ public class WhenTestingSynchronisePending : BaseCatchSynchroniserTest
         await MockCatchClient.Received(1).UpsertAsync(
             Arg.Is<CatchDto>(dto =>
                 dto.Id == CatchId
+                && dto.UserId == OwnerUserId
+                && dto.AnglerUserId == OwnerUserId
+                && dto.RecordedByUserId == OwnerUserId
                 && dto.Location != null
                 && dto.Location.Latitude == 53.2707
                 && dto.Location.Longitude == -9.0568
@@ -387,7 +390,9 @@ public class WhenTestingSynchronisePending : BaseCatchSynchroniserTest
         await MockCatchClient.Received(1).UpsertAsync(
             Arg.Is<CatchDto>(dto =>
                 dto.Id == CatchId
-                && dto.UserId == Guid.Empty
+                && dto.UserId == OwnerUserId
+                && dto.AnglerUserId == OwnerUserId
+                && dto.RecordedByUserId == OwnerUserId
                 && dto.Photographs.Count == 3
                 && dto.Location != null
                 && dto.Location.Latitude == expected.Location!.Latitude

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingRender.cs
@@ -55,6 +55,8 @@ public class WhenTestingRender : BaseCatchListTest
             cut.Find($"#catch-label-{catchId:D}").TextContent.Should().Contain("Catch");
             cut.Find($"#catch-thumb-{catchId:D}").GetAttribute("src").Should().StartWith("data:image/jpeg;base64,");
             cut.Find($"#catch-time-{catchId:D}").TextContent.Should().NotBeNullOrWhiteSpace();
+            cut.Find($"#catch-angler-{catchId:D}").TextContent.Should().Contain("Angler: You");
+            cut.Find($"#catch-recorded-by-{catchId:D}").TextContent.Should().Contain("Recorded by: You");
         });
         await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
@@ -124,7 +126,11 @@ public class WhenTestingRender : BaseCatchListTest
 
         // Assert
         cut.WaitForAssertion(() =>
-            cut.Find($"#catch-label-{catchId:D}").TextContent.Should().Contain("Prise"));
+        {
+            cut.Find($"#catch-label-{catchId:D}").TextContent.Should().Contain("Prise");
+            cut.Find($"#catch-angler-{catchId:D}").TextContent.Should().Contain("Pêcheur : Vous");
+            cut.Find($"#catch-recorded-by-{catchId:D}").TextContent.Should().Contain("Enregistré par : Vous");
+        });
         cut.FindAll("#catch-list-empty").Should().BeEmpty();
         await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/BaseCatchLocationPrivacyTest.cs
@@ -43,7 +43,9 @@ public class BaseCatchLocationPrivacyTest
             DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
             [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg, [1])],
             Location: location,
-            UserId: OwnerUserId);
+            UserId: OwnerUserId,
+            AnglerUserId: OwnerUserId,
+            RecordedByUserId: OwnerUserId);
     }
 
     protected static CatchModel LocatedCatch(Guid catchId, string visibility = LocationDefaults.Private)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchLocationPrivacyTests/WhenTestingSave.cs
@@ -343,7 +343,10 @@ public class WhenTestingSave : BaseCatchLocationPrivacyTest
                 && catchRecord.Location.Latitude == 53.2707
                 && catchRecord.Location.Longitude == -9.0568
                 && catchRecord.Location.AccuracyMetres == 12
-                && catchRecord.Location.Source == LocationDefaults.DeviceGps),
+                && catchRecord.Location.Source == LocationDefaults.DeviceGps
+                && catchRecord.UserId == OwnerUserId
+                && catchRecord.AnglerUserId == OwnerUserId
+                && catchRecord.RecordedByUserId == OwnerUserId),
             Arg.Any<CancellationToken>());
         await client.Received(1).UpdateLocationVisibilityAsync(
             catchId,

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingSave.cs
@@ -128,6 +128,8 @@ public class WhenTestingSave : BaseRecordCatchTest
         // Assert
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
+                catchRecord.AnglerUserId == OwnerUserId &&
+                catchRecord.RecordedByUserId == OwnerUserId &&
                 catchRecord.Photographs.Count == 1
                 && catchRecord.Photographs[0].Id == photographId
                 && catchRecord.Photographs[0].CatchId == catchRecord.Id
@@ -462,6 +464,8 @@ public class WhenTestingSave : BaseRecordCatchTest
         });
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord => catchRecord.UserId == OwnerUserId &&
+                catchRecord.AnglerUserId == OwnerUserId &&
+                catchRecord.RecordedByUserId == OwnerUserId &&
                 catchRecord.SyncStatus == SyncStatus.SavedLocally),
             Arg.Any<CancellationToken>());
         await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());


### PR DESCRIPTION
Closes #18

## Summary
- Recreational catches now store `AnglerUserId` and `RecordedByUserId` alongside the existing owner/security `UserId`.
- Local save, IndexedDB JSON, and server upsert all set both provenance IDs from the trusted current user; client-supplied provenance is ignored.
- Upsert retries do not overwrite established provenance. Pre-#18 DB rows and old IndexedDB JSON fall back to `UserId`.
- `/catches` shows compact EN/FR labels (`Angler: You` / `Recorded by: You` and French equivalents).

## Migration
Apply DbUp script `202608181200_18_AddCatchProvenance.sql` (nullable columns + FKs + idempotent backfill). Do not `SET NOT NULL` in this release.

Cleanup follow-up: #83

## Test plan
- [ ] Record a recreational catch offline; IndexedDB keeps owner = angler = recorder after close/reopen
- [ ] Sync/retry does not change provenance
- [ ] Spoofed client provenance cannot persist another user
- [ ] `/catches` shows English and French provenance labels
- [ ] Location privacy and photograph retry still work and do not mutate provenance

## Self review
- Issue/AC: PASS — recreational provenance stored, returned, shown; `UserId` not renamed/repurposed; spoofing rejected; retries immutable; legacy JSON/DB fallback to `UserId`
- Architecture/CQRS: PASS — upsert still Endpoint → MediatR → CatchService → CatchRepository; provenance derived from trusted `args.UserId`
- Rules: PASS — expand-only migration; no new catch blocks without logging; localisation EN/FR
- Security/privacy: PASS — server does not trust client provenance; owner-scoped sync/photos/location unchanged
- Database/migrations: PASS — additive nullable columns + FKs + backfill; `COALESCE` reads; NOT NULL deferred to #83
- Tests/coverage: PASS — targeted Catch suites plus full `dotnet test`, `npm test`, and Playwright
- Browser: N/A for authenticated Record Catch (existing harness is unauthenticated IndexedDB/PWA). Compensating coverage is CatchJson deserialize/fallback, MemoryCatchStore reopen, and bUnit RecordCatch/CatchList tests
- Web/UI/localisation: PASS — compact labels only; no #20 detail page; no emails
- Code smells: PASS — no extra provenance service or schema redesign
- CI/deployment: PASS — apply the new DbUp script after merge; no Terraform

Findings discovered during self-review:
1. `database.md` requires a contract/cleanup task before merging an expand PR that will later tighten nullability.

Fixes made:
1. Opened #83 to `SET NOT NULL` on provenance columns after the #18 backfill is proven live.

Remaining deliberate gaps:
- Guide/delegated recording and selecting another angler remain out of scope (#18)
- Catch editing (#19) and full catch detail/history (#20) not implemented
- Provenance columns stay nullable until #83
