### PR TITLE
FLB#111 | improve install guidance and onboarding validation

### DIFF
--- a/src/FishingLogBook.Web/Browser/Install/IInstallService.cs
+++ b/src/FishingLogBook.Web/Browser/Install/IInstallService.cs
@@ -4,7 +4,40 @@ public interface IInstallService
 {
     Task<InstallState> GetStateAsync(CancellationToken cancellationToken);
 
-    Task<bool> PromptAsync(CancellationToken cancellationToken);
+    Task<InstallResult> PromptAsync(CancellationToken cancellationToken);
 }
 
-public sealed record InstallState(bool IsInstalled, bool CanPrompt, bool IsIos, bool IsAndroid);
+public sealed record InstallState(
+    bool IsInstalled,
+    bool CanPrompt,
+    string PlatformFamily,
+    bool IsSafari)
+{
+    public InstallState(bool isInstalled, bool canPrompt, bool isIos, bool isAndroid)
+        : this(
+            isInstalled,
+            canPrompt,
+            isIos ? InstallPlatformFamilies.Ios : isAndroid ? InstallPlatformFamilies.Android : InstallPlatformFamilies.Other,
+            isIos)
+    {
+    }
+
+    public bool IsIos => PlatformFamily == InstallPlatformFamilies.Ios;
+    public bool IsAndroid => PlatformFamily == InstallPlatformFamilies.Android;
+    public bool IsWindows => PlatformFamily == InstallPlatformFamilies.Windows;
+}
+
+public enum InstallResult
+{
+    Unavailable,
+    Accepted,
+    Dismissed
+}
+
+public static class InstallPlatformFamilies
+{
+    public const string Ios = "iOS";
+    public const string Android = "Android";
+    public const string Windows = "Windows";
+    public const string Other = "Other";
+}

--- a/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor
+++ b/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor
@@ -1,0 +1,84 @@
+@namespace FishingLogBook.Web.Browser.Install
+
+<section class="install-guidance" aria-labelledby="install-guidance-title" id="install-guidance">
+    <MudText Typo="Typo.h5" id="install-guidance-title">@Loc["Install_Title"]</MudText>
+    @if (_isLoading)
+    {
+        <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="@Loc["Common_Loading"]" id="install-guidance-loading" />
+    }
+    else if (_state.IsInstalled || _result == InstallResult.Accepted)
+    {
+        <MudAlert Severity="Severity.Success" Icon="@Icons.Material.Filled.CheckCircle" id="install-guidance-installed">
+            <MudText Typo="Typo.subtitle1">@Loc["Install_InstalledTitle"]</MudText>
+            <MudText>@(_state.IsWindows ? Loc["Install_InstalledWindows"] : Loc["Install_InstalledBody"])</MudText>
+        </MudAlert>
+    }
+    else
+    {
+        <MudText id="install-guidance-benefit">@Loc["Install_Benefit"]</MudText>
+
+        @if (_result == InstallResult.Dismissed)
+        {
+            <MudAlert Severity="Severity.Info" id="install-guidance-dismissed">@Loc["Install_Dismissed"]</MudAlert>
+        }
+
+        @if (_state.CanPrompt)
+        {
+            <MudText id="install-guidance-native">@Loc["Install_NativeAvailable"]</MudText>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large"
+                       StartIcon="@Icons.Material.Filled.InstallMobile"
+                       OnClick="InstallAsync" Disabled="_isPrompting"
+                       aria-label="@Loc["Install_Action"]" id="install-guidance-action">
+                @Loc["Install_Action"]
+            </MudButton>
+        }
+
+        @if (_state.IsAndroid)
+        {
+            <MudText Typo="Typo.subtitle1" id="install-guidance-android-heading">@Loc["Install_AndroidHeading"]</MudText>
+            <MudText id="install-guidance-android-alternative">@Loc["Install_AndroidAlternative"]</MudText>
+            <ol class="install-steps" id="install-guidance-android-steps">
+                <li>@Loc["Install_AndroidStep1"]</li>
+                <li>@Loc["Install_AndroidStep2"]</li>
+                <li>@Loc["Install_AndroidStep3"]</li>
+            </ol>
+        }
+        else if (!_state.CanPrompt && _state.IsIos)
+        {
+            @if (!_state.IsSafari)
+            {
+                <MudAlert Severity="Severity.Info" id="install-guidance-ios-browser">@Loc["Install_IosUseSafari"]</MudAlert>
+            }
+            <MudText Typo="Typo.subtitle1" id="install-guidance-ios-heading">@Loc["Install_IosHeading"]</MudText>
+            <ol class="install-steps" id="install-guidance-ios-steps">
+                <li>@Loc["Install_IosStep1"]</li>
+                <li>@Loc["Install_IosStep2"]</li>
+                <li>@Loc["Install_IosStep3"]</li>
+                <li>@Loc["Install_IosStep4"]</li>
+                <li>@Loc["Install_IosStep5"]</li>
+            </ol>
+        }
+        else if (!_state.CanPrompt && _state.IsWindows)
+        {
+            <MudText Typo="Typo.subtitle1" id="install-guidance-windows-heading">@Loc["Install_WindowsHeading"]</MudText>
+            <ol class="install-steps" id="install-guidance-windows-steps">
+                <li>@Loc["Install_WindowsStep1"]</li>
+                <li>@Loc["Install_WindowsStep2"]</li>
+            </ol>
+        }
+        else if (!_state.CanPrompt)
+        {
+            <MudText Typo="Typo.subtitle1" id="install-guidance-other-heading">@Loc["Install_OtherHeading"]</MudText>
+            <MudText id="install-guidance-unsupported">@Loc["Install_Unsupported"]</MudText>
+            <ol class="install-steps" id="install-guidance-other-steps">
+                <li>@Loc["Install_OtherStep1"]</li>
+                <li>@Loc["Install_OtherStep2"]</li>
+            </ol>
+        }
+
+        @if (ShowInstallLaterMessage)
+        {
+            <MudText Typo="Typo.caption" Class="mud-text-secondary" id="install-guidance-later">@Loc["Install_Later"]</MudText>
+        }
+    }
+</section>

