### PR TITLE
FLB#123 | add lightweight release workflow

### DIFF
--- a/.github/scripts/release-version.mjs
+++ b/.github/scripts/release-version.mjs
@@ -1,0 +1,90 @@
+import { pathToFileURL } from 'node:url';
+
+const releaseTagPattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const allowedBumps = new Set(['patch', 'minor', 'major']);
+
+export function parseReleaseTag(tag) {
+    const match = releaseTagPattern.exec(tag);
+    if (!match) {
+        return null;
+    }
+
+    return {
+        tag,
+        major: BigInt(match[1]),
+        minor: BigInt(match[2]),
+        patch: BigInt(match[3]),
+    };
+}
+
+export function latestReleaseTag(tags) {
+    const versions = tags
+        .map(parseReleaseTag)
+        .filter(version => version !== null)
+        .sort(compareVersions);
+
+    if (versions.length === 0) {
+        throw new Error('No existing release tag matching vX.Y.Z was found.');
+    }
+
+    return versions.at(-1);
+}
+
+export function nextReleaseTag(tags, bump) {
+    if (!allowedBumps.has(bump)) {
+        throw new Error('Release bump must be patch, minor, or major.');
+    }
+
+    const latest = latestReleaseTag(tags);
+    if (bump === 'major') {
+        return `v${latest.major + 1n}.0.0`;
+    }
+
+    if (bump === 'minor') {
+        return `v${latest.major}.${latest.minor + 1n}.0`;
+    }
+
+    return `v${latest.major}.${latest.minor}.${latest.patch + 1n}`;
+}
+
+function compareVersions(left, right) {
+    if (left.major !== right.major) {
+        return left.major < right.major ? -1 : 1;
+    }
+
+    if (left.minor !== right.minor) {
+        return left.minor < right.minor ? -1 : 1;
+    }
+
+    if (left.patch !== right.patch) {
+        return left.patch < right.patch ? -1 : 1;
+    }
+
+    return 0;
+}
+
+async function main() {
+    const operation = process.argv[2];
+    const input = await readStandardInput();
+    const tags = input.split(/\r?\n/u).map(tag => tag.trim()).filter(Boolean);
+    const result = operation === 'latest'
+        ? latestReleaseTag(tags).tag
+        : nextReleaseTag(tags, operation);
+    process.stdout.write(`${result}\n`);
+}
+
+async function readStandardInput() {
+    let input = '';
+    for await (const chunk of process.stdin) {
+        input += chunk;
+    }
+
+    return input;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch(error => {
+        process.stderr.write(`${error.message}\n`);
+        process.exitCode = 1;
+    });
+}

