### PR TITLE
FLB#110 | Localise seeded fishing preferences

### DIFF
--- a/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModal.razor
+++ b/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModal.razor
@@ -13,29 +13,69 @@
                           Adornment="Adornment.Start"
                           AdornmentIcon="@Icons.Material.Filled.Search"
                           id="catalogue-picker-modal-search" />
-            @if (FilteredOptions.Count == 0)
-            {
-                <MudText Typo="Typo.body2"
-                         Class="mud-text-secondary"
-                         id="catalogue-picker-modal-empty">
-                    @Loc["Modal_NoMatches"]
+            <section class="catalogue-picker-section catalogue-picker-available"
+                     aria-labelledby="catalogue-picker-modal-available-label">
+                <MudText Typo="Typo.subtitle2" Class="catalogue-picker-label"
+                         id="catalogue-picker-modal-available-label">
+                    @Loc["Modal_Available"]
                 </MudText>
-            }
-            else
-            {
-                <MudStack Row="true" Spacing="1" Class="flex-wrap" id="catalogue-picker-modal-options">
-                    @foreach (var option in FilteredOptions)
-                    {
-                        <MudChip T="string"
-                                 Color="Color.Default"
-                                 Variant="Variant.Outlined"
-                                 OnClick="() => Select(option)"
-                                 id="@($"catalogue-picker-modal-option-{option.Code}")">
-                            @option.Name
-                        </MudChip>
-                    }
-                </MudStack>
-            }
+                @if (IsInitialListLimited && string.IsNullOrWhiteSpace(_search))
+                {
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary catalogue-picker-count"
+                             id="catalogue-picker-modal-limit-message">
+                        @string.Format(Loc["Modal_ShowingLimited"], FilteredOptions.Count, Model.Options.Count, Model.ItemPluralName)
+                    </MudText>
+                }
+                @if (FilteredOptions.Count == 0)
+                {
+                    <MudText Typo="Typo.body2" Class="mud-text-secondary"
+                             id="catalogue-picker-modal-empty">
+                        @Loc["Modal_NoMatches"]
+                    </MudText>
+                }
+                else
+                {
+                    <MudStack Row="true" Spacing="1" Class="flex-wrap" id="catalogue-picker-modal-options">
+                        @foreach (var option in FilteredOptions)
+                        {
+                            <MudChip T="string"
+                                     Color="@(_selectedOptionIds.Contains(option.Id) ? Color.Primary : Color.Default)"
+                                     Variant="@(_selectedOptionIds.Contains(option.Id) ? Variant.Filled : Variant.Outlined)"
+                                     OnClick="() => Toggle(option)"
+                                     id="@($"catalogue-picker-modal-option-{option.Code}")">
+                                @option.Name
+                            </MudChip>
+                        }
+                    </MudStack>
+                }
+            </section>
+            <section class="catalogue-picker-section catalogue-picker-selected"
+                     aria-labelledby="catalogue-picker-modal-selected-label">
+                <MudText Typo="Typo.subtitle2" Class="catalogue-picker-label"
+                         id="catalogue-picker-modal-selected-label">
+                    @Loc["Modal_Selected"]
+                </MudText>
+                @if (SelectedOptions.Count > 0)
+                {
+                    <MudStack Row="true" Spacing="1" Class="flex-wrap" id="catalogue-picker-modal-selected">
+                        @foreach (var option in SelectedOptions)
+                        {
+                            <MudChip T="string" Color="Color.Primary" Variant="Variant.Filled"
+                                     OnClose="() => Toggle(option)"
+                                     id="@($"catalogue-picker-modal-selected-{option.Code}")">
+                                @option.Name
+                            </MudChip>
+                        }
+                    </MudStack>
+                }
+                else
+                {
+                    <MudText Typo="Typo.body2" Class="mud-text-secondary"
+                             id="catalogue-picker-modal-none-selected">
+                        @Loc["Modal_NoneSelected"]
+                    </MudText>
+                }
+            </section>
         </MudStack>
     </DialogContent>
     <DialogActions>
@@ -43,6 +83,10 @@
                    OnClick="Cancel"
                    id="catalogue-picker-modal-cancel">
             @Loc["Modal_Cancel"]
+        </MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                   OnClick="Save" id="catalogue-picker-modal-save">
+            @Loc["Modal_Save"]
         </MudButton>
     </DialogActions>
 </MudDialog>

--- a/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModal.razor.cs
+++ b/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModal.razor.cs
@@ -7,7 +7,10 @@ namespace FishingLogBook.Web.Common.Modals;
 
 public partial class CataloguePickerModal : ComponentBase
 {
+    private const int InitialOptionLimit = 20;
+
     private string? _search;
+    private HashSet<Guid> _selectedOptionIds = [];
 
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = default!;
@@ -18,13 +21,20 @@ public partial class CataloguePickerModal : ComponentBase
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
+    protected override void OnParametersSet()
+    {
+        _selectedOptionIds = Model.SelectedOptionIds?.ToHashSet() ?? [];
+    }
+
     private IReadOnlyList<CatalogueOptionModel> FilteredOptions
     {
         get
         {
             if (string.IsNullOrWhiteSpace(_search))
             {
-                return Model.Options;
+                return Model.AllowMultiple
+                    ? [.. Model.Options.Take(InitialOptionLimit)]
+                    : Model.Options;
             }
 
             var term = _search.Trim();
@@ -33,10 +43,26 @@ public partial class CataloguePickerModal : ComponentBase
         }
     }
 
-    private void Select(CatalogueOptionModel option)
+    private IReadOnlyList<CatalogueOptionModel> SelectedOptions =>
+        [.. Model.Options.Where(option => _selectedOptionIds.Contains(option.Id))];
+
+    private bool IsInitialListLimited =>
+        Model.AllowMultiple && Model.Options.Count > InitialOptionLimit;
+
+    private void Toggle(CatalogueOptionModel option)
     {
-        MudDialog.Close(DialogResult.Ok(new CataloguePickerModalResult(option)));
+        if (!_selectedOptionIds.Remove(option.Id))
+        {
+            if (!Model.AllowMultiple)
+            {
+                _selectedOptionIds.Clear();
+            }
+
+            _selectedOptionIds.Add(option.Id);
+        }
     }
+
+    private void Save() => MudDialog.Close(DialogResult.Ok(new CataloguePickerModalResult(SelectedOptions)));
 
     private void Cancel()
     {

--- a/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModal.razor.css
+++ b/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModal.razor.css
@@ -1,0 +1,18 @@
+.catalogue-picker-section {
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    padding: 0.75rem;
+}
+
+.catalogue-picker-selected {
+    background-color: var(--mud-palette-background-gray);
+}
+
+.catalogue-picker-label {
+    margin-bottom: 0.5rem;
+}
+
+.catalogue-picker-count {
+    display: block;
+    margin-bottom: 0.5rem;
+}

--- a/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModalModel.cs
+++ b/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModalModel.cs
@@ -2,4 +2,7 @@ namespace FishingLogBook.Web.Common.Modals;
 
 public sealed record CataloguePickerModalModel(
     string Title,
-    IReadOnlyList<CatalogueOptionModel> Options);
+    IReadOnlyList<CatalogueOptionModel> Options,
+    IReadOnlySet<Guid>? SelectedOptionIds = null,
+    bool AllowMultiple = false,
+    string? ItemPluralName = null);

--- a/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModalResult.cs
+++ b/src/FishingLogBook.Web/Common/Modals/CataloguePicker/CataloguePickerModalResult.cs
@@ -1,3 +1,9 @@
 namespace FishingLogBook.Web.Common.Modals;
 
-public sealed record CataloguePickerModalResult(CatalogueOptionModel Option);
+public sealed record CataloguePickerModalResult(IReadOnlyList<CatalogueOptionModel> Options)
+{
+    public CataloguePickerModalResult(CatalogueOptionModel option)
+        : this([option])
+    {
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor.cs
@@ -308,7 +308,7 @@ public partial class CatchEdit : ComponentBase, IDisposable
         var result = await ModalService.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
             new CataloguePickerModalModel(title, options),
             _cancellationTokenSource.Token);
-        return result?.Option;
+        return result?.Options.SingleOrDefault();
     }
 
     private void TryToSynchronisePending()

--- a/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/RecordCatch/RecordCatch.razor.cs
@@ -198,7 +198,7 @@ public partial class RecordCatch : ComponentBase, IDisposable
         var result = await ModalService.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
             new CataloguePickerModalModel(title, options),
             _cancellationTokenSource.Token);