--- a/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.cs
+++ b/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.cs
@@ -1,0 +1,69 @@
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Browser.Install;
+
+public partial class InstallGuidance : ComponentBase
+{
+    private InstallState _state = new(false, false, false, false);
+    private InstallResult _result = InstallResult.Unavailable;
+    private bool _isLoading = true;
+    private bool _isPrompting;
+
+    [Parameter]
+    public bool ShowInstallLaterMessage { get; set; }
+
+    [Inject]
+    private IInstallService InstallService { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshAsync();
+    }
+
+    private async Task InstallAsync()
+    {
+        if (_isPrompting)
+        {
+            return;
+        }
+
+        _isPrompting = true;
+        try
+        {
+            _result = await InstallService.PromptAsync(CancellationToken.None);
+            if (_result == InstallResult.Accepted)
+            {
+                _state = _state with { IsInstalled = true, CanPrompt = false };
+            }
+            else
+            {
+                await RefreshAsync();
+            }
+        }
+        finally
+        {
+            _isPrompting = false;
+        }
+    }
+
+    private async Task RefreshAsync()
+    {
+        try
+        {
+            _state = await InstallService.GetStateAsync(CancellationToken.None);
+        }
+        catch (Exception)
+        {
+            _state = new InstallState(false, false, InstallPlatformFamilies.Other, false);
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.css
+++ b/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.css
@@ -1,0 +1,21 @@
+.install-guidance {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.install-steps {
+    margin: 0;
+    padding-left: 1.5rem;
+}
+
+.install-steps li {
+    margin-bottom: 1rem;
+    padding-left: 0.25rem;
+}
+
+.install-steps li:last-child {
+    margin-bottom: 0;
+}

--- a/src/FishingLogBook.Web/Browser/Install/InstallService.cs
+++ b/src/FishingLogBook.Web/Browser/Install/InstallService.cs
@@ -18,9 +18,15 @@ public sealed class InstallService : IInstallService
         return await module.InvokeAsync<InstallState>("getInstallState", cancellationToken);
     }
 
-    public async Task<bool> PromptAsync(CancellationToken cancellationToken)
+    public async Task<InstallResult> PromptAsync(CancellationToken cancellationToken)
     {
         var module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
-        return await module.InvokeAsync<bool>("promptInstall", cancellationToken);
+        var result = await module.InvokeAsync<string>("promptInstall", cancellationToken);
+        return result switch
+        {
+            "accepted" => InstallResult.Accepted,
+            "dismissed" => InstallResult.Dismissed,
+            _ => InstallResult.Unavailable
+        };
     }
 }

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Install/Install.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Install/Install.razor
@@ -1,38 +1,12 @@
 @page "/install"
 @using Microsoft.AspNetCore.Authorization
+@using FishingLogBook.Web.Browser.Install
 @attribute [Authorize]
 
 <PageTitle>@Loc["Onboarding_InstallTitle"]</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Small" Gutters="false">
     <MudPaper Class="pa-4">
-        <MudStack Spacing="3">
-            <MudText Typo="Typo.h4">@Loc["Onboarding_InstallTitle"]</MudText>
-            @if (_isLoading)
-            {
-                <MudProgressCircular Indeterminate="true" Color="Color.Primary" />
-            }
-            else if (_state.IsInstalled)
-            {
-                <MudAlert Severity="Severity.Success">@Loc["Onboarding_AlreadyInstalled"]</MudAlert>
-            }
-            else if (_state.CanPrompt)
-            {
-                <MudText>@Loc["Onboarding_InstallPromptBody"]</MudText>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="InstallAsync" id="install-app-button">@Loc["Onboarding_InstallAction"]</MudButton>
-            }
-            else if (_state.IsIos)
-            {
-                <MudText id="install-ios-guidance">@Loc["Onboarding_InstallIos"]</MudText>
-            }
-            else if (_state.IsAndroid)
-            {
-                <MudText id="install-android-guidance">@Loc["Onboarding_InstallAndroid"]</MudText>
-            }
-            else
-            {
-                <MudText>@Loc["Onboarding_InstallUnavailable"]</MudText>
-            }
-        </MudStack>
+        <InstallGuidance />
     </MudPaper>
 </MudContainer>

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Install/Install.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Install/Install.razor.cs
@@ -1,4 +1,3 @@
-using FishingLogBook.Web.Browser.Install;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -7,32 +6,5 @@ namespace FishingLogBook.Web.Features.Onboarding.Pages.Install;
 
 public partial class Install : ComponentBase
 {
-    private bool _isLoading = true;
-    private InstallState _state = new(false, false, false, false);
-
-    [Inject] private IInstallService InstallService { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await RefreshAsync();
-    }
-
-    private async Task InstallAsync()
-    {
-        await InstallService.PromptAsync(CancellationToken.None);
-        await RefreshAsync();
-    }
-
-    private async Task RefreshAsync()
-    {
-        try
-        {
-            _state = await InstallService.GetStateAsync(CancellationToken.None);
-        }
-        finally
-        {
-            _isLoading = false;
-        }
-    }
 }

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor
@@ -1,6 +1,7 @@
 @page "/onboarding"
 @using Microsoft.AspNetCore.Authorization
 @using FishingLogBook.Shared.Enums
+@using FishingLogBook.Web.Browser.Install
 @attribute [Authorize]
 
 <PageTitle>@Loc["Onboarding_PageTitle"]</PageTitle>
@@ -74,19 +75,24 @@
                                         <MudStack Row="true" Spacing="1" Class="flex-wrap">
                                             @foreach (var species in selectedMethod.Species)
                                             {
-                                                <MudChip T="string"
-                                                         Color="@(species.IsDefault ? Color.Secondary : Color.Primary)"
-                                                         Variant="Variant.Filled"
-                                                         Icon="@(species.IsDefault ? Icons.Material.Filled.Star : null)"
-                                                         OnClick="@(() => SetDefaultSpecies(selectedMethod.FishingMethodId, species.SpeciesId))"
-                                                         id="@($"onboarding-species-{selectedMethod.Code}-{species.Code}")">
-                                                    @species.Name
-                                                </MudChip>
-                                                <MudIconButton Icon="@Icons.Material.Filled.Close"
-                                                               Size="Size.Small"
-                                                               aria-label="@string.Format(Loc["Profile_FishingSpecies_Remove"], species.Name)"
-                                                               OnClick="@(() => RemoveSpecies(selectedMethod.FishingMethodId, species.SpeciesId))"
-                                                               id="@($"onboarding-species-remove-{selectedMethod.Code}-{species.Code}")" />
+                                                <span class="species-pill @(species.IsDefault ? "species-pill-secondary" : "species-pill-primary")"
+                                                      id="@($"onboarding-species-pill-{selectedMethod.Code}-{species.Code}")">
+                                                    <MudChip T="string"
+                                                             Color="@(species.IsDefault ? Color.Secondary : Color.Primary)"
+                                                             Variant="Variant.Filled"
+                                                             Icon="@(species.IsDefault ? Icons.Material.Filled.Star : null)"
+                                                             OnClick="@(() => SetDefaultSpecies(selectedMethod.FishingMethodId, species.SpeciesId))"
+                                                             id="@($"onboarding-species-{selectedMethod.Code}-{species.Code}")">
+                                                        @species.Name
+                                                    </MudChip>
+                                                    <MudIconButton Icon="@Icons.Material.Filled.Cancel"
+                                                                   Size="Size.Small"
+                                                                   Color="Color.Inherit"
+                                                                   Class="species-pill-remove"
+                                                                   aria-label="@string.Format(Loc["Profile_FishingSpecies_Remove"], species.Name)"
+                                                                   OnClick="@(() => RemoveSpecies(selectedMethod.FishingMethodId, species.SpeciesId))"
+                                                                   id="@($"onboarding-species-remove-{selectedMethod.Code}-{species.Code}")" />
+                                                </span>
                                             }
                                             <MudButton Size="Size.Small"
                                                        Variant="Variant.Outlined"
@@ -122,30 +128,9 @@
                             </MudStack>
                         </MudStep>
                         <MudStep Title="@Loc["Onboarding_InstallStep"]">
-                            <MudStack Spacing="3" Class="py-4">
-                                <MudText Typo="Typo.h5">@Loc["Onboarding_InstallTitle"]</MudText>
-                                @if (_installState.IsInstalled)
-                                {
-                                    <MudAlert Severity="Severity.Success">@Loc["Onboarding_AlreadyInstalled"]</MudAlert>
-                                }
-                                else if (_installState.CanPrompt)
-                                {
-                                    <MudText>@Loc["Onboarding_InstallPromptBody"]</MudText>
-                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="InstallAsync" id="onboarding-install">@Loc["Onboarding_InstallAction"]</MudButton>
-                                }
-                                else if (_installState.IsIos)
-                                {
-                                    <MudText>@Loc["Onboarding_InstallIos"]</MudText>
-                                }
-                                else if (_installState.IsAndroid)
-                                {
-                                    <MudText>@Loc["Onboarding_InstallAndroid"]</MudText>
-                                }
-                                else
-                                {
-                                    <MudText>@Loc["Onboarding_InstallUnavailable"]</MudText>
-                                }
-                            </MudStack>
+                            <div class="py-4">
+                                <InstallGuidance ShowInstallLaterMessage="true" />
+                            </div>
                         </MudStep>
                     </ChildContent>
                     <ActionContent></ActionContent>
@@ -154,6 +139,12 @@
                 @if (_saveFailed)
                 {
                     <MudAlert Severity="Severity.Error" id="onboarding-save-failed">@Loc["Onboarding_SaveFailed"]</MudAlert>
+                }
+                @if (!string.IsNullOrWhiteSpace(_preferenceValidationMessage))
+                {
+                    <MudAlert Severity="Severity.Warning" id="onboarding-preference-validation">
+                        @_preferenceValidationMessage
+                    </MudAlert>
                 }
                 <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2">
                     @if (_activeStep > 0)

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
@@ -75,9 +75,21 @@ public partial class Onboarding : ComponentBase, IDisposable
             return false;
         }
 
-        if (_selectedMethods.All(method => method.Species.Count == 0))
+        var incompleteMethods = _selectedMethods
+            .Where(method => method.Species.Count == 0)
+            .Select(method => method.Name)
+            .ToArray();
+        if (incompleteMethods.Length == 1)
         {
-            _preferenceValidationMessage = Loc["Onboarding_ValidationSpecies"];
+            _preferenceValidationMessage = string.Format(
+                Loc["Onboarding_ValidationSpeciesForMethod"], incompleteMethods[0]);
+            return false;
+        }
+
+        if (incompleteMethods.Length > 1)
+        {
+            _preferenceValidationMessage = string.Format(
+                Loc["Onboarding_ValidationSpeciesForMethods"], string.Join(", ", incompleteMethods));
             return false;
         }
 
@@ -278,6 +290,7 @@ public partial class Onboarding : ComponentBase, IDisposable
         }
 
         method.Species.Remove(species);