--- a/.github/scripts/release-version.test.mjs
+++ b/.github/scripts/release-version.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { latestReleaseTag, nextReleaseTag, parseReleaseTag } from './release-version.mjs';
+
+describe('release version calculation', () => {
+    it('ignores invalid tags and rejects numeric versions with leading zeroes', () => {
+        assert.equal(parseReleaseTag('release-1.2.3'), null);
+        assert.equal(parseReleaseTag('v01.2.3'), null);
+        assert.equal(parseReleaseTag('v1.2.3')?.tag, 'v1.2.3');
+    });
+
+    it('uses semantic numeric ordering instead of lexicographic ordering', () => {
+        const latest = latestReleaseTag(['v0.9.0', 'not-a-release', 'v0.10.0', 'v0.2.99']);
+        assert.equal(latest.tag, 'v0.10.0');
+    });
+
+    it('calculates the next patch release', () => {
+        assert.equal(nextReleaseTag(['v0.1.0'], 'patch'), 'v0.1.1');
+    });
+
+    it('calculates the next minor release and resets patch', () => {
+        assert.equal(nextReleaseTag(['v1.9.8'], 'minor'), 'v1.10.0');
+    });
+
+    it('calculates the next major release and resets minor and patch', () => {
+        assert.equal(nextReleaseTag(['v9.8.7'], 'major'), 'v10.0.0');
+    });
+
+    it('rejects an unsupported bump', () => {
+        assert.throws(() => nextReleaseTag(['v0.1.0'], 'prerelease'), /patch, minor, or major/);
+    });
+
+    it('fails safely when no valid release tag exists', () => {
+        assert.throws(() => nextReleaseTag(['latest'], 'patch'), /No existing release tag/);
+    });
+
+    it('calculates a release from newline-delimited tags on standard input', () => {
+        const result = spawnSync(
+            process.execPath,
+            [fileURLToPath(new URL('./release-version.mjs', import.meta.url)), 'minor'],
+            { input: 'v0.9.0\nv0.10.0\n', encoding: 'utf8' });
+
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, 'v0.11.0\n');
+        assert.equal(result.stderr, '');
+    });
+});
+
+describe('Create Release workflow safety', () => {
+    const workflow = readFileSync(
+        new URL('../workflows/create-release.yml', import.meta.url),
+        'utf8');
+    const productionWorkflow = readFileSync(
+        new URL('../workflows/deploy-production.yml', import.meta.url),
+        'utf8');
+    const buildWorkflow = readFileSync(
+        new URL('../workflows/build-test.yml', import.meta.url),
+        'utf8');
+
+    it('is manual and accepts only patch, minor, or major', () => {
+        assert.match(workflow, /workflow_dispatch:/);
+        assert.match(workflow, /options:\s*\n\s*- patch\s*\n\s*- minor\s*\n\s*- major/);
+        assert.doesNotMatch(workflow, /\n\s*push:/);
+    });
+
+    it('serializes release mutation without cancelling an active run', () => {
+        assert.match(workflow, /group: cbdf-create-release/);
+        assert.match(workflow, /cancel-in-progress: false/);
+    });
+
+    it('validates the exact current main commit before release mutation', () => {
+        assert.match(buildWorkflow, /workflow_call:/);
+        assert.match(workflow, /ref: main/);
+        assert.match(workflow, /refs\/heads\/main/);
+        assert.match(workflow, /git ls-remote --exit-code origin refs\/heads\/main/);
+        assert.match(workflow, /needs: \[verify-main, validate\]/);
+    });
+
+    it('rechecks main and tags and never force-pushes a tag', () => {
+        assert.match(workflow, /git fetch origin main --tags/);
+        assert.match(workflow, /git ls-remote --exit-code --tags origin "refs\/tags\/\$\{NEXT_TAG\}"/);
+        assert.match(workflow, /git push origin "refs\/tags\/\$\{NEXT_TAG\}"/);
+        assert.doesNotMatch(workflow, /git push[^\n]*--force/);
+        assert.doesNotMatch(workflow, /git tag -d|git push[^\n]*--delete|v0\.1\.0/);
+    });
+
+    it('refuses to release the same main commit twice', () => {
+        assert.match(workflow, /LATEST_TAG/);
+        assert.match(workflow, /already released as/);
+        assert.match(workflow, /git rev-list -n 1 "\$\{LATEST_TAG\}"/);
+    });
+
+    it('uses least-privilege job permissions for release and dispatch', () => {
+        assert.match(workflow, /contents: read/);
+        assert.match(workflow, /contents: write\s*\n\s*actions: write/);
+        assert.doesNotMatch(workflow, /pull-requests: write|issues: write/);
+    });
+
+    it('creates a release only for the pushed tag then dispatches all production targets', () => {
+        assert.match(workflow, /gh release create "\$\{NEXT_TAG\}"/);
+        assert.match(workflow, /--verify-tag/);
+        assert.match(workflow, /gh workflow run deploy-production\.yml/);
+        assert.match(workflow, /--raw-field release_tag="\$\{NEXT_TAG\}"/);
+        assert.match(workflow, /--raw-field target=all/);
+        assert.match(productionWorkflow, /environment: prod/);
+        assert.ok(workflow.indexOf('uses: ./.github/workflows/build-test.yml')
+            < workflow.indexOf('git tag -a'));
+    });
+});

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,7 @@
 name: build-test
 
 on:
+  workflow_call:
   push:
     branches: [main, develop]
   pull_request:
@@ -62,6 +63,7 @@ jobs:
       - run: npm ci
       - run: >-
           node --test
