### PR TITLE
FLB#118 | Remove legacy method and species inputs

### DIFF
--- a/infrastructure/terraform/environments/prod/backend.tf
+++ b/infrastructure/terraform/environments/prod/backend.tf
@@ -20,6 +20,7 @@ terraform {
     skip_region_validation      = true
     skip_requesting_account_id  = true
     skip_metadata_api_check     = true
-    skip_s3_checksum           = true
+    skip_s3_checksum            = true
   }
 }
+

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor
@@ -117,11 +117,6 @@
                                     @Loc["Common_More"]
                                 </MudButton>
                             </MudStack>
-                            <MudTextField @bind-Value="MethodInput"
-                                          Label="@Loc["Catch_EditMethod"]"
-                                          MaxLength="@CatchDetailConstants.MaxMethodLength"
-                                          Immediate="true"
-                                          id="catch-edit-method" />
                         </MudStack>
 
                         <MudStack Spacing="2">
@@ -145,11 +140,6 @@
                                     @Loc["Common_More"]
                                 </MudButton>
                             </MudStack>
-                            <MudTextField @bind-Value="SpeciesInput"
-                                          Label="@Loc["Catch_EditSpecies"]"
-                                          MaxLength="@CatchDetailConstants.MaxSpeciesNameLength"
-                                          Immediate="true"
-                                          id="catch-edit-species" />
                         </MudStack>
 
                         <MudTextField @bind-Value="_weightText"
@@ -240,3 +230,4 @@
         }
     </MudStack>
 </MudContainer>
+

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor.cs
@@ -252,33 +252,6 @@ public partial class CatchEdit : ComponentBase, IDisposable
         _speciesIsExplicit = true;
     }
 
-    private string MethodInput
-    {
-        get
-        {
-            return _method;
-        }
-
-        set
-        {
-            SelectMethod(value);
-        }
-    }
-
-    private string SpeciesInput
-    {
-        get
-        {
-            return _speciesName;
-        }
-
-        set
-        {
-            _speciesName = value;
-            _speciesIsExplicit = !string.IsNullOrWhiteSpace(value);
-        }
-    }
-
     private async Task ChooseMethodAsync()
     {
         var chosen = await ChooseFromCatalogueAsync(
@@ -341,3 +314,4 @@ public partial class CatchEdit : ComponentBase, IDisposable
         _cancellationTokenSource.Dispose();
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingChips.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingChips.cs
@@ -1,6 +1,8 @@
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
@@ -33,8 +35,8 @@ public class WhenTestingChips : BaseCatchEditTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#catch-edit-catalogue-unavailable").Should().NotBeNull();
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Pike");
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Trotting");
+            cut.Find("#catch-edit-species-Pike").ClassList.Should().Contain("mud-chip-filled");
+            cut.Find("#catch-edit-method-Trotting").ClassList.Should().Contain("mud-chip-filled");
         });
         await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
     }
@@ -56,9 +58,8 @@ public class WhenTestingChips : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Spinning");
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Pike");
             cut.Find("#catch-edit-method-Spinning").ClassList.Should().Contain("mud-chip-filled");
+            cut.Find("#catch-edit-species-Pike").ClassList.Should().Contain("mud-chip-filled");
         });
         await preferences.Received(1).GetAsync(Arg.Any<CancellationToken>());
     }
@@ -80,8 +81,6 @@ public class WhenTestingChips : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Fly");
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Brown Trout");
             cut.Find("#catch-edit-method-Fly").ClassList.Should().Contain("mud-chip-filled");
             cut.Find("#catch-edit-species-BrownTrout").ClassList.Should().Contain("mud-chip-filled");
         });
@@ -105,8 +104,7 @@ public class WhenTestingChips : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Spinning");
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Pike");
+            cut.Find("#catch-edit-method-Spinning").ClassList.Should().Contain("mud-chip-filled");
             cut.Find("#catch-edit-species-Pike").ClassList.Should().Contain("mud-chip-filled");
         });
     }
@@ -130,8 +128,8 @@ public class WhenTestingChips : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().BeEmpty();
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().BeEmpty();
+            cut.Find("#catch-edit-method-chips").QuerySelectorAll(".mud-chip-filled").Should().BeEmpty();
+            cut.Find("#catch-edit-species-chips").QuerySelectorAll(".mud-chip-filled").Should().BeEmpty();
         });
     }
 