+        _preferenceValidationMessage = null;
         EnsureDefaultSpecies(method);
     }
 

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
@@ -1,6 +1,5 @@
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
-using FishingLogBook.Web.Browser.Install;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Onboarding.Services;
@@ -21,19 +20,18 @@ public partial class Onboarding : ComponentBase, IDisposable
     private bool _isSaving;
     private bool _saveFailed;
     private bool _locationHandled;
+    private string? _preferenceValidationMessage;
     private WeightUnitEnum _weightUnit = WeightUnitEnum.Kg;
     private LengthUnitEnum _lengthUnit = LengthUnitEnum.Cm;
     private FishingCatalogueDto _catalogue = new([], []);
     private List<SelectedMethodPreference> _selectedMethods = [];
     private ProfileDto? _profile;
-    private InstallState _installState = new(false, false, false, false);
 
     [Inject] private IOnboardingService OnboardingService { get; set; } = default!;
     [Inject] private IProfileClient ProfileClient { get; set; } = default!;
     [Inject] private IFishingPreferenceClient FishingPreferenceClient { get; set; } = default!;
     [Inject] private IModalService ModalService { get; set; } = default!;
     [Inject] private ILocationService LocationService { get; set; } = default!;
-    [Inject] private IInstallService InstallService { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
@@ -54,15 +52,6 @@ public partial class Onboarding : ComponentBase, IDisposable
         ApplyPreferences(await preferencesTask);
         _weightUnit = _profile.PreferredWeightUnit;
         _lengthUnit = _profile.PreferredLengthUnit;
-        try
-        {
-            _installState = await InstallService.GetStateAsync(CancellationToken.None);
-        }
-        catch (Exception)
-        {
-            _installState = new InstallState(false, false, false, false);
-        }
-
         _isLoading = false;
     }
 
@@ -70,12 +59,30 @@ public partial class Onboarding : ComponentBase, IDisposable
 
     private async Task NextAsync()
     {
-        if (_activeStep == 1 && !await SavePreferencesAsync())
+        if (_activeStep == 1 && (!ValidatePreferences() || !await SavePreferencesAsync()))
         {
             return;
         }
 
         _activeStep++;
+    }
+
+    private bool ValidatePreferences()
+    {
+        if (_selectedMethods.Count == 0)
+        {
+            _preferenceValidationMessage = Loc["Onboarding_ValidationFishingMethod"];
+            return false;
+        }
+
+        if (_selectedMethods.All(method => method.Species.Count == 0))
+        {
+            _preferenceValidationMessage = Loc["Onboarding_ValidationSpecies"];
+            return false;
+        }
+
+        _preferenceValidationMessage = null;
+        return true;
     }
 
     private async Task<bool> SavePreferencesAsync()
