### PR TITLE
FLB#114 | prepare production v0.1 repository support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -50,6 +50,21 @@ jobs:
       - name: Test JavaScript
         run: npm test
 
+  deployment-config-test:
+    name: Deployment configuration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: >-
+          node --test
+          src/FishingLogBook.Web/build/configure-web.test.mjs
+          src/FishingLogBook.Root/build/root-site.test.mjs
+
   javascript-browser-test:
     name: JavaScript browser tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,133 @@
+name: deploy-production
+
+# Repository deployment only. Production infrastructure and database migrations remain
+# deliberate manual operations and must be complete before this workflow is approved.
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Production deployment target
+        required: true
+        type: choice
+        options:
+          - web
+          - api
+          - root
+
+concurrency:
+  group: deploy-production-${{ inputs.target }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet restore FishingLogBook.sln
+      - run: dotnet build FishingLogBook.sln --configuration Release --no-restore
+      - run: dotnet test FishingLogBook.sln --configuration Release --no-build --verbosity normal
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Test deployment configuration guard
+        run: >-
+          node --test
+          src/FishingLogBook.Web/build/configure-web.test.mjs
+          src/FishingLogBook.Root/build/root-site.test.mjs
+
+  deploy-web:
+    name: Deploy production PWA
+    if: inputs.target == 'web'
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Create and validate production public configuration
+        env:
+          API_BASE_URL: ${{ vars.API_BASE_URL }}
+          AUTH_AUTHORITY: ${{ vars.AUTH_AUTHORITY }}
+          AUTH_CLIENT_ID: ${{ vars.AUTH_CLIENT_ID }}
+          AUTH_HOSTED_UI_DOMAIN: ${{ vars.AUTH_HOSTED_UI_DOMAIN }}
+          AUTH_API_SCOPE: ${{ vars.AUTH_API_SCOPE }}
+          AUTH_API_RESOURCE: ${{ vars.AUTH_API_RESOURCE }}
+        run: >-
+          node src/FishingLogBook.Web/build/configure-web.mjs
+          --environment prod
+          --template src/FishingLogBook.Web/wwwroot/appsettings.Production.json
+          --output src/FishingLogBook.Web/wwwroot/appsettings.Production.json
+      - run: dotnet publish src/FishingLogBook.Web --configuration Release -o artifacts/web
+      - name: Revalidate published production artifact
+        env:
+          API_BASE_URL: ${{ vars.API_BASE_URL }}
+          AUTH_AUTHORITY: ${{ vars.AUTH_AUTHORITY }}
+          AUTH_CLIENT_ID: ${{ vars.AUTH_CLIENT_ID }}
+          AUTH_HOSTED_UI_DOMAIN: ${{ vars.AUTH_HOSTED_UI_DOMAIN }}
+          AUTH_API_SCOPE: ${{ vars.AUTH_API_SCOPE }}
+          AUTH_API_RESOURCE: ${{ vars.AUTH_API_RESOURCE }}
+        run: >-
+          node src/FishingLogBook.Web/build/configure-web.mjs
+          --environment prod
+          --template artifacts/web/wwwroot/appsettings.Production.json
+          --output artifacts/web/wwwroot/appsettings.Production.json
+          --artifact-root artifacts/web/wwwroot
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: '4.86.0'
+          command: pages deploy artifacts/web/wwwroot --project-name fishing-logbook-prod --branch main
+      - name: Smoke check branded PWA origin
+        run: curl -fsS --retry 8 --retry-all-errors --retry-delay 5 https://app.catchbutdontforget.com/ | grep -q FishingLogBook
+
+  deploy-api:
+    name: Deploy production API
+    if: inputs.target == 'api'
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+        with:
+          version: 0.4.82
+      - name: Deploy to existing production Fly app
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy . --config infrastructure/fly/fly.prod.toml --app fishing-logbook-prod-api --remote-only
+      - name: Smoke check branded API origin
+        run: |
+          set -euo pipefail
+          for url in https://api.catchbutdontforget.com/health https://api.catchbutdontforget.com/api/system/database
+          do
+            curl -fsS --retry 8 --retry-all-errors --retry-delay 5 "${url}" | grep -q '"status":"Healthy"'
+          done
+
+  deploy-root:
+    name: Deploy production root site
+    if: inputs.target == 'root'
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: '4.86.0'
+          command: pages deploy src/FishingLogBook.Root --project-name catch-but-dont-forget-root --branch main
+      - name: Smoke check root site
+        run: curl -fsS --retry 8 --retry-all-errors --retry-delay 5 https://catchbutdontforget.com/ | grep -q 'Open the app'

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -54,44 +54,17 @@ jobs:
       # set; missing values fail this step instead of emitting Dev defaults.
       - name: Apply public Auth configuration
         env:
+          API_BASE_URL: https://fishing-logbook-dev-api.fly.dev
           AUTH_AUTHORITY: ${{ vars.AUTH_AUTHORITY }}
           AUTH_CLIENT_ID: ${{ vars.AUTH_CLIENT_ID }}
           AUTH_HOSTED_UI_DOMAIN: ${{ vars.AUTH_HOSTED_UI_DOMAIN }}
           AUTH_API_SCOPE: ${{ vars.AUTH_API_SCOPE }}
           AUTH_API_RESOURCE: ${{ vars.AUTH_API_RESOURCE }}
-        run: |
-          python3 <<'PY'
-          import json
-          import os
-          import sys
-          from pathlib import Path
-
-          required = [
-              "AUTH_AUTHORITY",
-              "AUTH_CLIENT_ID",
-              "AUTH_HOSTED_UI_DOMAIN",
-              "AUTH_API_SCOPE",
-              "AUTH_API_RESOURCE",
-          ]
-          missing = [name for name in required if not os.environ.get(name, "").strip()]
-          if missing:
-              sys.exit(
-                  "Missing required GitHub environment variables: "
-                  + ", ".join(missing)
-                  + ". Set them on the GitHub dev environment."
-              )
-
-          path = Path("src/FishingLogBook.Web/wwwroot/appsettings.Production.json")
-          data = json.loads(path.read_text(encoding="utf-8"))
-          data["Auth"] = {
-              "Authority": os.environ["AUTH_AUTHORITY"].strip(),
-              "ClientId": os.environ["AUTH_CLIENT_ID"].strip(),
-              "HostedUiDomain": os.environ["AUTH_HOSTED_UI_DOMAIN"].strip(),
-              "ApiScope": os.environ["AUTH_API_SCOPE"].strip(),
-              "ApiResource": os.environ["AUTH_API_RESOURCE"].strip(),
-          }
-          path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-          PY
+        run: >-
+          node src/FishingLogBook.Web/build/configure-web.mjs
+          --environment dev
+          --template src/FishingLogBook.Web/wwwroot/appsettings.Production.json
+          --output src/FishingLogBook.Web/wwwroot/appsettings.Production.json
 
       - name: Publish Web
         run: dotnet publish src/FishingLogBook.Web --configuration Release -o artifacts/web

--- a/docs/ProductionRunbook.md
+++ b/docs/ProductionRunbook.md
@@ -1,0 +1,120 @@
+# Production v0.1 runbook
+
+Production uses the existing provider accounts with isolated resources and credentials.
+Terraform remains manual: never add `terraform apply` or `terraform destroy` to CI.
+
+## Permanent origins
+
+| Role | Origin |
+|---|---|
+| Public entry | `https://catchbutdontforget.com` |
+| PWA | `https://app.catchbutdontforget.com` |
+| API | `https://api.catchbutdontforget.com` |
+
+The generated Pages and Fly hostnames remain provider endpoints, not supported user-facing
+origins. Cloudflare DNS for the API starts DNS-only; Fly terminates TLS.
+
+## Resource isolation
+
+- Cloudflare Pages: `fishing-logbook-prod` and `catch-but-dont-forget-root`.
+- R2: private `fishing-logbook-prod` bucket with production-scoped credentials and CORS
+  restricted to the PWA origin.
+- Fly: `fishing-logbook-prod-api`, 256 MB `shared-cpu-1x`, auto-stop and auto-start with
+  zero minimum running machines.
+- Neon: separate `fishing-logbook-prod` project. Production never uses a Dev branch,
+  database or connection string.
+- Cognito: separate production pool, public client, hosted domain, resource server and
+  pre-token Lambda.
+- Grafana Cloud: reuse the existing stack with a separate production write token. Loki
+  streams use `app="fishing-logbook-api"` and `env="prod"`.
+
+R2 protects object durability but this release does not add object versioning or a media
+backup/export system. An accidental application-level delete might therefore be
+unrecoverable. Neon Free provides only its current limited PITR window; confirm it in the
+provider console before launch.
+
+## GitHub production environment
+
+Create a protected GitHub environment named `prod` and require manual approval.
+
+Variables (public identifiers):
+
+```text
+API_BASE_URL=https://api.catchbutdontforget.com
+AUTH_AUTHORITY=<production Cognito issuer>
+AUTH_CLIENT_ID=<production public app-client id>
+AUTH_HOSTED_UI_DOMAIN=https://fishing-logbook-prod.auth.<region>.amazoncognito.com
+AUTH_API_SCOPE=https://api.catchbutdontforget.com/access
+AUTH_API_RESOURCE=https://api.catchbutdontforget.com
+```
+
+Secrets:
+
+```text
+CLOUDFLARE_API_TOKEN=<Pages deploy token>
+CLOUDFLARE_ACCOUNT_ID=<account id>
+FLY_API_TOKEN=<app-scoped production deploy token>
+```
+
+The production Web workflow refuses incomplete configuration, any HTTP/local/dev marker,
+or an API resource/scope that does not exactly match the permanent production API. It
+validates the published artifact again before upload.
+
+API runtime secrets stay in Fly and are not committed:
+
+```text
+ConnectionStrings__Postgres
+ObjectStorage__ServiceUrl
+ObjectStorage__BucketName=fishing-logbook-prod
+ObjectStorage__AccessKeyId
+ObjectStorage__SecretAccessKey
+Auth__Authority
+Auth__ClientId
+ExternalLogging__Provider=GrafanaCloud
+ExternalLogging__Url
+ExternalLogging__User
+ExternalLogging__ApiToken
+```
+
+Non-secret API configuration comes from `fly.prod.toml`, including the one allowed CORS
+origin, API audience/scope and `ExternalLogging__Environment=prod`.
+
+## Provisioning and first deployment
+
+1. Confirm Cloudflare zone ownership, provider plans, regions and all account identifiers.
+2. Copy prod `terraform.tfvars.example` to gitignored `terraform.tfvars` and complete it.
+3. Initialise the prod backend and run `terraform fmt`, `validate`, then `plan -out
+   prod.tfplan`. Review every action; abort on unexpected replacement or destruction.
+4. Manually apply only the reviewed plan.
+5. Create `fishing-logbook-prod-api` manually in the existing Fly organisation.
+6. Configure production-only Fly secrets, including the separate R2 and Grafana tokens.
+7. Run `fly certs add api.catchbutdontforget.com`; add its exact DNS-only CNAME and
+   ownership/validation records in Cloudflare, then use `fly certs check`.
+8. Run the existing DbUp runner against the production connection string first without
+   `--run` to review pending scripts, then explicitly with `--run`. Run it again and
+   require no pending migrations.
+9. Dispatch `deploy-production` for `api`; approve the `prod` environment gate and verify
+   both health endpoints.
+10. Dispatch it for `web`, then for `root`; verify their branded smoke checks.
+11. Confirm Pages custom-domain TLS is active and provider-generated origins are not
+    exposed in normal navigation.
+12. Complete the production acceptance journey on physical iPhone and Android devices
+    and applicable Windows browsers.
+
+Production deployment is never triggered by a normal Dev push. The workflow deploys only
+one explicitly chosen target per manually approved dispatch. Infrastructure creation and
+database migrations are not workflow jobs.
+
+## Recovery and rollback
+
+- Pages: roll back to a known previous deployment in Cloudflare.
+- Fly: redeploy a known image/release after confirming schema compatibility.
+- Neon: use provider PITR within the available Free-plan window or restore a separately
+  captured logical export when one exists.
+- R2: diagnose failed upload/sync operations through production API/client diagnostics;
+  there is no v0.1 recovery mechanism for an object that has been successfully deleted.
+- Grafana: query `{app="fishing-logbook-api", env="prod"}`. Free retention is diagnostic
+  history, not a permanent audit record.
+
+Never log bearer, access or refresh tokens, database/storage credentials, connection
+strings, photos, private notes or precise private locations.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -313,6 +313,11 @@ Production follows the equivalent process from `environments/prod` and must be p
 with extra care. There is intentionally **no** one-command script that plans and applies
 without review.
 
+The complete production provisioning, deployment and recovery sequence is documented in
+[`docs/ProductionRunbook.md`](../docs/ProductionRunbook.md). Production deployments are
+manual workflow dispatches protected by the GitHub `prod` environment; they never apply
+Terraform or run database migrations.
+
 ## State
 
 Remote state is stored in **Cloudflare R2** (an S3-compatible bucket) using Terraform's

--- a/infrastructure/fly/README.md
+++ b/infrastructure/fly/README.md
@@ -9,6 +9,11 @@ Fly Terraform provider). These files live here so all infrastructure config sits
 | `fly.dev.toml` | `fishing-logbook-dev-api` | Dev |
 | `fly.prod.toml` | `fishing-logbook-prod-api` | Prod (create later, manually) |
 