-        return result?.Option;
+        return result?.Options.SingleOrDefault();
     }
 
     private bool CanSave

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
@@ -181,21 +181,28 @@ public partial class Onboarding : ComponentBase, IDisposable
 
     private async Task AddMethodAsync()
     {
-        var shown = MethodChips.Select(method => method.Id).ToHashSet();
         var options = _catalogue.Methods
-            .Where(method => !shown.Contains(method.Id))
             .Select(method => new CatalogueOptionModel(method.Id, method.Code, method.Name))
             .ToArray();
+        var selected = _selectedMethods.Select(method => method.FishingMethodId).ToHashSet();
         var result = await ModalService.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
-            new CataloguePickerModalModel(Loc["Profile_FishingMethods"], options),
+            new CataloguePickerModalModel(
+                Loc["Profile_FishingMethods"], options, selected, true, Loc["Modal_FishingMethods"]),
             _cancellationTokenSource.Token);
-        var chosen = result is null
-            ? null
-            : _catalogue.Methods.FirstOrDefault(method => method.Id == result.Option.Id);
-        if (chosen is not null && !IsMethodSelected(chosen.Id))
+        if (result is null)
+        {
+            return;
+        }
+
+        var chosenIds = result.Options.Select(option => option.Id).ToHashSet();
+        _selectedMethods.RemoveAll(method => !chosenIds.Contains(method.FishingMethodId));
+        foreach (var chosen in _catalogue.Methods.Where(method =>
+                     chosenIds.Contains(method.Id) && !IsMethodSelected(method.Id)))
         {
             ToggleMethod(chosen);
         }
+
+        EnsureDefaultMethod();
     }
 
     private void SetDefaultMethod(Guid methodId)
@@ -214,24 +221,31 @@ public partial class Onboarding : ComponentBase, IDisposable
             return;
         }
 
-        var selected = method.Species.Select(species => species.SpeciesId).ToHashSet();
         var options = _catalogue.AllSpecies
-            .Where(species => !selected.Contains(species.Id))
             .Select(species => new CatalogueOptionModel(species.Id, species.Code, species.Name))
             .ToArray();
+        var selected = method.Species.Select(species => species.SpeciesId).ToHashSet();
         var result = await ModalService.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
-            new CataloguePickerModalModel(string.Format(Loc["Profile_FishingMethod_Species"], method.Name), options),
+            new CataloguePickerModalModel(
+                string.Format(Loc["Profile_FishingMethod_Species"], method.Name),
+                options,
+                selected,
+                true,
+                Loc["Modal_Species"]),
             _cancellationTokenSource.Token);
         if (result is null)
         {
             return;
         }
 
-        method.Species.Add(new SelectedSpeciesPreference(
-            result.Option.Id,
-            result.Option.Code,
-            result.Option.Name,
-            false));
+        var chosenIds = result.Options.Select(option => option.Id).ToHashSet();
+        method.Species.RemoveAll(species => !chosenIds.Contains(species.SpeciesId));
+        foreach (var chosen in result.Options.Where(option =>
+                     method.Species.All(species => species.SpeciesId != option.Id)))
+        {
+            method.Species.Add(new SelectedSpeciesPreference(chosen.Id, chosen.Code, chosen.Name, false));
+        }
+
         EnsureDefaultSpecies(method);
     }
 

--- a/src/FishingLogBook.Web/Features/Profile/Clients/FishingPreferenceClient.cs
+++ b/src/FishingLogBook.Web/Features/Profile/Clients/FishingPreferenceClient.cs
@@ -1,16 +1,21 @@
 using System.Net.Http.Json;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Localization;
 
 namespace FishingLogBook.Web.Features.Profile.Clients;
 
 public sealed class FishingPreferenceClient : IFishingPreferenceClient
 {
     private readonly HttpClient _apiClient;
+    private readonly ICatalogueLocalizer _catalogueLocalizer;
 
-    public FishingPreferenceClient(IHttpClientFactory httpClientFactory)
+    public FishingPreferenceClient(
+        IHttpClientFactory httpClientFactory,
+        ICatalogueLocalizer catalogueLocalizer)
     {
         _apiClient = httpClientFactory.CreateClient(HttpClientNames.AuthorizedApi);
+        _catalogueLocalizer = catalogueLocalizer;
     }
 
     public async Task<FishingCatalogueDto> GetCatalogueAsync(CancellationToken cancellationToken)
@@ -18,7 +23,8 @@ public sealed class FishingPreferenceClient : IFishingPreferenceClient
         var catalogue = await _apiClient.GetFromJsonAsync<FishingCatalogueDto>(
             "api/fishing-catalogue",
             cancellationToken);
-        return catalogue ?? throw new HttpRequestException("Fishing catalogue was missing.");
+        return _catalogueLocalizer.Localize(
+            catalogue ?? throw new HttpRequestException("Fishing catalogue was missing."));
     }
 
     public async Task<FishingPreferencesDto> GetPreferencesAsync(CancellationToken cancellationToken)