@@ -167,6 +174,7 @@ public partial class Onboarding : ComponentBase, IDisposable
 
     private void ToggleMethod(FishingMethodDto method)
     {
+        _preferenceValidationMessage = null;
         var selected = _selectedMethods.FirstOrDefault(item => item.FishingMethodId == method.Id);
         if (selected is null)
         {
@@ -194,6 +202,7 @@ public partial class Onboarding : ComponentBase, IDisposable
             return;
         }
 
+        _preferenceValidationMessage = null;
         var chosenIds = result.Options.Select(option => option.Id).ToHashSet();
         _selectedMethods.RemoveAll(method => !chosenIds.Contains(method.FishingMethodId));
         foreach (var chosen in _catalogue.Methods.Where(method =>
@@ -238,6 +247,7 @@ public partial class Onboarding : ComponentBase, IDisposable
             return;
         }
 
+        _preferenceValidationMessage = null;
         var chosenIds = result.Options.Select(option => option.Id).ToHashSet();
         method.Species.RemoveAll(species => !chosenIds.Contains(species.SpeciesId));
         foreach (var chosen in result.Options.Where(option =>
@@ -297,12 +307,6 @@ public partial class Onboarding : ComponentBase, IDisposable
     {
         await LocationService.DismissPromptAsync(CancellationToken.None);
         _locationHandled = true;
-    }
-
-    private async Task InstallAsync()
-    {
-        await InstallService.PromptAsync(CancellationToken.None);
-        _installState = await InstallService.GetStateAsync(CancellationToken.None);
     }
 
     private async Task FinishAsync()

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.css
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.css
@@ -8,6 +8,46 @@
     max-width: min(100%, 365px);
 }
 
+.species-pill {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;
+    overflow: hidden;
+}
+
+.species-pill-primary {
+    background-color: var(--mud-palette-primary);
+    color: var(--mud-palette-primary-text);
+}
+
+.species-pill-secondary {
+    background-color: var(--mud-palette-secondary);
+    color: var(--mud-palette-secondary-text);
+}
+
+::deep .species-pill .mud-chip {
+    margin: 0;
+    border-radius: 9999px 0 0 9999px;
+    padding-right: 0;
+}
+
+::deep .species-pill .species-pill-remove {
+    position: relative;
+    z-index: 1;
+    width: 1.125rem;
+    height: 1.125rem;
+    padding: 0.0625rem;
+    margin-left: 0.25rem;
+    margin-right: 0.5rem;
+    border-radius: 0 9999px 9999px 0;
+}
+
+::deep .species-pill .species-pill-remove::before {
+    content: "";
+    position: absolute;
+    inset: -0.4375rem;
+}
+
 ::deep .onboarding-stepper .mud-stepper-header {
     scrollbar-width: none;
 }

--- a/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor
+++ b/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor
@@ -102,23 +102,28 @@
                             <MudStack Row="true" Spacing="1" Class="flex-wrap">
                                 @foreach (var species in selectedMethod.Species)
                                 {
-                                    <MudChip T="string"
-                                             Color="@(species.IsDefault ? Color.Secondary : Color.Primary)"
-                                             Variant="Variant.Filled"
-                                             Icon="@(species.IsDefault ? Icons.Material.Filled.Star : null)"
-                                             OnClick="@(() => SetDefaultSpeciesForMethod(selectedMethod.FishingMethodId, species.SpeciesId))"
-                                             id="@($"profile-species-{selectedMethod.Code}-{species.Code}")">
-                                        @species.Name
-                                        @if (species.IsDefault)
-                                        {
-                                            <span class="profile-default-label">&#160;@Loc["Profile_FishingMethod_Default"]</span>
-                                        }
-                                    </MudChip>
-                                    <MudIconButton Icon="@Icons.Material.Filled.Close"
-                                                   Size="Size.Small"
-                                                   aria-label="@string.Format(Loc["Profile_FishingSpecies_Remove"], species.Name)"
-                                                   OnClick="@(() => RemoveSpeciesFromMethod(selectedMethod.FishingMethodId, species.SpeciesId))"
-                                                   id="@($"profile-species-remove-{selectedMethod.Code}-{species.Code}")" />
+                                    <span class="species-pill @(species.IsDefault ? "species-pill-secondary" : "species-pill-primary")"
+                                          id="@($"profile-species-pill-{selectedMethod.Code}-{species.Code}")">
+                                        <MudChip T="string"
+                                                 Color="@(species.IsDefault ? Color.Secondary : Color.Primary)"
+                                                 Variant="Variant.Filled"
+                                                 Icon="@(species.IsDefault ? Icons.Material.Filled.Star : null)"
+                                                 OnClick="@(() => SetDefaultSpeciesForMethod(selectedMethod.FishingMethodId, species.SpeciesId))"
+                                                 id="@($"profile-species-{selectedMethod.Code}-{species.Code}")">
+                                            @species.Name
+                                            @if (species.IsDefault)
+                                            {
+                                                <span class="profile-default-label">&#160;@Loc["Profile_FishingMethod_Default"]</span>
+                                            }
+                                        </MudChip>
+                                        <MudIconButton Icon="@Icons.Material.Filled.Cancel"
+                                                       Size="Size.Small"
+                                                       Color="Color.Inherit"
+                                                       Class="species-pill-remove"
+                                                       aria-label="@string.Format(Loc["Profile_FishingSpecies_Remove"], species.Name)"
+                                                       OnClick="@(() => RemoveSpeciesFromMethod(selectedMethod.FishingMethodId, species.SpeciesId))"
+                                                       id="@($"profile-species-remove-{selectedMethod.Code}-{species.Code}")" />
+                                    </span>
                                 }
                                 <MudButton Size="Size.Small"
                                            Variant="Variant.Outlined"

--- a/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor.css
+++ b/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor.css
@@ -16,6 +16,46 @@
     gap: 0.75rem;
 }
 
+.species-pill {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;
+    overflow: hidden;
+}
+
+.species-pill-primary {
+    background-color: var(--mud-palette-primary);
+    color: var(--mud-palette-primary-text);
+}
+
+.species-pill-secondary {
+    background-color: var(--mud-palette-secondary);
+    color: var(--mud-palette-secondary-text);
+}
+
+::deep .species-pill .mud-chip {
+    margin: 0;
+    border-radius: 9999px 0 0 9999px;
+    padding-right: 0;
+}
+
+::deep .species-pill .species-pill-remove {
+    position: relative;
+    z-index: 1;
+    width: 1.125rem;
+    height: 1.125rem;
+    padding: 0.0625rem;
+    margin-left: 0.25rem;
+    margin-right: 0.5rem;
+    border-radius: 0 9999px 9999px 0;
+}
+
+::deep .species-pill .species-pill-remove::before {
+    content: "";
+    position: absolute;
+    inset: -0.4375rem;
+}
+
 .profile-photo-picker {
     flex: 1;
     display: inline-flex;

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -692,5 +692,6 @@
   <data name="Install_OtherStep2" xml:space="preserve"><value>Si aucune icône n’apparaît, ouvrez le menu du navigateur et recherchez Installer l’application ou Ajouter à l’écran d’accueil. Si aucune option n’est proposée, vous pouvez continuer dans le navigateur.</value></data>
   <data name="Install_Later" xml:space="preserve"><value>L’installation est facultative. Vous pouvez continuer et retrouver ces instructions plus tard depuis le menu de l’application.</value></data>
   <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choisissez au moins une méthode de pêche.</value></data>
-  <data name="Onboarding_ValidationSpecies" xml:space="preserve"><value>Choisissez au moins une espèce.</value></data>
+  <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choisissez au moins une espèce pour {0}.</value></data>
+  <data name="Onboarding_ValidationSpeciesForMethods" xml:space="preserve"><value>Choisissez au moins une espèce pour chacune de ces méthodes de pêche : {0}.</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -663,4 +663,34 @@
   <data name="Modal_ShowingLimited" xml:space="preserve"><value>Affichage de {0} sur {1} {2}. Recherchez pour en trouver davantage.</value></data>
   <data name="Modal_Species" xml:space="preserve"><value>espèces</value></data>
   <data name="Modal_FishingMethods" xml:space="preserve"><value>méthodes de pêche</value></data>
+  <data name="Install_Title" xml:space="preserve"><value>Installer Catch, But Don’t Forget</value></data>
+  <data name="Install_Benefit" xml:space="preserve"><value>Installez l’application pour y accéder rapidement depuis votre appareil et profiter d’une expérience plus fiable lorsque vous pêchez.</value></data>
+  <data name="Install_NativeAvailable" xml:space="preserve"><value>Votre navigateur peut installer l’application pour vous.</value></data>
+  <data name="Install_Action" xml:space="preserve"><value>Installer l’application</value></data>
+  <data name="Install_Dismissed" xml:space="preserve"><value>L’application n’a pas été installée. Vous pouvez réessayer ou continuer et l’installer plus tard.</value></data>
+  <data name="Install_InstalledTitle" xml:space="preserve"><value>L’application est installée</value></data>
+  <data name="Install_InstalledBody" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget depuis votre écran d’accueil comme vos autres applications.</value></data>
+  <data name="Install_InstalledWindows" xml:space="preserve"><value>Vous pouvez maintenant ouvrir Catch, But Don’t Forget comme une application Windows normale depuis le menu Démarrer ou la recherche, puis l’épingler où vous le souhaitez.</value></data>
+  <data name="Install_IosHeading" xml:space="preserve"><value>Ajouter l’application à l’écran d’accueil</value></data>
+  <data name="Install_IosUseSafari" xml:space="preserve"><value>Pour une installation fiable sur iPhone ou iPad, ouvrez d’abord ce site dans Safari.</value></data>
+  <data name="Install_IosStep1" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget dans Safari.</value></data>
+  <data name="Install_IosStep2" xml:space="preserve"><value>Touchez Partager.</value></data>
+  <data name="Install_IosStep3" xml:space="preserve"><value>Choisissez Sur l’écran d’accueil.</value></data>
+  <data name="Install_IosStep4" xml:space="preserve"><value>Touchez Ajouter.</value></data>
+  <data name="Install_IosStep5" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget depuis sa nouvelle icône sur l’écran d’accueil.</value></data>
+  <data name="Install_AndroidHeading" xml:space="preserve"><value>Installer depuis le menu du navigateur</value></data>
+  <data name="Install_AndroidAlternative" xml:space="preserve"><value>Vous ne voyez pas d’option d’installation près de la barre d’adresse ? Vous pouvez toujours installer l’application depuis le menu du navigateur.</value></data>
+  <data name="Install_AndroidStep1" xml:space="preserve"><value>Ouvrez le menu de votre navigateur.</value></data>
+  <data name="Install_AndroidStep2" xml:space="preserve"><value>Choisissez l’option Installer l’application ou Ajouter à l’écran d’accueil. Le libellé peut varier selon le navigateur.</value></data>
+  <data name="Install_AndroidStep3" xml:space="preserve"><value>Confirmez, puis ouvrez Catch, But Don’t Forget depuis votre écran d’accueil.</value></data>
+  <data name="Install_WindowsHeading" xml:space="preserve"><value>Installer sous Windows</value></data>
+  <data name="Install_WindowsStep1" xml:space="preserve"><value>Dans Edge ou Chrome, ouvrez le menu du navigateur et recherchez son option d’installation d’application.</value></data>
+  <data name="Install_WindowsStep2" xml:space="preserve"><value>Après l’installation, ouvrez l’application depuis le menu Démarrer ou la recherche, puis épinglez-la où vous le souhaitez.</value></data>
+  <data name="Install_OtherHeading" xml:space="preserve"><value>Installer depuis votre navigateur</value></data>
+  <data name="Install_Unsupported" xml:space="preserve"><value>Votre navigateur peut proposer l’installation sans afficher de bouton sur cette page.</value></data>
+  <data name="Install_OtherStep1" xml:space="preserve"><value>Recherchez une icône d’installation dans la barre d’adresse et sélectionnez-la.</value></data>
+  <data name="Install_OtherStep2" xml:space="preserve"><value>Si aucune icône n’apparaît, ouvrez le menu du navigateur et recherchez Installer l’application ou Ajouter à l’écran d’accueil. Si aucune option n’est proposée, vous pouvez continuer dans le navigateur.</value></data>
+  <data name="Install_Later" xml:space="preserve"><value>L’installation est facultative. Vous pouvez continuer et retrouver ces instructions plus tard depuis le menu de l’application.</value></data>
+  <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choisissez au moins une méthode de pêche.</value></data>
+  <data name="Onboarding_ValidationSpecies" xml:space="preserve"><value>Choisissez au moins une espèce.</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -663,4 +663,34 @@
   <data name="Modal_ShowingLimited" xml:space="preserve"><value>Showing {0} of {1} {2}. Search to find more.</value></data>
   <data name="Modal_Species" xml:space="preserve"><value>species</value></data>
   <data name="Modal_FishingMethods" xml:space="preserve"><value>fishing methods</value></data>
+  <data name="Install_Title" xml:space="preserve"><value>Install Catch, But Don’t Forget</value></data>
+  <data name="Install_Benefit" xml:space="preserve"><value>Install the app for quick access from your device and a more reliable experience when you are out fishing.</value></data>
+  <data name="Install_NativeAvailable" xml:space="preserve"><value>Your browser can install the app for you.</value></data>
+  <data name="Install_Action" xml:space="preserve"><value>Install app</value></data>
+  <data name="Install_Dismissed" xml:space="preserve"><value>The app was not installed. You can try again or continue and install it later.</value></data>
+  <data name="Install_InstalledTitle" xml:space="preserve"><value>The app is installed</value></data>
+  <data name="Install_InstalledBody" xml:space="preserve"><value>Open Catch, But Don’t Forget from your home screen like your other apps.</value></data>
+  <data name="Install_InstalledWindows" xml:space="preserve"><value>You can now open Catch, But Don’t Forget like a normal Windows app from Start or search, and pin it where convenient.</value></data>
+  <data name="Install_IosHeading" xml:space="preserve"><value>Add the app to your Home Screen</value></data>
+  <data name="Install_IosUseSafari" xml:space="preserve"><value>For the reliable install option on iPhone or iPad, open this site in Safari first.</value></data>
+  <data name="Install_IosStep1" xml:space="preserve"><value>Open Catch, But Don’t Forget in Safari.</value></data>
+  <data name="Install_IosStep2" xml:space="preserve"><value>Tap Share.</value></data>
+  <data name="Install_IosStep3" xml:space="preserve"><value>Choose Add to Home Screen.</value></data>
+  <data name="Install_IosStep4" xml:space="preserve"><value>Tap Add.</value></data>
+  <data name="Install_IosStep5" xml:space="preserve"><value>Open Catch, But Don’t Forget from its new Home Screen icon.</value></data>
+  <data name="Install_AndroidHeading" xml:space="preserve"><value>Install from your browser menu</value></data>
+  <data name="Install_AndroidAlternative" xml:space="preserve"><value>Can’t see an install option near the address bar? You can still install the app from the browser menu.</value></data>
+  <data name="Install_AndroidStep1" xml:space="preserve"><value>Open your browser menu.</value></data>
+  <data name="Install_AndroidStep2" xml:space="preserve"><value>Choose the option called Install app or Add to Home screen. The wording may vary by browser.</value></data>
+  <data name="Install_AndroidStep3" xml:space="preserve"><value>Follow the confirmation, then open Catch, But Don’t Forget from your Home Screen.</value></data>
+  <data name="Install_WindowsHeading" xml:space="preserve"><value>Install on Windows</value></data>
+  <data name="Install_WindowsStep1" xml:space="preserve"><value>In Edge or Chrome, open the browser menu and look for its app installation option.</value></data>
+  <data name="Install_WindowsStep2" xml:space="preserve"><value>After installation, open the app from Start or search and pin it where convenient.</value></data>
+  <data name="Install_OtherHeading" xml:space="preserve"><value>Install from your browser</value></data>
+  <data name="Install_Unsupported" xml:space="preserve"><value>Your browser may offer installation without showing a button on this page.</value></data>
+  <data name="Install_OtherStep1" xml:space="preserve"><value>Look for an install icon in the address bar and select it.</value></data>
+  <data name="Install_OtherStep2" xml:space="preserve"><value>If there is no icon, open the browser menu and look for Install app or Add to Home screen. If neither option appears, you can keep using the app in your browser.</value></data>
+  <data name="Install_Later" xml:space="preserve"><value>Installation is optional. You can continue now and find this guidance again from the app menu.</value></data>
+  <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choose at least one fishing method.</value></data>
+  <data name="Onboarding_ValidationSpecies" xml:space="preserve"><value>Choose at least one species.</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -692,5 +692,6 @@
   <data name="Install_OtherStep2" xml:space="preserve"><value>If there is no icon, open the browser menu and look for Install app or Add to Home screen. If neither option appears, you can keep using the app in your browser.</value></data>
   <data name="Install_Later" xml:space="preserve"><value>Installation is optional. You can continue now and find this guidance again from the app menu.</value></data>
   <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choose at least one fishing method.</value></data>
-  <data name="Onboarding_ValidationSpecies" xml:space="preserve"><value>Choose at least one species.</value></data>
+  <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choose at least one species for {0}.</value></data>
+  <data name="Onboarding_ValidationSpeciesForMethods" xml:space="preserve"><value>Choose at least one species for each of these fishing methods: {0}.</value></data>
 </root>

--- a/src/FishingLogBook.Web/wwwroot/js/browser/install.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/install.js
@@ -1,8 +1,14 @@
 let deferredInstallPrompt;
+let appInstalled = false;
 
 window.addEventListener('beforeinstallprompt', event => {
     event.preventDefault();
     deferredInstallPrompt = event;
+});
+
+window.addEventListener('appinstalled', () => {
+    appInstalled = true;
+    deferredInstallPrompt = undefined;
 });
 
 export function detectInstallState(navigatorValue, matchMediaValue, canPrompt) {
@@ -11,23 +17,30 @@ export function detectInstallState(navigatorValue, matchMediaValue, canPrompt) {
     const isIos = /iPad|iPhone|iPod/.test(userAgent) ||
         (platform === 'MacIntel' && navigatorValue.maxTouchPoints > 1);
     const isAndroid = /Android/i.test(userAgent);
-    const isInstalled = Boolean(navigatorValue.standalone) ||
+    const isWindows = /Windows/i.test(userAgent) || /^Win/i.test(platform);
+    const isSafari = isIos && /Safari/i.test(userAgent) &&
+        !/CriOS|FxiOS|EdgiOS|OPiOS/i.test(userAgent);
+    const isInstalled = appInstalled || Boolean(navigatorValue.standalone) ||
         Boolean(matchMediaValue('(display-mode: standalone)').matches);
-    return { isInstalled, canPrompt: canPrompt && !isInstalled, isIos, isAndroid };
+    const platformFamily = isIos ? 'iOS' : isAndroid ? 'Android' : isWindows ? 'Windows' : 'Other';
+    return { isInstalled, canPrompt: canPrompt && !isInstalled, platformFamily, isSafari };
 }
 
 export function getInstallState() {
-    return detectInstallState(navigator, window.matchMedia.bind(window), Boolean(deferredInstallPrompt));
+    const matchMedia = typeof window.matchMedia === 'function'
+        ? window.matchMedia.bind(window)
+        : () => ({ matches: false });
+    return detectInstallState(navigator, matchMedia, Boolean(deferredInstallPrompt));
 }
 
 export async function promptInstall() {
     if (!deferredInstallPrompt) {
-        return false;
+        return 'unavailable';
     }
 
     const prompt = deferredInstallPrompt;
     deferredInstallPrompt = undefined;
     await prompt.prompt();
     const choice = await prompt.userChoice;
-    return choice.outcome === 'accepted';
+    return choice.outcome === 'accepted' ? 'accepted' : 'dismissed';
 }

--- a/src/FishingLogBook.Web/wwwroot/js/browser/install.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/install.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { detectInstallState } from './install.js';
+import { detectInstallState, getInstallState, promptInstall } from './install.js';
 
 describe('install detection', () => {
     it('detects an installed standalone app', () => {
@@ -8,7 +8,7 @@ describe('install detection', () => {
             () => ({ matches: true }),
             true);
 
-        expect(state).toEqual({ isInstalled: true, canPrompt: false, isIos: false, isAndroid: false });
+        expect(state).toEqual({ isInstalled: true, canPrompt: false, platformFamily: 'Windows', isSafari: false });
     });
 
     it('provides iOS instructions without showing a fake prompt', () => {
@@ -17,7 +17,19 @@ describe('install detection', () => {
             () => ({ matches: false }),
             false);
 
-        expect(state.isIos).toBe(true);
+        expect(state.platformFamily).toBe('iOS');
+        expect(state.isSafari).toBe(false);
+        expect(state.canPrompt).toBe(false);
+    });
+
+    it('detects an iOS app already running from the Home Screen', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (iPhone)', platform: 'iPhone', maxTouchPoints: 5, standalone: true },
+            () => ({ matches: false }),
+            true);
+
+        expect(state.isInstalled).toBe(true);
+        expect(state.platformFamily).toBe('iOS');
         expect(state.canPrompt).toBe(false);
     });
 
@@ -27,7 +39,69 @@ describe('install detection', () => {
             () => ({ matches: false }),
             false);
 
-        expect(state.isAndroid).toBe(true);
+        expect(state.platformFamily).toBe('Android');
         expect(state.canPrompt).toBe(false);
+    });
+
+    it('recognises Safari on iPhone without pretending a native prompt exists', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 Safari/604.1', platform: 'iPhone', maxTouchPoints: 5 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('iOS');
+        expect(state.isSafari).toBe(true);
+        expect(state.canPrompt).toBe(false);
+    });
+
+    it('detects Windows with a captured native prompt', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (Windows NT 10.0) Chrome/140', platform: 'Win32', maxTouchPoints: 0 },
+            () => ({ matches: false }),
+            true);
+
+        expect(state.platformFamily).toBe('Windows');
+        expect(state.canPrompt).toBe(true);
+    });
+
+    it('falls back safely for an unknown browser', () => {
+        const state = detectInstallState(
+            { userAgent: 'Unknown', platform: 'Unknown', maxTouchPoints: 0 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('Other');
+        expect(state.canPrompt).toBe(false);
+    });
+
+    it('returns unavailable when no native prompt was captured', async () => {
+        expect(await promptInstall()).toBe('unavailable');
+    });
+
+    it('returns accepted and consumes the captured native prompt', async () => {
+        const event = new Event('beforeinstallprompt');
+        event.prompt = () => Promise.resolve();
+        event.userChoice = Promise.resolve({ outcome: 'accepted' });
+        window.dispatchEvent(event);
+
+        expect(getInstallState().canPrompt).toBe(true);
+        expect(await promptInstall()).toBe('accepted');
+        expect(await promptInstall()).toBe('unavailable');
+    });
+
+    it('returns dismissed without treating dismissal as an error', async () => {
+        const event = new Event('beforeinstallprompt');
+        event.prompt = () => Promise.resolve();
+        event.userChoice = Promise.resolve({ outcome: 'dismissed' });
+        window.dispatchEvent(event);
+
+        expect(await promptInstall()).toBe('dismissed');
+    });
+
+    it('updates to installed when the browser reports app installation', () => {
+        window.dispatchEvent(new Event('appinstalled'));
+
+        expect(getInstallState().isInstalled).toBe(true);
+        expect(getInstallState().canPrompt).toBe(false);
     });
 });

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingRender.cs
@@ -1,0 +1,175 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Browser.Install;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallGuidanceTests;
+
+public class WhenTestingRender
+{
+    [Fact]
+    public void ItShouldShowIosSafariInstructions()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        using var context = CreateContext(new InstallState(false, false, InstallPlatformFamilies.Ios, true));
+
+        var cut = context.Render<InstallGuidance>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.FindAll("#install-guidance-ios-browser").Should().BeEmpty();
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+        });
+    }
+
+    [Fact]
+    public void ItShouldTellIosUsersInAnotherBrowserToUseSafari()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        using var context = CreateContext(new InstallState(false, false, InstallPlatformFamilies.Ios, false));
+
+        var cut = context.Render<InstallGuidance>();
+
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-ios-browser").TextContent.Should().Contain("Safari"));
+    }
+
+    [Theory]
+    [InlineData(InstallPlatformFamilies.Android, "#install-guidance-android-steps")]
+    [InlineData(InstallPlatformFamilies.Windows, "#install-guidance-windows-steps")]
+    public void ItShouldShowPlatformFallbackInstructionsWhenNoPromptExists(string platform, string selector)
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        using var context = CreateContext(new InstallState(false, false, platform, false));
+
+        var cut = context.Render<InstallGuidance>();
+
+        cut.WaitForAssertion(() => cut.Find(selector).Should().NotBeNull());
+    }
+
+    [Fact]
+    public void ItShouldShowBothAndroidInstallRoutesWhenTheNativePromptExists()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        using var context = CreateContext(new InstallState(false, true, InstallPlatformFamilies.Android, false));
+
+        var cut = context.Render<InstallGuidance>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-action").Should().NotBeNull();
+            cut.Find("#install-guidance-android-alternative").TextContent
+                .Should().Contain("browser menu");
+            cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(3);
+        });
+    }
+
+    [Fact]
+    public void ItShouldShowTheUnknownBrowserFallback()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        using var context = CreateContext(new InstallState(false, false, InstallPlatformFamilies.Other, false));
+
+        var cut = context.Render<InstallGuidance>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-unsupported").TextContent
+                .Should().Contain("without showing a button");
+            cut.Find("#install-guidance-other-steps").TextContent
+                .Should().Contain("install icon").And.Contain("browser menu");
+        });
+    }
+
+    [Fact]
+    public void ItShouldShowTheAlreadyInstalledStateWithoutInstructions()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        using var context = CreateContext(new InstallState(true, false, InstallPlatformFamilies.Ios, true));
+
+        var cut = context.Render<InstallGuidance>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-installed").Should().NotBeNull();
+            cut.FindAll("#install-guidance-ios-steps").Should().BeEmpty();
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldUpdateToInstalledAfterTheNativePromptIsAccepted()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = Substitute.For<IInstallService>();
+        service.GetStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new InstallState(false, true, InstallPlatformFamilies.Windows, false));
+        service.PromptAsync(Arg.Any<CancellationToken>()).Returns(InstallResult.Accepted);
+        await using var context = CreateContext(service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+
+        await cut.Find("#install-guidance-action").ClickAsync();
+
+        cut.WaitForAssertion(() =>
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("Windows"));
+        await service.Received(1).PromptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepGuidanceUsableWhenTheNativePromptIsDismissed()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = Substitute.For<IInstallService>();
+        var state = new InstallState(false, true, InstallPlatformFamilies.Android, false);
+        service.GetStateAsync(Arg.Any<CancellationToken>()).Returns(state);
+        service.PromptAsync(Arg.Any<CancellationToken>()).Returns(InstallResult.Dismissed);
+        await using var context = CreateContext(service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+
+        await cut.Find("#install-guidance-action").ClickAsync();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-dismissed").Should().NotBeNull();
+            cut.Find("#install-guidance-action").Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public void ItShouldShowFrenchGuidance()
+    {
+        using var culture = TestCulture.Use(CultureNames.French);
+        using var context = CreateContext(new InstallState(false, false, InstallPlatformFamilies.Windows, false));
+
+        var cut = context.Render<InstallGuidance>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-title").TextContent.Should().Contain("Installer");
+            cut.Find("#install-guidance-windows-heading").TextContent.Should().Contain("Windows");
+        });
+    }
+
+    private static BunitContext CreateContext(InstallState state)
+    {
+        var service = Substitute.For<IInstallService>();
+        service.GetStateAsync(Arg.Any<CancellationToken>()).Returns(state);
+        return CreateContext(service);
+    }
+
+    private static BunitContext CreateContext(IInstallService service)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        context.Services.AddSingleton(service);
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
@@ -7,6 +7,7 @@ using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Onboarding.Services;
 using FishingLogBook.Web.Features.Profile.Clients;
 using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
 using NSubstitute;