+          .github/scripts/release-version.test.mjs
           src/FishingLogBook.Web/build/configure-web.test.mjs
           src/FishingLogBook.Root/build/root-site.test.mjs
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,131 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Semantic version increment
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+concurrency:
+  group: cbdf-create-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify-main:
+    name: Verify current main candidate
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.candidate.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Confirm workflow targets current remote main
+        id: candidate
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "${DISPATCH_REF}" = "refs/heads/main"
+          git fetch origin main --tags
+          MAIN_SHA="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+          test "${DISPATCH_SHA}" = "${MAIN_SHA}"
+          test "$(git rev-parse HEAD)" = "${MAIN_SHA}"
+          echo "sha=${MAIN_SHA}" >> "${GITHUB_OUTPUT}"
+
+  validate:
+    name: Validate release candidate
+    needs: verify-main
+    uses: ./.github/workflows/build-test.yml
+    permissions:
+      contents: read
+
+  create-release:
+    name: Create immutable tag and release
+    needs: [verify-main, validate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Calculate release version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags
+          LATEST_TAG="$(git tag --list | node .github/scripts/release-version.mjs latest)"
+          LATEST_SHA="$(git rev-list -n 1 "${LATEST_TAG}")"
+          if test "${LATEST_SHA}" = "${{ needs.verify-main.outputs.sha }}"
+          then
+            echo "Current main is already released as ${LATEST_TAG}; refusing to create a duplicate release." >&2
+            exit 1
+          fi
+          NEXT_TAG="$(git tag --list | node .github/scripts/release-version.mjs "${BUMP}")"
+          echo "tag=${NEXT_TAG}" >> "${GITHUB_OUTPUT}"
+      - name: Recheck candidate and push immutable tag
+        env:
+          BUMP: ${{ inputs.bump }}
+          CANDIDATE_SHA: ${{ needs.verify-main.outputs.sha }}
+          EXPECTED_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags
+          REMOTE_MAIN_SHA="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+          test "${REMOTE_MAIN_SHA}" = "${CANDIDATE_SHA}"
+          test "$(git rev-parse HEAD)" = "${CANDIDATE_SHA}"
+          LATEST_TAG="$(git tag --list | node .github/scripts/release-version.mjs latest)"
+          LATEST_SHA="$(git rev-list -n 1 "${LATEST_TAG}")"
+          if test "${LATEST_SHA}" = "${CANDIDATE_SHA}"
+          then
+            echo "Current main is already released as ${LATEST_TAG}; refusing to create a duplicate release." >&2
+            exit 1
+          fi
+          NEXT_TAG="$(git tag --list | node .github/scripts/release-version.mjs "${BUMP}")"
+          test "${NEXT_TAG}" = "${EXPECTED_TAG}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${NEXT_TAG}" >/dev/null 2>&1
+          then
+            echo "Release tag ${NEXT_TAG} already exists; refusing to move or replace it." >&2
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${NEXT_TAG}" "${CANDIDATE_SHA}" -m "CBDF ${NEXT_TAG}"
+          git push origin "refs/tags/${NEXT_TAG}"
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ steps.version.outputs.tag }}
+        run: >-
+          gh release create "${NEXT_TAG}"
+          --verify-tag
+          --generate-notes
+          --title "CBDF ${NEXT_TAG}"
+      - name: Start protected production deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ steps.version.outputs.tag }}
+        run: >-
+          gh workflow run deploy-production.yml
+          --ref main
+          --raw-field release_tag="${NEXT_TAG}"
+          --raw-field target=all

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -7,25 +7,31 @@ Production deploys are manual and must use an immutable annotated tag in the exa
 ## Normal release
 
 1. Merge the reviewed feature PR into `main` and wait for CI and development deployment checks.