@@ -26,7 +32,8 @@ public sealed class FishingPreferenceClient : IFishingPreferenceClient
         var preferences = await _apiClient.GetFromJsonAsync<FishingPreferencesDto>(
             "api/profiles/me/fishing-preferences",
             cancellationToken);
-        return preferences ?? throw new HttpRequestException("Fishing preferences were missing.");
+        return _catalogueLocalizer.Localize(
+            preferences ?? throw new HttpRequestException("Fishing preferences were missing."));
     }
 
     public async Task<FishingPreferencesDto> UpdatePreferencesAsync(
@@ -39,6 +46,8 @@ public sealed class FishingPreferenceClient : IFishingPreferenceClient
             cancellationToken);
         response.EnsureSuccessStatusCode();
         var saved = await response.Content.ReadFromJsonAsync<FishingPreferencesDto>(cancellationToken);
-        return saved ?? throw new HttpRequestException("Saved fishing preferences were missing.");
+        return _catalogueLocalizer.Localize(
+            saved ?? throw new HttpRequestException("Saved fishing preferences were missing."));
     }
+
 }

--- a/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor.cs
+++ b/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor.cs
@@ -261,24 +261,28 @@ public partial class Profile : ComponentBase, IDisposable
 
     private async Task AddMethodAsync()
     {
-        var shown = MethodChips.Select(method => method.Id).ToHashSet();
         var options = _catalogueMethods
-            .Where(method => !shown.Contains(method.Id))
             .Select(method => new CatalogueOptionModel(method.Id, method.Code, method.Name))
             .ToArray();
+        var selected = _selectedMethods.Select(method => method.FishingMethodId).ToHashSet();
         var result = await ModalService.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
-            new CataloguePickerModalModel(Loc["Profile_FishingMethods"], options),
+            new CataloguePickerModalModel(
+                Loc["Profile_FishingMethods"], options, selected, true, Loc["Modal_FishingMethods"]),
             _cancellationTokenSource.Token);
         if (result is null)
         {
             return;
         }
 
-        var chosen = _catalogueMethods.FirstOrDefault(method => method.Id == result.Option.Id);
-        if (chosen is not null && !IsMethodSelected(chosen.Id))
+        var chosenIds = result.Options.Select(option => option.Id).ToHashSet();
+        _selectedMethods.RemoveAll(method => !chosenIds.Contains(method.FishingMethodId));
+        foreach (var chosen in _catalogueMethods.Where(method =>
+                     chosenIds.Contains(method.Id) && !IsMethodSelected(method.Id)))
         {
             ToggleMethod(chosen);
         }
+
+        EnsureDefaultMethod();
     }
 
     private void ToggleMethod(FishingMethodDto method)
@@ -331,26 +335,31 @@ public partial class Profile : ComponentBase, IDisposable
             return;
         }
 
-        var selected = method.Species.Select(species => species.SpeciesId).ToHashSet();
         var options = _catalogueSpecies
-            .Where(species => !selected.Contains(species.Id))
             .Select(species => new CatalogueOptionModel(species.Id, species.Code, species.Name))
             .ToArray();
+        var selected = method.Species.Select(species => species.SpeciesId).ToHashSet();
         var result = await ModalService.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
             new CataloguePickerModalModel(
                 string.Format(Loc["Profile_FishingMethod_Species"], method.Name),
-                options),
+                options,
+                selected,
+                true,
+                Loc["Modal_Species"]),
             _cancellationTokenSource.Token);
         if (result is null)
         {
             return;
         }
 
-        method.Species.Add(new SelectedSpeciesPreference(
-            result.Option.Id,
-            result.Option.Code,
-            result.Option.Name,
-            false));
+        var chosenIds = result.Options.Select(option => option.Id).ToHashSet();
+        method.Species.RemoveAll(species => !chosenIds.Contains(species.SpeciesId));
+        foreach (var chosen in result.Options.Where(option =>
+                     method.Species.All(species => species.SpeciesId != option.Id)))
+        {
+            method.Species.Add(new SelectedSpeciesPreference(chosen.Id, chosen.Code, chosen.Name, false));
+        }
+
         EnsureDefaultSpecies(method);
     }
 

--- a/src/FishingLogBook.Web/Localization/CatalogueLocalizer.cs
+++ b/src/FishingLogBook.Web/Localization/CatalogueLocalizer.cs
@@ -52,7 +52,7 @@ public sealed class CatalogueLocalizer : ICatalogueLocalizer
     private SpeciesDto Localize(SpeciesDto species) =>
         species with { Name = GetSpeciesLabel(species) };
 