@@ -154,8 +152,8 @@ public class WhenTestingChips : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Spinning");
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Pike");
+            cut.Find("#catch-edit-method-Spinning").ClassList.Should().Contain("mud-chip-filled");
+            cut.Find("#catch-edit-species-Pike").ClassList.Should().Contain("mud-chip-filled");
         });
     }
 
@@ -171,7 +169,7 @@ public class WhenTestingChips : BaseCatchEditTest
         await using var context = CreateContext(store, anglerPreferences: preferences);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(page => page.CatchId, EditedCatchId));
         cut.WaitForAssertion(() =>
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Brown Trout"));
+            cut.Find("#catch-edit-species-BrownTrout").ClassList.Should().Contain("mud-chip-filled"));
 
         // Act
         await cut.Find("#catch-edit-method-Spinning").ClickAsync();
@@ -179,8 +177,8 @@ public class WhenTestingChips : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Spinning");
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Pike");
+            cut.Find("#catch-edit-method-Spinning").ClassList.Should().Contain("mud-chip-filled");
+            cut.Find("#catch-edit-species-Pike").ClassList.Should().Contain("mud-chip-filled");
         });
     }
 
@@ -217,7 +215,7 @@ public class WhenTestingChips : BaseCatchEditTest
         await using var context = CreateContext(store, anglerPreferences: preferences);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(page => page.CatchId, EditedCatchId));
         cut.WaitForAssertion(() =>
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Brown Trout"));
+            cut.Find("#catch-edit-species-BrownTrout").ClassList.Should().Contain("mud-chip-filled"));
 
         // Act
         await cut.Find("#catch-edit-method-Spinning").ClickAsync();
@@ -225,8 +223,8 @@ public class WhenTestingChips : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Spinning");
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().BeEmpty();
+            cut.Find("#catch-edit-method-Spinning").ClassList.Should().Contain("mud-chip-filled");
+            cut.Find("#catch-edit-species-chips").QuerySelectorAll(".mud-chip-filled").Should().BeEmpty();
         });
     }
 
@@ -249,8 +247,8 @@ public class WhenTestingChips : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Spinning");
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Grayling");
+            cut.Find("#catch-edit-method-Spinning").ClassList.Should().Contain("mud-chip-filled");
+            cut.Find("#catch-edit-species-Grayling").ClassList.Should().Contain("mud-chip-filled");
         });
     }
 
@@ -273,7 +271,6 @@ public class WhenTestingChips : BaseCatchEditTest
         {
             cut.Find("#catch-edit-species-Grayling").ClassList.Should().Contain("mud-chip-filled");
             cut.Find("#catch-edit-species-BrownTrout").Should().NotBeNull();
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Grayling");
         });
     }
 
@@ -306,21 +303,67 @@ public class WhenTestingChips : BaseCatchEditTest
     }
 
     [Fact]
-    public async Task ItShouldApplyTheMethodChosenFromTheFullCatalogue()
+    public async Task ItShouldPreserveLegacyUnmappedValuesWhenSavingWithoutChanges()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
         store.GetAsync(OwnerUserId, EditedCatchId, Arg.Any<CancellationToken>())
-            .Returns(StoredCatch(EditedCatchId, method: "Fly"));
+            .Returns(StoredCatch(
+                EditedCatchId,
+                SyncStatus.Synchronised,
+                SyncStatus.Synchronised,
+                speciesName: "Mystery fish",
+                method: "Hand lining"));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
         var preferences = QuietAnglerPreferences(SamplePreferences(), SampleCatalogue());