-2. From an up-to-date `main`, create and push an annotated tag:
+2. Open **Actions**, select **Create Release**, choose `patch`, `minor`, or `major`, and run the workflow from `main`.
+3. The workflow validates that exact current `main` commit, calculates the next semantic version, creates the immutable tag and GitHub Release, then starts **Deploy production** with `target = all`.
+4. Approve the protected `prod` environment gate after confirming the tag and commit shown by the deployment workflow.
+5. Verify the root site, Web/PWA and API. Confirm the authenticated About/System screen shows the expected, independent Web and API versions and SHAs, and that Grafana diagnostics contain the API build metadata.
+
+Never move, delete or reuse a published release tag. Correct mistakes with a new version. Do not rerun **Create Release** to recover a partially completed release: it will correctly calculate a newer version.
+
+## Release recovery
+
+If the immutable tag was pushed but GitHub Release creation failed, keep the tag and create the missing Release against it:
 
    ```bash
-   git tag -a v0.2.0 -m "Release v0.2.0"
-   git push origin v0.2.0
+   gh release create v0.2.0 --verify-tag --generate-notes --title "CBDF v0.2.0"
    ```
 
-3. Run **Deploy production** manually, enter the exact tag, and choose the required target.
-4. Approve the protected `prod` environment gate after confirming the tag and commit shown by the workflow.
-5. Verify the authenticated About/System screen shows the expected, independent Web and API versions and SHAs.
+If release creation succeeded but production dispatch failed, manually run **Deploy production** using that existing tag and `target = all`. These recovery steps never move or recreate the tag.
 
-Never move, delete, or reuse a published release tag. Correct mistakes with a new version.
+As an emergency-only procedure when Actions is unavailable, an authorised maintainer may create the next correctly calculated annotated tag on a verified `main` commit and push it without force, then create the GitHub Release and manually start **Deploy production**. This is not the normal CBDF release path.
 
 ## Hotfix
 
 1. Branch from the currently deployed production tag and make the smallest fix.
-2. Review and validate that temporary hotfix branch, then create the next patch tag from its exact commit (for example `v0.2.1`).
-3. Follow the normal production workflow and verification steps above.
-4. Bring the same commit back into `main` by merge or cherry-pick, according to the actual history, and delete the temporary branch.
+2. Review and fully validate that temporary hotfix branch. Because **Create Release** deliberately accepts only current `main`, calculate the next patch version, create its annotated tag on the hotfix commit, and push it without force using the emergency procedure above.
+3. Create the GitHub Release for that existing tag, manually run **Deploy production** with `target = all`, approve the protected `prod` gate, and complete the normal verification steps.
+4. Bring the same fix back into `main` by merge or cherry-pick, according to the actual history, and delete the temporary branch.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary

- add a manual **Create Release** workflow with only patch/minor/major inputs
- calculate the next immutable `vX.Y.Z` tag using deterministic numeric semantic ordering
- validate the exact current remote `main` commit through the existing build/test workflow before mutation
- serialize release runs and re-check `main`, tags, and duplicate-main releases immediately before pushing
- create the GitHub Release, then dispatch the existing production workflow with the exact tag and `target = all`
- document the normal release path and explicit partial-release/emergency recovery procedures

## Safety

- existing tags, including `v0.1.0`, are never moved, deleted, recreated, or force-pushed
- a queued concurrent run cannot release the same `main` commit twice
- a moved `main` or an already-existing calculated tag fails before mutation
- if GitHub Release creation or deployment dispatch fails after the tag push, the immutable tag remains and the documented recovery path resumes from it
- permissions are job-scoped and least-privilege: `contents: write` and `actions: write` only for the mutation job
- production deployment remains implemented solely by `deploy-production.yml`, including its protected `prod` approval gate

## Validation

- focused Node release/configuration tests: **33 passed**
- Release build: **succeeded, 0 errors**
- .NET application/API/Web/migration/shared tests: **green**
- full .NET suite: infrastructure tests require Docker and could not connect to the local Docker named pipe; all 14 non-container infrastructure tests passed
- JavaScript/PWA tests: **165 passed**
- Playwright browser tests: **27 passed, 1 existing WebKit offline-shell skip**
- mandatory self-review completed; duplicate-main concurrency and hotfix recovery documentation findings were corrected

No real release tag, GitHub Release, production deployment, Terraform apply, DNS change, or live infrastructure mutation was performed while implementing this PR.

Closes #123