@@ -18,6 +19,7 @@ public class WhenTestingPreferences
 {
     private static readonly Guid FlyMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
     private static readonly Guid SpinningMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000002");
+    private static readonly Guid BrownTroutSpeciesId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
 
     [Fact]
     public async Task ItShouldUseTheReusableMultiSelectWithExistingMethodsSelected()
@@ -52,6 +54,156 @@ public class WhenTestingPreferences
                     && model.SelectedOptionIds != null
                     && model.SelectedOptionIds.Contains(FlyMethodId)),
                 Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRequireAtLeastOneFishingMethod()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(new FishingPreferencesDto([]));
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        cut.WaitForAssertion(() =>
+            cut.Find("#onboarding-preference-validation").TextContent
+                .Should().Contain("Choose at least one fishing method."));
+        cut.Find("#onboarding-method-chips").Should().NotBeNull();
+        await fixture.Preferences.DidNotReceive().UpdatePreferencesAsync(
+            Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRequireAtLeastOneSpeciesOverall()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(PreferencesWithoutSpecies());
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        cut.WaitForAssertion(() =>
+            cut.Find("#onboarding-preference-validation").TextContent
+                .Should().Contain("Choose at least one species."));
+        await fixture.Preferences.DidNotReceive().UpdatePreferencesAsync(
+            Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAdvanceAndPersistCanonicalPreferenceIdentityWhenRequirementsAreMet()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(ValidPreferences());
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        cut.WaitForAssertion(() => cut.Find("#onboarding-allow-location").Should().NotBeNull());
+        await fixture.Preferences.Received(1).UpdatePreferencesAsync(
+            Arg.Is<UpdateFishingPreferencesDto>(update =>
+                update.Methods.Count == 1
+                && update.Methods[0].FishingMethodId == FlyMethodId
+                && update.Methods[0].Species.Count == 1
+                && update.Methods[0].Species[0].SpeciesId == BrownTroutSpeciesId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheRemoveActionInsideTheSelectedSpeciesPill()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(ValidPreferences());
+        var cut = fixture.Context.Render<OnboardingPage>();
+        await MoveToPreferencesAsync(cut);
+
+        // Act
+        var pill = cut.Find("#onboarding-species-pill-Fly-BrownTrout");
+        pill.QuerySelector("#onboarding-species-Fly-BrownTrout").Should().NotBeNull();
+        var remove = pill.QuerySelector("#onboarding-species-remove-Fly-BrownTrout");
+        remove.Should().NotBeNull();
+        remove!.ClassList.Should().Contain("mud-inherit-text");
+        await remove.ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.FindAll("#onboarding-species-Fly-BrownTrout").Should().BeEmpty());
+    }
+
+    [Theory]
+    [InlineData(false, "Choisissez au moins une méthode de pêche.")]
+    [InlineData(true, "Choisissez au moins une espèce.")]
+    public async Task ItShouldLocalisePreferenceValidation(bool hasMethod, string expected)
+    {
+        using var culture = TestCulture.Use(CultureNames.French);
+        var preferences = hasMethod ? PreferencesWithoutSpecies() : new FishingPreferencesDto([]);
+        await using var fixture = CreateFixture(preferences);
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        cut.WaitForAssertion(() =>
+            cut.Find("#onboarding-preference-validation").TextContent.Should().Contain(expected));
+    }
+
+    [Fact]
+    public async Task ItShouldAllowInstallationToBeSkippedAfterRequiredPreferencesAreSaved()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(ValidPreferences());
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#onboarding-skip-location"));
+        await cut.Find("#onboarding-skip-location").ClickAsync();
+        await cut.Find("#onboarding-next").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-later").Should().NotBeNull());
+        await cut.Find("#onboarding-finish").ClickAsync();
+
+        await fixture.Onboarding.Received(1).CompleteAsync(Arg.Any<CancellationToken>());
+        fixture.Context.Services.GetRequiredService<NavigationManager>().Uri.Should().EndWith("/catches");
+        await fixture.Install.DidNotReceive().PromptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldUpdateTheOnboardingInstallStepAfterInstallationSucceeds()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(
+            ValidPreferences(),
+            installState: new InstallState(false, true, InstallPlatformFamilies.Windows, false),
+            installResult: InstallResult.Accepted);
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#onboarding-skip-location"));
+        await cut.Find("#onboarding-skip-location").ClickAsync();
+        await cut.Find("#onboarding-next").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+        await cut.Find("#install-guidance-action").ClickAsync();
+
+        cut.WaitForAssertion(() =>
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("installed"));
+        await fixture.Install.Received(1).PromptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotRevalidateUsersWhoAlreadyCompletedOnboarding()
+    {
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(new FishingPreferencesDto([]), isCompleted: true);
+
+        fixture.Context.Render<OnboardingPage>();
+
+        fixture.Context.Services.GetRequiredService<NavigationManager>().Uri.Should().EndWith("/catches");
+        await fixture.Preferences.DidNotReceive().GetPreferencesAsync(Arg.Any<CancellationToken>());
+        await fixture.Onboarding.DidNotReceive().CompleteAsync(Arg.Any<CancellationToken>());
     }
 
     private static BunitContext CreateContext(IModalService modal)
@@ -91,5 +243,89 @@ public class WhenTestingPreferences
         context.Services.AddSingleton(Substitute.For<ILocationService>());
         context.AddAuthorization().SetAuthorized("tester@example.test");
         return context;
+    }
+
+    private static async Task MoveToPreferencesAsync(IRenderedComponent<OnboardingPage> cut)
+    {
+        cut.WaitForAssertion(() => cut.Find("#onboarding-next"));
+        await cut.Find("#onboarding-next").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#onboarding-method-chips"));
+    }
+
+    private static FishingPreferencesDto PreferencesWithoutSpecies()
+    {
+        return new FishingPreferencesDto(
+        [
+            new FishingMethodPreferenceDto(FlyMethodId, "Fly", "Fly", true, [])
+        ]);
+    }
+
+    private static FishingPreferencesDto ValidPreferences()
+    {
+        return new FishingPreferencesDto(
+        [
+            new FishingMethodPreferenceDto(
+                FlyMethodId,
+                "Fly",
+                "Fly",
+                true,
+                [new FishingSpeciesPreferenceDto(BrownTroutSpeciesId, "BrownTrout", "Brown Trout", true)])
+        ]);
+    }
+
+    private static Fixture CreateFixture(
+        FishingPreferencesDto savedPreferences,
+        bool isCompleted = false,
+        InstallState? installState = null,
+        InstallResult installResult = InstallResult.Unavailable)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        context.Services.AddSingleton(Substitute.For<IModalService>());
+
+        var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.IsCompletedAsync(Arg.Any<CancellationToken>()).Returns(isCompleted);
+        context.Services.AddSingleton(onboarding);
+
+        var profileDto = new ProfileDto(
+            Guid.NewGuid(), null, null, null, null, null, true, false, false, false, false);
+        var profile = Substitute.For<IProfileClient>();
+        profile.GetOwnAsync(Arg.Any<CancellationToken>()).Returns(profileDto);
+        profile.UpdateOwnAsync(Arg.Any<UpdateProfileDto>(), Arg.Any<CancellationToken>()).Returns(profileDto);
+        context.Services.AddSingleton(profile);
+
+        var preferences = Substitute.For<IFishingPreferenceClient>();
+        preferences.GetCatalogueAsync(Arg.Any<CancellationToken>()).Returns(new FishingCatalogueDto(
+            [
+                new FishingMethodDto(FlyMethodId, "Fly", "Fly"),
+                new FishingMethodDto(SpinningMethodId, "Spinning", "Spinning")
+            ],
+            [new SpeciesDto(BrownTroutSpeciesId, "BrownTrout", "Brown Trout")]));
+        preferences.GetPreferencesAsync(Arg.Any<CancellationToken>()).Returns(savedPreferences);
+        preferences.UpdatePreferencesAsync(
+                Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>())
+            .Returns(savedPreferences);
+        context.Services.AddSingleton(preferences);
+
+        var install = Substitute.For<IInstallService>();
+        install.GetStateAsync(Arg.Any<CancellationToken>())
+            .Returns(installState ?? new InstallState(false, false, InstallPlatformFamilies.Other, false));
+        install.PromptAsync(Arg.Any<CancellationToken>()).Returns(installResult);
+        context.Services.AddSingleton(install);
+        context.Services.AddSingleton(Substitute.For<ILocationService>());
+        context.AddAuthorization().SetAuthorized("tester@example.test");
+        return new Fixture(context, onboarding, preferences, install);
+    }
+
+    private sealed record Fixture(
+        BunitContext Context,
+        IOnboardingService Onboarding,
+        IFishingPreferenceClient Preferences,
+        IInstallService Install) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => Context.DisposeAsync();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
@@ -59,13 +59,16 @@ public class WhenTestingPreferences
     [Fact]
     public async Task ItShouldRequireAtLeastOneFishingMethod()
     {
+        // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         await using var fixture = CreateFixture(new FishingPreferencesDto([]));
         var cut = fixture.Context.Render<OnboardingPage>();
 
+        // Act
         await MoveToPreferencesAsync(cut);
         await cut.Find("#onboarding-next").ClickAsync();
 
+        // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#onboarding-preference-validation").TextContent
                 .Should().Contain("Choose at least one fishing method."));