-    private static string Resolve<TResource>(
+    internal static string Resolve<TResource>(
         IStringLocalizer<TResource> localizer,
         string code,
         string canonicalName)

--- a/src/FishingLogBook.Web/Localization/CatalogueLocalizer.cs
+++ b/src/FishingLogBook.Web/Localization/CatalogueLocalizer.cs
@@ -1,0 +1,65 @@
+using FishingLogBook.Shared.Dtos;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Localization;
+
+public sealed class CatalogueLocalizer : ICatalogueLocalizer
+{
+    private readonly IStringLocalizer<SpeciesStrings> _speciesLocalizer;
+    private readonly IStringLocalizer<FishingMethodStrings> _fishingMethodLocalizer;
+
+    public CatalogueLocalizer(
+        IStringLocalizer<SpeciesStrings> speciesLocalizer,
+        IStringLocalizer<FishingMethodStrings> fishingMethodLocalizer)
+    {
+        _speciesLocalizer = speciesLocalizer;
+        _fishingMethodLocalizer = fishingMethodLocalizer;
+    }
+
+    public string GetSpeciesLabel(SpeciesDto species) =>
+        Resolve(_speciesLocalizer, species.Code, species.Name);
+
+    public string GetFishingMethodLabel(FishingMethodDto method) =>
+        Resolve(_fishingMethodLocalizer, method.Code, method.Name);
+
+    public FishingCatalogueDto Localize(FishingCatalogueDto catalogue)
+    {
+        return new FishingCatalogueDto(
+            [.. catalogue.Methods.Select(Localize)],
+            [.. catalogue.AllSpecies.Select(Localize)]);
+    }
+
+    public FishingPreferencesDto Localize(FishingPreferencesDto preferences)
+    {
+        return new FishingPreferencesDto(
+        [
+            .. preferences.Methods.Select(method => new FishingMethodPreferenceDto(
+                method.FishingMethodId,
+                method.Code,
+                Resolve(_fishingMethodLocalizer, method.Code, method.Name),
+                method.IsDefault,
+                [.. method.Species.Select(species => new FishingSpeciesPreferenceDto(
+                    species.SpeciesId,
+                    species.Code,
+                    Resolve(_speciesLocalizer, species.Code, species.Name),
+                    species.IsDefault))]))
+        ]);
+    }
+
+    private FishingMethodDto Localize(FishingMethodDto method) =>
+        method with { Name = GetFishingMethodLabel(method) };
+
+    private SpeciesDto Localize(SpeciesDto species) =>
+        species with { Name = GetSpeciesLabel(species) };
+
+    private static string Resolve<TResource>(
+        IStringLocalizer<TResource> localizer,
+        string code,
+        string canonicalName)
+    {
+        var translation = localizer[code];
+        return translation.ResourceNotFound || string.IsNullOrWhiteSpace(translation.Value)
+            ? canonicalName
+            : translation.Value;
+    }
+}

--- a/src/FishingLogBook.Web/Localization/FishingMethodStrings.cs
+++ b/src/FishingLogBook.Web/Localization/FishingMethodStrings.cs
@@ -1,0 +1,5 @@
+namespace FishingLogBook.Web.Localization;
+
+public sealed class FishingMethodStrings
+{
+}

--- a/src/FishingLogBook.Web/Localization/FishingMethodStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/FishingMethodStrings.fr.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Fly" xml:space="preserve"><value>Pêche à la mouche</value></data>
+  <data name="Spinning" xml:space="preserve"><value>Pêche au lancer</value></data>
+  <data name="Bait" xml:space="preserve"><value>Pêche à l’appât</value></data>
+  <data name="Lure" xml:space="preserve"><value>Pêche aux leurres</value></data>
+  <data name="Trolling" xml:space="preserve"><value>Pêche à la traîne</value></data>
+</root>

--- a/src/FishingLogBook.Web/Localization/FishingMethodStrings.resx
+++ b/src/FishingLogBook.Web/Localization/FishingMethodStrings.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="Fly" xml:space="preserve"><value>Fly</value></data>
+  <data name="Spinning" xml:space="preserve"><value>Spinning</value></data>
+  <data name="Bait" xml:space="preserve"><value>Bait</value></data>
+  <data name="Lure" xml:space="preserve"><value>Lure</value></data>
+  <data name="Trolling" xml:space="preserve"><value>Trolling</value></data>
+</root>

--- a/src/FishingLogBook.Web/Localization/ICatalogueLocalizer.cs
+++ b/src/FishingLogBook.Web/Localization/ICatalogueLocalizer.cs
@@ -1,0 +1,14 @@
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Localization;
+
+public interface ICatalogueLocalizer
+{
+    string GetSpeciesLabel(SpeciesDto species);
+
+    string GetFishingMethodLabel(FishingMethodDto method);
+
+    FishingCatalogueDto Localize(FishingCatalogueDto catalogue);
+
+    FishingPreferencesDto Localize(FishingPreferencesDto preferences);
+}

--- a/src/FishingLogBook.Web/Localization/SpeciesStrings.cs
+++ b/src/FishingLogBook.Web/Localization/SpeciesStrings.cs
@@ -1,0 +1,5 @@
+namespace FishingLogBook.Web.Localization;
+
+public sealed class SpeciesStrings
+{
+}

--- a/src/FishingLogBook.Web/Localization/SpeciesStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/SpeciesStrings.fr.resx
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="BrownTrout" xml:space="preserve"><value>Truite brune</value></data>
+  <data name="RainbowTrout" xml:space="preserve"><value>Truite arc-en-ciel</value></data>
+  <data name="BrookTrout" xml:space="preserve"><value>Omble de fontaine</value></data>
+  <data name="SeaTrout" xml:space="preserve"><value>Truite de mer</value></data>
+  <data name="Salmon" xml:space="preserve"><value>Saumon</value></data>
+  <data name="Pike" xml:space="preserve"><value>Brochet</value></data>
+  <data name="Perch" xml:space="preserve"><value>Perche</value></data>
+  <data name="Carp" xml:space="preserve"><value>Carpe</value></data>
+  <data name="Bream" xml:space="preserve"><value>Brème</value></data>
+  <data name="Roach" xml:space="preserve"><value>Gardon</value></data>
+  <data name="Tench" xml:space="preserve"><value>Tanche</value></data>
+  <data name="Grayling" xml:space="preserve"><value>Ombre commun</value></data>
+</root>

--- a/src/FishingLogBook.Web/Localization/SpeciesStrings.resx
+++ b/src/FishingLogBook.Web/Localization/SpeciesStrings.resx
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="BrownTrout" xml:space="preserve"><value>Brown Trout</value></data>
+  <data name="RainbowTrout" xml:space="preserve"><value>Rainbow Trout</value></data>
+  <data name="BrookTrout" xml:space="preserve"><value>Brook Trout</value></data>
+  <data name="SeaTrout" xml:space="preserve"><value>Sea Trout</value></data>
+  <data name="Salmon" xml:space="preserve"><value>Salmon</value></data>
+  <data name="Pike" xml:space="preserve"><value>Pike</value></data>
+  <data name="Perch" xml:space="preserve"><value>Perch</value></data>
+  <data name="Carp" xml:space="preserve"><value>Carp</value></data>
+  <data name="Bream" xml:space="preserve"><value>Bream</value></data>
+  <data name="Roach" xml:space="preserve"><value>Roach</value></data>
+  <data name="Tench" xml:space="preserve"><value>Tench</value></data>
+  <data name="Grayling" xml:space="preserve"><value>Grayling</value></data>
+</root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -656,4 +656,11 @@
   <data name="Landing_BenefitRecord" xml:space="preserve"><value>Enregistrez rapidement prises et photos</value></data>
   <data name="Landing_BenefitPrivate" xml:space="preserve"><value>Vos lieux de pêche restent privés par défaut</value></data>
   <data name="Landing_BenefitOffline" xml:space="preserve"><value>Conçu pour les zones sans réseau ou hors ligne</value></data>
+  <data name="Modal_Save" xml:space="preserve"><value>Enregistrer</value></data>
+  <data name="Modal_Selected" xml:space="preserve"><value>Sélection</value></data>
+  <data name="Modal_Available" xml:space="preserve"><value>Options disponibles</value></data>
+  <data name="Modal_NoneSelected" xml:space="preserve"><value>Aucune sélection</value></data>
+  <data name="Modal_ShowingLimited" xml:space="preserve"><value>Affichage de {0} sur {1} {2}. Recherchez pour en trouver davantage.</value></data>
+  <data name="Modal_Species" xml:space="preserve"><value>espèces</value></data>
+  <data name="Modal_FishingMethods" xml:space="preserve"><value>méthodes de pêche</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -656,4 +656,11 @@
   <data name="Landing_BenefitRecord" xml:space="preserve"><value>Quickly record catches and photographs</value></data>
   <data name="Landing_BenefitPrivate" xml:space="preserve"><value>Fishing spots stay private by default</value></data>
   <data name="Landing_BenefitOffline" xml:space="preserve"><value>Designed for poor signal and offline use</value></data>
+  <data name="Modal_Save" xml:space="preserve"><value>Save</value></data>
+  <data name="Modal_Selected" xml:space="preserve"><value>Selected</value></data>
+  <data name="Modal_Available" xml:space="preserve"><value>Available</value></data>
+  <data name="Modal_NoneSelected" xml:space="preserve"><value>None selected</value></data>
+  <data name="Modal_ShowingLimited" xml:space="preserve"><value>Showing {0} of {1} {2}. Search to find more.</value></data>
+  <data name="Modal_Species" xml:space="preserve"><value>species</value></data>
+  <data name="Modal_FishingMethods" xml:space="preserve"><value>fishing methods</value></data>
 </root>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -80,6 +80,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IDiagnosticLogger, DiagnosticLogger>();
         services.AddScoped<IDiagnosticSynchroniser, DiagnosticSynchroniser>();
         services.AddLocalization();
+        services.AddScoped<ICatalogueLocalizer, CatalogueLocalizer>();
         services.AddScoped<ICultureService, CultureService>();
         services.AddScoped<ISignedInUserDisplayService, SignedInUserDisplayService>();
         services.AddMudServices();

--- a/tests/FishingLogBook.Web.Tests/Common/Modals/CataloguePickerModalTests/WhenTestingSelect.cs
+++ b/tests/FishingLogBook.Web.Tests/Common/Modals/CataloguePickerModalTests/WhenTestingSelect.cs
@@ -19,6 +19,10 @@ public class WhenTestingSelect : BaseCataloguePickerModalTest
 
         // Assert
         cut.Find("#catalogue-picker-modal-empty").TextContent.Should().Contain("No matches found.");
+        cut.Find("#catalogue-picker-modal-selected-label").TextContent.Should().Contain("Selected");
+        cut.Find("#catalogue-picker-modal-available-label").TextContent.Should().Contain("Available");
+        cut.Markup.IndexOf("catalogue-picker-modal-available-label", StringComparison.Ordinal)
+            .Should().BeLessThan(cut.Markup.IndexOf("catalogue-picker-modal-selected-label", StringComparison.Ordinal));
         cut.FindAll("#catalogue-picker-modal-options").Should().BeEmpty();
     }
 