+        var synchroniser = QuietSynchroniser();
+        await using var context = CreateContext(
+            store,
+            synchroniser: synchroniser,
+            anglerPreferences: preferences);
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(page => page.CatchId, EditedCatchId));
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-edit-method-Handlining").ClassList.Should().Contain("mud-chip-filled");
+            cut.Find("#catch-edit-species-Mysteryfish").ClassList.Should().Contain("mud-chip-filled");
+        });
+
+        // Act
+        await cut.Find("#catch-edit-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-saved").Should().NotBeNull());
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Method == "Hand lining"
+                && catchRecord.SpeciesName == "Mystery fish"
+                && catchRecord.MetadataSyncStatus == SyncStatus.Synchronised),
+            Arg.Any<CancellationToken>());
+        await synchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldApplyTheMethodChosenFromTheFullCatalogue()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var trottingMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000003");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, EditedCatchId, Arg.Any<CancellationToken>())
+            .Returns(StoredCatch(EditedCatchId, method: "Fly"));
+        var sampleCatalogue = SampleCatalogue();
+        var catalogue = new FishingCatalogueDto(
+            [.. sampleCatalogue.Methods, new FishingMethodDto(trottingMethodId, "Trotting", "Trotting")],
+            sampleCatalogue.AllSpecies);
+        var preferences = QuietAnglerPreferences(SamplePreferences(), catalogue);
         var modalService = Substitute.For<IModalService>();
         modalService
             .ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
                 Arg.Any<CataloguePickerModalModel>(),
                 Arg.Any<CancellationToken>())
             .Returns(new CataloguePickerModalResult(
-                new CatalogueOptionModel(SpinningMethodId, "Spinning", "Spinning")));
+                new CatalogueOptionModel(trottingMethodId, "Trotting", "Trotting")));
         await using var context = CreateContext(
             store,
             anglerPreferences: preferences,
@@ -333,10 +376,13 @@ public class WhenTestingChips : BaseCatchEditTest
 
         // Assert
         cut.WaitForAssertion(() =>
-            cut.Find("#catch-edit-method").GetAttribute("value").Should().Be("Spinning"));
+            cut.Find("#catch-edit-method-Trotting").ClassList.Should().Contain("mud-chip-filled"));
         await modalService.Received(1)
             .ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
-                Arg.Is<CataloguePickerModalModel>(model => model.Options.Count == 2),
+                Arg.Is<CataloguePickerModalModel>(model =>
+                    model.Options.Count == 3
+                    && model.Options.Any(option => option.Code == "Trotting")),
                 Arg.Any<CancellationToken>());
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingRender.cs
@@ -51,10 +51,14 @@ public class WhenTestingRender : BaseCatchEditTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#catch-edit-title").TextContent.Should().Contain("Edit catch");
-            cut.Find("#catch-edit-species").Should().NotBeNull();
+            cut.Find("#catch-edit-method-chips").Should().NotBeNull();
+            cut.Find("#catch-edit-species-chips").Should().NotBeNull();
+            cut.Find("#catch-edit-method-more").Should().NotBeNull();
+            cut.Find("#catch-edit-species-more").Should().NotBeNull();
+            cut.FindAll("#catch-edit-method").Should().BeEmpty();
+            cut.FindAll("#catch-edit-species").Should().BeEmpty();
             cut.Find("#catch-edit-weight").Should().NotBeNull();
             cut.Find("#catch-edit-length").Should().NotBeNull();
-            cut.Find("#catch-edit-method").Should().NotBeNull();
             cut.Find("#catch-edit-bait").Should().NotBeNull();
             cut.Find("#catch-edit-notes").Should().NotBeNull();
             cut.Find("#catch-edit-caught-on").GetAttribute("value").Should().Be("2026-08-17T08:00");
@@ -111,7 +115,7 @@ public class WhenTestingRender : BaseCatchEditTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#catch-edit-title").TextContent.Should().Contain("Modifier la prise");
-            cut.Find("#catch-edit-save").TextContent.Should().Contain("Enregistrer les détails");
+            cut.Find("#catch-edit-save").TextContent.Should().Contain("Enregistrer les dÃ©tails");
         });
         await store.Received(1).GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
     }
@@ -193,7 +197,7 @@ public class WhenTestingRender : BaseCatchEditTest
 
         // Assert
         cut.WaitForAssertion(() =>
-            cut.Find("#catch-edit-species").GetAttribute("value").Should().Be("Pike"));
+            cut.Find("#catch-edit-species-Pike").ClassList.Should().Contain("mud-chip-filled"));
         await catchClient.Received(1).DownloadPhotographAsync("https://r2.test/one", Arg.Any<CancellationToken>());
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord =>
@@ -265,3 +269,4 @@ public class WhenTestingRender : BaseCatchEditTest
         await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingRender.cs
@@ -115,7 +115,7 @@ public class WhenTestingRender : BaseCatchEditTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#catch-edit-title").TextContent.Should().Contain("Modifier la prise");
-            cut.Find("#catch-edit-save").TextContent.Should().Contain("Enregistrer les dÃ©tails");
+            cut.Find("#catch-edit-save").TextContent.Should().Contain("Enregistrer les détails");
         });
         await store.Received(1).GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingSave.cs