@@ -75,18 +78,65 @@ public class WhenTestingPreferences
     }
 
     [Fact]
-    public async Task ItShouldRequireAtLeastOneSpeciesOverall()
+    public async Task ItShouldRequireAtLeastOneSpeciesForTheSelectedMethod()
     {
+        // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         await using var fixture = CreateFixture(PreferencesWithoutSpecies());
         var cut = fixture.Context.Render<OnboardingPage>();
 
+        // Act
         await MoveToPreferencesAsync(cut);
         await cut.Find("#onboarding-next").ClickAsync();
 
+        // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#onboarding-preference-validation").TextContent
-                .Should().Contain("Choose at least one species."));
+                .Should().Contain("Choose at least one species for Fly."));
+        await fixture.Preferences.DidNotReceive().UpdatePreferencesAsync(
+            Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldIdentifyASelectedMethodWithoutSpecies()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(TwoMethodPreferences(spinningHasSpecies: false));
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        // Act
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#onboarding-preference-validation").TextContent
+                .Should().Contain("Choose at least one species for Spinning."));
+        await fixture.Preferences.DidNotReceive().UpdatePreferencesAsync(
+            Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldListAllSelectedMethodsWithoutSpecies()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var preferences = new FishingPreferencesDto(
+        [
+            new FishingMethodPreferenceDto(FlyMethodId, "Fly", "Fly", true, []),
+            new FishingMethodPreferenceDto(SpinningMethodId, "Spinning", "Spinning", false, [])
+        ]);
+        await using var fixture = CreateFixture(preferences);
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        // Act
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#onboarding-preference-validation").TextContent.Should().Contain("Fly, Spinning"));
         await fixture.Preferences.DidNotReceive().UpdatePreferencesAsync(
             Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>());
     }