@@ -87,7 +91,34 @@ public class WhenTestingSelect : BaseCataloguePickerModalTest
 
         // Assert
         cut.Find("#catalogue-picker-modal-empty").TextContent.Should().Contain("Aucun résultat.");
+        cut.Find("#catalogue-picker-modal-selected-label").TextContent.Should().Contain("Sélection");
+        cut.Find("#catalogue-picker-modal-available-label").TextContent.Should().Contain("Options disponibles");
         cut.Find("#catalogue-picker-modal-cancel").TextContent.Should().Contain("Annuler");
+    }
+
+    [Fact]
+    public async Task ItShouldSearchTheCurrentLanguageDisplayName()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        await using var context = CreateContext();
+        var (cut, _) = await ShowAsync(context, new CataloguePickerModalModel(
+            "Espèces",
+            [
+                new CatalogueOptionModel(PikeSpeciesId, "Pike", "Brochet"),
+                new CatalogueOptionModel(TenchSpeciesId, "Tench", "Tanche")
+            ],
+            AllowMultiple: true));
+
+        // Act
+        cut.Find("#catalogue-picker-modal-search").Input("bro");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catalogue-picker-modal-option-Pike").Should().NotBeNull();
+            cut.FindAll("#catalogue-picker-modal-option-Tench").Should().BeEmpty();
+        });
     }
 
     [Fact]
@@ -101,12 +132,105 @@ public class WhenTestingSelect : BaseCataloguePickerModalTest
 
         // Act
         await cut.Find("#catalogue-picker-modal-option-Pike").ClickAsync();
+        await cut.Find("#catalogue-picker-modal-save").ClickAsync();
         var result = await dialog.Result;
 
         // Assert
         result!.Canceled.Should().BeFalse();
         result.Data.Should().BeOfType<CataloguePickerModalResult>();