@@ -426,7 +426,7 @@ public class WhenTestingSave : BaseCatchEditTest
         cut.WaitForAssertion(() =>
             cut.Find("#catch-edit-saved").TextContent
                 .Should()
-                .Contain("DÃ©tails enregistrÃ©s sur cet appareil"));
+                .Contain("Détails enregistrés sur cet appareil"));
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord =>
                 catchRecord.Id == catchId && catchRecord.SpeciesName == "Brown Trout"),

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingSave.cs
@@ -310,13 +310,17 @@ public class WhenTestingSave : BaseCatchEditTest
             .Returns(Task.CompletedTask);
         var synchroniser = QuietSynchroniser();
         var time = UtcTime();
-        await using var context = CreateContext(store, synchroniser: synchroniser, time: time);
+        var preferences = QuietAnglerPreferences(SamplePreferences(), SampleCatalogue());
+        await using var context = CreateContext(
+            store,
+            synchroniser: synchroniser,
+            time: time,
+            anglerPreferences: preferences);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, catchId));
-        cut.WaitForAssertion(() => cut.Find("#catch-edit-species").Should().NotBeNull());
-        cut.Find("#catch-edit-species").Input("Pike");
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-method-Spinning"));
+        await cut.Find("#catch-edit-method-Spinning").ClickAsync();
         cut.Find("#catch-edit-weight").Input("2.5");
         cut.Find("#catch-edit-length").Input("64");
-        cut.Find("#catch-edit-method").Input("Lure");
         cut.Find("#catch-edit-bait").Input("Spinner");
         cut.Find("#catch-edit-notes").Input("Weedline");
         cut.Find("#catch-edit-caught-on").Input("2026-08-17T09:15");
@@ -334,7 +338,7 @@ public class WhenTestingSave : BaseCatchEditTest
                 && catchRecord.SpeciesName == "Pike"
                 && catchRecord.Weight == 2.5m
                 && catchRecord.Length == 64m
-                && catchRecord.Method == "Lure"
+                && catchRecord.Method == "Spinning"
                 && catchRecord.BaitOrLure == "Spinner"
                 && catchRecord.Notes == "Weedline"
                 && catchRecord.CaughtOn == DateTimeOffset.Parse("2026-08-17T09:15:00Z")
@@ -363,16 +367,20 @@ public class WhenTestingSave : BaseCatchEditTest
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
         store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
-            .Returns(StoredCatch(catchId, SyncStatus.Synchronised, SyncStatus.Synchronised));
+            .Returns(StoredCatch(catchId, SyncStatus.Synchronised, SyncStatus.Synchronised, method: "Fly"));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var synchroniser = Substitute.For<ICatchSynchroniser>();
         synchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException());
-        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var preferences = QuietAnglerPreferences(SamplePreferences(), SampleCatalogue());
+        await using var context = CreateContext(
+            store,
+            synchroniser: synchroniser,
+            anglerPreferences: preferences);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, catchId));
-        cut.WaitForAssertion(() => cut.Find("#catch-edit-species").Should().NotBeNull());
-        cut.Find("#catch-edit-species").Input("Pike");
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-method-Spinning"));
+        await cut.Find("#catch-edit-method-Spinning").ClickAsync();
 
         // Act
         await cut.Find("#catch-edit-save").ClickAsync();
@@ -398,14 +406,18 @@ public class WhenTestingSave : BaseCatchEditTest
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
         store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
-            .Returns(StoredCatch(catchId));
+            .Returns(StoredCatch(catchId, method: "Fly"));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var synchroniser = QuietSynchroniser();
-        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var preferences = QuietAnglerPreferences(SamplePreferences(), SampleCatalogue());
+        await using var context = CreateContext(
+            store,
+            synchroniser: synchroniser,
+            anglerPreferences: preferences);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, catchId));
-        cut.WaitForAssertion(() => cut.Find("#catch-edit-species").Should().NotBeNull());
-        cut.Find("#catch-edit-species").Input("Brochet");
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-species-BrownTrout"));
+        cut.Find("#catch-edit-weight").Input("1.5");
 
         // Act
         await cut.Find("#catch-edit-save").ClickAsync();
