### PR TITLE
FLB#121 | deploy all production targets by default

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,6 +14,7 @@ on:
         required: true
         type: choice
         options:
+          - all
           - web
           - api
           - root
@@ -68,7 +69,7 @@ jobs:
 
   deploy-web:
     name: Deploy production PWA
-    if: inputs.target == 'web'
+    if: inputs.target == 'all' || inputs.target == 'web'
     needs: validate
     runs-on: ubuntu-latest
     environment: prod
@@ -127,7 +128,7 @@ jobs:
 
   deploy-api:
     name: Deploy production API
-    if: inputs.target == 'api'
+    if: inputs.target == 'all' || inputs.target == 'api'
     needs: validate
     runs-on: ubuntu-latest
     environment: prod
@@ -161,7 +162,7 @@ jobs:
 
   deploy-root:
     name: Deploy production root site
-    if: inputs.target == 'root'
+    if: inputs.target == 'all' || inputs.target == 'root'
     needs: validate
     runs-on: ubuntu-latest
     environment: prod


### PR DESCRIPTION
## Summary

- add `all` as the first/default production deployment target
- deploy Web when target is `all` or `web`
- deploy API when target is `all` or `api`
- deploy root when target is `all` or `root`
- retain single-component redeploy options
- keep one shared validation/build/test job and the existing protected `prod` environment gate

Closes #121

## Release note

`v0.1.0` already points to the pre-fix commit and must remain immutable. After this PR merges and dev is validated, create `v0.1.1` on the new `main` commit and use `target = all` for the first full production deployment.

No Terraform or live infrastructure changes.