-        ((CataloguePickerModalResult)result.Data!).Option.Id.Should().Be(PikeSpeciesId);
-        ((CataloguePickerModalResult)result.Data!).Option.Name.Should().Be("Pike");
+        ((CataloguePickerModalResult)result.Data!).Options.Single().Id.Should().Be(PikeSpeciesId);
+        ((CataloguePickerModalResult)result.Data!).Options.Single().Name.Should().Be("Pike");
+    }
+
+    [Fact]
+    public async Task ItShouldKeepMultipleSelectionsUntilTheyAreSaved()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+        var model = DefaultModel() with { AllowMultiple = true };
+        var (cut, dialog) = await ShowAsync(context, model);
+
+        // Act
+        await cut.Find("#catalogue-picker-modal-option-Pike").ClickAsync();
+        await cut.Find("#catalogue-picker-modal-option-Tench").ClickAsync();
+        await cut.Find("#catalogue-picker-modal-save").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        var selected = ((CataloguePickerModalResult)result!.Data!).Options;
+        selected.Select(option => option.Id).Should().BeEquivalentTo([PikeSpeciesId, TenchSpeciesId]);
+    }
+
+    [Fact]
+    public async Task ItShouldSearchTheCompleteCatalogueBeyondTheInitialLimit()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+        var options = Enumerable.Range(1, 25)
+            .Select(number => new CatalogueOptionModel(
+                Guid.Parse($"cccccccc-0000-0000-0000-{number:D12}"),
+                $"Species{number}",
+                $"Species {number}"))
+            .ToArray();
+        var (cut, dialog) = await ShowAsync(context, new CataloguePickerModalModel(
+            "Species", options, AllowMultiple: true, ItemPluralName: "species"));
+
+        // Act
+        cut.FindAll("#catalogue-picker-modal-options .mud-chip").Should().HaveCount(20);
+        cut.Find("#catalogue-picker-modal-limit-message").TextContent
+            .Should().Contain("Showing 20 of 25 species. Search to find more.");
+        cut.Find("#catalogue-picker-modal-search").Input("Species 25");
+        cut.WaitForAssertion(() => cut.Find("#catalogue-picker-modal-option-Species25"));
+        await cut.Find("#catalogue-picker-modal-option-Species25").ClickAsync();
+        await cut.Find("#catalogue-picker-modal-save").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        ((CataloguePickerModalResult)result!.Data!).Options.Single().Code.Should().Be("Species25");
+    }
+
+    [Fact]
+    public async Task ItShouldNotShowALimitMessageForTwentyOptions()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+        var options = Enumerable.Range(1, 20)
+            .Select(number => new CatalogueOptionModel(Guid.NewGuid(), $"Species{number}", $"Species {number}"))
+            .ToArray();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, new CataloguePickerModalModel(
+            "Species", options, AllowMultiple: true, ItemPluralName: "species"));
+
+        // Assert
+        cut.FindAll("#catalogue-picker-modal-limit-message").Should().BeEmpty();
+        cut.FindAll("#catalogue-picker-modal-options .mud-chip").Should().HaveCount(20);
+    }
+
+    [Fact]
+    public async Task ItShouldShowExistingSelectionsAndCancelWithoutReturningChanges()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+        var model = DefaultModel() with
+        {
+            AllowMultiple = true,
+            SelectedOptionIds = new HashSet<Guid> { BrownTroutSpeciesId }
+        };
+        var (cut, dialog) = await ShowAsync(context, model);
+
+        // Act
+        cut.Find("#catalogue-picker-modal-selected-BrownTrout").Should().NotBeNull();
+        await cut.Find("#catalogue-picker-modal-option-Pike").ClickAsync();
+        await cut.Find("#catalogue-picker-modal-cancel").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        result!.Canceled.Should().BeTrue();
+        result.Data.Should().BeNull();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
@@ -1,0 +1,95 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Install;
+using FishingLogBook.Web.Browser.Location;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Onboarding.Services;
+using FishingLogBook.Web.Features.Profile.Clients;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+using OnboardingPage = FishingLogBook.Web.Features.Onboarding.Pages.Onboarding.Onboarding;
+
+namespace FishingLogBook.Web.Tests.Features.Onboarding.Pages.OnboardingTests;
+
+public class WhenTestingPreferences
+{
+    private static readonly Guid FlyMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly Guid SpinningMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000002");
+
+    [Fact]
+    public async Task ItShouldUseTheReusableMultiSelectWithExistingMethodsSelected()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var modal = Substitute.For<IModalService>();
+        modal.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
+                Arg.Any<CataloguePickerModalModel>(), Arg.Any<CancellationToken>())
+            .Returns(new CataloguePickerModalResult(
+            [
+                new CatalogueOptionModel(FlyMethodId, "Fly", "Fly"),
+                new CatalogueOptionModel(SpinningMethodId, "Spinning", "Spinning")
+            ]));
+        await using var context = CreateContext(modal);
+        var cut = context.Render<OnboardingPage>();
+        cut.WaitForAssertion(() => cut.Find("#onboarding-next"));
+        await cut.Find("#onboarding-next").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#onboarding-method-more"));
+
+        // Act
+        await cut.Find("#onboarding-method-more").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#onboarding-method-Spinning").ClassList.Should().Contain("mud-chip-filled"));
+        await modal.Received(1)
+            .ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
+                Arg.Is<CataloguePickerModalModel>(model =>
+                    model.AllowMultiple
+                    && model.Options.Count == 2
+                    && model.SelectedOptionIds != null
+                    && model.SelectedOptionIds.Contains(FlyMethodId)),
+                Arg.Any<CancellationToken>());
+    }
+
+    private static BunitContext CreateContext(IModalService modal)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        context.Services.AddSingleton(modal);
+
+        var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.IsCompletedAsync(Arg.Any<CancellationToken>()).Returns(false);
+        context.Services.AddSingleton(onboarding);
+
+        var profile = Substitute.For<IProfileClient>();
+        profile.GetOwnAsync(Arg.Any<CancellationToken>()).Returns(new ProfileDto(
+            Guid.NewGuid(), null, null, null, null, null, true, false, false, false, false));
+        context.Services.AddSingleton(profile);
+
+        var preferences = Substitute.For<IFishingPreferenceClient>();
+        preferences.GetCatalogueAsync(Arg.Any<CancellationToken>()).Returns(new FishingCatalogueDto(
+            [
+                new FishingMethodDto(FlyMethodId, "Fly", "Fly"),
+                new FishingMethodDto(SpinningMethodId, "Spinning", "Spinning")
+            ],
+            []));
+        preferences.GetPreferencesAsync(Arg.Any<CancellationToken>()).Returns(new FishingPreferencesDto(
+        [
+            new FishingMethodPreferenceDto(FlyMethodId, "Fly", "Fly", true, [])
+        ]));
+        context.Services.AddSingleton(preferences);
+
+        var install = Substitute.For<IInstallService>();
+        install.GetStateAsync(Arg.Any<CancellationToken>()).Returns(new InstallState(false, false, false, false));
+        context.Services.AddSingleton(install);
+        context.Services.AddSingleton(Substitute.For<ILocationService>());
+        context.AddAuthorization().SetAuthorized("tester@example.test");
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Profile/Clients/FishingPreferenceClientTests/BaseFishingPreferenceClientTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Profile/Clients/FishingPreferenceClientTests/BaseFishingPreferenceClientTest.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Profile.Clients;
+using FishingLogBook.Web.Localization;
 using NSubstitute;
 
 namespace FishingLogBook.Web.Tests.Features.Profile.Clients.FishingPreferenceClientTests;
@@ -16,7 +17,12 @@ public class BaseFishingPreferenceClientTest
         var factory = Substitute.For<IHttpClientFactory>();
         factory.CreateClient(HttpClientNames.AuthorizedApi)
             .Returns(new HttpClient(apiHandler) { BaseAddress = new Uri("https://api.test/") });
-        return new FishingPreferenceClient(factory);
+        var localizer = Substitute.For<ICatalogueLocalizer>();
+        localizer.Localize(Arg.Any<FishingLogBook.Shared.Dtos.FishingCatalogueDto>())
+            .Returns(call => call.Arg<FishingLogBook.Shared.Dtos.FishingCatalogueDto>());
+        localizer.Localize(Arg.Any<FishingLogBook.Shared.Dtos.FishingPreferencesDto>())
+            .Returns(call => call.Arg<FishingLogBook.Shared.Dtos.FishingPreferencesDto>());
+        return new FishingPreferenceClient(factory, localizer);
     }
 
     protected sealed class RecordingHandler : HttpMessageHandler

--- a/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingPreferences.cs
@@ -163,7 +163,10 @@ public class WhenTestingPreferences : BaseProfileTest
                 Arg.Any<CataloguePickerModalModel>(),
                 Arg.Any<CancellationToken>())
             .Returns(new CataloguePickerModalResult(
-                new CatalogueOptionModel(PikeSpeciesId, "Pike", "Pike")));
+            [
+                new CatalogueOptionModel(BrownTroutSpeciesId, "BrownTrout", "Brown Trout"),
+                new CatalogueOptionModel(PikeSpeciesId, "Pike", "Pike")
+            ]));
         await using var context = CreateContext(profileClient, preferenceClient, modalService);
         var cut = context.Render<ProfilePage>();
         cut.WaitForAssertion(() => cut.Find("#profile-species-more-Fly"));