+Production starts in the private-alpha low-cost configuration: auto-stop and auto-start
+enabled, with zero minimum running Machines. Cold-start latency is accepted initially.
+See [`docs/ProductionRunbook.md`](../../docs/ProductionRunbook.md) for the production-only
+secrets, custom-domain and ordered deployment procedure.
+
 The API **image** is still built from the repo-root [`Dockerfile`](../../Dockerfile)
 (`dockerfile = "../../Dockerfile"` in the toml — Fly resolves that path relative to
 the config file, not the deploy context). Always run `flyctl` from the **repository

--- a/infrastructure/fly/fly.prod.toml
+++ b/infrastructure/fly/fly.prod.toml
@@ -13,13 +13,18 @@ primary_region = "iad"
   ASPNETCORE_ENVIRONMENT = "Production"
   ASPNETCORE_HTTP_PORTS = "8080"
   ExternalLogging__Environment = "prod"
+  Cors__AllowedOrigins__0 = "https://app.catchbutdontforget.com"
+  Auth__ApiScope = "https://api.catchbutdontforget.com/access"
+  Auth__ApiResource = "https://api.catchbutdontforget.com"
+  # Auth__Authority and Auth__ClientId are public identifiers but are supplied as
+  # production Fly configuration after Cognito is created; never copy Dev values here.
 
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = false
+  auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ["app"]
 
 [[vm]]

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -35,6 +35,16 @@ module "cloudflare_pages" {
   environment       = var.environment
   account_id        = var.cloudflare_account_id
   production_branch = var.pages_production_branch
+  custom_domains    = [var.app_domain]
+}
+
+module "cloudflare_root_pages" {
+  source            = "../../modules/cloudflare-pages"
+  environment       = var.environment
+  account_id        = var.cloudflare_account_id
+  project_name      = "catch-but-dont-forget-root"
+  production_branch = var.pages_production_branch
+  custom_domains    = [var.root_domain]
 }
 
 module "grafana_cloud" {

--- a/infrastructure/terraform/environments/prod/outputs.tf
+++ b/infrastructure/terraform/environments/prod/outputs.tf
@@ -79,6 +79,26 @@ output "cloudflare_pages_subdomain" {
   value       = module.cloudflare_pages.subdomain
 }
 
+output "cloudflare_pages_domains" {
+  description = "Custom domains attached to the production PWA Pages project."
+  value       = module.cloudflare_pages.domains
+}
+
+output "cloudflare_root_pages_project_name" {
+  description = "Cloudflare Pages project name for the small public root site."
+  value       = module.cloudflare_root_pages.project_name
+}
+
+output "cloudflare_root_pages_subdomain" {
+  description = "Cloudflare Pages subdomain for the small public root site."
+  value       = module.cloudflare_root_pages.subdomain
+}
+
+output "cloudflare_root_pages_domains" {
+  description = "Custom domains attached to the public root Pages project."
+  value       = module.cloudflare_root_pages.domains
+}
+
 output "grafana_url" {
   description = "Grafana UI URL. Null until grafana_cloud_stack_slug is set."
   value       = try(module.grafana_cloud[0].grafana_url, null)

--- a/infrastructure/terraform/environments/prod/terraform.tfvars.example
+++ b/infrastructure/terraform/environments/prod/terraform.tfvars.example
@@ -10,17 +10,16 @@
 
 environment = "prod"
 
-# cognito_api_resource_identifier = "https://<production-api-host>"
+cognito_api_resource_identifier = "https://api.catchbutdontforget.com"
 
 # cloudflare_account_id = "<from dash.cloudflare.com → account ID>"
 # r2_location           = "enam"
 
-# Production callback URLs are required before apply. Do not guess the production domain.
-# cognito_callback_urls = ["https://<your-prod-web-domain>/authentication/login-callback"]
-# cognito_logout_urls = [
-#   "https://<your-prod-web-domain>/authentication/logout-callback",
-#   "https://<your-prod-web-domain>/",
-# ]
+cognito_callback_urls = ["https://app.catchbutdontforget.com/authentication/login-callback"]
+cognito_logout_urls = [
+  "https://app.catchbutdontforget.com/authentication/logout-callback",
+  "https://app.catchbutdontforget.com/",
+]
 
 # neon_org_id     = "<neon-organisation-id>"
 # neon_region     = "aws-us-east-1"
@@ -31,5 +30,7 @@ environment = "prod"
 # fly_vm_size = "shared-cpu-1x"
 
 # pages_production_branch = "main"
+# root_domain = "catchbutdontforget.com"
+# app_domain  = "app.catchbutdontforget.com"
 
 # grafana_cloud_stack_slug = "<slug from https://<slug>.grafana.net after Grafana Cloud signup>"

--- a/infrastructure/terraform/environments/prod/variables.tf
+++ b/infrastructure/terraform/environments/prod/variables.tf
@@ -83,6 +83,18 @@ variable "pages_production_branch" {
   default     = "main"
 }
 
+variable "root_domain" {
+  type        = string
+  description = "Permanent production root-site domain."
+  default     = "catchbutdontforget.com"
+}
+
+variable "app_domain" {
+  type        = string
+  description = "Permanent production PWA domain."
+  default     = "app.catchbutdontforget.com"
+}
+
 variable "grafana_cloud_stack_slug" {
   type        = string
   description = "Existing Grafana Cloud stack slug (https://<slug>.grafana.net). Leave empty to skip Grafana resources. Account-specific; supply locally, never commit."

--- a/infrastructure/terraform/modules/cloudflare-pages/main.tf
+++ b/infrastructure/terraform/modules/cloudflare-pages/main.tf
@@ -16,14 +16,23 @@ terraform {
 
 locals {
   resource_prefix = "fishing-logbook-${var.environment}"
+  project_name    = var.project_name == "" ? local.resource_prefix : var.project_name
 }
 
 resource "cloudflare_pages_project" "web" {
   account_id        = var.account_id
-  name              = local.resource_prefix
+  name              = local.project_name
   production_branch = var.production_branch
 
   lifecycle {
     prevent_destroy = true
   }
+}
+
+resource "cloudflare_pages_domain" "this" {
+  for_each = var.custom_domains
+
+  account_id   = var.account_id
+  project_name = cloudflare_pages_project.web.name
+  name         = each.value
 }

--- a/infrastructure/terraform/modules/cloudflare-pages/outputs.tf
+++ b/infrastructure/terraform/modules/cloudflare-pages/outputs.tf
@@ -10,5 +10,5 @@ output "subdomain" {
 
 output "domains" {
   description = "Custom domains attached to the Pages project."
-  value       = cloudflare_pages_project.web.domains
+  value       = sort([for domain in cloudflare_pages_domain.this : domain.name])
 }

--- a/infrastructure/terraform/modules/cloudflare-pages/variables.tf
+++ b/infrastructure/terraform/modules/cloudflare-pages/variables.tf
@@ -13,3 +13,15 @@ variable "production_branch" {
   description = "Git branch that maps to this Pages environment."
   default     = "main"
 }
+
+variable "project_name" {
+  type        = string
+  description = "Optional explicit Pages project name. Defaults to fishing-logbook-<environment>."
+  default     = ""
+}
+
+variable "custom_domains" {
+  type        = set(string)
+  description = "Custom domains to attach to the Pages project. DNS records are managed separately."
+  default     = []
+}

--- a/src/FishingLogBook.Root/build/root-site.test.mjs
+++ b/src/FishingLogBook.Root/build/root-site.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+describe('production root site', () => {
+    it('presents the exact brand name', () => {
+        assert.match(html, /<h1>Catch, But Don't Forget<\/h1>/);
+    });
+
+    it('links to the permanent production PWA origin', () => {
+        assert.match(html, /href="https:\/\/app\.catchbutdontforget\.com"[^>]*>Open the app<\/a>/);
+    });
+});

--- a/src/FishingLogBook.Root/index.html
+++ b/src/FishingLogBook.Root/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="A private fishing logbook for your catches, photographs and memories.">
+  <title>Catch, But Don't Forget</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main>
+    <p class="eyebrow">Catch · Release · Remember</p>
+    <h1>Catch, But Don't Forget</h1>
+    <p>Keep your catches, photographs and fishing memories together—wherever you fish.</p>
+    <a href="https://app.catchbutdontforget.com">Open the app</a>
+  </main>
+</body>
+</html>

--- a/src/FishingLogBook.Root/styles.css
+++ b/src/FishingLogBook.Root/styles.css
@@ -1,0 +1,54 @@
+:root {
+  color-scheme: light;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #09213e;
+  background: #eef5ea;
+}
+
+body {
+  display: grid;
+  min-height: 100vh;
+  margin: 0;
+  place-items: center;
+}
+
+main {
+  width: min(34rem, calc(100% - 3rem));
+  text-align: center;
+}
+
+.eyebrow {
+  color: #16863e;
+  font-size: .85rem;
+  font-weight: 700;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: .5rem 0 1rem;
+  font-size: clamp(2.25rem, 8vw, 4rem);
+  line-height: 1.05;
+}
+
+main > p:not(.eyebrow) {
+  margin: 0 auto 2rem;
+  color: #34485c;
+  font-size: 1.125rem;
+  line-height: 1.6;
+}
+
+a {
+  display: inline-block;
+  padding: .85rem 1.5rem;
+  border-radius: .35rem;
+  background: #5746e8;
+  color: white;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+a:focus-visible,
+a:hover {
+  background: #4232c7;
+}

--- a/src/FishingLogBook.Web/FishingLogBook.Web.csproj
+++ b/src/FishingLogBook.Web/FishingLogBook.Web.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <Content Remove="wwwroot\**\*.test.js" />
     <None Include="wwwroot\**\*.test.js" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
+    <Content Update="wwwroot\appsettings.Development.json" CopyToPublishDirectory="Never" />
     <Content Remove="BrowserTests\**" />
     <None Include="BrowserTests\**" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
   </ItemGroup>

--- a/src/FishingLogBook.Web/build/configure-web.mjs
+++ b/src/FishingLogBook.Web/build/configure-web.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const requiredEnvironmentValues = {
+    API_BASE_URL: ['Api', 'BaseUrl'],
+    AUTH_AUTHORITY: ['Auth', 'Authority'],
+    AUTH_CLIENT_ID: ['Auth', 'ClientId'],
+    AUTH_HOSTED_UI_DOMAIN: ['Auth', 'HostedUiDomain'],
+    AUTH_API_SCOPE: ['Auth', 'ApiScope'],
+    AUTH_API_RESOURCE: ['Auth', 'ApiResource'],
+};
+
+export const productionExpectedValues = {
+    API_BASE_URL: 'https://api.catchbutdontforget.com',
+    AUTH_API_RESOURCE: 'https://api.catchbutdontforget.com',
+    AUTH_API_SCOPE: 'https://api.catchbutdontforget.com/access',
+};
+
+export const productionForbiddenMarkers = [
+    'fishing-logbook-dev',
+    'pages.dev',
+    'localhost',
+    '127.0.0.1',
+];
+
+const productionUrlValues = [
+    'API_BASE_URL',
+    'AUTH_AUTHORITY',
+    'AUTH_HOSTED_UI_DOMAIN',
+    'AUTH_API_SCOPE',
+    'AUTH_API_RESOURCE',
+];
+
+export function buildConfiguration(template, values, environment) {
+    const missing = Object.keys(requiredEnvironmentValues).filter(name => !values[name]?.trim());
+    if (missing.length > 0) {
+        throw new Error(`Missing required deployment values: ${missing.join(', ')}`);
+    }
+
+    const result = structuredClone(template);
+    for (const [name, [section, key]] of Object.entries(requiredEnvironmentValues)) {
+        result[section] ??= {};
+        result[section][key] = values[name].trim();
+    }
+
+    if (environment === 'prod') {
+        const errors = Object.entries(productionExpectedValues)
+            .filter(([name, expected]) => values[name].trim() !== expected)
+            .map(([name, expected]) => `${name} must be ${expected}`);
+        errors.push(...productionUrlValues
+            .filter(name => !values[name].trim().startsWith('https://'))
+            .map(name => `${name} must use HTTPS`));
+        const serialized = JSON.stringify(result).toLowerCase();
+        errors.push(...productionForbiddenMarkers
+            .filter(marker => serialized.includes(marker))
+            .map(marker => `Production configuration contains forbidden marker: ${marker}`));
+        if (errors.length > 0) {
+            throw new Error(`Unsafe production configuration: ${errors.join('; ')}`);
+        }
+    }
+
+    return result;
+}
+
+export function validateProductionArtifactFiles(files) {
+    const errors = [];
+    for (const [name, content] of files) {
+        const normalized = content.toLowerCase();
+        errors.push(...productionForbiddenMarkers
+            .filter(marker => normalized.includes(marker))
+            .map(marker => `${name} contains forbidden marker: ${marker}`));
+    }
+    if (errors.length > 0) {
+        throw new Error(`Unsafe production artifact: ${errors.join('; ')}`);
+    }
+}
+
+async function findTextFiles(directory) {
+    const files = [];
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+        const path = resolve(directory, entry.name);
+        if (entry.isDirectory()) files.push(...await findTextFiles(path));
+        else if (/\.(?:css|html|js|json|map|txt|webmanifest)$/i.test(entry.name)) files.push(path);
+    }
+    return files;
+}
+
+async function main(args = process.argv.slice(2)) {
+    const options = Object.fromEntries(args.reduce((pairs, value, index) => {
+        if (value.startsWith('--')) pairs.push([value.slice(2), args[index + 1]]);
+        return pairs;
+    }, []));
+    if (!['dev', 'prod'].includes(options.environment) || !options.template || !options.output) {
+        throw new Error('Usage: configure-web.mjs --environment <dev|prod> --template <path> --output <path>');
+    }
+
+    const template = JSON.parse(await readFile(options.template, 'utf8'));
+    const configured = buildConfiguration(template, process.env, options.environment);
+    await writeFile(options.output, `${JSON.stringify(configured, null, 2)}\n`, 'utf8');
+    if (options['artifact-root']) {
+        const paths = await findTextFiles(options['artifact-root']);
+        validateProductionArtifactFiles(await Promise.all(paths.map(async path => [
+            path,
+            await readFile(path, 'utf8'),
+        ])));
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+    main().catch(error => {
+        console.error(error.message);
+        process.exitCode = 1;
+    });
+}

--- a/src/FishingLogBook.Web/build/configure-web.test.mjs
+++ b/src/FishingLogBook.Web/build/configure-web.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+    buildConfiguration,
+    productionForbiddenMarkers,
+    validateProductionArtifactFiles,
+} from './configure-web.mjs';
+
+const template = { Api: { BaseUrl: '' }, Auth: {} };
+const production = {
+    API_BASE_URL: 'https://api.catchbutdontforget.com',
+    AUTH_AUTHORITY: 'https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_prod',
+    AUTH_CLIENT_ID: 'production-public-client',
+    AUTH_HOSTED_UI_DOMAIN: 'https://fishing-logbook-prod.auth.eu-west-2.amazoncognito.com',
+    AUTH_API_SCOPE: 'https://api.catchbutdontforget.com/access',
+    AUTH_API_RESOURCE: 'https://api.catchbutdontforget.com',
+};
+
+describe('production Web configuration', () => {
+    it('emits complete production configuration', () => {
+        const result = buildConfiguration(template, production, 'prod');
+        assert.equal(result.Api.BaseUrl, 'https://api.catchbutdontforget.com');
+        assert.equal(result.Auth.ClientId, 'production-public-client');
+    });
+
+    it('rejects missing values', () => {
+        assert.throws(
+            () => buildConfiguration(template, { ...production, AUTH_CLIENT_ID: '' }, 'prod'),
+            /AUTH_CLIENT_ID/);
+    });
+
+    for (const marker of productionForbiddenMarkers) {
+        it(`rejects the production marker ${marker} in any field`, () => {
+            assert.throws(() => buildConfiguration(template, {
+                ...production,
+                AUTH_CLIENT_ID: `client-${marker}`,
+            }, 'prod'), /forbidden marker/);
+        });
+    }
+
+    it('rejects a different production API origin', () => {
+        assert.throws(() => buildConfiguration(template, {
+            ...production,
+            API_BASE_URL: 'https://some-other-api.example',
+        }, 'prod'), /API_BASE_URL must be/);
+    });
+
+    it('rejects non-HTTPS production identity URLs', () => {
+        assert.throws(() => buildConfiguration(template, {
+            ...production,
+            AUTH_AUTHORITY: 'http://identity.example',
+        }, 'prod'), /AUTH_AUTHORITY must use HTTPS/);
+    });
+
+    it('allows environment-specific dev configuration', () => {
+        const values = { ...production, API_BASE_URL: 'https://fishing-logbook-dev-api.fly.dev' };
+        assert.equal(buildConfiguration(template, values, 'dev').Api.BaseUrl, values.API_BASE_URL);
+    });
+
+    it('rejects dev markers outside the configuration file', () => {
+        assert.throws(() => validateProductionArtifactFiles([
+            ['appsettings.Production.json', JSON.stringify(buildConfiguration(template, production, 'prod'))],
+            ['unexpected.json', '{"origin":"https://fishing-logbook-dev.pages.dev"}'],
+        ]), /unexpected.json contains forbidden marker/);
+    });
+
+    it('accepts an artifact containing only production origins', () => {
+        assert.doesNotThrow(() => validateProductionArtifactFiles([
+            ['appsettings.Production.json', JSON.stringify(buildConfiguration(template, production, 'prod'))],
+            ['index.html', '<a href="https://app.catchbutdontforget.com">Open</a>'],
+        ]));
+    });
+});

--- a/src/FishingLogBook.Web/wwwroot/appsettings.Production.json
+++ b/src/FishingLogBook.Web/wwwroot/appsettings.Production.json
@@ -1,13 +1,13 @@
 {
   "Api": {
-    "BaseUrl": "https://fishing-logbook-dev-api.fly.dev"
+    "BaseUrl": ""
   },
   "Auth": {
-    "Authority": "https://cognito-idp.eu-west-2.amazonaws.com/eu-west-2_J4Kt9QB06",
-    "ClientId": "e80socqio7bpv79or57fb1e5l",
-    "HostedUiDomain": "https://fishing-logbook-dev.auth.eu-west-2.amazoncognito.com",
-    "ApiScope": "https://fishing-logbook-dev-api.fly.dev/access",
-    "ApiResource": "https://fishing-logbook-dev-api.fly.dev"
+    "Authority": "",
+    "ClientId": "",
+    "HostedUiDomain": "",
+    "ApiScope": "",
+    "ApiResource": ""
   },
   "Diagnostics": {
     "ShowInspector": true,


### PR DESCRIPTION
## Summary

Implements the repository-only Phase 2A foundation for #114.

Production retains the proven development architecture while isolating mutable resources and deployment targets:

- a minimal Cloudflare Pages entry site at `https://catchbutdontforget.com`;
- a separate Cloudflare Pages PWA at `https://app.catchbutdontforget.com`;
- a separate Fly API at `https://api.catchbutdontforget.com`;
- separate production Neon project, private R2 bucket/credentials, and Cognito pool/client/domain;
- the existing Grafana Cloud/Loki stack reused with a separate production write token and `app="fishing-logbook-api", env="prod"`;
- manually dispatched, protected production deployments, with Terraform remaining manual.

This PR intentionally does **not** close #114. Phase 2B provisioning, deployment, and production acceptance remain outstanding.

## Phase 2B resources planned

Terraform will eventually create, only after a separately reviewed plan and explicit approval:

- Cloudflare Pages projects `fishing-logbook-prod` and `catch-but-dont-forget-root`;
- Pages domain attachments for `app.catchbutdontforget.com` and `catchbutdontforget.com`;
- private R2 bucket `fishing-logbook-prod`;
- separate Neon project `fishing-logbook-prod`;
- separate Cognito user pool, public PWA client, resource server, hosted domain, managed-login branding, pre-token Lambda, IAM/log resources and invocation permission;
- a production Loki write access policy and token in the existing Grafana stack.

Manual Phase 2B resources/actions will include the Fly app/certificate, DNS records, production-scoped R2 credentials, Fly secrets, and the protected GitHub `prod` environment.

## Cost

Expected initial near-zero-traffic cost is approximately **$0–$3/month**:

- Pages, R2, Neon, Cognito and Grafana are expected to remain within their current free allowances;
- Fly is usage-based and configured to stop when idle;
- domain registration/renewal is separate.

## Isolation and domains

DEV and PROD reuse provider accounts but have separate:

- Pages projects and deployment targets;
- Fly applications and deploy tokens;
- Neon projects and connection strings;
- R2 buckets and credentials;
- Cognito pools, clients, hosted domains and API resources;
- GitHub environments, variables and secrets;
- Grafana Loki write tokens and environment labels.

The permanent production origins are:

- `https://catchbutdontforget.com` — minimal public entry site;
- `https://app.catchbutdontforget.com` — production PWA;
- `https://api.catchbutdontforget.com` — production API.

Cloudflare-to-Fly API routing starts DNS-only. Fly manages API TLS. Cloudflare Pages manages TLS for the root and app sites.

## Authentication

Production uses a separate Cognito user pool/client/domain through the existing Terraform architecture.

- Callback: `https://app.catchbutdontforget.com/authentication/login-callback`
- Logout callback: `https://app.catchbutdontforget.com/authentication/logout-callback`
- Logout return: `https://app.catchbutdontforget.com/`
- API resource: `https://api.catchbutdontforget.com`
- API scope: `https://api.catchbutdontforget.com/access`

DEV Cognito resources and users remain untouched.

## Fly and observability

Production Fly starts with the approved private-alpha settings:

```toml
auto_stop_machines = true
auto_start_machines = true
min_machines_running = 0
```

The existing Grafana Cloud/Loki stack is reused. Production receives a separate write token and is independently queryable with:

```logql
{app="fishing-logbook-api", env="prod"}
```

No additional Grafana stack is proposed.

## Production configuration safety

The checked-in production Web overlay no longer contains DEV API or Cognito values.

The publish guard:

- requires every API/auth deployment value;
- enforces HTTPS for URL-bearing values;
- requires the exact production API URL, resource and scope;
- rejects known DEV, `pages.dev`, localhost and loopback markers;
- scans the complete published text artifact before upload;
- excludes `appsettings.Development.json` from production publish output;
- fails closed before any production Pages deployment.

The normal DEV deployment remains separate and explicitly uses its DEV API target.

## Validation

- Release build: passed, 0 warnings/errors
- .NET tests: 1,175 passed
- JavaScript tests: 165 passed
- Production configuration/root tests: 13 passed
- Playwright: 27 passed, 1 expected WebKit offline-navigation skip
- Production-style publish and complete artifact safety scan: passed
- Terraform `fmt -check`: passed
- Terraform production `init -backend=false` and `validate`: passed
- Diff/whitespace and workflow path checks: passed

The service worker, bootstrap, IndexedDB, offline queue and sync architecture were not changed.

## Phase 2B manual steps remaining

1. Confirm Cloudflare zone ownership, plans, account identifiers and regions.
2. Complete gitignored production Terraform inputs and backend configuration.
3. Run Terraform init/fmt/validate and create `prod.tfplan`.
4. Review every planned action and abort on unexpected replacement/destruction.
5. Manually apply only the reviewed plan after explicit Phase 2B approval.
6. Create `fishing-logbook-prod-api` manually in the existing Fly organisation.
7. Create production-scoped R2 credentials and configure PWA-origin CORS.
8. Configure production Neon, R2, Cognito and Grafana values as Fly secrets.
9. Attach `api.catchbutdontforget.com` to Fly and add the exact DNS-only validation/routing records.
10. Confirm Fly certificate issuance.
11. Preview and explicitly run the existing DbUp migrations against production.
12. Run migrations again and require no pending scripts.
13. Create and protect the GitHub `prod` environment; add its variables and scoped secrets.
14. Manually dispatch and approve the API deployment; verify API/database health.
15. Manually dispatch and approve the PWA and root-site deployments.
16. Verify all branded domains and certificates.
17. Complete the physical iPhone, Android and applicable Windows production acceptance journey.
18. Confirm API and uploaded client diagnostics are independently visible with `env="prod"`.

## Infrastructure status

**No live production infrastructure has been created or modified.**

This PR has not:

- run `terraform apply`;
- created or modified provider resources;
- changed DNS;
- deployed production;
- run production database migrations;
- created production users;
- changed existing DEV resources.

## Self review

- Issue/AC: PASS for Phase 2A; Phase 2B and production acceptance deliberately remain open.
- Architecture/CQRS: PASS — no application/domain architecture changed.
- Rules: PASS — Terraform remains manual; CI contains no apply/destroy/import.
- Security/privacy: PASS — isolated targets, scoped credentials plan and fail-closed artifact validation.
- Database/migrations: PASS — existing separate DbUp runner retained; no schema or seed changes.
- Tests/coverage: PASS — configuration guard, full artifact scan and root-domain link are covered.
- Browser: PASS — existing Chromium/WebKit PWA suite remains green.
- Web/UI/localisation: PASS — only the deliberately minimal public entry artifact was introduced.
- Code smells: PASS — build tooling is owned by its respective project, not a generic root scripts folder.
- CI/deployment: PASS — production is explicit, manual and protected from normal DEV pushes.

### Findings fixed during self-review

1. Expanded configuration validation to scan the complete production text artifact.
2. Excluded the DEV appsettings overlay from production publish output.
3. Replaced an over-broad generic HTTP scan with precise HTTPS configuration validation.
4. Moved project-specific build/test tooling under the Web and root-site artifacts.

### Remaining deliberate gaps

- Provider-side plan and provisioning require explicit Phase 2B approval.
- No production or physical-device verification is claimed.
- R2 v0.1 does not add an application-level media deletion recovery system.

Refs #114