@@ -414,11 +426,12 @@ public class WhenTestingSave : BaseCatchEditTest
         cut.WaitForAssertion(() =>
             cut.Find("#catch-edit-saved").TextContent
                 .Should()
-                .Contain("Détails enregistrés sur cet appareil"));
+                .Contain("DÃ©tails enregistrÃ©s sur cet appareil"));
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord =>
-                catchRecord.Id == catchId && catchRecord.SpeciesName == "Brochet"),
+                catchRecord.Id == catchId && catchRecord.SpeciesName == "Brown Trout"),
             Arg.Any<CancellationToken>());
         await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingPreferences.cs
@@ -41,6 +41,8 @@ public class WhenTestingPreferences : BaseProfileTest
             cut.Find("#profile-species-section-Fly").Should().NotBeNull();
             cut.Find("#profile-species-Fly-BrownTrout").Should().NotBeNull();
             cut.FindAll("#profile-species-section-Spinning").Should().BeEmpty();
+            cut.Find("#profile-method-chips").QuerySelectorAll("input").Should().BeEmpty();
+            cut.Find("#profile-species-section-Fly").QuerySelectorAll("input").Should().BeEmpty();
         });
         await preferenceClient.Received(1).GetCatalogueAsync(Arg.Any<CancellationToken>());
         await preferenceClient.Received(1).GetPreferencesAsync(Arg.Any<CancellationToken>());
@@ -65,8 +67,8 @@ public class WhenTestingPreferences : BaseProfileTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#profile-method-default-Fly").TextContent.Should().Be("Fly Default");
-            cut.Find("#profile-species-Fly-BrownTrout").TextContent.Should().Be("Brown Trout Default");
+            cut.Find("#profile-method-default-Fly").TextContent.Should().Be("FlyÂ Default");
+            cut.Find("#profile-species-Fly-BrownTrout").TextContent.Should().Be("Brown TroutÂ Default");
         });
     }
 
@@ -92,7 +94,7 @@ public class WhenTestingPreferences : BaseProfileTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#profile-method-default-Spinning").TextContent.Should().Be("Spinning");
-            cut.Find("#profile-method-default-Fly").TextContent.Should().Be("Fly Default");
+            cut.Find("#profile-method-default-Fly").TextContent.Should().Be("FlyÂ Default");
         });
     }
 
@@ -386,10 +388,11 @@ public class WhenTestingPreferences : BaseProfileTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Markup.Should().Contain("Méthodes de pêche préférées");
-            cut.Markup.Should().Contain("Unité de poids préférée");
-            cut.Markup.Should().Contain("Espèces préférées pour Fly");
-            cut.Find("#profile-species-more-Fly").TextContent.Should().Contain("Plus…");
+            cut.Markup.Should().Contain("MÃ©thodes de pÃªche prÃ©fÃ©rÃ©es");
+            cut.Markup.Should().Contain("UnitÃ© de poids prÃ©fÃ©rÃ©e");
+            cut.Markup.Should().Contain("EspÃ¨ces prÃ©fÃ©rÃ©es pour Fly");
+            cut.Find("#profile-species-more-Fly").TextContent.Should().Contain("Plusâ€¦");
         });
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingPreferences.cs
@@ -67,8 +67,8 @@ public class WhenTestingPreferences : BaseProfileTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#profile-method-default-Fly").TextContent.Should().Be("FlyÂ Default");
-            cut.Find("#profile-species-Fly-BrownTrout").TextContent.Should().Be("Brown TroutÂ Default");
+            cut.Find("#profile-method-default-Fly").TextContent.Should().Be("Fly Default");
+            cut.Find("#profile-species-Fly-BrownTrout").TextContent.Should().Be("Brown Trout Default");
         });
     }
 
@@ -94,7 +94,7 @@ public class WhenTestingPreferences : BaseProfileTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#profile-method-default-Spinning").TextContent.Should().Be("Spinning");
-            cut.Find("#profile-method-default-Fly").TextContent.Should().Be("FlyÂ Default");
+            cut.Find("#profile-method-default-Fly").TextContent.Should().Be("Fly Default");
         });
     }
 