@@ -175,11 +178,16 @@ public class WhenTestingPreferences : BaseProfileTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#profile-species-Fly-Pike").Should().NotBeNull();
+            cut.Find("#profile-species-Fly-BrownTrout").Should().NotBeNull();
             cut.Find("#profile-species-remove-Fly-Pike").Should().NotBeNull();
         });
         await modalService.Received(1)
             .ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
-                Arg.Is<CataloguePickerModalModel>(model => model.Options.Count == 2),
+                Arg.Is<CataloguePickerModalModel>(model =>
+                    model.Options.Count == 2
+                    && model.AllowMultiple
+                    && model.SelectedOptionIds != null
+                    && model.SelectedOptionIds.Count == 0),
                 Arg.Any<CancellationToken>());
     }
 

--- a/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/CatalogueFallbackProbeStrings.cs
+++ b/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/CatalogueFallbackProbeStrings.cs
@@ -1,0 +1,5 @@
+namespace FishingLogBook.Web.Tests.Localization.CatalogueLocalizerTests;
+
+public sealed class CatalogueFallbackProbeStrings
+{
+}

--- a/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/CatalogueFallbackProbeStrings.fr.resx
+++ b/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/CatalogueFallbackProbeStrings.fr.resx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="ParentCulture" xml:space="preserve"><value>Valeur française parente</value></data>
+</root>

--- a/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/CatalogueFallbackProbeStrings.resx
+++ b/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/CatalogueFallbackProbeStrings.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <data name="EnglishOnly" xml:space="preserve"><value>English fallback</value></data>
+  <data name="ParentCulture" xml:space="preserve"><value>English parent fallback</value></data>
+</root>

--- a/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/WhenTestingLocalize.cs
+++ b/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/WhenTestingLocalize.cs
@@ -3,6 +3,7 @@ using Bunit;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 
 namespace FishingLogBook.Web.Tests.Localization.CatalogueLocalizerTests;
 
@@ -78,6 +79,51 @@ public class WhenTestingLocalize
 
         // Assert
         actual.Methods.Single().Name.Should().Be("Fly");
+    }
+
+    [Fact]
+    public void ItShouldUseEnglishWhenTheFrenchResourceDoesNotContainTheKey()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        using var context = CreateContext();
+        var localizer = context.Services.GetRequiredService<IStringLocalizer<CatalogueFallbackProbeStrings>>();
+
+        // Act
+        var actual = CatalogueLocalizer.Resolve(localizer, "EnglishOnly", "Canonical label");
+
+        // Assert
+        actual.Should().Be("English fallback");
+    }
+
+    [Fact]
+    public void ItShouldUseTheFrenchParentResourceForFrenchFrance()
+    {
+        // Arrange
+        using var culture = TestCulture.Use("fr-FR");
+        using var context = CreateContext();
+        var localizer = context.Services.GetRequiredService<IStringLocalizer<CatalogueFallbackProbeStrings>>();
+
+        // Act
+        var actual = CatalogueLocalizer.Resolve(localizer, "ParentCulture", "Canonical label");
+
+        // Assert
+        actual.Should().Be("Valeur française parente");
+    }
+
+    [Fact]
+    public void ItShouldUseTheCanonicalNameWhenNeitherFrenchNorEnglishContainsTheKey()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        using var context = CreateContext();
+        var localizer = context.Services.GetRequiredService<IStringLocalizer<CatalogueFallbackProbeStrings>>();
+
+        // Act
+        var actual = CatalogueLocalizer.Resolve(localizer, "MissingEverywhere", "Canonical label");
+
+        // Assert
+        actual.Should().Be("Canonical label");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/WhenTestingLocalize.cs
+++ b/tests/FishingLogBook.Web.Tests/Localization/CatalogueLocalizerTests/WhenTestingLocalize.cs
@@ -1,0 +1,117 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FishingLogBook.Web.Tests.Localization.CatalogueLocalizerTests;
+
+public class WhenTestingLocalize
+{
+    private static readonly Guid MethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly Guid SpeciesId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
+
+    [Fact]
+    public void ItShouldTranslateCatalogueNamesWithoutChangingIdentity()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        using var context = CreateContext();
+        var subject = context.Services.GetRequiredService<ICatalogueLocalizer>();
+
+        // Act
+        var actual = subject.Localize(new FishingCatalogueDto(
+            [new FishingMethodDto(MethodId, "Fly", "Fly")],
+            [new SpeciesDto(SpeciesId, "BrownTrout", "Brown Trout")]));
+
+        // Assert
+        actual.Methods.Single().Should().Be(new FishingMethodDto(MethodId, "Fly", "Pêche à la mouche"));
+        actual.AllSpecies.Single().Should().Be(new SpeciesDto(SpeciesId, "BrownTrout", "Truite brune"));
+    }
+
+    [Fact]
+    public void ItShouldUseTheParentCultureBeforeTheEnglishFallback()
+    {
+        // Arrange
+        using var culture = TestCulture.Use("fr-CA");
+        using var context = CreateContext();
+        var subject = context.Services.GetRequiredService<ICatalogueLocalizer>();
+
+        // Act
+        var actual = subject.Localize(new FishingCatalogueDto(
+            [new FishingMethodDto(MethodId, "Fly", "Canonical fly")],
+            []));
+
+        // Assert
+        actual.Methods.Single().Name.Should().Be("Pêche à la mouche");
+    }
+
+    [Fact]
+    public void ItShouldUseTheCanonicalNameWhenNoResourceExists()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        using var context = CreateContext();
+        var subject = context.Services.GetRequiredService<ICatalogueLocalizer>();
+
+        // Act
+        var actual = subject.Localize(new FishingCatalogueDto(
+            [new FishingMethodDto(MethodId, "FutureMethod", "Future method")],
+            []));
+
+        // Assert
+        actual.Methods.Single().Name.Should().Be("Future method");
+    }
+
+    [Fact]
+    public void ItShouldFallBackToEnglishForAnUnsupportedCulture()
+    {
+        // Arrange
+        using var culture = TestCulture.Use("de-DE");
+        using var context = CreateContext();
+        var subject = context.Services.GetRequiredService<ICatalogueLocalizer>();
+
+        // Act
+        var actual = subject.Localize(new FishingCatalogueDto(
+            [new FishingMethodDto(MethodId, "Fly", "Canonical fly")],
+            []));
+
+        // Assert
+        actual.Methods.Single().Name.Should().Be("Fly");
+    }
+
+    [Fact]
+    public void ItShouldTranslateSavedPreferencesWithoutChangingTheirIdsOrDefaults()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        using var context = CreateContext();
+        var subject = context.Services.GetRequiredService<ICatalogueLocalizer>();
+        var preferences = new FishingPreferencesDto(
+        [
+            new FishingMethodPreferenceDto(MethodId, "Fly", "Fly", true,
+            [
+                new FishingSpeciesPreferenceDto(SpeciesId, "BrownTrout", "Brown Trout", true)
+            ])
+        ]);
+
+        // Act
+        var actual = subject.Localize(preferences);
+
+        // Assert
+        actual.Methods.Single().FishingMethodId.Should().Be(MethodId);
+        actual.Methods.Single().IsDefault.Should().BeTrue();
+        actual.Methods.Single().Name.Should().Be("Pêche à la mouche");
+        actual.Methods.Single().Species.Single().SpeciesId.Should().Be(SpeciesId);
+        actual.Methods.Single().Species.Single().IsDefault.Should().BeTrue();
+        actual.Methods.Single().Species.Single().Name.Should().Be("Truite brune");
+    }
+
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.Services.AddLocalization();
+        context.Services.AddScoped<ICatalogueLocalizer, CatalogueLocalizer>();
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Localization/CatalogueResourcesTests/WhenTestingCompleteness.cs
+++ b/tests/FishingLogBook.Web.Tests/Localization/CatalogueResourcesTests/WhenTestingCompleteness.cs
@@ -1,0 +1,81 @@
+using System.Globalization;
+using System.Resources;
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using FishingLogBook.Web.Localization;
+
+namespace FishingLogBook.Web.Tests.Localization.CatalogueResourcesTests;
+
+public partial class WhenTestingCompleteness
+{
+    [Fact]
+    public void ItShouldHaveEnglishAndFrenchLabelsForEverySeededCatalogueCode()
+    {
+        // Arrange
+        var seed = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "src",
+            "FishingLogBook.Db.Migrations",
+            "02_SeedData",
+            "202608181902_87_SeedFishingCatalogue.sql"));
+        var speciesStart = seed.IndexOf("INSERT INTO \"Species\"", StringComparison.Ordinal);
+        var methodCodes = ExtractCodes(seed[..speciesStart]);
+        var speciesCodes = ExtractCodes(seed[speciesStart..]);
+
+        // Act
+        var methodEnglish = Keys(new ResourceManager(typeof(FishingMethodStrings)), CultureInfo.InvariantCulture);
+        var methodFrench = Keys(new ResourceManager(typeof(FishingMethodStrings)), new CultureInfo(CultureNames.French));
+        var speciesEnglish = Keys(new ResourceManager(typeof(SpeciesStrings)), CultureInfo.InvariantCulture);
+        var speciesFrench = Keys(new ResourceManager(typeof(SpeciesStrings)), new CultureInfo(CultureNames.French));
+
+        // Assert
+        methodEnglish.Should().Contain(methodCodes);
+        methodFrench.Should().Contain(methodCodes);
+        speciesEnglish.Should().Contain(speciesCodes);
+        speciesFrench.Should().Contain(speciesCodes);
+    }
+
+    [Fact]
+    public void ItShouldKeepCatalogueLabelsOutOfTheGeneralUiResources()
+    {
+        // Arrange
+        var uiKeys = Keys(new ResourceManager(typeof(UiStrings)), CultureInfo.InvariantCulture);
+
+        // Act
+        var species = new ResourceManager(typeof(SpeciesStrings)).GetString("Pike", CultureInfo.InvariantCulture);
+        var method = new ResourceManager(typeof(FishingMethodStrings)).GetString("Fly", CultureInfo.InvariantCulture);
+
+        // Assert
+        species.Should().Be("Pike");
+        method.Should().Be("Fly");
+        uiKeys.Should().NotContain(key => key.StartsWith("Catalogue_", StringComparison.Ordinal));
+    }
+
+    private static IReadOnlyCollection<string> ExtractCodes(string sql)
+    {
+        return [.. SeedRowRegex().Matches(sql).Select(match => match.Groups[1].Value)];
+    }
+
+    private static IReadOnlyCollection<string> Keys(ResourceManager manager, CultureInfo culture)
+    {
+        var resources = manager.GetResourceSet(culture, true, false);
+        return resources is null
+            ? []
+            : [.. resources.Cast<System.Collections.DictionaryEntry>().Select(entry => (string)entry.Key)];
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "FishingLogBook.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new DirectoryNotFoundException("Could not find the repository root.");
+    }
+
+    [GeneratedRegex(@"'[^']+'\s*,\s*'([^']+)'\s*,\s*'[^']+'", RegexOptions.CultureInvariant)]
+    private static partial Regex SeedRowRegex();
+}