@@ -94,13 +144,16 @@ public class WhenTestingPreferences
     [Fact]
     public async Task ItShouldAdvanceAndPersistCanonicalPreferenceIdentityWhenRequirementsAreMet()
     {
+        // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         await using var fixture = CreateFixture(ValidPreferences());
         var cut = fixture.Context.Render<OnboardingPage>();
 
+        // Act
         await MoveToPreferencesAsync(cut);
         await cut.Find("#onboarding-next").ClickAsync();
 
+        // Assert
         cut.WaitForAssertion(() => cut.Find("#onboarding-allow-location").Should().NotBeNull());
         await fixture.Preferences.Received(1).UpdatePreferencesAsync(
             Arg.Is<UpdateFishingPreferencesDto>(update =>
@@ -108,6 +161,27 @@ public class WhenTestingPreferences
                 && update.Methods[0].FishingMethodId == FlyMethodId
                 && update.Methods[0].Species.Count == 1
                 && update.Methods[0].Species[0].SpeciesId == BrownTroutSpeciesId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAdvanceWhenEverySelectedMethodHasSpecies()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(TwoMethodPreferences(spinningHasSpecies: true));
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        // Act
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#onboarding-allow-location").Should().NotBeNull());
+        await fixture.Preferences.Received(1).UpdatePreferencesAsync(
+            Arg.Is<UpdateFishingPreferencesDto>(update =>
+                update.Methods.Count == 2
+                && update.Methods.All(method => method.Species.Count == 1)),
             Arg.Any<CancellationToken>());
     }
 
@@ -133,21 +207,46 @@ public class WhenTestingPreferences
             cut.FindAll("#onboarding-species-Fly-BrownTrout").Should().BeEmpty());
     }
 