@@ -388,10 +388,10 @@ public class WhenTestingPreferences : BaseProfileTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Markup.Should().Contain("MÃ©thodes de pÃªche prÃ©fÃ©rÃ©es");
-            cut.Markup.Should().Contain("UnitÃ© de poids prÃ©fÃ©rÃ©e");
-            cut.Markup.Should().Contain("EspÃ¨ces prÃ©fÃ©rÃ©es pour Fly");
-            cut.Find("#profile-species-more-Fly").TextContent.Should().Contain("Plusâ€¦");
+            cut.Markup.Should().Contain("Méthodes de pêche préférées");
+            cut.Markup.Should().Contain("Unité de poids préférée");
+            cut.Markup.Should().Contain("Espèces préférées pour Fly");
+            cut.Find("#profile-species-more-Fly").TextContent.Should().Contain("Plus…");
         });
     }
 }


### PR DESCRIPTION
## Summary

- remove the duplicate free-text Fishing Method and Species fields from Catch Edit
- retain preferred/default chips and the canonical `More…` searchable catalogue path
- preserve historical/unmapped saved values as selected compatibility chips and save them unchanged
- strengthen Profile, Record Catch, Catch Edit, canonical selection, legacy-value, offline save/sync, and localisation regression coverage

Closes #118

## Scope and compatibility

Profile, Record Catch, and onboarding were audited and already use the canonical catalogue interaction model, so their production code is unchanged. This PR does not add user-created catalogue values, change persistence/synchronisation, alter the database, or require deployment configuration.

Legacy Method/Species strings remain readable: the existing shortlist compatibility logic displays the saved value as the selected chip when it is not in the catalogue. Saving without changing it preserves the exact stored strings and does not create catalogue entries.

## Validation

- `dotnet format FishingLogBook.sln` — passed
- `dotnet build FishingLogBook.sln --no-restore` — passed (NuGet vulnerability-feed warnings only because nuget.org is unavailable in the managed session)
- Targeted Catch Edit tests — 46 passed
- Surrounding Profile/Record Catch/onboarding/catalogue/localisation/sync tests — 144 passed
- Full .NET suites — Shared 18, Db Migrations 10, Application 298, API 145, Web 588, and Infrastructure non-container 14 passed
- Infrastructure PostgreSQL tests — 103 could not start because this managed Windows session cannot access the Docker named pipe; this change does not touch infrastructure or persistence
- `npm test` — 165 passed
- `npm run test:browser` — 27 passed, 1 existing WebKit offline-service-worker test skipped

## Self review

- Issue/AC: PASS — every #118 acceptance criterion is implemented or confirmed by existing catalogue behaviour and focused tests
- Architecture/CQRS: PASS — UI-only removal; no CQRS or layering changes
- Rules: PASS — repository workflow, Blazor, testing, Git, and GitHub rules followed
- Security/privacy: PASS — no identity, authorization, location, or privacy surface changed
- Database/migrations: N/A — no schema, seed, repository, or migration changes
- Tests/coverage: PASS — duplicate-control, canonical More selection, saved/legacy value preservation, offline save/sync, Record Catch, Profile, onboarding, and localisation paths covered
- Browser: PASS with deliberate boundary — IndexedDB/offline browser tests pass; authenticated Blazor UI is covered by bUnit because the current Playwright harness is intentionally not an authenticated Blazor host
- Web/UI/localisation: PASS — no new copy; EN/FR suites remain green
- Code smells: PASS — obsolete binding wrappers were removed with the fields; no new abstraction or duplication
- CI/deployment: PASS — no deployment, configuration, infrastructure, or manual post-merge step required

### Findings discovered during self-review

1. No BLOCKER or SHOULD FIX findings.
2. Physical browser rendering of the authenticated Catch Edit page is not exercised by the current Playwright architecture.

### Fixes made

1. Updated Catch Edit tests to assert canonical chip state instead of removed text input state.
2. Added explicit coverage that unmapped historical values remain selected and survive save unchanged.
3. Strengthened the full-catalogue test with a canonical method outside the preferred shortlist.
4. Added Profile regression assertions preventing Method/Species text inputs from returning.

### Remaining deliberate gaps

- No authenticated Blazor Playwright test was added; doing so would require out-of-scope test authentication/hosting infrastructure. Existing bUnit coverage is appropriate, and no follow-up is warranted solely for this small markup removal.
- The Docker-dependent Infrastructure suite must run in CI or a local session with Docker access.