--- a/tests/FishingLogBook.Web.Tests/Localization/CatalogueResourcesTests/WhenTestingCompleteness.cs
+++ b/tests/FishingLogBook.Web.Tests/Localization/CatalogueResourcesTests/WhenTestingCompleteness.cs
@@ -29,10 +29,10 @@ public partial class WhenTestingCompleteness
         var speciesFrench = Keys(new ResourceManager(typeof(SpeciesStrings)), new CultureInfo(CultureNames.French));
 
         // Assert
-        methodEnglish.Should().Contain(methodCodes);
-        methodFrench.Should().Contain(methodCodes);
-        speciesEnglish.Should().Contain(speciesCodes);
-        speciesFrench.Should().Contain(speciesCodes);
+        methodEnglish.Should().BeEquivalentTo(methodCodes);
+        methodFrench.Should().BeEquivalentTo(methodCodes);
+        speciesEnglish.Should().BeEquivalentTo(speciesCodes);
+        speciesFrench.Should().BeEquivalentTo(speciesCodes);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- localise seeded Species and Fishing Method labels in dedicated English and French resource sets while preserving stable IDs, codes, API contracts, and stored preferences
- introduce a small catalogue-label abstraction with current culture, parent culture, English, then canonical-name fallback
- replace the one-shot catalogue picker with the shared searchable transactional multi-select used by onboarding and Profile
- clearly separate available and selected choices, retain removable selected pills, and cap the initial multi-select catalogue view at 20 entries while searching the complete catalogue
- add localised limit/count guidance and exact seed-to-resource completeness checks
- prove the complete fallback contract with the real .NET resource provider, including missing French and `fr-FR` parent-culture cases

## Validation

- `dotnet test tests/FishingLogBook.Web.Tests/FishingLogBook.Web.Tests.csproj --no-restore` — 565 passed
- `dotnet build src/FishingLogBook.Web/FishingLogBook.Web.csproj --no-restore --configuration Release` — succeeded with 0 warnings and 0 errors
- focused catalogue fallback/resource/picker tests — 21 passed
- `git diff --check` — clean

## Scope

- no database schema, seed-data, preference-persistence, Terraform, authentication, service-worker, manifest, or startup changes
- real-device verification remains a manual post-deployment check and is not claimed here

Closes #110