-    [Theory]
-    [InlineData(false, "Choisissez au moins une méthode de pêche.")]
-    [InlineData(true, "Choisissez au moins une espèce.")]
-    public async Task ItShouldLocalisePreferenceValidation(bool hasMethod, string expected)
+    [Fact]
+    public async Task ItShouldLocaliseTheIncompleteMethodValidation()
     {
+        // Arrange
         using var culture = TestCulture.Use(CultureNames.French);
-        var preferences = hasMethod ? PreferencesWithoutSpecies() : new FishingPreferencesDto([]);
+        var preferences = PreferencesWithoutSpecies("Pêche à la mouche");
         await using var fixture = CreateFixture(preferences);
         var cut = fixture.Context.Render<OnboardingPage>();
 
+        // Act
         await MoveToPreferencesAsync(cut);
         await cut.Find("#onboarding-next").ClickAsync();
 
+        // Assert
         cut.WaitForAssertion(() =>
-            cut.Find("#onboarding-preference-validation").TextContent.Should().Contain(expected));
+            cut.Find("#onboarding-preference-validation").TextContent
+                .Should().Contain("Choisissez au moins une espèce pour Pêche à la mouche."));
+        await fixture.Preferences.DidNotReceive().UpdatePreferencesAsync(
+            Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldBecomeInvalidWhenTheLastSpeciesIsRemoved()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(ValidPreferences());
+        var cut = fixture.Context.Render<OnboardingPage>();
+        await MoveToPreferencesAsync(cut);
+
+        // Act
+        await cut.Find("#onboarding-species-remove-Fly-BrownTrout").ClickAsync();
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#onboarding-preference-validation").TextContent
+                .Should().Contain("Choose at least one species for Fly."));
+        await fixture.Preferences.DidNotReceive().UpdatePreferencesAsync(
+            Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -252,11 +351,11 @@ public class WhenTestingPreferences
         cut.WaitForAssertion(() => cut.Find("#onboarding-method-chips"));
     }
 
-    private static FishingPreferencesDto PreferencesWithoutSpecies()
+    private static FishingPreferencesDto PreferencesWithoutSpecies(string methodName = "Fly")
     {
         return new FishingPreferencesDto(
         [
-            new FishingMethodPreferenceDto(FlyMethodId, "Fly", "Fly", true, [])
+            new FishingMethodPreferenceDto(FlyMethodId, "Fly", methodName, true, [])
         ]);
     }
 
@@ -270,6 +369,22 @@ public class WhenTestingPreferences
                 "Fly",
                 true,
                 [new FishingSpeciesPreferenceDto(BrownTroutSpeciesId, "BrownTrout", "Brown Trout", true)])
+        ]);
+    }
+
+    private static FishingPreferencesDto TwoMethodPreferences(bool spinningHasSpecies)
+    {
+        var species = new FishingSpeciesPreferenceDto(
+            BrownTroutSpeciesId, "BrownTrout", "Brown Trout", true);
+        return new FishingPreferencesDto(
+        [
+            new FishingMethodPreferenceDto(FlyMethodId, "Fly", "Fly", true, [species]),
+            new FishingMethodPreferenceDto(
+                SpinningMethodId,
+                "Spinning",
+                "Spinning",
+                false,
+                spinningHasSpecies ? [species] : [])
         ]);
     }
 


### PR DESCRIPTION
## Summary

- replace duplicated onboarding/menu install copy with one reusable install-guidance component and browser capability model
- provide localised iOS, Android, Windows, installed, dismissed and generic browser guidance
- support both Android native prompting and address-bar/browser-menu installation routes
- require at least one fishing method and one species before first-run onboarding can advance
- keep installation optional and preserve completed-user behaviour
- tidy removable preference pills consistently across onboarding and Profile

Closes #111

## Validation

- Release solution build: passed with 0 warnings and 0 errors
- FishingLogBook.Web.Tests: 584 passed
- Vitest browser/JavaScript suite: 165 passed
- focused final onboarding/Profile checks: 23 passed
- focused install/localisation checks: 12 passed
- solution-wide non-Docker tests: 1,053 passed
- Docker-backed infrastructure tests could not run because Docker was unavailable in the local environment

## Scope and deployment

- no database, schema, migration or seed changes
- no Terraform or deployment configuration changes
- no authentication changes
- no service-worker, registration, app-shell cache, Blazor bootstrap or index startup changes
- no screenshots introduced
- no manual post-merge configuration required

## Self review

- Issue/AC: PASS — reusable guidance covers the requested platforms and states; installation remains optional; additional required preference validation uses the existing canonical preference graph
- Architecture/CQRS: PASS — existing install abstraction was extended; no server/CQRS path changed
- Rules: PASS — Web component structure, localisation and focused tests follow repository conventions
- Security/privacy: PASS — no identity, permissions, location-sharing or private-data behaviour changed
- Database/migrations: N/A — none changed
- Tests/coverage: PASS — component, onboarding, localisation and JS capability behaviour covered; Docker-only infrastructure failures are environmental and unrelated
- Browser: PASS with manual verification remaining — lower-level JS and bUnit coverage is green; browser-owned native install UI cannot be automated reliably by the current authenticated Playwright harness
- Web/UI/localisation: PASS — all new copy has EN/FR resources; mobile touch targets and keyboard-accessible controls retained
- Code smells: PASS — platform detection and raw JS remain isolated; no duplicate install logic
- CI/deployment: PASS — no infrastructure or environment changes required

## Findings discovered during self-review

1. Chrome can expose an address-bar install icon without exposing a programmatic prompt to the app.
2. A separate close button could wrap away from its selected-species pill.

## Fixes made

1. Added neutral address-bar and browser-menu fallback guidance instead of incorrectly claiming installation is unavailable.
2. Unified each selected pill and remove action visually and as a non-breaking layout unit while preserving default-species selection and accessible removal.

## Remaining deliberate gaps

- Manual checks after deployment are still required on iPhone Safari, Android Chrome, and Windows Edge/Chrome.
- Full browser-owned native prompt UI is intentionally not automated; adding test-only authentication or a second host solely for this ticket would be disproportionate.
