### PR TITLE
FLB#103 | Fix Safari authentication callback navigation

### DIFF
--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -46,14 +46,12 @@
     <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js" autostart="false"></script>
     <script type="module">
+        const { registerServiceWorker } = await import('./js/bootstrap/service-worker-registration.js');
+        await registerServiceWorker();
         await import('./js/bootstrap/app.js');
         await Blazor.start();
     </script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
-    <script type="module">
-        import { registerServiceWorker } from './js/bootstrap/service-worker-registration.js';
-        registerServiceWorker();
-    </script>
 </body>
 
 </html>

--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -47,7 +47,7 @@
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js" autostart="false"></script>
     <script type="module">
         const { registerServiceWorker } = await import('./js/bootstrap/service-worker-registration.js');
-        await registerServiceWorker();
+        registerServiceWorker();
         await import('./js/bootstrap/app.js');
         await Blazor.start();
     </script>

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/index-startup.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/index-startup.test.js
@@ -5,11 +5,14 @@ import { describe, expect, it } from 'vitest';
 describe('application startup', () => {
     it('installs browser globals before starting Blazor', () => {
         const indexHtml = readFileSync(resolve(import.meta.dirname, '../../index.html'), 'utf8');
+        const registrationPosition = indexHtml.indexOf('await registerServiceWorker();');
         const bootstrapPosition = indexHtml.indexOf("await import('./js/bootstrap/app.js');");
         const blazorStartPosition = indexHtml.indexOf('await Blazor.start();');
 
         expect(indexHtml).toContain('autostart="false"');
         expect(indexHtml).not.toContain('type="module" src="js/bootstrap/app.js"');
+        expect(registrationPosition).toBeGreaterThan(-1);
+        expect(bootstrapPosition).toBeGreaterThan(registrationPosition);
         expect(bootstrapPosition).toBeGreaterThan(-1);
         expect(blazorStartPosition).toBeGreaterThan(bootstrapPosition);
     });

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/index-startup.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/index-startup.test.js
@@ -5,12 +5,13 @@ import { describe, expect, it } from 'vitest';
 describe('application startup', () => {
     it('installs browser globals before starting Blazor', () => {
         const indexHtml = readFileSync(resolve(import.meta.dirname, '../../index.html'), 'utf8');
-        const registrationPosition = indexHtml.indexOf('await registerServiceWorker();');
+        const registrationPosition = indexHtml.indexOf('registerServiceWorker();');
         const bootstrapPosition = indexHtml.indexOf("await import('./js/bootstrap/app.js');");
         const blazorStartPosition = indexHtml.indexOf('await Blazor.start();');
 
         expect(indexHtml).toContain('autostart="false"');
         expect(indexHtml).not.toContain('type="module" src="js/bootstrap/app.js"');
+        expect(indexHtml).not.toContain('await registerServiceWorker();');
         expect(registrationPosition).toBeGreaterThan(-1);
         expect(bootstrapPosition).toBeGreaterThan(registrationPosition);
         expect(bootstrapPosition).toBeGreaterThan(-1);

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
@@ -1,0 +1,166 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+
+const workerScript = readFileSync(
+    resolve(import.meta.dirname, '../../service-worker.published.js'),
+    'utf8');
+
+class TestRequest {
+    constructor(input, options = {}) {
+        this.url = new URL(typeof input === 'string' ? input : input.url, 'https://app.test/').href;
+        this.method = options.method ?? input?.method ?? 'GET';
+        this.mode = options.mode ?? input?.mode ?? 'cors';
+        this.cache = options.cache;
+    }
+}
+
+class TestResponse {
+    constructor(body, options = {}) {
+        this.body = body;
+        this.headers = options.headers ?? {};
+        this.status = options.status ?? 200;
+        this.statusText = options.statusText ?? 'OK';
+        this.ok = this.status >= 200 && this.status < 300;
+        this.redirected = options.redirected ?? false;
+    }
+
+    clone() {
+        return new TestResponse(this.body, {
+            headers: this.headers,
+            status: this.status,
+            statusText: this.statusText,
+            redirected: this.redirected
+        });
+    }
+
+    static error() {
+        return new TestResponse(undefined, { status: 0 });
+    }
+}
+
+function createWorker({ match, fetch: fetchImplementation } = {}) {
+    const listeners = {};
+    const cache = {
+        match: vi.fn(match ?? (async () => undefined)),
+        keys: vi.fn(async () => []),
+        put: vi.fn(async () => undefined)
+    };
+    const fetch = vi.fn(fetchImplementation ?? (async () => new TestResponse('network')));
+    const serviceWorker = {
+        origin: 'https://app.test',
+        location: new URL('https://app.test/service-worker.js'),
+        assetsManifest: { version: 'test', assets: [] },
+        importScripts: vi.fn(),
+        addEventListener: (type, listener) => { listeners[type] = listener; },
+        skipWaiting: vi.fn(async () => undefined),
+        clients: {
+            claim: vi.fn(async () => undefined),
+            matchAll: vi.fn(async () => [])
+        }
+    };
+
+    vm.runInNewContext(workerScript, {
+        self: serviceWorker,
+        caches: {
+            open: vi.fn(async () => cache),
+            keys: vi.fn(async () => []),
+            delete: vi.fn(async () => true)
+        },
+        fetch,
+        Request: TestRequest,
+        Response: TestResponse,
+        URL,
+        console
+    });
+
+    function dispatchFetch(url, { mode = 'navigate' } = {}) {
+        let responsePromise;
+        const request = new TestRequest(url, { mode });
+        listeners.fetch({
+            request,
+            respondWith: response => { responsePromise = Promise.resolve(response); }
+        });
+
+        return {
+            wasIntercepted: responsePromise !== undefined,
+            response: responsePromise
+        };
+    }
+
+    return { cache, dispatchFetch, fetch };
+}
+
+describe('published service worker', () => {
+    it('serves the cached app shell for a route navigation without using the network', async () => {
+        const shell = new TestResponse('cached shell');
+        const worker = createWorker({
+            match: async request => request === 'index.html' ? shell : undefined
+        });
+
+        const result = worker.dispatchFetch('https://app.test/catches');
+
+        expect(result.wasIntercepted).toBe(true);
+        expect(await result.response).toBe(shell);
+        expect(worker.fetch).not.toHaveBeenCalled();
+    });
+
+    it('fetches and caches the root app shell when a navigation cache entry is missing', async () => {
+        const shell = new TestResponse('network shell');
+        const worker = createWorker({ fetch: async () => shell });
+
+        const response = await worker.dispatchFetch('https://app.test/catches').response;
+
+        expect(response).toBe(shell);
+        expect(worker.fetch).toHaveBeenCalledOnce();
+        expect(worker.fetch.mock.calls[0][0].url).toBe('https://app.test/');
+        expect(worker.fetch.mock.calls[0][0].url).not.toContain('/catches');
+        expect(worker.cache.put).toHaveBeenCalledWith('index.html', expect.any(TestResponse));
+    });
+
+    it('normalizes a redirected network app shell before caching and returning it', async () => {
+        const worker = createWorker({
+            fetch: async () => new TestResponse('redirected shell', { redirected: true })
+        });
+
+        const response = await worker.dispatchFetch('https://app.test/catches').response;
+
+        expect(response.redirected).toBe(false);
+        expect(response.body).toBe('redirected shell');
+        expect(worker.cache.put.mock.calls[0][1].redirected).toBe(false);
+    });
+
+    it('serves an alternate cached shell while offline', async () => {
+        const shell = new TestResponse('offline shell');
+        const worker = createWorker({
+            match: async request => request === '/' ? shell : undefined,
+            fetch: async () => { throw new TypeError('Failed to fetch'); }
+        });
+
+        const response = await worker.dispatchFetch('https://app.test/catches').response;
+
+        expect(response).toBe(shell);
+        expect(worker.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not intercept cross-origin requests', () => {
+        const worker = createWorker();
+
+        const result = worker.dispatchFetch('https://photos.example/catch.jpg', { mode: 'cors' });
+
+        expect(result.wasIntercepted).toBe(false);
+        expect(worker.fetch).not.toHaveBeenCalled();
+    });
+
+    it('always fetches service-worker scripts from the network', async () => {
+        const worker = createWorker({
+            match: async () => new TestResponse('stale worker')
+        });
+
+        await worker.dispatchFetch('https://app.test/service-worker.js', { mode: 'same-origin' }).response;
+
+        expect(worker.fetch).toHaveBeenCalledOnce();
+        expect(worker.cache.match).not.toHaveBeenCalled();
+    });
+});

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
@@ -40,7 +40,7 @@ class TestResponse {
     }
 }
 
-function createWorker({ match, fetch: fetchImplementation } = {}) {
+function createWorker({ assets = [], match, fetch: fetchImplementation } = {}) {
     const listeners = {};
     const cache = {
         match: vi.fn(match ?? (async () => undefined)),
@@ -48,10 +48,11 @@ function createWorker({ match, fetch: fetchImplementation } = {}) {
         put: vi.fn(async () => undefined)
     };
     const fetch = vi.fn(fetchImplementation ?? (async () => new TestResponse('network')));
+    const cacheDelete = vi.fn(async () => true);
     const serviceWorker = {
         origin: 'https://app.test',
         location: new URL('https://app.test/service-worker.js'),
-        assetsManifest: { version: 'test', assets: [] },
+        assetsManifest: { version: 'test', assets },
         importScripts: vi.fn(),
         addEventListener: (type, listener) => { listeners[type] = listener; },
         skipWaiting: vi.fn(async () => undefined),
@@ -66,7 +67,7 @@ function createWorker({ match, fetch: fetchImplementation } = {}) {
         caches: {
             open: vi.fn(async () => cache),
             keys: vi.fn(async () => []),
-            delete: vi.fn(async () => true)
+            delete: cacheDelete
         },
         fetch,
         Request: TestRequest,
@@ -89,10 +90,64 @@ function createWorker({ match, fetch: fetchImplementation } = {}) {
         };
     }
 
-    return { cache, dispatchFetch, fetch };
+    function dispatchInstall() {
+        let installation;
+        listeners.install({ waitUntil: promise => { installation = Promise.resolve(promise); } });
+        return installation;
+    }
+
+    return { cache, cacheDelete, dispatchFetch, dispatchInstall, fetch, serviceWorker };
 }
 
 describe('published service worker', () => {
+    it('rejects a partial installation and preserves the active worker', async () => {
+        const worker = createWorker({
+            assets: [{ url: '_framework/app.wasm' }],
+            fetch: async request => {
+                if (request.url.endsWith('/_framework/app.wasm')) {
+                    throw new TypeError('Failed to fetch');
+                }
+
+                return new TestResponse('shell');
+            }
+        });
+
+        await expect(worker.dispatchInstall()).rejects.toThrow('Failed to fetch');
+
+        expect(worker.cacheDelete).not.toHaveBeenCalled();
+        expect(worker.serviceWorker.skipWaiting).not.toHaveBeenCalled();
+    });
+
+    it('installs the complete app shell and framework assets without taking over existing pages', async () => {
+        const worker = createWorker({
+            assets: [{ url: '_framework/app.wasm' }],
+            fetch: async request => new TestResponse(request.url)
+        });
+
+        await worker.dispatchInstall();
+
+        expect(worker.cache.put).toHaveBeenCalledTimes(2);
+        expect(worker.cacheDelete).not.toHaveBeenCalled();
+        expect(worker.serviceWorker.skipWaiting).not.toHaveBeenCalled();
+    });
+
+    it('serves framework assets from the same versioned cache as the app shell', async () => {
+        const frameworkAsset = new TestResponse('framework');
+        const worker = createWorker({
+            assets: [{ url: '_framework/app.wasm' }],
+            match: async request => request.url?.endsWith('/_framework/app.wasm')
+                ? frameworkAsset
+                : undefined
+        });
+
+        const response = await worker.dispatchFetch(
+            'https://app.test/_framework/app.wasm',
+            { mode: 'cors' }).response;
+
+        expect(response).toBe(frameworkAsset);
+        expect(worker.fetch).not.toHaveBeenCalled();
+    });
+
     it('serves the cached app shell for a route navigation without using the network', async () => {
         const shell = new TestResponse('cached shell');
         const worker = createWorker({

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js
@@ -1,4 +1,4 @@
-const epoch = '20260821-spa-shell-navigation';
+const epoch = '20260821-atomic-app-shell';
 
 export function listenForServiceWorkerErrors(targetWindow = window) {
     targetWindow.navigator.serviceWorker?.addEventListener('message', (event) => {
@@ -9,17 +9,19 @@ export function listenForServiceWorkerErrors(targetWindow = window) {
 }
 
 export async function registerServiceWorker(targetWindow = window) {
+    let epochChanged = false;
     try {
-        if (targetWindow.localStorage.getItem('flb-sw-epoch') !== epoch) {
-            const registrations = await targetWindow.navigator.serviceWorker.getRegistrations();
-            await Promise.all(registrations.map(registration => registration.unregister()));
-            const keys = await targetWindow.caches.keys();
-            await Promise.all(keys.map(key => targetWindow.caches.delete(key)));
+        epochChanged = targetWindow.localStorage.getItem('flb-sw-epoch') !== epoch;
+    } catch { /* ignore */ }
+
+    try {
+        await targetWindow.navigator.serviceWorker.register(
+            'service-worker.js',
+            { updateViaCache: 'none' });
+
+        if (epochChanged) {
             targetWindow.localStorage.setItem('flb-sw-epoch', epoch);
         }
-    } catch { /* ignore */ }
-    try {
-        await targetWindow.navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });
     } catch (error) {
         targetWindow.console.error('[FLB] ServiceWorkerRegistrationError', error);
     }

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js
@@ -1,4 +1,4 @@
-const epoch = '20260814-cache-first-unredirected';
+const epoch = '20260821-spa-shell-navigation';
 
 export function listenForServiceWorkerErrors(targetWindow = window) {
     targetWindow.navigator.serviceWorker?.addEventListener('message', (event) => {
@@ -18,5 +18,9 @@ export async function registerServiceWorker(targetWindow = window) {
             targetWindow.localStorage.setItem('flb-sw-epoch', epoch);
         }
     } catch { /* ignore */ }
-    targetWindow.navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });
+    try {
+        await targetWindow.navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' });
+    } catch (error) {
+        targetWindow.console.error('[FLB] ServiceWorkerRegistrationError', error);
+    }
 }

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.test.js
@@ -4,16 +4,22 @@ import {
     registerServiceWorker
 } from './service-worker-registration.js';
 
-const currentEpoch = '20260814-cache-first-unredirected';
+const currentEpoch = '20260821-spa-shell-navigation';
 
-function createTargetWindow({ epoch, localStorageThrows = false } = {}) {
+function createTargetWindow({ epoch, localStorageThrows = false, registrationThrows = false } = {}) {
     const storage = {};
     if (epoch) {
         storage['flb-sw-epoch'] = epoch;
     }
 
     const unregister = vi.fn(async () => true);
-    const register = vi.fn(async () => ({}));
+    const register = vi.fn(async () => {
+        if (registrationThrows) {
+            throw new Error('registration failed');
+        }
+
+        return {};
+    });
     const cacheDelete = vi.fn(async () => true);
 
     return {
@@ -76,6 +82,19 @@ describe('service worker registration', () => {
         await registerServiceWorker(targetWindow);
 
         expect(targetWindow.register).toHaveBeenCalledWith('service-worker.js', { updateViaCache: 'none' });
+    });
+
+    it('does not block application startup when service worker registration fails', async () => {
+        const targetWindow = createTargetWindow({
+            epoch: currentEpoch,
+            registrationThrows: true
+        });
+
+        await expect(registerServiceWorker(targetWindow)).resolves.toBeUndefined();
+
+        expect(targetWindow.console.error).toHaveBeenCalledWith(
+            '[FLB] ServiceWorkerRegistrationError',
+            expect.any(Error));
     });
 
     it('logs ServiceWorkerError messages and ignores other worker messages', () => {

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.test.js
@@ -4,7 +4,7 @@ import {
     registerServiceWorker
 } from './service-worker-registration.js';
 
-const currentEpoch = '20260821-spa-shell-navigation';
+const currentEpoch = '20260821-atomic-app-shell';
 
 function createTargetWindow({ epoch, localStorageThrows = false, registrationThrows = false } = {}) {
     const storage = {};
@@ -56,18 +56,18 @@ function createTargetWindow({ epoch, localStorageThrows = false, registrationThr
 }
 
 describe('service worker registration', () => {
-    it('unregisters stale workers and caches when the epoch changes', async () => {
+    it('registers the replacement without deleting the last complete cache when the epoch changes', async () => {
         const targetWindow = createTargetWindow({ epoch: 'old-epoch' });
 
         await registerServiceWorker(targetWindow);
 
-        expect(targetWindow.unregister).toHaveBeenCalledTimes(1);
-        expect(targetWindow.cacheDelete).toHaveBeenCalledWith('cache-v1');
+        expect(targetWindow.unregister).not.toHaveBeenCalled();
+        expect(targetWindow.cacheDelete).not.toHaveBeenCalled();
         expect(targetWindow.localStorage.getItem('flb-sw-epoch')).toBe(currentEpoch);
         expect(targetWindow.register).toHaveBeenCalledWith('service-worker.js', { updateViaCache: 'none' });
     });
 
-    it('skips unregister when the current epoch is already stored', async () => {
+    it('registers normally when the current epoch is already stored', async () => {
         const targetWindow = createTargetWindow({ epoch: currentEpoch });
 
         await registerServiceWorker(targetWindow);

--- a/src/FishingLogBook.Web/wwwroot/service-worker.published.js
+++ b/src/FishingLogBook.Web/wwwroot/service-worker.published.js
@@ -75,24 +75,37 @@ async function onFetch(event) {
     }
 
     if (cachedResponse) {
-        cachedResponse = await withoutRedirect(cachedResponse);
+        return withoutRedirect(cachedResponse);
     }
 
-    return cachedResponse || fetch(event.request);
+    if (shouldServeIndexHtml) {
+        return (await fetchAppShell(cache)) || Response.error();
+    }
+
+    return fetch(event.request);
 }
 
 async function cacheAppShell(cache) {
-    const response = await fetch(new Request('./', { cache: 'no-cache' }));
-    if (!response.ok) {
-        return;
-    }
+    await fetchAppShell(cache);
+}
 
-    const shell = await withoutRedirect(response);
-    if (!shell) {
-        return;
-    }
+async function fetchAppShell(cache) {
+    try {
+        const response = await fetch(new Request(baseUrl.href, { cache: 'no-cache' }));
+        if (!response.ok) {
+            return undefined;
+        }
 
-    await cache.put('index.html', shell);
+        const shell = await withoutRedirect(response);
+        if (!shell) {
+            return undefined;
+        }
+
+        await cache.put('index.html', shell.clone());
+        return shell;
+    } catch {
+        return undefined;
+    }
 }
 
 async function cacheUnredirected(cache, request) {

--- a/src/FishingLogBook.Web/wwwroot/service-worker.published.js
+++ b/src/FishingLogBook.Web/wwwroot/service-worker.published.js
@@ -38,9 +38,8 @@ async function onInstall(event) {
         .filter(asset => !offlineAssetsExclude.some(pattern => pattern.test(asset.url)))
         .map(asset => new Request(asset.url, { cache: 'no-cache' }));
 
-    await Promise.all(assetsRequests.map(request => cacheUnredirected(cache, request).catch(() => undefined)));
+    await Promise.all(assetsRequests.map(request => cacheUnredirected(cache, request)));
     await cacheAppShell(cache);
-    await self.skipWaiting();
 }
 
 async function onActivate(event) {
@@ -86,7 +85,10 @@ async function onFetch(event) {
 }
 
 async function cacheAppShell(cache) {
-    await fetchAppShell(cache);
+    const shell = await fetchAppShell(cache);
+    if (!shell) {
+        throw new Error('App shell could not be cached');
+    }
 }
 
 async function fetchAppShell(cache) {
@@ -111,7 +113,7 @@ async function fetchAppShell(cache) {
 async function cacheUnredirected(cache, request) {
     const response = await fetch(request);
     if (!response.ok) {
-        return;
+        throw new Error(`Asset could not be cached: ${request.url}`);
     }
 
     const stored = await withoutRedirect(response);

--- a/tests/FishingLogBook.Web.Tests/ServiceWorker/WhenTestingPublishedWorker.cs
+++ b/tests/FishingLogBook.Web.Tests/ServiceWorker/WhenTestingPublishedWorker.cs
@@ -15,10 +15,12 @@ public class WhenTestingPublishedWorker : BaseServiceWorkerTest
         script.Should().Contain("event.request.mode === 'navigate'");
         script.Should().Contain("shouldServeIndexHtml");
         script.Should().Contain("? 'index.html'");
-        script.Should().Contain("cachedResponse || fetch(event.request)");
+        script.Should().Contain("return withoutRedirect(cachedResponse)");
+        script.Should().Contain("fetchAppShell(cache)");
+        script.Should().Contain("new Request(baseUrl.href");
         script.IndexOf("cache.match", StringComparison.Ordinal)
-            .Should().BeLessThan(script.IndexOf("cachedResponse || fetch(event.request)", StringComparison.Ordinal));
-        script.Should().NotContain("const networkResponse = await fetch(event.request)");
+            .Should().BeLessThan(script.IndexOf("fetchAppShell(cache)", StringComparison.Ordinal));
+        script.Should().NotContain("cachedResponse || fetch(event.request)");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- fix Safari authentication callback navigation when the app-shell cache lookup misses
- fetch and safely normalise the root app shell instead of fetching an arbitrary SPA route such as `/catches`
- make service-worker installation atomic so a partial framework/app-shell cache cannot activate
- preserve the previous complete cache until its replacement is fully installed
- avoid immediate worker takeover that could mix an old index with new fingerprinted `_framework/*` assets
- start service-worker registration before Blazor without blocking `Blazor.start()`
- add behavioral tests that execute the published worker

Follow-up to #103.

## Corrected affected-device symptom

On the affected iPhones, the Blazor bootstrap loader remains at **0%**. The initial loading UI from `wwwroot/index.html` renders, but the WebAssembly application never mounts.

The console also records the service-worker navigation failure for `/catches`:

```
FetchEvent for ".../catches" resulted in a network error response
[FLB] ServiceWorkerError TypeError: Failed to fetch
```

This means the rejected `/catches` fallback is concrete evidence, but it is not sufficient to assume that `RemoteAuthenticatorView` or later component routing is the first failure. The fix therefore covers both document navigation and pre-mount framework loading.

## Findings and causal analysis

The published worker intercepts same-origin `_framework/*` requests cache-first. Its cache name is tied to `service-worker-assets.js` manifest version, and the Release publish confirms that `index.html`, `blazor.webassembly.*.js`, and all fingerprinted WASM assemblies are listed in the same versioned manifest.

Three concrete failure paths existed:

1. **Broken SPA navigation fallback:** when the app-shell lookup missed, the worker fetched the arbitrary route `/catches`. Safari rejected this FetchEvent path.
2. **Partial cache activation:** individual asset-download failures during installation were swallowed. A worker could therefore activate with `index.html` present but one or more bootstrap/WASM assets absent, which is consistent with the loader remaining at 0%.
3. **Cross-version takeover race:** `skipWaiting()` and `clients.claim()`, combined with deletion of old caches, could let a new worker take over a page that began with the previous index. That page could then request old fingerprinted framework URLs from a new cache that only contains the new fingerprints.

The epoch recovery code also unregistered workers and deleted caches before a replacement was safely installed, removing the last known-complete offline shell.

The available evidence does not establish which pre-mount race occurred first on the physical device without its complete Safari Network timeline. The implementation removes each concrete service-worker path capable of producing the observed state.

Private Browsing can reproduce the defect because Safari still creates service-worker registrations and caches for the lifetime of the private session.

## Changes

- Navigation cache misses fetch the root app shell rather than `/catches`.
- Redirected Cloudflare shell responses are normalised before caching and serving.
- Every required manifest/framework asset must cache successfully before installation succeeds.
- Failed or partial installations cannot replace the active worker.
- Immediate `skipWaiting()` takeover was removed, preventing an existing page from changing manifest versions during bootstrap.
- Old caches are cleaned only during safe activation, not destructively from page startup.
- Service-worker registration begins before Blazor startup but is not awaited, so registration lifecycle delays cannot hold the loader at 0%.
- Registration failures remain logged and non-fatal.
- Recovery epoch is now `20260821-atomic-app-shell`.

## Validation

- Release publish succeeded and generated a single versioned manifest containing the app shell, Blazor bootstrap, and fingerprinted framework assets
- `npm test` — 154 passed
- `dotnet test tests/FishingLogBook.Web.Tests/FishingLogBook.Web.Tests.csproj --no-restore` — 549 passed
- `npm run test-local-browser -- storage.spec.js` — 14 passed
- `git diff --check` — clean

## Self review

- Issue/AC: PASS — covers both the rejected SPA navigation and the corrected pre-mount 0% loader symptom
- Architecture/CQRS: N/A — browser bootstrap and service-worker-only change
- Rules: PASS — focused Web/PWA change following repository rules
- Security/privacy: PASS — Cognito configuration, callback processing, and token handling are unchanged
- Database/migrations: N/A
- Tests/coverage: PASS — actual published worker covers atomic install success/failure, versioned framework-cache serving, navigation cache hit/miss, redirect normalisation, offline shell, cross-origin requests, and worker assets
- Browser: PASS — existing Chromium application-shell activation and offline-navigation tests pass; physical iPhone verification remains a deployment check
- Web/UI/localisation: N/A — no user-visible copy changed
- Code smells: PASS — installation, activation, navigation, and registration responsibilities remain focused
- CI/deployment: PASS — no infrastructure, migration, secret, or manual apply required

## Findings discovered during self-review

1. The first analysis over-attributed the visible hang to the later `/catches` navigation despite the real loader remaining at 0%.
2. Asset failures were swallowed during installation, allowing partial caches to activate.
3. Immediate worker takeover could mix an old document with a new framework manifest.
4. Epoch cleanup deleted the last complete cache before replacement.
5. Awaiting registration could itself delay `Blazor.start()`.

## Fixes made

1. Expanded the fix and regression coverage to the pre-mount framework-loading path.
2. Made manifest/app-shell installation all-or-nothing.
3. Removed immediate update takeover and retained the browser's safe worker lifecycle.
4. Removed destructive page-side worker/cache cleanup.
5. Made registration concurrent and non-fatal while preserving startup ordering.

## Remaining deliberate gaps

- Final confirmation on physical iPhone/Safari requires deployment because CI does not provide the production Cognito callback and iOS service-worker environment.
- Without the affected device's complete Network timeline, the exact ordering among the confirmed service-worker failure paths cannot be reconstructed retrospectively.
