### PR TITLE
FLB#103 | Restore iPhone-safe Blazor startup

### DIFF
--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -20,6 +20,7 @@
             location.replace(location.pathname || '/');
         }
     </script>
+    <script type="module" src="js/bootstrap/app.js"></script>
 </head>
 
 <body>
@@ -44,14 +45,12 @@
         <span class="dismiss" role="button" tabindex="0" aria-label="Dismiss">🗙</span>
     </div>
     <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
-    <script src="_framework/blazor.webassembly#[.{fingerprint}].js" autostart="false"></script>
-    <script type="module">
-        const { registerServiceWorker } = await import('./js/bootstrap/service-worker-registration.js');
-        registerServiceWorker();
-        await import('./js/bootstrap/app.js');
-        await Blazor.start();
-    </script>
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script type="module">
+        import { registerServiceWorker } from './js/bootstrap/service-worker-registration.js';
+        registerServiceWorker();
+    </script>
 </body>
 
 </html>

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/index-startup.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/index-startup.test.js
@@ -3,18 +3,17 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('application startup', () => {
-    it('installs browser globals before starting Blazor', () => {
+    it('uses the proven autostart lifecycle and registers the worker afterwards', () => {
         const indexHtml = readFileSync(resolve(import.meta.dirname, '../../index.html'), 'utf8');
+        const bootstrapPosition = indexHtml.indexOf('type="module" src="js/bootstrap/app.js"');
+        const blazorPosition = indexHtml.indexOf('_framework/blazor.webassembly');
         const registrationPosition = indexHtml.indexOf('registerServiceWorker();');
-        const bootstrapPosition = indexHtml.indexOf("await import('./js/bootstrap/app.js');");
-        const blazorStartPosition = indexHtml.indexOf('await Blazor.start();');
 
-        expect(indexHtml).toContain('autostart="false"');
-        expect(indexHtml).not.toContain('type="module" src="js/bootstrap/app.js"');
-        expect(indexHtml).not.toContain('await registerServiceWorker();');
-        expect(registrationPosition).toBeGreaterThan(-1);
-        expect(bootstrapPosition).toBeGreaterThan(registrationPosition);
+        expect(indexHtml).not.toContain('autostart="false"');
+        expect(indexHtml).not.toContain('Blazor.start()');
         expect(bootstrapPosition).toBeGreaterThan(-1);
-        expect(blazorStartPosition).toBeGreaterThan(bootstrapPosition);
+        expect(blazorPosition).toBeGreaterThan(bootstrapPosition);
+        expect(indexHtml).not.toContain('await registerServiceWorker();');
+        expect(registrationPosition).toBeGreaterThan(blazorPosition);
     });
 });

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
@@ -40,15 +40,28 @@ class TestResponse {
     }
 }
 
-function createWorker({ assets = [], match, fetch: fetchImplementation } = {}) {
+function createWorker({ assets = [], cacheKeys = [], match, fetch: fetchImplementation } = {}) {
     const listeners = {};
     const cache = {
         match: vi.fn(match ?? (async () => undefined)),
         keys: vi.fn(async () => []),
         put: vi.fn(async () => undefined)
     };
+    let recoveryComplete = false;
+    const recoveryCache = {
+        match: vi.fn(async () => recoveryComplete ? new TestResponse('complete') : undefined),
+        put: vi.fn(async () => { recoveryComplete = true; })
+    };
     const fetch = vi.fn(fetchImplementation ?? (async () => new TestResponse('network')));
-    const cacheDelete = vi.fn(async () => true);
+    const activeCacheKeys = [...cacheKeys];
+    const cacheDelete = vi.fn(async name => {
+        const index = activeCacheKeys.indexOf(name);
+        if (index >= 0) {
+            activeCacheKeys.splice(index, 1);
+        }
+
+        return true;
+    });
     const serviceWorker = {
         origin: 'https://app.test',
         location: new URL('https://app.test/service-worker.js'),
@@ -62,13 +75,15 @@ function createWorker({ assets = [], match, fetch: fetchImplementation } = {}) {
         }
     };
 
+    const caches = {
+        open: vi.fn(async name => name === 'service-worker-recovery' ? recoveryCache : cache),
+        keys: vi.fn(async () => activeCacheKeys),
+        delete: cacheDelete
+    };
+
     vm.runInNewContext(workerScript, {
         self: serviceWorker,
-        caches: {
-            open: vi.fn(async () => cache),
-            keys: vi.fn(async () => []),
-            delete: cacheDelete
-        },
+        caches,
         fetch,
         Request: TestRequest,
         Response: TestResponse,
@@ -96,7 +111,23 @@ function createWorker({ assets = [], match, fetch: fetchImplementation } = {}) {
         return installation;
     }
 
-    return { cache, cacheDelete, dispatchFetch, dispatchInstall, fetch, serviceWorker };
+    function dispatchActivate() {
+        let activation;
+        listeners.activate({ waitUntil: promise => { activation = Promise.resolve(promise); } });
+        return activation;
+    }
+
+    return {
+        cache,
+        cacheDelete,
+        caches,
+        dispatchActivate,
+        dispatchFetch,
+        dispatchInstall,
+        fetch,
+        recoveryCache,
+        serviceWorker
+    };
 }
 
 describe('published service worker', () => {
@@ -118,7 +149,7 @@ describe('published service worker', () => {
         expect(worker.serviceWorker.skipWaiting).not.toHaveBeenCalled();
     });
 
-    it('installs the complete app shell and framework assets without taking over existing pages', async () => {
+    it('activates only after the complete app shell and framework assets are cached', async () => {
         const worker = createWorker({
             assets: [{ url: '_framework/app.wasm' }],
             fetch: async request => new TestResponse(request.url)
@@ -128,7 +159,57 @@ describe('published service worker', () => {
 
         expect(worker.cache.put).toHaveBeenCalledTimes(2);
         expect(worker.cacheDelete).not.toHaveBeenCalled();
-        expect(worker.serviceWorker.skipWaiting).not.toHaveBeenCalled();
+        expect(worker.serviceWorker.skipWaiting).toHaveBeenCalledOnce();
+    });
+
+    it('reloads existing controlled clients once after a complete replacement activates', async () => {
+        const navigate = vi.fn(async () => undefined);
+        const worker = createWorker({
+            cacheKeys: ['offline-cache-previous', 'offline-cache-test']
+        });
+        worker.serviceWorker.clients.matchAll.mockResolvedValue([
+            { url: 'https://app.test/', navigate }
+        ]);
+
+        await worker.dispatchActivate();
+        await worker.dispatchActivate();
+
+        expect(worker.cacheDelete).toHaveBeenCalledOnce();
+        expect(worker.cacheDelete).toHaveBeenCalledWith('offline-cache-previous');
+        expect(worker.recoveryCache.put).toHaveBeenCalledOnce();
+        expect(navigate).toHaveBeenCalledOnce();
+        expect(navigate).toHaveBeenCalledWith('https://app.test/');
+    });
+
+    it('does not reload clients on a first service worker installation', async () => {
+        const navigate = vi.fn(async () => undefined);
+        const worker = createWorker({ cacheKeys: ['offline-cache-test'] });
+        worker.serviceWorker.clients.matchAll.mockResolvedValue([
+            { url: 'https://app.test/', navigate }
+        ]);
+
+        await worker.dispatchActivate();
+
+        expect(worker.recoveryCache.put).not.toHaveBeenCalled();
+        expect(navigate).not.toHaveBeenCalled();
+    });
+
+    it('does not replay authentication callback URLs during migration', async () => {
+        const navigate = vi.fn(async () => undefined);
+        const worker = createWorker({
+            cacheKeys: ['offline-cache-previous', 'offline-cache-test']
+        });
+        worker.serviceWorker.clients.matchAll.mockResolvedValue([
+            {
+                url: 'https://app.test/authentication/login-callback?code=test&state=test',
+                navigate
+            }
+        ]);
+
+        await worker.dispatchActivate();
+
+        expect(worker.recoveryCache.put).toHaveBeenCalledOnce();
+        expect(navigate).not.toHaveBeenCalled();
     });
 
     it('serves framework assets from the same versioned cache as the app shell', async () => {

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js
@@ -1,4 +1,4 @@
-const epoch = '20260821-atomic-app-shell';
+const epoch = '20260821-pre-onboarding-startup';
 
 export function listenForServiceWorkerErrors(targetWindow = window) {
     targetWindow.navigator.serviceWorker?.addEventListener('message', (event) => {

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.test.js
@@ -4,7 +4,7 @@ import {
     registerServiceWorker
 } from './service-worker-registration.js';
 
-const currentEpoch = '20260821-atomic-app-shell';
+const currentEpoch = '20260821-pre-onboarding-startup';
 
 function createTargetWindow({ epoch, localStorageThrows = false, registrationThrows = false } = {}) {
     const storage = {};

--- a/src/FishingLogBook.Web/wwwroot/service-worker.published.js
+++ b/src/FishingLogBook.Web/wwwroot/service-worker.published.js
@@ -22,6 +22,8 @@ self.addEventListener('unhandledrejection', event => notifyServiceWorkerError(St
 
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
+const recoveryCacheName = 'service-worker-recovery';
+const recoveryKey = 'pre-onboarding-startup-20260821';
 const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.woff2$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.svg$/, /\.blat$/, /\.dat$/, /\.webmanifest$/ ];
 const offlineAssetsExclude = [ /^service-worker\.js$/, /\/_redirects$/, /\/_headers$/, /\.test\.js$/ ];
 
@@ -40,16 +42,38 @@ async function onInstall(event) {
 
     await Promise.all(assetsRequests.map(request => cacheUnredirected(cache, request)));
     await cacheAppShell(cache);
+    await self.skipWaiting();
 }
 
 async function onActivate(event) {
     console.info('Service worker: Activate');
-    await self.clients.claim();
-
     const cacheKeys = await caches.keys();
+    const hasPreviousAppShell = cacheKeys.some(key =>
+        key.startsWith(cacheNamePrefix) && key !== cacheName);
+
+    await self.clients.claim();
     await Promise.all(cacheKeys
         .filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName)
         .map(key => caches.delete(key)));
+
+    if (hasPreviousAppShell) {
+        await reloadClientsOnce();
+    }
+}
+
+async function reloadClientsOnce() {
+    try {
+        const recoveryCache = await caches.open(recoveryCacheName);
+        if (await recoveryCache.match(recoveryKey)) {
+            return;
+        }
+
+        await recoveryCache.put(recoveryKey, new Response('complete'));
+        const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+        const appClients = clients.filter(client =>
+            !new URL(client.url).pathname.startsWith('/authentication/'));
+        await Promise.all(appClients.map(client => client.navigate(client.url)));
+    } catch { /* ignore */ }
 }
 
 async function onFetch(event) {


### PR DESCRIPTION
## Summary

- restore the proven pre-onboarding Blazor startup behavior from the PR #102 baseline
- keep the landing page, onboarding, branding, authentication bridge, Profile changes, and Logbook functionality
- move service-worker registration back outside the critical Blazor startup path
- safely migrate browsers currently controlled by the PR #107 worker
- preserve offline data, Cloudflare SPA routing, cross-origin R2 behavior, and version-consistent framework caching

Follow-up hotfix for #103.

## Release-blocking symptom

On two previously visited iPhones, the anonymous landing page and branding render but Blazor never becomes interactive. Sign in, Create account, and other Blazor actions do nothing. Repeated hard refreshes do not recover the devices.

This PR deliberately does not claim the device issue is fixed until the deployed build is verified on both affected phones.

## Controlled rollback baseline

The exact known-good baseline is commit `1271f26`, the merge commit for PR #102.

Current `main` before this hotfix is `783a9f1`, the merge commit for PR #107. PR #107 head `20bd2e9` is the parent tree used for the focused comparison.

Compared files:

- `src/FishingLogBook.Web/wwwroot/index.html`
- `src/FishingLogBook.Web/wwwroot/service-worker.published.js`
- `src/FishingLogBook.Web/wwwroot/js/bootstrap/app.js`
- `src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js`
- associated Vitest, C# service-worker, and Playwright/PWA tests

## Changes by PR

### PR #104

Retained:

- branding title, theme color, favicon and Apple touch icon changes
- onboarding authentication bridge installed by `app.js`

PR #104 did not otherwise change the proven startup ordering.

### PR #105

No startup/service-worker code changed. Its deployment-workflow change is outside this hotfix.

### PR #106

Reverted:

- `autostart="false"`
- the explicit async `Blazor.start()` chain
- dynamically importing `app.js` inside that chain

The page again loads `app.js` as a normal module and uses Blazor's normal autostart behavior, matching PR #102.

### PR #107

Reverted:

- service-worker registration inside the critical Blazor startup chain

Retained because they address independently demonstrated safety problems:

- safe root app-shell fallback for SPA routes
- Cloudflare redirected-response normalization
- cross-origin request bypass
- all-or-nothing framework/app-shell cache installation
- registration failures remain non-fatal
- published-worker behavioral tests

## Existing #107 client migration

A source-only rollback is insufficient because affected browsers may still be controlled by the #107 worker and serving its cached index.

The replacement worker therefore:

1. downloads and caches every required app-shell and framework asset;
2. fails installation without replacing the active worker if any required asset fails;
3. calls `skipWaiting()` only after the replacement cache is complete;
4. activates and claims existing clients;
5. removes the previous app-shell cache only after the replacement is valid;
6. reloads ordinary application routes once using a persistent recovery marker;
7. does not replay `/authentication/*` callback URLs.

IndexedDB catches and photographs are not cleared or migrated.

Recovery epoch: `20260821-pre-onboarding-startup`.

## Why this should restore interactivity

The generated Release `index.html` now has the same loading model as PR #102:

- `app.js` is a normal module in the document head
- Blazor uses normal autostart
- there is no manual `Blazor.start()`
- service-worker registration occurs afterward and cannot hold Blazor startup open

The one-time worker transition ensures previously controlled devices receive that replacement document without manual Safari-data clearing.

## Validation

Passed:

- focused startup/service-worker tests — 19
- final Vitest suite — 157
- Web tests — 549
- full Playwright browser/PWA suite — 27 passed, 1 expected WebKit offline-navigation skip
- Release Web publish
- generated Release `index.html` and service-worker manifest inspection
- `git diff --check`

Additional compiled solution suites passed:

- Application — 298
- API — 145
- Shared — 18
- migrations — 10

Environment/repository limitations:

- Infrastructure suite: 14 passed; 103 could not start because Docker/Testcontainers is unavailable
- solution build could not overwrite API assemblies because a locally running API process held them open
- format verification reports two pre-existing import-order findings in onboarding `UserMenu` files outside this focused hotfix

## Self review

- Issue/AC: PASS for implementation — startup behavior restored and #107 migration covered; physical-device outcome remains unverified
- Architecture/CQRS: N/A — static browser bootstrap/PWA change
- Rules: PASS — six-file focused change; no product or persistence rollback
- Security/privacy: PASS — Cognito flow and token handling unchanged; callback URLs excluded from migration reload
- Database/migrations: N/A
- Tests/coverage: PASS — startup ordering, registration failure, controlled-client migration, framework consistency, online/offline navigation, Cloudflare normalization, and cross-origin bypass covered
- Browser: PASS within available harness — Chromium and WebKit PWA suites run; physical iPhone deployment remains required
- Web/UI/localisation: PASS — no user-visible copy changed
- Code smells: PASS — migration is isolated and one-time
- CI/deployment: PASS for Web publish; unrelated local Docker/file-lock limitations documented

## Findings discovered during self-review

1. A literal source rollback would not migrate devices already controlled by PR #107.
2. Deleting the current cache before a complete replacement would risk another non-interactive/offline failure.
3. Automatically reloading an authentication callback could replay an OIDC code/state URL.
4. Full-solution local validation is constrained by the running API process and unavailable Docker endpoint.

## Fixes made

1. Added an atomic one-time controlled-client transition.
2. Preserved the working cache until replacement installation succeeds.
3. Excluded `/authentication/*` clients from automatic reload.
4. Kept the PR scoped to browser startup, worker lifecycle, and their tests.

## Remaining deliberate gap

- Deploy and verify interactivity, Sign in, Create account, callback, onboarding/Logbook, refresh, and offline behavior on both affected physical iPhones before declaring the release blocker fixed.
