### PR TITLE
FLB#124 | replace generic install page with platform-specific PWA guidance

### DIFF
--- a/src/FishingLogBook.Web/Browser/Install/IInstallService.cs
+++ b/src/FishingLogBook.Web/Browser/Install/IInstallService.cs
@@ -5,39 +5,8 @@ public interface IInstallService
     Task<InstallState> GetStateAsync(CancellationToken cancellationToken);
 
     Task<InstallResult> PromptAsync(CancellationToken cancellationToken);
-}
 
-public sealed record InstallState(
-    bool IsInstalled,
-    bool CanPrompt,
-    string PlatformFamily,
-    bool IsSafari)
-{
-    public InstallState(bool isInstalled, bool canPrompt, bool isIos, bool isAndroid)
-        : this(
-            isInstalled,
-            canPrompt,
-            isIos ? InstallPlatformFamilies.Ios : isAndroid ? InstallPlatformFamilies.Android : InstallPlatformFamilies.Other,
-            isIos)
-    {
-    }
-
-    public bool IsIos => PlatformFamily == InstallPlatformFamilies.Ios;
-    public bool IsAndroid => PlatformFamily == InstallPlatformFamilies.Android;
-    public bool IsWindows => PlatformFamily == InstallPlatformFamilies.Windows;
-}
-
-public enum InstallResult
-{
-    Unavailable,
-    Accepted,
-    Dismissed
-}
-
-public static class InstallPlatformFamilies
-{
-    public const string Ios = "iOS";
-    public const string Android = "Android";
-    public const string Windows = "Windows";
-    public const string Other = "Other";
+    Task<IAsyncDisposable> SubscribeAsync(
+        Func<InstallState, Task> onStateChanged,
+        CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor
+++ b/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor
@@ -2,16 +2,18 @@
 
 <section class="install-guidance" aria-labelledby="install-guidance-title" id="install-guidance">
     <MudText Typo="Typo.h5" id="install-guidance-title">@Loc["Install_Title"]</MudText>
-    @if (_isLoading)
+
+    @if (_isDetecting)
     {
         <MudProgressCircular Indeterminate="true" Color="Color.Primary" aria-label="@Loc["Common_Loading"]" id="install-guidance-loading" />
     }
-    else if (_state.IsInstalled || _result == InstallResult.Accepted)
+    else if (IsInstalled)
     {
         <MudAlert Severity="Severity.Success" Icon="@Icons.Material.Filled.CheckCircle" id="install-guidance-installed">
             <MudText Typo="Typo.subtitle1">@Loc["Install_InstalledTitle"]</MudText>
-            <MudText>@(_state.IsWindows ? Loc["Install_InstalledWindows"] : Loc["Install_InstalledBody"])</MudText>
+            <MudText>@(_state.IsDesktop ? Loc["Install_InstalledDesktop"] : Loc["Install_InstalledBody"])</MudText>
         </MudAlert>
+        <MudText Typo="Typo.body2" Class="mud-text-secondary" id="install-guidance-other-devices">@Loc["Install_InstalledOtherDevices"]</MudText>
     }
     else
     {
@@ -33,52 +35,62 @@
             </MudButton>
         }
 
-        @if (_state.IsAndroid)
-        {
-            <MudText Typo="Typo.subtitle1" id="install-guidance-android-heading">@Loc["Install_AndroidHeading"]</MudText>
-            <MudText id="install-guidance-android-alternative">@Loc["Install_AndroidAlternative"]</MudText>
-            <ol class="install-steps" id="install-guidance-android-steps">
-                <li>@Loc["Install_AndroidStep1"]</li>
-                <li>@Loc["Install_AndroidStep2"]</li>
-                <li>@Loc["Install_AndroidStep3"]</li>
-            </ol>
-        }
-        else if (!_state.CanPrompt && _state.IsIos)
-        {
-            @if (!_state.IsSafari)
-            {
-                <MudAlert Severity="Severity.Info" id="install-guidance-ios-browser">@Loc["Install_IosUseSafari"]</MudAlert>
-            }
-            <MudText Typo="Typo.subtitle1" id="install-guidance-ios-heading">@Loc["Install_IosHeading"]</MudText>
-            <ol class="install-steps" id="install-guidance-ios-steps">
-                <li>@Loc["Install_IosStep1"]</li>
-                <li>@Loc["Install_IosStep2"]</li>
-                <li>@Loc["Install_IosStep3"]</li>
-                <li>@Loc["Install_IosStep4"]</li>
-                <li>@Loc["Install_IosStep5"]</li>
-            </ol>
-        }
-        else if (!_state.CanPrompt && _state.IsWindows)
-        {
-            <MudText Typo="Typo.subtitle1" id="install-guidance-windows-heading">@Loc["Install_WindowsHeading"]</MudText>
-            <ol class="install-steps" id="install-guidance-windows-steps">
-                <li>@Loc["Install_WindowsStep1"]</li>
-                <li>@Loc["Install_WindowsStep2"]</li>
-            </ol>
-        }
-        else if (!_state.CanPrompt)
-        {
-            <MudText Typo="Typo.subtitle1" id="install-guidance-other-heading">@Loc["Install_OtherHeading"]</MudText>
-            <MudText id="install-guidance-unsupported">@Loc["Install_Unsupported"]</MudText>
-            <ol class="install-steps" id="install-guidance-other-steps">
-                <li>@Loc["Install_OtherStep1"]</li>
-                <li>@Loc["Install_OtherStep2"]</li>
-            </ol>
-        }
+        <MudText Typo="Typo.body2" id="install-guidance-manual-intro">@Loc["Install_ManualIntro"]</MudText>
+    }
 
-        @if (ShowInstallLaterMessage)
-        {
-            <MudText Typo="Typo.caption" Class="mud-text-secondary" id="install-guidance-later">@Loc["Install_Later"]</MudText>
-        }
+    <MudExpansionPanels MultiExpansion="true" Elevation="1" id="install-guidance-platforms">
+        <MudExpansionPanel Text="@Loc["Install_IosPanel"]" @bind-Expanded="_isIosExpanded" id="install-guidance-ios-panel">
+            <MudStack Spacing="3">
+                @if (_state.IsIos && !_state.IsSafari)
+                {
+                    <MudAlert Severity="Severity.Info" id="install-guidance-ios-browser">@Loc["Install_IosUseSafari"]</MudAlert>
+                }
+                <MudText Typo="Typo.subtitle2" id="install-guidance-ios-heading">@Loc["Install_IosHeading"]</MudText>
+                <ol class="install-steps" id="install-guidance-ios-steps">
+                    <li>@Loc["Install_IosStep1"]</li>
+                    <li>@Loc["Install_IosStep2"]</li>
+                    <li>@Loc["Install_IosStep3"]</li>
+                    <li>@Loc["Install_IosStep4"]</li>
+                    <li>@Loc["Install_IosStep5"]</li>
+                </ol>
+                <MudText Typo="Typo.subtitle2" id="install-guidance-ios-fallback-heading">@Loc["Install_IosFallbackHeading"]</MudText>
+                <MudText id="install-guidance-ios-fallback">@Loc["Install_IosFallbackBody"]</MudText>
+            </MudStack>
+        </MudExpansionPanel>
+
+        <MudExpansionPanel Text="@Loc["Install_AndroidPanel"]" @bind-Expanded="_isAndroidExpanded" id="install-guidance-android-panel">
+            <MudStack Spacing="3">
+                <MudText Typo="Typo.subtitle2" id="install-guidance-android-heading">@Loc["Install_AndroidHeading"]</MudText>
+                <ol class="install-steps" id="install-guidance-android-steps">
+                    <li>@Loc["Install_AndroidStep1"]</li>
+                    <li>@Loc["Install_AndroidStep2"]</li>
+                    <li>@Loc["Install_AndroidStep3"]</li>
+                    <li>@Loc["Install_AndroidStep4"]</li>
+                </ol>
+                <MudText Typo="Typo.subtitle2" id="install-guidance-samsung-heading">@Loc["Install_SamsungHeading"]</MudText>
+                <ol class="install-steps" id="install-guidance-samsung-steps">
+                    <li>@Loc["Install_SamsungStep1"]</li>
+                    <li>@Loc["Install_SamsungStep2"]</li>
+                    <li>@Loc["Install_SamsungStep3"]</li>
+                </ol>
+            </MudStack>
+        </MudExpansionPanel>
+
+        <MudExpansionPanel Text="@Loc["Install_ComputerPanel"]" @bind-Expanded="_isDesktopExpanded" id="install-guidance-computer-panel">
+            <MudStack Spacing="3">
+                <MudText Typo="Typo.subtitle2" id="install-guidance-computer-heading">@Loc["Install_ComputerHeading"]</MudText>
+                <ol class="install-steps" id="install-guidance-computer-steps">
+                    <li>@Loc["Install_ComputerStep1"]</li>
+                    <li>@Loc["Install_ComputerStep2"]</li>
+                    <li>@Loc["Install_ComputerStep3"]</li>
+                    <li>@Loc["Install_ComputerStep4"]</li>
+                </ol>
+            </MudStack>
+        </MudExpansionPanel>
+    </MudExpansionPanels>
+
+    @if (ShowInstallLaterMessage)
+    {
+        <MudText Typo="Typo.caption" Class="mud-text-secondary" id="install-guidance-later">@Loc["Install_Later"]</MudText>
     }
 </section>

--- a/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.cs
+++ b/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.cs
@@ -1,15 +1,25 @@
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
 
 namespace FishingLogBook.Web.Browser.Install;
 
-public partial class InstallGuidance : ComponentBase
+public partial class InstallGuidance : ComponentBase, IAsyncDisposable
 {
-    private InstallState _state = new(false, false, false, false);
+    private const string DetectionSource = "install detection";
+
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    private InstallState _state = InstallState.Unknown;
     private InstallResult _result = InstallResult.Unavailable;
-    private bool _isLoading = true;
+    private IAsyncDisposable? _subscription;
+    private bool _isDetecting = true;
     private bool _isPrompting;
+    private bool _initialExpansionApplied;
+    private bool _isIosExpanded;
+    private bool _isAndroidExpanded;
+    private bool _isDesktopExpanded;
 
     [Parameter]
     public bool ShowInstallLaterMessage { get; set; }
@@ -18,11 +28,24 @@ public partial class InstallGuidance : ComponentBase
     private IInstallService InstallService { get; set; } = default!;
 
     [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool IsInstalled => _state.IsInstalled || _result == InstallResult.Accepted;
 
     protected override async Task OnInitializedAsync()
     {
         await RefreshAsync();
+        await SubscribeAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cancellationTokenSource.CancelAsync();
+        await ReleaseSubscriptionAsync();
+        _cancellationTokenSource.Dispose();
     }
 
     private async Task InstallAsync()
@@ -35,7 +58,7 @@ public partial class InstallGuidance : ComponentBase
         _isPrompting = true;
         try
         {
-            _result = await InstallService.PromptAsync(CancellationToken.None);
+            _result = await InstallService.PromptAsync(_cancellationTokenSource.Token);
             if (_result == InstallResult.Accepted)
             {
                 _state = _state with { IsInstalled = true, CanPrompt = false };
@@ -44,6 +67,16 @@ public partial class InstallGuidance : ComponentBase
             {
                 await RefreshAsync();
             }
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await LogFailureAsync(exception);
+            _result = InstallResult.Unavailable;
+            _state = _state with { CanPrompt = false };
         }
         finally
         {
@@ -55,15 +88,90 @@ public partial class InstallGuidance : ComponentBase
     {
         try
         {
-            _state = await InstallService.GetStateAsync(CancellationToken.None);
+            ApplyState(await InstallService.GetStateAsync(_cancellationTokenSource.Token));
         }
-        catch (Exception)
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
-            _state = new InstallState(false, false, InstallPlatformFamilies.Other, false);
+            return;
+        }
+        catch (Exception exception)
+        {
+            await LogFailureAsync(exception);
+            ApplyState(InstallState.Unknown);
         }
         finally
         {
-            _isLoading = false;
+            _isDetecting = false;
         }
+    }
+
+    private async Task SubscribeAsync()
+    {
+        try
+        {
+            _subscription = await InstallService.SubscribeAsync(
+                OnInstallStateChangedAsync,
+                _cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await LogFailureAsync(exception);
+        }
+    }
+
+    private Task OnInstallStateChangedAsync(InstallState state)
+    {
+        return InvokeAsync(() =>
+        {
+            ApplyState(state);
+            StateHasChanged();
+        });
+    }
+
+    private void ApplyState(InstallState state)
+    {
+        _state = state;
+        if (_initialExpansionApplied)
+        {
+            return;
+        }
+
+        _initialExpansionApplied = true;
+        if (state.IsInstalled)
+        {
+            return;
+        }
+
+        _isIosExpanded = state.IsIos;
+        _isAndroidExpanded = state.IsAndroid;
+        _isDesktopExpanded = state.IsDesktop;
+    }
+
+    private async Task ReleaseSubscriptionAsync()
+    {
+        if (_subscription is null)
+        {
+            return;
+        }
+
+        var subscription = _subscription;
+        _subscription = null;
+        try
+        {
+            await subscription.DisposeAsync();
+        }
+        catch (Exception exception)
+        {
+            await LogFailureAsync(exception);
+        }
+    }
+
+    private Task LogFailureAsync(Exception exception)
+    {
+        return Logging.LogErrorAsync(DetectionSource, exception, CancellationToken.None);
     }
 }

--- a/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.css
+++ b/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.css
@@ -19,3 +19,14 @@
 .install-steps li:last-child {
     margin-bottom: 0;
 }
+
+.install-guidance ::deep .mud-expand-panel-header {
+    min-height: 3rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    font-size: 1.0625rem;
+}
+
+.install-guidance ::deep .mud-expand-panel-text {
+    padding-bottom: 1.25rem;
+}

--- a/src/FishingLogBook.Web/Browser/Install/InstallPlatformFamilies.cs
+++ b/src/FishingLogBook.Web/Browser/Install/InstallPlatformFamilies.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Web.Browser.Install;
+
+public static class InstallPlatformFamilies
+{
+    public const string Ios = "iOS";
+    public const string Android = "Android";
+    public const string Desktop = "Desktop";
+    public const string Other = "Other";
+}

--- a/src/FishingLogBook.Web/Browser/Install/InstallResult.cs
+++ b/src/FishingLogBook.Web/Browser/Install/InstallResult.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Web.Browser.Install;
+
+public enum InstallResult
+{
+    Unavailable,
+    Accepted,
+    Dismissed
+}

--- a/src/FishingLogBook.Web/Browser/Install/InstallService.cs
+++ b/src/FishingLogBook.Web/Browser/Install/InstallService.cs
@@ -14,13 +14,13 @@ public sealed class InstallService : IInstallService
 
     public async Task<InstallState> GetStateAsync(CancellationToken cancellationToken)
     {
-        var module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+        var module = await ImportModuleAsync(cancellationToken);
         return await module.InvokeAsync<InstallState>("getInstallState", cancellationToken);
     }
 
     public async Task<InstallResult> PromptAsync(CancellationToken cancellationToken)
     {
-        var module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+        var module = await ImportModuleAsync(cancellationToken);
         var result = await module.InvokeAsync<string>("promptInstall", cancellationToken);
         return result switch
         {
@@ -28,5 +28,21 @@ public sealed class InstallService : IInstallService
             "dismissed" => InstallResult.Dismissed,
             _ => InstallResult.Unavailable
         };
+    }
+
+    public async Task<IAsyncDisposable> SubscribeAsync(
+        Func<InstallState, Task> onStateChanged,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(onStateChanged);
+        var module = await ImportModuleAsync(cancellationToken);
+        var subscription = new InstallStateSubscription(module, onStateChanged);
+        await subscription.StartAsync(cancellationToken);
+        return subscription;
+    }
+
+    private ValueTask<IJSObjectReference> ImportModuleAsync(CancellationToken cancellationToken)
+    {
+        return _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
     }
 }

--- a/src/FishingLogBook.Web/Browser/Install/InstallState.cs
+++ b/src/FishingLogBook.Web/Browser/Install/InstallState.cs
@@ -1,0 +1,17 @@
+namespace FishingLogBook.Web.Browser.Install;
+
+public sealed record InstallState(
+    bool IsInstalled,
+    bool CanPrompt,
+    string PlatformFamily,
+    bool IsSafari)
+{
+    public static InstallState Unknown { get; } =
+        new(false, false, InstallPlatformFamilies.Other, false);
+
+    public bool IsIos => PlatformFamily == InstallPlatformFamilies.Ios;
+
+    public bool IsAndroid => PlatformFamily == InstallPlatformFamilies.Android;
+
+    public bool IsDesktop => PlatformFamily == InstallPlatformFamilies.Desktop;
+}

--- a/src/FishingLogBook.Web/Browser/Install/InstallStateSubscription.cs
+++ b/src/FishingLogBook.Web/Browser/Install/InstallStateSubscription.cs
@@ -1,0 +1,62 @@
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Browser.Install;
+
+public sealed class InstallStateSubscription : IAsyncDisposable
+{
+    private readonly IJSObjectReference _module;
+    private readonly Func<InstallState, Task> _onStateChanged;
+    private DotNetObjectReference<InstallStateSubscription>? _reference;
+    private long _token;
+    private bool _disposed;
+
+    internal InstallStateSubscription(IJSObjectReference module, Func<InstallState, Task> onStateChanged)
+    {
+        _module = module;
+        _onStateChanged = onStateChanged;
+    }
+
+    internal async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _reference = DotNetObjectReference.Create(this);
+        _token = await _module.InvokeAsync<long>("subscribeInstallState", cancellationToken, _reference);
+    }
+
+    [JSInvokable]
+    public Task OnInstallStateChanged(InstallState state)
+    {
+        if (_disposed)
+        {
+            return Task.CompletedTask;
+        }
+
+        return _onStateChanged(state);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        try
+        {
+            await _module.InvokeVoidAsync("unsubscribeInstallState", _token);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+        catch (JSException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        finally
+        {
+            _reference?.Dispose();
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -667,29 +667,38 @@
   <data name="Install_Benefit" xml:space="preserve"><value>Installez l’application pour y accéder rapidement depuis votre appareil et profiter d’une expérience plus fiable lorsque vous pêchez.</value></data>
   <data name="Install_NativeAvailable" xml:space="preserve"><value>Votre navigateur peut installer l’application pour vous.</value></data>
   <data name="Install_Action" xml:space="preserve"><value>Installer l’application</value></data>
-  <data name="Install_Dismissed" xml:space="preserve"><value>L’application n’a pas été installée. Vous pouvez réessayer ou continuer et l’installer plus tard.</value></data>
+  <data name="Install_Dismissed" xml:space="preserve"><value>L’application n’a pas été installée. Vous pouvez réessayer ou suivre les étapes correspondant à votre appareil ci-dessous.</value></data>
+  <data name="Install_ManualIntro" xml:space="preserve"><value>Choisissez votre appareil ci-dessous pour obtenir les étapes détaillées.</value></data>
   <data name="Install_InstalledTitle" xml:space="preserve"><value>L’application est installée</value></data>
-  <data name="Install_InstalledBody" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget depuis votre écran d’accueil comme vos autres applications.</value></data>
-  <data name="Install_InstalledWindows" xml:space="preserve"><value>Vous pouvez maintenant ouvrir Catch, But Don’t Forget comme une application Windows normale depuis le menu Démarrer ou la recherche, puis l’épingler où vous le souhaitez.</value></data>
+  <data name="Install_InstalledBody" xml:space="preserve"><value>Vous utilisez l’application installée. Ouvrez Catch, But Don’t Forget depuis votre écran d’accueil chaque fois que vous partez pêcher.</value></data>
+  <data name="Install_InstalledDesktop" xml:space="preserve"><value>Vous utilisez l’application installée. Ouvrez Catch, But Don’t Forget depuis le menu Démarrer, le Dock ou votre liste d’applications, et épinglez-la où vous le souhaitez.</value></data>
+  <data name="Install_InstalledOtherDevices" xml:space="preserve"><value>Vous installez l’application sur un autre téléphone, une tablette ou un ordinateur ? Les étapes pour chaque appareil se trouvent ci-dessous.</value></data>
+  <data name="Install_IosPanel" xml:space="preserve"><value>iPhone / iPad</value></data>
+  <data name="Install_AndroidPanel" xml:space="preserve"><value>Android</value></data>
+  <data name="Install_ComputerPanel" xml:space="preserve"><value>Ordinateur</value></data>
   <data name="Install_IosHeading" xml:space="preserve"><value>Ajouter l’application à l’écran d’accueil</value></data>
-  <data name="Install_IosUseSafari" xml:space="preserve"><value>Pour une installation fiable sur iPhone ou iPad, ouvrez d’abord ce site dans Safari.</value></data>
+  <data name="Install_IosUseSafari" xml:space="preserve"><value>Vous n’utilisez pas Safari. Ouvrez d’abord Catch, But Don’t Forget dans Safari, puis suivez les étapes ci-dessous.</value></data>
   <data name="Install_IosStep1" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget dans Safari.</value></data>
-  <data name="Install_IosStep2" xml:space="preserve"><value>Touchez Partager.</value></data>
-  <data name="Install_IosStep3" xml:space="preserve"><value>Choisissez Sur l’écran d’accueil.</value></data>
-  <data name="Install_IosStep4" xml:space="preserve"><value>Touchez Ajouter.</value></data>
+  <data name="Install_IosStep2" xml:space="preserve"><value>Touchez Partager, le carré avec une flèche vers le haut.</value></data>
+  <data name="Install_IosStep3" xml:space="preserve"><value>Faites défiler la liste et choisissez Sur l’écran d’accueil.</value></data>
+  <data name="Install_IosStep4" xml:space="preserve"><value>Vérifiez le nom proposé pour l’application, puis touchez Ajouter.</value></data>
   <data name="Install_IosStep5" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget depuis sa nouvelle icône sur l’écran d’accueil.</value></data>
-  <data name="Install_AndroidHeading" xml:space="preserve"><value>Installer depuis le menu du navigateur</value></data>
-  <data name="Install_AndroidAlternative" xml:space="preserve"><value>Vous ne voyez pas d’option d’installation près de la barre d’adresse ? Vous pouvez toujours installer l’application depuis le menu du navigateur.</value></data>
-  <data name="Install_AndroidStep1" xml:space="preserve"><value>Ouvrez le menu de votre navigateur.</value></data>
-  <data name="Install_AndroidStep2" xml:space="preserve"><value>Choisissez l’option Installer l’application ou Ajouter à l’écran d’accueil. Le libellé peut varier selon le navigateur.</value></data>
-  <data name="Install_AndroidStep3" xml:space="preserve"><value>Confirmez, puis ouvrez Catch, But Don’t Forget depuis votre écran d’accueil.</value></data>
-  <data name="Install_WindowsHeading" xml:space="preserve"><value>Installer sous Windows</value></data>
-  <data name="Install_WindowsStep1" xml:space="preserve"><value>Dans Edge ou Chrome, ouvrez le menu du navigateur et recherchez son option d’installation d’application.</value></data>
-  <data name="Install_WindowsStep2" xml:space="preserve"><value>Après l’installation, ouvrez l’application depuis le menu Démarrer ou la recherche, puis épinglez-la où vous le souhaitez.</value></data>
-  <data name="Install_OtherHeading" xml:space="preserve"><value>Installer depuis votre navigateur</value></data>
-  <data name="Install_Unsupported" xml:space="preserve"><value>Votre navigateur peut proposer l’installation sans afficher de bouton sur cette page.</value></data>
-  <data name="Install_OtherStep1" xml:space="preserve"><value>Recherchez une icône d’installation dans la barre d’adresse et sélectionnez-la.</value></data>
-  <data name="Install_OtherStep2" xml:space="preserve"><value>Si aucune icône n’apparaît, ouvrez le menu du navigateur et recherchez Installer l’application ou Ajouter à l’écran d’accueil. Si aucune option n’est proposée, vous pouvez continuer dans le navigateur.</value></data>
+  <data name="Install_IosFallbackHeading" xml:space="preserve"><value>Aucune option Sur l’écran d’accueil ?</value></data>
+  <data name="Install_IosFallbackBody" xml:space="preserve"><value>Vous avez probablement ouvert la page dans un autre navigateur, ou dans une autre application comme une messagerie. Choisissez Ouvrir dans Safari si l’option est proposée, ou copiez l’adresse web, collez-la dans Safari, puis suivez les cinq étapes ci-dessus.</value></data>
+  <data name="Install_AndroidHeading" xml:space="preserve"><value>Installer avec Chrome ou un autre navigateur Chromium</value></data>
+  <data name="Install_AndroidStep1" xml:space="preserve"><value>Ouvrez le menu du navigateur, les trois points (⋮) en haut de l’écran.</value></data>
+  <data name="Install_AndroidStep2" xml:space="preserve"><value>Choisissez Installer l’application, ou Ajouter à l’écran d’accueil selon le libellé affiché.</value></data>
+  <data name="Install_AndroidStep3" xml:space="preserve"><value>Confirmez l’installation lorsque le navigateur vous le demande.</value></data>
+  <data name="Install_AndroidStep4" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget depuis sa nouvelle icône sur l’écran d’accueil.</value></data>
+  <data name="Install_SamsungHeading" xml:space="preserve"><value>Samsung Internet</value></data>
+  <data name="Install_SamsungStep1" xml:space="preserve"><value>Ouvrez le menu du navigateur en bas de l’écran.</value></data>
+  <data name="Install_SamsungStep2" xml:space="preserve"><value>Choisissez Ajouter la page à.</value></data>
+  <data name="Install_SamsungStep3" xml:space="preserve"><value>Choisissez Écran d’accueil, puis confirmez.</value></data>
+  <data name="Install_ComputerHeading" xml:space="preserve"><value>Installer sur votre ordinateur</value></data>
+  <data name="Install_ComputerStep1" xml:space="preserve"><value>Dans Chrome ou Edge, recherchez l’icône d’installation à droite de la barre d’adresse et sélectionnez-la.</value></data>
+  <data name="Install_ComputerStep2" xml:space="preserve"><value>Aucune icône dans Chrome ? Ouvrez le menu du navigateur (⋮), puis choisissez Diffuser, enregistrer et partager, puis Installer la page en tant qu’application.</value></data>
+  <data name="Install_ComputerStep3" xml:space="preserve"><value>Dans Edge, ouvrez le menu du navigateur, puis choisissez Applications, puis Installer ce site en tant qu’application.</value></data>
+  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirmez l’installation, puis ouvrez Catch, But Don’t Forget depuis le menu Démarrer, le Dock ou votre liste d’applications.</value></data>
   <data name="Install_Later" xml:space="preserve"><value>L’installation est facultative. Vous pouvez continuer et retrouver ces instructions plus tard depuis le menu de l’application.</value></data>
   <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choisissez au moins une méthode de pêche.</value></data>
   <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choisissez au moins une espèce pour {0}.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -667,29 +667,38 @@
   <data name="Install_Benefit" xml:space="preserve"><value>Install the app for quick access from your device and a more reliable experience when you are out fishing.</value></data>
   <data name="Install_NativeAvailable" xml:space="preserve"><value>Your browser can install the app for you.</value></data>
   <data name="Install_Action" xml:space="preserve"><value>Install app</value></data>
-  <data name="Install_Dismissed" xml:space="preserve"><value>The app was not installed. You can try again or continue and install it later.</value></data>
-  <data name="Install_InstalledTitle" xml:space="preserve"><value>The app is installed</value></data>
-  <data name="Install_InstalledBody" xml:space="preserve"><value>Open Catch, But Don’t Forget from your home screen like your other apps.</value></data>
-  <data name="Install_InstalledWindows" xml:space="preserve"><value>You can now open Catch, But Don’t Forget like a normal Windows app from Start or search, and pin it where convenient.</value></data>
+  <data name="Install_Dismissed" xml:space="preserve"><value>The app was not installed. You can try again, or follow the steps for your device below.</value></data>
+  <data name="Install_ManualIntro" xml:space="preserve"><value>Choose your device below for step-by-step instructions.</value></data>
+  <data name="Install_InstalledTitle" xml:space="preserve"><value>App is installed</value></data>
+  <data name="Install_InstalledBody" xml:space="preserve"><value>You are using the installed app. Open Catch, But Don’t Forget from your Home Screen whenever you go fishing.</value></data>
+  <data name="Install_InstalledDesktop" xml:space="preserve"><value>You are using the installed app. Open Catch, But Don’t Forget from your Start menu, Dock or app list, and pin it where convenient.</value></data>
+  <data name="Install_InstalledOtherDevices" xml:space="preserve"><value>Installing on another phone, tablet or computer? The steps for every device are below.</value></data>
+  <data name="Install_IosPanel" xml:space="preserve"><value>iPhone / iPad</value></data>
+  <data name="Install_AndroidPanel" xml:space="preserve"><value>Android</value></data>
+  <data name="Install_ComputerPanel" xml:space="preserve"><value>Computer</value></data>
   <data name="Install_IosHeading" xml:space="preserve"><value>Add the app to your Home Screen</value></data>
-  <data name="Install_IosUseSafari" xml:space="preserve"><value>For the reliable install option on iPhone or iPad, open this site in Safari first.</value></data>
+  <data name="Install_IosUseSafari" xml:space="preserve"><value>You are not using Safari. Open Catch, But Don’t Forget in Safari first, then follow the steps below.</value></data>
   <data name="Install_IosStep1" xml:space="preserve"><value>Open Catch, But Don’t Forget in Safari.</value></data>
-  <data name="Install_IosStep2" xml:space="preserve"><value>Tap Share.</value></data>
-  <data name="Install_IosStep3" xml:space="preserve"><value>Choose Add to Home Screen.</value></data>
-  <data name="Install_IosStep4" xml:space="preserve"><value>Tap Add.</value></data>
+  <data name="Install_IosStep2" xml:space="preserve"><value>Tap Share, the square with an arrow pointing up.</value></data>
+  <data name="Install_IosStep3" xml:space="preserve"><value>Scroll down the list and choose Add to Home Screen.</value></data>
+  <data name="Install_IosStep4" xml:space="preserve"><value>Check the name shown for the app, then tap Add.</value></data>
   <data name="Install_IosStep5" xml:space="preserve"><value>Open Catch, But Don’t Forget from its new Home Screen icon.</value></data>
-  <data name="Install_AndroidHeading" xml:space="preserve"><value>Install from your browser menu</value></data>
-  <data name="Install_AndroidAlternative" xml:space="preserve"><value>Can’t see an install option near the address bar? You can still install the app from the browser menu.</value></data>
-  <data name="Install_AndroidStep1" xml:space="preserve"><value>Open your browser menu.</value></data>
-  <data name="Install_AndroidStep2" xml:space="preserve"><value>Choose the option called Install app or Add to Home screen. The wording may vary by browser.</value></data>
-  <data name="Install_AndroidStep3" xml:space="preserve"><value>Follow the confirmation, then open Catch, But Don’t Forget from your Home Screen.</value></data>
-  <data name="Install_WindowsHeading" xml:space="preserve"><value>Install on Windows</value></data>
-  <data name="Install_WindowsStep1" xml:space="preserve"><value>In Edge or Chrome, open the browser menu and look for its app installation option.</value></data>
-  <data name="Install_WindowsStep2" xml:space="preserve"><value>After installation, open the app from Start or search and pin it where convenient.</value></data>
-  <data name="Install_OtherHeading" xml:space="preserve"><value>Install from your browser</value></data>
-  <data name="Install_Unsupported" xml:space="preserve"><value>Your browser may offer installation without showing a button on this page.</value></data>
-  <data name="Install_OtherStep1" xml:space="preserve"><value>Look for an install icon in the address bar and select it.</value></data>
-  <data name="Install_OtherStep2" xml:space="preserve"><value>If there is no icon, open the browser menu and look for Install app or Add to Home screen. If neither option appears, you can keep using the app in your browser.</value></data>
+  <data name="Install_IosFallbackHeading" xml:space="preserve"><value>No Add to Home Screen option?</value></data>
+  <data name="Install_IosFallbackBody" xml:space="preserve"><value>You have probably opened the page in another browser, or inside another app such as a messaging app. Choose Open in Safari if it is offered, or copy the web address, paste it into Safari, then follow the five steps above.</value></data>
+  <data name="Install_AndroidHeading" xml:space="preserve"><value>Install with Chrome or another Chromium browser</value></data>
+  <data name="Install_AndroidStep1" xml:space="preserve"><value>Open the browser menu, the three dots (⋮) at the top of the screen.</value></data>
+  <data name="Install_AndroidStep2" xml:space="preserve"><value>Choose Install app, or Add to Home screen if that is the wording you see.</value></data>
+  <data name="Install_AndroidStep3" xml:space="preserve"><value>Confirm the installation when your browser asks.</value></data>
+  <data name="Install_AndroidStep4" xml:space="preserve"><value>Open Catch, But Don’t Forget from its new Home Screen icon.</value></data>
+  <data name="Install_SamsungHeading" xml:space="preserve"><value>Samsung Internet</value></data>
+  <data name="Install_SamsungStep1" xml:space="preserve"><value>Open the browser menu at the bottom of the screen.</value></data>
+  <data name="Install_SamsungStep2" xml:space="preserve"><value>Choose Add page to.</value></data>
+  <data name="Install_SamsungStep3" xml:space="preserve"><value>Choose Home screen, then confirm.</value></data>
+  <data name="Install_ComputerHeading" xml:space="preserve"><value>Install on your computer</value></data>
+  <data name="Install_ComputerStep1" xml:space="preserve"><value>In Chrome or Edge, look for the install icon at the right-hand end of the address bar and select it.</value></data>
+  <data name="Install_ComputerStep2" xml:space="preserve"><value>No icon in Chrome? Open the browser menu (⋮), then choose Cast, save and share, then Install page as app.</value></data>
+  <data name="Install_ComputerStep3" xml:space="preserve"><value>In Edge, open the browser menu, then choose Apps, then Install this site as an app.</value></data>
+  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirm the installation, then open Catch, But Don’t Forget from your Start menu, Dock or app list.</value></data>
   <data name="Install_Later" xml:space="preserve"><value>Installation is optional. You can continue now and find this guidance again from the app menu.</value></data>
   <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choose at least one fishing method.</value></data>
   <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choose at least one species for {0}.</value></data>

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/app.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/app.js
@@ -1,9 +1,11 @@
+import { captureInstallEvents } from '../browser/install.js';
 import { applyStoredCulture, installCulture } from '../browser/culture.js';
 import { installNetwork } from '../browser/network.js';
 import { installDiagnostics } from './diagnostics.js';
 import { installAuthentication } from '../browser/authentication.js';
 import { listenForServiceWorkerErrors } from './service-worker-registration.js';
 
+captureInstallEvents(window);
 installCulture(window);
 installNetwork(window);
 installDiagnostics(window);

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/app.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/app.test.js
@@ -14,4 +14,16 @@ describe('app bootstrap', () => {
         expect(window.fishingLogBookCulture.browser()).toBeTruthy();
         expect(typeof window.fishingLogBookNetwork.isOnline()).toBe('boolean');
     });
+
+    it('captures a browser install prompt offered before any page asks for it', async () => {
+        await import('./app.js');
+        const event = new Event('beforeinstallprompt');
+        event.prompt = () => Promise.resolve();
+        event.userChoice = Promise.resolve({ outcome: 'accepted' });
+
+        window.dispatchEvent(event);
+
+        const { getInstallState } = await import('../browser/install.js');
+        expect(getInstallState().canPrompt).toBe(true);
+    });
 });

--- a/src/FishingLogBook.Web/wwwroot/js/browser/install.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/install.js
@@ -1,46 +1,121 @@
-let deferredInstallPrompt;
-let appInstalled = false;
+export function captureInstallEvents(targetWindow) {
+    const state = store(targetWindow);
+    if (state.capturing) {
+        return;
+    }
 
-window.addEventListener('beforeinstallprompt', event => {
-    event.preventDefault();
-    deferredInstallPrompt = event;
-});
+    state.capturing = true;
+    targetWindow.addEventListener('beforeinstallprompt', event => {
+        event.preventDefault();
+        state.prompt = event;
+        publish(targetWindow);
+    });
+    targetWindow.addEventListener('appinstalled', () => {
+        state.installed = true;
+        state.prompt = undefined;
+        publish(targetWindow);
+    });
 
-window.addEventListener('appinstalled', () => {
-    appInstalled = true;
-    deferredInstallPrompt = undefined;
-});
+    const standalone = typeof targetWindow.matchMedia === 'function'
+        ? targetWindow.matchMedia('(display-mode: standalone)')
+        : undefined;
+    if (typeof standalone?.addEventListener === 'function') {
+        standalone.addEventListener('change', () => publish(targetWindow));
+    }
+}
 
-export function detectInstallState(navigatorValue, matchMediaValue, canPrompt) {
+export function detectInstallState(navigatorValue, matchMediaValue, canPrompt, appInstalled = false) {
     const userAgent = navigatorValue.userAgent || '';
     const platform = navigatorValue.platform || '';
     const isIos = /iPad|iPhone|iPod/.test(userAgent) ||
         (platform === 'MacIntel' && navigatorValue.maxTouchPoints > 1);
-    const isAndroid = /Android/i.test(userAgent);
-    const isWindows = /Windows/i.test(userAgent) || /^Win/i.test(platform);
+    const isAndroid = !isIos && /Android/i.test(userAgent);
+    const isDesktop = !isIos && !isAndroid && isDesktopFamily(userAgent, platform);
     const isSafari = isIos && /Safari/i.test(userAgent) &&
-        !/CriOS|FxiOS|EdgiOS|OPiOS/i.test(userAgent);
+        !/CriOS|FxiOS|EdgiOS|OPiOS|GSA|FBAN|FBAV|Instagram/i.test(userAgent);
     const isInstalled = appInstalled || Boolean(navigatorValue.standalone) ||
         Boolean(matchMediaValue('(display-mode: standalone)').matches);
-    const platformFamily = isIos ? 'iOS' : isAndroid ? 'Android' : isWindows ? 'Windows' : 'Other';
+    const platformFamily = isIos ? 'iOS' : isAndroid ? 'Android' : isDesktop ? 'Desktop' : 'Other';
     return { isInstalled, canPrompt: canPrompt && !isInstalled, platformFamily, isSafari };
 }
 
 export function getInstallState() {
-    const matchMedia = typeof window.matchMedia === 'function'
-        ? window.matchMedia.bind(window)
-        : () => ({ matches: false });
-    return detectInstallState(navigator, matchMedia, Boolean(deferredInstallPrompt));
+    captureInstallEvents(window);
+    return currentState(window);
+}
+
+export function subscribeInstallState(subscriber) {
+    captureInstallEvents(window);
+    const state = store(window);
+    state.nextToken += 1;
+    state.subscribers.set(state.nextToken, subscriber);
+    return state.nextToken;
+}
+
+export function unsubscribeInstallState(token) {
+    store(window).subscribers.delete(token);
 }
 
 export async function promptInstall() {
-    if (!deferredInstallPrompt) {
+    const state = store(window);
+    if (!state.prompt) {
         return 'unavailable';
     }
 
-    const prompt = deferredInstallPrompt;
-    deferredInstallPrompt = undefined;
+    const prompt = state.prompt;
+    state.prompt = undefined;
     await prompt.prompt();
     const choice = await prompt.userChoice;
+    publish(window);
     return choice.outcome === 'accepted' ? 'accepted' : 'dismissed';
+}
+
+function store(targetWindow) {
+    if (!targetWindow.fishingLogBookInstall) {
+        targetWindow.fishingLogBookInstall = {
+            prompt: undefined,
+            installed: false,
+            capturing: false,
+            nextToken: 0,
+            subscribers: new Map()
+        };
+    }
+
+    return targetWindow.fishingLogBookInstall;
+}
+
+function currentState(targetWindow) {
+    const state = store(targetWindow);
+    const matchMedia = typeof targetWindow.matchMedia === 'function'
+        ? targetWindow.matchMedia.bind(targetWindow)
+        : () => ({ matches: false });
+    return detectInstallState(targetWindow.navigator, matchMedia, Boolean(state.prompt), state.installed);
+}
+
+function isDesktopFamily(userAgent, platform) {
+    return /Windows|Macintosh|Mac OS X|CrOS|X11|Linux/i.test(userAgent) ||
+        /^Win|^Mac|^Linux/i.test(platform);
+}
+
+function publish(targetWindow) {
+    const state = store(targetWindow);
+    if (state.subscribers.size === 0) {
+        return;
+    }
+
+    const current = currentState(targetWindow);
+    for (const [token, subscriber] of [...state.subscribers]) {
+        notify(state, token, subscriber, current);
+    }
+}
+
+function notify(state, token, subscriber, current) {
+    try {
+        const pending = subscriber.invokeMethodAsync('OnInstallStateChanged', current);
+        if (typeof pending?.catch === 'function') {
+            pending.catch(() => state.subscribers.delete(token));
+        }
+    } catch {
+        state.subscribers.delete(token);
+    }
 }

--- a/src/FishingLogBook.Web/wwwroot/js/browser/install.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/install.test.js
@@ -1,69 +1,21 @@
-import { describe, expect, it } from 'vitest';
-import { detectInstallState, getInstallState, promptInstall } from './install.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    captureInstallEvents,
+    detectInstallState,
+    getInstallState,
+    promptInstall,
+    subscribeInstallState,
+    unsubscribeInstallState
+} from './install.js';
 
-describe('install detection', () => {
-    it('detects an installed standalone app', () => {
-        const state = detectInstallState(
-            { userAgent: 'Mozilla/5.0', platform: 'Win32', maxTouchPoints: 0 },
-            () => ({ matches: true }),
-            true);
+function capturablePrompt(outcome) {
+    const event = new Event('beforeinstallprompt');
+    event.prompt = () => Promise.resolve();
+    event.userChoice = Promise.resolve({ outcome });
+    return event;
+}
 
-        expect(state).toEqual({ isInstalled: true, canPrompt: false, platformFamily: 'Windows', isSafari: false });
-    });
-
-    it('provides iOS instructions without showing a fake prompt', () => {
-        const state = detectInstallState(
-            { userAgent: 'Mozilla/5.0 (iPhone)', platform: 'iPhone', maxTouchPoints: 5 },
-            () => ({ matches: false }),
-            false);
-
-        expect(state.platformFamily).toBe('iOS');
-        expect(state.isSafari).toBe(false);
-        expect(state.canPrompt).toBe(false);
-    });
-
-    it('detects an iOS app already running from the Home Screen', () => {
-        const state = detectInstallState(
-            { userAgent: 'Mozilla/5.0 (iPhone)', platform: 'iPhone', maxTouchPoints: 5, standalone: true },
-            () => ({ matches: false }),
-            true);
-
-        expect(state.isInstalled).toBe(true);
-        expect(state.platformFamily).toBe('iOS');
-        expect(state.canPrompt).toBe(false);
-    });
-
-    it('provides Android instructions when no prompt was captured', () => {
-        const state = detectInstallState(
-            { userAgent: 'Mozilla/5.0 Android', platform: 'Linux', maxTouchPoints: 5 },
-            () => ({ matches: false }),
-            false);
-
-        expect(state.platformFamily).toBe('Android');
-        expect(state.canPrompt).toBe(false);
-    });
-
-    it('recognises Safari on iPhone without pretending a native prompt exists', () => {
-        const state = detectInstallState(
-            { userAgent: 'Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 Safari/604.1', platform: 'iPhone', maxTouchPoints: 5 },
-            () => ({ matches: false }),
-            false);
-
-        expect(state.platformFamily).toBe('iOS');
-        expect(state.isSafari).toBe(true);
-        expect(state.canPrompt).toBe(false);
-    });
-
-    it('detects Windows with a captured native prompt', () => {
-        const state = detectInstallState(
-            { userAgent: 'Mozilla/5.0 (Windows NT 10.0) Chrome/140', platform: 'Win32', maxTouchPoints: 0 },
-            () => ({ matches: false }),
-            true);
-
-        expect(state.platformFamily).toBe('Windows');
-        expect(state.canPrompt).toBe(true);
-    });
-
+describe('install platform detection', () => {
     it('falls back safely for an unknown browser', () => {
         const state = detectInstallState(
             { userAgent: 'Unknown', platform: 'Unknown', maxTouchPoints: 0 },
@@ -74,34 +26,228 @@ describe('install detection', () => {
         expect(state.canPrompt).toBe(false);
     });
 
-    it('returns unavailable when no native prompt was captured', async () => {
+    it('detects an iPhone without pretending a native prompt exists', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0)', platform: 'iPhone', maxTouchPoints: 5 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('iOS');
+        expect(state.isSafari).toBe(false);
+        expect(state.canPrompt).toBe(false);
+    });
+
+    it('detects an iPad reporting a desktop user agent', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15', platform: 'MacIntel', maxTouchPoints: 5 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('iOS');
+        expect(state.isSafari).toBe(true);
+    });
+
+    it('recognises Safari on iPhone', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 Safari/604.1', platform: 'iPhone', maxTouchPoints: 5 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.isSafari).toBe(true);
+    });
+
+    it.each([
+        ['Mozilla/5.0 (iPhone) CriOS/140 Safari/604.1'],
+        ['Mozilla/5.0 (iPhone) FxiOS/140 Safari/604.1'],
+        ['Mozilla/5.0 (iPhone) EdgiOS/140 Safari/604.1'],
+        ['Mozilla/5.0 (iPhone) Safari/604.1 FBAV/500']
+    ])('does not treat an in-app or third-party iOS browser as Safari: %s', userAgent => {
+        const state = detectInstallState(
+            { userAgent, platform: 'iPhone', maxTouchPoints: 5 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('iOS');
+        expect(state.isSafari).toBe(false);
+    });
+
+    it('detects Android rather than the Linux kernel in its user agent', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (Linux; Android 15; SM-S928B) Chrome/140 Mobile Safari/537.36', platform: 'Linux armv8l', maxTouchPoints: 5 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('Android');
+    });
+
+    it('detects Samsung Internet on Android', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (Linux; Android 15) SamsungBrowser/27.0 Chrome/140 Mobile Safari/537.36', platform: 'Linux armv8l', maxTouchPoints: 5 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('Android');
+    });
+
+    it.each([
+        ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/140', 'Win32'],
+        ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/140', 'MacIntel'],
+        ['Mozilla/5.0 (X11; Linux x86_64) Chrome/140', 'Linux x86_64'],
+        ['Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) Chrome/140', 'Linux x86_64']
+    ])('treats a desktop browser as a computer: %s', (userAgent, platform) => {
+        const state = detectInstallState(
+            { userAgent, platform, maxTouchPoints: 0 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('Desktop');
+    });
+
+    it('does not treat a desktop MacIntel without touch as iOS', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15', platform: 'MacIntel', maxTouchPoints: 0 },
+            () => ({ matches: false }),
+            false);
+
+        expect(state.platformFamily).toBe('Desktop');
+    });
+
+    it('detects a standalone display mode as installed', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (Linux; Android 15) Chrome/140', platform: 'Linux armv8l', maxTouchPoints: 5 },
+            () => ({ matches: true }),
+            true);
+
+        expect(state).toEqual({ isInstalled: true, canPrompt: false, platformFamily: 'Android', isSafari: false });
+    });
+
+    it('detects an iOS app launched from the Home Screen as installed', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (iPhone) Safari/604.1', platform: 'iPhone', maxTouchPoints: 5, standalone: true },
+            () => ({ matches: false }),
+            true);
+
+        expect(state.isInstalled).toBe(true);
+        expect(state.platformFamily).toBe('iOS');
+        expect(state.canPrompt).toBe(false);
+    });
+
+    it('detects a captured native prompt on a computer', () => {
+        const state = detectInstallState(
+            { userAgent: 'Mozilla/5.0 (Windows NT 10.0) Chrome/140', platform: 'Win32', maxTouchPoints: 0 },
+            () => ({ matches: false }),
+            true);
+
+        expect(state.platformFamily).toBe('Desktop');
+        expect(state.canPrompt).toBe(true);
+    });
+});
+
+describe('install event capture', () => {
+    it('reports no native prompt before the browser offers one', async () => {
+        expect(getInstallState().canPrompt).toBe(false);
         expect(await promptInstall()).toBe('unavailable');
     });
 
-    it('returns accepted and consumes the captured native prompt', async () => {
-        const event = new Event('beforeinstallprompt');
-        event.prompt = () => Promise.resolve();
-        event.userChoice = Promise.resolve({ outcome: 'accepted' });
-        window.dispatchEvent(event);
+    it('registers its window listeners once for the lifetime of the page', () => {
+        const targetWindow = { addEventListener: vi.fn() };
 
+        captureInstallEvents(targetWindow);
+        captureInstallEvents(targetWindow);
+
+        expect(targetWindow.addEventListener.mock.calls.map(call => call[0]))
+            .toEqual(['beforeinstallprompt', 'appinstalled']);
+    });
+
+    it('keeps the captured prompt where every module instance can reach it', async () => {
+        const another = await import('./install.js?instance=shared');
+        window.dispatchEvent(capturablePrompt('dismissed'));
+
+        expect(another.getInstallState().canPrompt).toBe(true);
+        expect(await another.promptInstall()).toBe('dismissed');
+        expect(getInstallState().canPrompt).toBe(false);
+    });
+
+    it('keeps a captured prompt available until it is used', async () => {
+        window.dispatchEvent(capturablePrompt('accepted'));
+
+        expect(getInstallState().canPrompt).toBe(true);
         expect(getInstallState().canPrompt).toBe(true);
         expect(await promptInstall()).toBe('accepted');
         expect(await promptInstall()).toBe('unavailable');
+        expect(getInstallState().canPrompt).toBe(false);
     });
 
-    it('returns dismissed without treating dismissal as an error', async () => {
-        const event = new Event('beforeinstallprompt');
-        event.prompt = () => Promise.resolve();
-        event.userChoice = Promise.resolve({ outcome: 'dismissed' });
-        window.dispatchEvent(event);
+    it('treats dismissal as a normal outcome', async () => {
+        window.dispatchEvent(capturablePrompt('dismissed'));
 
         expect(await promptInstall()).toBe('dismissed');
+        expect(getInstallState().canPrompt).toBe(false);
+    });
+});
+
+describe('install state subscriptions', () => {
+    it('publishes a prompt that arrives after the first state read', () => {
+        const subscriber = { invokeMethodAsync: vi.fn(() => Promise.resolve()) };
+        const token = subscribeInstallState(subscriber);
+
+        window.dispatchEvent(capturablePrompt('accepted'));
+
+        expect(subscriber.invokeMethodAsync).toHaveBeenCalledTimes(1);
+        const [method, state] = subscriber.invokeMethodAsync.mock.calls[0];
+        expect(method).toBe('OnInstallStateChanged');
+        expect(state.canPrompt).toBe(true);
+        unsubscribeInstallState(token);
     });
 
-    it('updates to installed when the browser reports app installation', () => {
+    it('publishes to every current subscriber', async () => {
+        const first = { invokeMethodAsync: vi.fn(() => Promise.resolve()) };
+        const second = { invokeMethodAsync: vi.fn(() => Promise.resolve()) };
+        const firstToken = subscribeInstallState(first);
+        const secondToken = subscribeInstallState(second);
+
+        expect(await promptInstall()).toBe('accepted');
+
+        expect(first.invokeMethodAsync).toHaveBeenCalledTimes(1);
+        expect(second.invokeMethodAsync).toHaveBeenCalledTimes(1);
+        unsubscribeInstallState(firstToken);
+        unsubscribeInstallState(secondToken);
+    });
+
+    it('stops publishing to a subscriber that has been removed', () => {
+        const subscriber = { invokeMethodAsync: vi.fn(() => Promise.resolve()) };
+        const token = subscribeInstallState(subscriber);
+        unsubscribeInstallState(token);
+
+        window.dispatchEvent(capturablePrompt('accepted'));
+
+        expect(subscriber.invokeMethodAsync).not.toHaveBeenCalled();
+    });
+
+    it('drops a subscriber whose callback can no longer be reached', async () => {
+        const subscriber = {
+            invokeMethodAsync: vi.fn(() => Promise.reject(new Error('disposed')))
+        };
+        const token = subscribeInstallState(subscriber);
+
+        window.dispatchEvent(capturablePrompt('accepted'));
+        await Promise.resolve();
+        window.dispatchEvent(capturablePrompt('accepted'));
+
+        expect(subscriber.invokeMethodAsync).toHaveBeenCalledTimes(1);
+        unsubscribeInstallState(token);
+    });
+
+    it('publishes an installed state when the browser reports installation', () => {
+        const subscriber = { invokeMethodAsync: vi.fn(() => Promise.resolve()) };
+        const token = subscribeInstallState(subscriber);
+
         window.dispatchEvent(new Event('appinstalled'));
 
+        expect(subscriber.invokeMethodAsync).toHaveBeenCalledTimes(1);
+        expect(subscriber.invokeMethodAsync.mock.calls[0][1].isInstalled).toBe(true);
         expect(getInstallState().isInstalled).toBe(true);
         expect(getInstallState().canPrompt).toBe(false);
+        unsubscribeInstallState(token);
     });
 });

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/BaseInstallGuidanceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/BaseInstallGuidanceTest.cs
@@ -1,0 +1,70 @@
+using Bunit;
+using FishingLogBook.Web.Browser.Install;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Browser.Install.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallGuidanceTests;
+
+public class BaseInstallGuidanceTest
+{
+    protected static readonly InstallState IosSafari =
+        new(false, false, InstallPlatformFamilies.Ios, true);
+
+    protected static readonly InstallState Android =
+        new(false, false, InstallPlatformFamilies.Android, false);
+
+    protected static readonly InstallState Desktop =
+        new(false, false, InstallPlatformFamilies.Desktop, false);
+
+    protected static IInstallService CreateService(
+        InstallState state,
+        InstallResult promptResult = InstallResult.Unavailable)
+    {
+        var service = Substitute.For<IInstallService>();
+        service.GetStateAsync(Arg.Any<CancellationToken>()).Returns(state);
+        service.PromptAsync(Arg.Any<CancellationToken>()).Returns(promptResult);
+        service.SubscribeAsync(Arg.Any<Func<InstallState, Task>>(), Arg.Any<CancellationToken>())
+            .Returns(Substitute.For<IAsyncDisposable>());
+        return service;
+    }
+
+    protected static BunitContext CreateContext(
+        IInstallService service,
+        ILoggingService? logging = null)
+    {
+        var context = CreateContext();
+        context.Services.AddSingleton(service);
+        context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
+        return context;
+    }
+
+    protected static BunitContext CreateBrowserContext(FakeInstallJsRuntime jsRuntime)
+    {
+        var context = CreateContext();
+        context.Services.AddSingleton<IJSRuntime>(jsRuntime);
+        context.Services.AddSingleton<IInstallService>(new InstallService(jsRuntime));
+        context.Services.AddSingleton(Substitute.For<ILoggingService>());
+        return context;
+    }
+
+    protected static bool IsPanelExpanded(IRenderedComponent<InstallGuidance> cut, string panelId)
+    {
+        return cut.Find($"#{panelId}").ClassList.Contains("mud-panel-expanded");
+    }
+
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddTransient<MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingBrowserState.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingBrowserState.cs
@@ -1,0 +1,135 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Browser.Install;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Browser.Install.TestSupport;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallGuidanceTests;
+
+public class WhenTestingBrowserState : BaseInstallGuidanceTest
+{
+    private const string IosSafariStateJson =
+        """{"isInstalled":false,"canPrompt":false,"platformFamily":"iOS","isSafari":true}""";
+
+    private const string AndroidPromptableStateJson =
+        """{"isInstalled":false,"canPrompt":true,"platformFamily":"Android","isSafari":false}""";
+
+    private const string InstalledAndroidStateJson =
+        """{"isInstalled":true,"canPrompt":false,"platformFamily":"Android","isSafari":false}""";
+
+    [Fact]
+    public async Task ItShouldShowCompleteManualGuidanceWhenTheBrowserModuleFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var jsRuntime = new FakeInstallJsRuntime
+        {
+            StateFailure = new InvalidOperationException("module unavailable")
+        };
+        await using var context = CreateBrowserContext(jsRuntime);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
+            cut.Find("#install-guidance-computer-steps").Children.Should().HaveCount(4);
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+        });
+        jsRuntime.ImportedModules.Should().Contain("./js/browser/install.js");
+    }
+
+    [Theory]
+    [InlineData(IosSafariStateJson, "install-guidance-ios-panel")]
+    [InlineData(AndroidPromptableStateJson, "install-guidance-android-panel")]
+    [InlineData(
+        """{"isInstalled":false,"canPrompt":false,"platformFamily":"Desktop","isSafari":false}""",
+        "install-guidance-computer-panel")]
+    public async Task ItShouldExpandTheSectionForTheStateReturnedByTheBrowser(
+        string stateJson,
+        string expectedPanelId)
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var jsRuntime = new FakeInstallJsRuntime { StateJson = stateJson };
+        await using var context = CreateBrowserContext(jsRuntime);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            IsPanelExpanded(cut, expectedPanelId).Should().BeTrue();
+            cut.Find("#install-guidance-ios-steps").Should().NotBeNull();
+            cut.Find("#install-guidance-android-steps").Should().NotBeNull();
+            cut.Find("#install-guidance-computer-steps").Should().NotBeNull();
+        });
+        jsRuntime.Invocations.Should().Contain("getInstallState").And.Contain("subscribeInstallState");
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheInstalledStateReturnedByTheBrowser()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var jsRuntime = new FakeInstallJsRuntime { StateJson = InstalledAndroidStateJson };
+        await using var context = CreateBrowserContext(jsRuntime);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("App is installed");
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+            cut.FindAll("#install-guidance-benefit").Should().BeEmpty();
+        });
+        jsRuntime.Invocations.Should().Contain("getInstallState");
+    }
+
+    [Fact]
+    public async Task ItShouldUpdateTheMountedPageWhenTheBrowserPublishesANewState()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var jsRuntime = new FakeInstallJsRuntime { StateJson = AndroidPromptableStateJson };
+        await using var context = CreateBrowserContext(jsRuntime);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+
+        // Act
+        await jsRuntime.PublishAsync(InstalledAndroidStateJson);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("App is installed");
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+            cut.Find("#install-guidance-android-steps").Should().NotBeNull();
+        });
+        jsRuntime.UnsubscribedTokens.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldUnsubscribeFromTheBrowserWhenThePageIsDisposed()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var jsRuntime = new FakeInstallJsRuntime { StateJson = AndroidPromptableStateJson };
+        var context = CreateBrowserContext(jsRuntime);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+
+        // Act
+        await context.DisposeAsync();
+
+        // Assert
+        jsRuntime.UnsubscribedTokens.Should().Equal(jsRuntime.SubscriptionToken);
+        jsRuntime.Invocations.Should().Contain("unsubscribeInstallState");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingInstall.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingInstall.cs
@@ -1,0 +1,94 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Browser.Install;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallGuidanceTests;
+
+public class WhenTestingInstall : BaseInstallGuidanceTest
+{
+    private static readonly InstallState AndroidPromptable =
+        new(false, true, InstallPlatformFamilies.Android, false);
+
+    [Fact]
+    public async Task ItShouldFallBackToManualGuidanceWhenTheNativePromptFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var logging = Substitute.For<ILoggingService>();
+        var service = CreateService(AndroidPromptable);
+        service.PromptAsync(Arg.Any<CancellationToken>())
+            .Returns<InstallResult>(_ => throw new InvalidOperationException("prompt failed"));
+        await using var context = CreateContext(service, logging);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+
+        // Act
+        await cut.Find("#install-guidance-action").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+            cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
+            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-computer-steps").Children.Should().HaveCount(4);
+        });
+        await service.Received(1).PromptAsync(Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "install detection",
+            Arg.Is<Exception>(exception => exception.Message == "prompt failed"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepManualGuidanceWhenTheNativePromptIsDismissed()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(AndroidPromptable, InstallResult.Dismissed);
+        await using var context = CreateContext(service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+
+        // Act
+        await cut.Find("#install-guidance-action").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-dismissed").TextContent.Should().Contain("not installed");
+            cut.Find("#install-guidance-action").Should().NotBeNull();
+            cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
+            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+        });
+        await service.Received(1).PromptAsync(Arg.Any<CancellationToken>());
+        await service.Received(2).GetStateAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheInstalledStateAfterTheNativePromptIsAccepted()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(AndroidPromptable, InstallResult.Accepted);
+        await using var context = CreateContext(service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+
+        // Act
+        await cut.Find("#install-guidance-action").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("App is installed");
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+            cut.Find("#install-guidance-android-steps").Should().NotBeNull();
+        });
+        await service.Received(1).PromptAsync(Arg.Any<CancellationToken>());
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingRender.cs
@@ -1,175 +1,269 @@
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Web.Browser.Install;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
-using Microsoft.Extensions.DependencyInjection;
-using MudBlazor.Services;
 using NSubstitute;
 
 namespace FishingLogBook.Web.Tests.Browser.Install.InstallGuidanceTests;
 
-public class WhenTestingRender
+public class WhenTestingRender : BaseInstallGuidanceTest
 {
     [Fact]
-    public void ItShouldShowIosSafariInstructions()
+    public async Task ItShouldShowCompleteManualGuidanceWhenDetectionFails()
     {
+        // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        using var context = CreateContext(new InstallState(false, false, InstallPlatformFamilies.Ios, true));
+        var logging = Substitute.For<ILoggingService>();
+        var service = CreateService(InstallState.Unknown);
+        service.GetStateAsync(Arg.Any<CancellationToken>())
+            .Returns<InstallState>(_ => throw new InvalidOperationException("interop failed"));
+        await using var context = CreateContext(service, logging);
 
+        // Act
         var cut = context.Render<InstallGuidance>();
 
+        // Assert
         cut.WaitForAssertion(() =>
         {
             cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
-            cut.FindAll("#install-guidance-ios-browser").Should().BeEmpty();
+            cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
+            cut.Find("#install-guidance-samsung-steps").Children.Should().HaveCount(3);
+            cut.Find("#install-guidance-computer-steps").Children.Should().HaveCount(4);
             cut.FindAll("#install-guidance-action").Should().BeEmpty();
+            cut.FindAll("#install-guidance-loading").Should().BeEmpty();
         });
+        await logging.Received(1).LogErrorAsync(
+            "install detection",
+            Arg.Is<Exception>(exception => exception.Message == "interop failed"),
+            Arg.Any<CancellationToken>());
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
+        await service.DidNotReceive().PromptAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public void ItShouldTellIosUsersInAnotherBrowserToUseSafari()
+    public async Task ItShouldNotGuessAPlatformForAnUnknownBrowser()
     {
+        // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        using var context = CreateContext(new InstallState(false, false, InstallPlatformFamilies.Ios, false));
+        var service = CreateService(InstallState.Unknown);
+        await using var context = CreateContext(service);
 
+        // Act
         var cut = context.Render<InstallGuidance>();
 
-        cut.WaitForAssertion(() => cut.Find("#install-guidance-ios-browser").TextContent.Should().Contain("Safari"));
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            IsPanelExpanded(cut, "install-guidance-ios-panel").Should().BeFalse();
+            IsPanelExpanded(cut, "install-guidance-android-panel").Should().BeFalse();
+            IsPanelExpanded(cut, "install-guidance-computer-panel").Should().BeFalse();
+            cut.Find("#install-guidance-manual-intro").TextContent.Should().Contain("Choose your device");
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+        });
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
     }
 
     [Theory]
-    [InlineData(InstallPlatformFamilies.Android, "#install-guidance-android-steps")]
-    [InlineData(InstallPlatformFamilies.Windows, "#install-guidance-windows-steps")]
-    public void ItShouldShowPlatformFallbackInstructionsWhenNoPromptExists(string platform, string selector)
+    [InlineData(InstallPlatformFamilies.Ios)]
+    [InlineData(InstallPlatformFamilies.Android)]
+    [InlineData(InstallPlatformFamilies.Desktop)]
+    [InlineData(InstallPlatformFamilies.Other)]
+    public async Task ItShouldKeepEveryPlatformSectionAvailableWithoutANativePrompt(string platformFamily)
     {
+        // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        using var context = CreateContext(new InstallState(false, false, platform, false));
+        var service = CreateService(new InstallState(false, false, platformFamily, false));
+        await using var context = CreateContext(service);
 
+        // Act
         var cut = context.Render<InstallGuidance>();
 
-        cut.WaitForAssertion(() => cut.Find(selector).Should().NotBeNull());
-    }
-
-    [Fact]
-    public void ItShouldShowBothAndroidInstallRoutesWhenTheNativePromptExists()
-    {
-        using var culture = TestCulture.Use(CultureNames.English);
-        using var context = CreateContext(new InstallState(false, true, InstallPlatformFamilies.Android, false));
-
-        var cut = context.Render<InstallGuidance>();
-
+        // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#install-guidance-action").Should().NotBeNull();
-            cut.Find("#install-guidance-android-alternative").TextContent
-                .Should().Contain("browser menu");
-            cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(3);
-        });
-    }
-
-    [Fact]
-    public void ItShouldShowTheUnknownBrowserFallback()
-    {
-        using var culture = TestCulture.Use(CultureNames.English);
-        using var context = CreateContext(new InstallState(false, false, InstallPlatformFamilies.Other, false));
-
-        var cut = context.Render<InstallGuidance>();
-
-        cut.WaitForAssertion(() =>
-        {
-            cut.Find("#install-guidance-unsupported").TextContent
-                .Should().Contain("without showing a button");
-            cut.Find("#install-guidance-other-steps").TextContent
-                .Should().Contain("install icon").And.Contain("browser menu");
-        });
-    }
-
-    [Fact]
-    public void ItShouldShowTheAlreadyInstalledStateWithoutInstructions()
-    {
-        using var culture = TestCulture.Use(CultureNames.English);
-        using var context = CreateContext(new InstallState(true, false, InstallPlatformFamilies.Ios, true));
-
-        var cut = context.Render<InstallGuidance>();
-
-        cut.WaitForAssertion(() =>
-        {
-            cut.Find("#install-guidance-installed").Should().NotBeNull();
-            cut.FindAll("#install-guidance-ios-steps").Should().BeEmpty();
+            cut.Find("#install-guidance-ios-panel").TextContent.Should().Contain("iPhone / iPad");
+            cut.Find("#install-guidance-ios-steps").TextContent.Should()
+                .Contain("Safari").And.Contain("Share").And.Contain("Add to Home Screen");
+            cut.Find("#install-guidance-ios-fallback").TextContent.Should().Contain("Open in Safari");
+            cut.Find("#install-guidance-android-steps").TextContent.Should()
+                .Contain("⋮").And.Contain("Install app").And.Contain("Add to Home screen");
+            cut.Find("#install-guidance-samsung-heading").TextContent.Should().Contain("Samsung Internet");
+            cut.Find("#install-guidance-samsung-steps").TextContent.Should()
+                .Contain("Add page to").And.Contain("Home screen");
+            cut.Find("#install-guidance-computer-steps").TextContent.Should()
+                .Contain("address bar").And.Contain("Install this site as an app");
             cut.FindAll("#install-guidance-action").Should().BeEmpty();
         });
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
     }
 
-    [Fact]
-    public async Task ItShouldUpdateToInstalledAfterTheNativePromptIsAccepted()
+    [Theory]
+    [InlineData(InstallPlatformFamilies.Ios, "install-guidance-ios-panel")]
+    [InlineData(InstallPlatformFamilies.Android, "install-guidance-android-panel")]
+    [InlineData(InstallPlatformFamilies.Desktop, "install-guidance-computer-panel")]
+    public async Task ItShouldExpandOnlyTheDetectedPlatformSection(string platformFamily, string expectedPanelId)
     {
+        // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        var service = Substitute.For<IInstallService>();
-        service.GetStateAsync(Arg.Any<CancellationToken>())
-            .Returns(new InstallState(false, true, InstallPlatformFamilies.Windows, false));
-        service.PromptAsync(Arg.Any<CancellationToken>()).Returns(InstallResult.Accepted);
+        var service = CreateService(new InstallState(false, false, platformFamily, false));
+        var panelIds = new[]
+        {
+            "install-guidance-ios-panel",
+            "install-guidance-android-panel",
+            "install-guidance-computer-panel"
+        };
         await using var context = CreateContext(service);
+
+        // Act
         var cut = context.Render<InstallGuidance>();
-        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
 
-        await cut.Find("#install-guidance-action").ClickAsync();
-
-        cut.WaitForAssertion(() =>
-            cut.Find("#install-guidance-installed").TextContent.Should().Contain("Windows"));
-        await service.Received(1).PromptAsync(Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ItShouldKeepGuidanceUsableWhenTheNativePromptIsDismissed()
-    {
-        using var culture = TestCulture.Use(CultureNames.English);
-        var service = Substitute.For<IInstallService>();
-        var state = new InstallState(false, true, InstallPlatformFamilies.Android, false);
-        service.GetStateAsync(Arg.Any<CancellationToken>()).Returns(state);
-        service.PromptAsync(Arg.Any<CancellationToken>()).Returns(InstallResult.Dismissed);
-        await using var context = CreateContext(service);
-        var cut = context.Render<InstallGuidance>();
-        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
-
-        await cut.Find("#install-guidance-action").ClickAsync();
-
+        // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#install-guidance-dismissed").Should().NotBeNull();
-            cut.Find("#install-guidance-action").Should().NotBeNull();
+            foreach (var panelId in panelIds)
+            {
+                IsPanelExpanded(cut, panelId).Should().Be(panelId == expectedPanelId);
+            }
         });
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public void ItShouldShowFrenchGuidance()
+    public async Task ItShouldTellIosUsersInAnotherBrowserToSwitchToSafari()
     {
-        using var culture = TestCulture.Use(CultureNames.French);
-        using var context = CreateContext(new InstallState(false, false, InstallPlatformFamilies.Windows, false));
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(new InstallState(false, false, InstallPlatformFamilies.Ios, false));
+        await using var context = CreateContext(service);
 
+        // Act
         var cut = context.Render<InstallGuidance>();
 
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-ios-browser").TextContent.Should().Contain("Safari");
+            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+        });
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotRepeatTheSafariWarningForSafariUsers()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(IosSafari);
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("#install-guidance-ios-browser").Should().BeEmpty();
+            cut.Find("#install-guidance-ios-fallback-heading").TextContent
+                .Should().Contain("Add to Home Screen");
+        });
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotAskAnInstalledDeviceToInstallAgain()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(new InstallState(true, false, InstallPlatformFamilies.Android, false));
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("App is installed");
+            cut.Find("#install-guidance-other-devices").TextContent.Should().Contain("another phone");
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+            cut.FindAll("#install-guidance-benefit").Should().BeEmpty();
+            cut.FindAll("#install-guidance-manual-intro").Should().BeEmpty();
+            cut.Find("#install-guidance-android-steps").Should().NotBeNull();
+            IsPanelExpanded(cut, "install-guidance-android-panel").Should().BeFalse();
+        });
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
+        await service.DidNotReceive().PromptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDescribeAnInstalledComputerApp()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(new InstallState(true, false, InstallPlatformFamilies.Desktop, false));
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("Start menu"));
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOfferTheNativeInstallButtonWhenTheBrowserCapturedAPrompt()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(new InstallState(false, true, InstallPlatformFamilies.Android, false));
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-action").TextContent.Should().Contain("Install app");
+            cut.Find("#install-guidance-android-steps").Should().NotBeNull();
+            cut.Find("#install-guidance-ios-steps").Should().NotBeNull();
+            cut.Find("#install-guidance-computer-steps").Should().NotBeNull();
+        });
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
+        await service.Received(1).SubscribeAsync(
+            Arg.Is<Func<InstallState, Task>>(callback => callback != null),
+            Arg.Any<CancellationToken>());
+        await service.DidNotReceive().PromptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchGuidance()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var service = CreateService(Desktop);
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
         cut.WaitForAssertion(() =>
         {
             cut.Find("#install-guidance-title").TextContent.Should().Contain("Installer");
-            cut.Find("#install-guidance-windows-heading").TextContent.Should().Contain("Windows");
+            cut.Find("#install-guidance-computer-panel").TextContent.Should().Contain("Ordinateur");
+            cut.Find("#install-guidance-ios-steps").TextContent.Should()
+                .Contain("Safari").And.Contain("Partager").And.Contain("Sur l’écran d’accueil");
+            cut.Find("#install-guidance-android-steps").TextContent.Should()
+                .Contain("Installer l’application");
+            cut.Find("#install-guidance-samsung-steps").TextContent.Should()
+                .Contain("Ajouter la page à");
+            cut.Find("#install-guidance-computer-steps").TextContent.Should()
+                .Contain("barre d’adresse");
         });
-    }
-
-    private static BunitContext CreateContext(InstallState state)
-    {
-        var service = Substitute.For<IInstallService>();
-        service.GetStateAsync(Arg.Any<CancellationToken>()).Returns(state);
-        return CreateContext(service);
-    }
-
-    private static BunitContext CreateContext(IInstallService service)
-    {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        context.Services.AddMudServices();
-        context.Services.AddLocalization();
-        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
-        context.Services.AddSingleton(service);
-        return context;
+        await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingStateChange.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingStateChange.cs
@@ -1,0 +1,198 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Browser.Install;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallGuidanceTests;
+
+public class WhenTestingStateChange : BaseInstallGuidanceTest
+{
+    [Fact]
+    public async Task ItShouldStillShowManualGuidanceWhenTheSubscriptionCannotBeCreated()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var logging = Substitute.For<ILoggingService>();
+        var service = CreateService(Android);
+        service.SubscribeAsync(Arg.Any<Func<InstallState, Task>>(), Arg.Any<CancellationToken>())
+            .Returns<IAsyncDisposable>(_ => throw new InvalidOperationException("subscribe failed"));
+        await using var context = CreateContext(service, logging);
+
+        // Act
+        var cut = context.Render<InstallGuidance>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
+            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-computer-steps").Children.Should().HaveCount(4);
+        });
+        await logging.Received(1).LogErrorAsync(
+            "install detection",
+            Arg.Is<Exception>(exception => exception.Message == "subscribe failed"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotMoveTheExpandedSectionWhenStateArrivesLater()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var subscribed = CreateSubscribedService(InstallState.Unknown);
+        await using var context = CreateContext(subscribed.Service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-android-panel"));
+
+        // Act
+        await subscribed.PublishAsync(new InstallState(false, true, InstallPlatformFamilies.Android, false));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-action").Should().NotBeNull();
+            IsPanelExpanded(cut, "install-guidance-android-panel").Should().BeFalse();
+            IsPanelExpanded(cut, "install-guidance-ios-panel").Should().BeFalse();
+            IsPanelExpanded(cut, "install-guidance-computer-panel").Should().BeFalse();
+        });
+        await subscribed.Service.Received(1).SubscribeAsync(
+            Arg.Is<Func<InstallState, Task>>(callback => callback != null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOfferTheNativeInstallButtonWhenTheBrowserPromptArrivesLater()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var subscribed = CreateSubscribedService(Android);
+        await using var context = CreateContext(subscribed.Service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.FindAll("#install-guidance-action").Should().BeEmpty());
+
+        // Act
+        await subscribed.PublishAsync(new InstallState(false, true, InstallPlatformFamilies.Android, false));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-action").TextContent.Should().Contain("Install app");
+            cut.Find("#install-guidance-native").Should().NotBeNull();
+        });
+        await subscribed.Service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheInstalledStateWhenTheBrowserReportsInstallation()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var subscribed = CreateSubscribedService(new InstallState(false, true, InstallPlatformFamilies.Android, false));
+        await using var context = CreateContext(subscribed.Service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+
+        // Act
+        await subscribed.PublishAsync(new InstallState(true, false, InstallPlatformFamilies.Android, false));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("App is installed");
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+            cut.Find("#install-guidance-android-steps").Should().NotBeNull();
+        });
+        await subscribed.Service.DidNotReceive().PromptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheInstalledStateWhenTheBrowserHasNotConfirmedTheAcceptedInstallYet()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var subscribed = CreateSubscribedService(
+            new InstallState(false, true, InstallPlatformFamilies.Android, false),
+            InstallResult.Accepted);
+        await using var context = CreateContext(subscribed.Service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-action"));
+        await cut.Find("#install-guidance-action").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-installed"));
+
+        // Act
+        await subscribed.PublishAsync(Android);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#install-guidance-installed").TextContent.Should().Contain("App is installed");
+            cut.FindAll("#install-guidance-action").Should().BeEmpty();
+            cut.FindAll("#install-guidance-benefit").Should().BeEmpty();
+        });
+        await subscribed.Service.Received(1).PromptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReleaseTheBrowserSubscriptionWhenDisposed()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var subscribed = CreateSubscribedService(Android);
+        var context = CreateContext(subscribed.Service);
+        var cut = context.Render<InstallGuidance>();
+        cut.WaitForAssertion(() => cut.Find("#install-guidance-android-panel"));
+
+        // Act
+        await context.DisposeAsync();
+
+        // Assert
+        await subscribed.Subscription.Received(1).DisposeAsync();
+        await subscribed.Service.Received(1).SubscribeAsync(
+            Arg.Is<Func<InstallState, Task>>(callback => callback != null),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static SubscribedInstallService CreateSubscribedService(
+        InstallState state,
+        InstallResult promptResult = InstallResult.Unavailable)
+    {
+        var subscribed = new SubscribedInstallService(
+            CreateService(state, promptResult),
+            Substitute.For<IAsyncDisposable>());
+        subscribed.Service
+            .SubscribeAsync(Arg.Any<Func<InstallState, Task>>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                subscribed.Published = call.Arg<Func<InstallState, Task>>();
+                return subscribed.Subscription;
+            });
+        return subscribed;
+    }
+
+    private sealed class SubscribedInstallService
+    {
+        public SubscribedInstallService(IInstallService service, IAsyncDisposable subscription)
+        {
+            Service = service;
+            Subscription = subscription;
+        }
+
+        public IInstallService Service { get; }
+
+        public IAsyncDisposable Subscription { get; }
+
+        public Func<InstallState, Task>? Published { get; set; }
+
+        public Task PublishAsync(InstallState state)
+        {
+            if (Published is null)
+            {
+                throw new InvalidOperationException("The component did not subscribe to state changes.");
+            }
+
+            return Published(state);
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallServiceTests/BaseInstallServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallServiceTests/BaseInstallServiceTest.cs
@@ -1,0 +1,22 @@
+using FishingLogBook.Web.Tests.Browser.Install.TestSupport;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallServiceTests;
+
+public class BaseInstallServiceTest
+{
+    protected const string ModulePath = "./js/browser/install.js";
+
+    protected const string IosSafariStateJson =
+        """{"isInstalled":false,"canPrompt":false,"platformFamily":"iOS","isSafari":true}""";
+
+    protected const string AndroidPromptableStateJson =
+        """{"isInstalled":false,"canPrompt":true,"platformFamily":"Android","isSafari":false}""";
+
+    protected const string InstalledDesktopStateJson =
+        """{"isInstalled":true,"canPrompt":false,"platformFamily":"Desktop","isSafari":false}""";
+
+    protected static FakeInstallJsRuntime CreateJsRuntime(string stateJson)
+    {
+        return new FakeInstallJsRuntime { StateJson = stateJson };
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallServiceTests/WhenTestingGetState.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallServiceTests/WhenTestingGetState.cs
@@ -1,0 +1,69 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Browser.Install;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallServiceTests;
+
+public class WhenTestingGetState : BaseInstallServiceTest
+{
+    [Fact]
+    public async Task ItShouldSurfaceTheFailureWhenTheBrowserModuleCannotBeInvoked()
+    {
+        // Arrange
+        var js = CreateJsRuntime(IosSafariStateJson);
+        js.StateFailure = new InvalidOperationException("module missing");
+        var sut = new InstallService(js);
+
+        // Act
+        var act = async () => await sut.GetStateAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        js.ImportedModules.Should().Equal(ModulePath);
+    }
+
+    [Fact]
+    public async Task ItShouldImportTheBrowserModuleAndReadTheCurrentState()
+    {
+        // Arrange
+        var js = CreateJsRuntime(IosSafariStateJson);
+        var sut = new InstallService(js);
+
+        // Act
+        var state = await sut.GetStateAsync(CancellationToken.None);
+
+        // Assert
+        state.Should().Be(new InstallState(false, false, InstallPlatformFamilies.Ios, true));
+        js.ImportedModules.Should().Equal(ModulePath);
+        js.Invocations.Should().Equal("import", "getInstallState");
+    }
+
+    [Theory]
+    [InlineData(IosSafariStateJson, InstallPlatformFamilies.Ios, false, false, true)]
+    [InlineData(AndroidPromptableStateJson, InstallPlatformFamilies.Android, false, true, false)]
+    [InlineData(InstalledDesktopStateJson, InstallPlatformFamilies.Desktop, true, false, false)]
+    [InlineData(
+        """{"isInstalled":false,"canPrompt":false,"platformFamily":"Other","isSafari":false}""",
+        InstallPlatformFamilies.Other,
+        false,
+        false,
+        false)]
+    public async Task ItShouldDeserialiseEveryStateTheBrowserModuleReturns(
+        string stateJson,
+        string expectedFamily,
+        bool expectedInstalled,
+        bool expectedCanPrompt,
+        bool expectedSafari)
+    {
+        // Arrange
+        var sut = new InstallService(CreateJsRuntime(stateJson));
+
+        // Act
+        var state = await sut.GetStateAsync(CancellationToken.None);
+
+        // Assert
+        state.PlatformFamily.Should().Be(expectedFamily);
+        state.IsInstalled.Should().Be(expectedInstalled);
+        state.CanPrompt.Should().Be(expectedCanPrompt);
+        state.IsSafari.Should().Be(expectedSafari);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallServiceTests/WhenTestingPrompt.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallServiceTests/WhenTestingPrompt.cs
@@ -1,0 +1,28 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Browser.Install;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallServiceTests;
+
+public class WhenTestingPrompt : BaseInstallServiceTest
+{
+    [Theory]
+    [InlineData("unavailable", InstallResult.Unavailable)]
+    [InlineData("something-unexpected", InstallResult.Unavailable)]
+    [InlineData("dismissed", InstallResult.Dismissed)]
+    [InlineData("accepted", InstallResult.Accepted)]
+    public async Task ItShouldTranslateTheBrowserOutcome(string outcome, InstallResult expected)
+    {
+        // Arrange
+        var js = CreateJsRuntime(AndroidPromptableStateJson);
+        js.PromptOutcome = outcome;
+        var sut = new InstallService(js);
+
+        // Act
+        var result = await sut.PromptAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().Be(expected);
+        js.ImportedModules.Should().Equal(ModulePath);
+        js.Invocations.Should().Equal("import", "promptInstall");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallServiceTests/WhenTestingSubscribe.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallServiceTests/WhenTestingSubscribe.cs
@@ -1,0 +1,132 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Browser.Install;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.InstallServiceTests;
+
+public class WhenTestingSubscribe : BaseInstallServiceTest
+{
+    [Fact]
+    public async Task ItShouldRejectAMissingCallback()
+    {
+        // Arrange
+        var js = CreateJsRuntime(IosSafariStateJson);
+        var sut = new InstallService(js);
+
+        // Act
+        var act = async () => await sut.SubscribeAsync(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+        js.Invocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldSurfaceTheFailureWhenTheBrowserCannotRegisterTheSubscription()
+    {
+        // Arrange
+        var js = CreateJsRuntime(IosSafariStateJson);
+        js.SubscribeFailure = new InvalidOperationException("no subscribe export");
+        var sut = new InstallService(js);
+
+        // Act
+        var act = async () => await sut.SubscribeAsync(_ => Task.CompletedTask, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        js.Invocations.Should().Equal("import", "subscribeInstallState");
+    }
+
+    [Fact]
+    public async Task ItShouldReleaseTheCallbackTargetWhenDisposed()
+    {
+        // Arrange
+        var js = CreateJsRuntime(IosSafariStateJson);
+        var sut = new InstallService(js);
+        var received = new List<InstallState>();
+        var subscription = await sut.SubscribeAsync(
+            state =>
+            {
+                received.Add(state);
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        // Act
+        await subscription.DisposeAsync();
+        var act = async () => await js.PublishAsync(InstalledDesktopStateJson);
+
+        // Assert
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+        received.Should().BeEmpty();
+        js.UnsubscribedTokens.Should().Equal(js.SubscriptionToken);
+        js.Invocations.Should().Equal("import", "subscribeInstallState", "unsubscribeInstallState");
+    }
+
+    [Fact]
+    public async Task ItShouldIgnoreALateStateChangeThatArrivesDuringDisposal()
+    {
+        // Arrange
+        var js = CreateJsRuntime(IosSafariStateJson);
+        var sut = new InstallService(js);
+        var received = new List<InstallState>();
+        var subscription = (InstallStateSubscription)await sut.SubscribeAsync(
+            state =>
+            {
+                received.Add(state);
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+        await subscription.DisposeAsync();
+
+        // Act
+        await subscription.OnInstallStateChanged(
+            new InstallState(true, false, InstallPlatformFamilies.Desktop, false));
+
+        // Assert
+        received.Should().BeEmpty();
+        js.UnsubscribedTokens.Should().Equal(js.SubscriptionToken);
+    }
+
+    [Fact]
+    public async Task ItShouldOnlyUnsubscribeOnceWhenDisposedRepeatedly()
+    {
+        // Arrange
+        var js = CreateJsRuntime(IosSafariStateJson);
+        var sut = new InstallService(js);
+        var subscription = await sut.SubscribeAsync(_ => Task.CompletedTask, CancellationToken.None);
+
+        // Act
+        await subscription.DisposeAsync();
+        await subscription.DisposeAsync();
+
+        // Assert
+        js.UnsubscribedTokens.Should().Equal(js.SubscriptionToken);
+        js.Invocations.Should().Equal("import", "subscribeInstallState", "unsubscribeInstallState");
+    }
+
+    [Fact]
+    public async Task ItShouldRouteBrowserStateChangesToTheCallback()
+    {
+        // Arrange
+        var js = CreateJsRuntime(IosSafariStateJson);
+        var sut = new InstallService(js);
+        var received = new List<InstallState>();
+
+        // Act
+        await using var subscription = await sut.SubscribeAsync(
+            state =>
+            {
+                received.Add(state);
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+        await js.PublishAsync(AndroidPromptableStateJson);
+        await js.PublishAsync(InstalledDesktopStateJson);
+
+        // Assert
+        received.Should().Equal(
+            new InstallState(false, true, InstallPlatformFamilies.Android, false),
+            new InstallState(true, false, InstallPlatformFamilies.Desktop, false));
+        js.Invocations.Should().Equal("import", "subscribeInstallState");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/TestSupport/FakeInstallJsRuntime.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/TestSupport/FakeInstallJsRuntime.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using FishingLogBook.Web.Browser.Install;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Tests.Browser.Install.TestSupport;
+
+public sealed class FakeInstallJsRuntime : IJSRuntime, IJSObjectReference
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    public const string UnknownStateJson =
+        """{"isInstalled":false,"canPrompt":false,"platformFamily":"Other","isSafari":false}""";
+
+    public string StateJson { get; set; } = UnknownStateJson;
+
+    public string PromptOutcome { get; set; } = "unavailable";
+
+    public long SubscriptionToken { get; set; } = 42;
+
+    public Exception? StateFailure { get; set; }
+
+    public Exception? SubscribeFailure { get; set; }
+
+    public List<string> ImportedModules { get; } = [];
+
+    public List<string> Invocations { get; } = [];
+
+    public List<long> UnsubscribedTokens { get; } = [];
+
+    public DotNetObjectReference<InstallStateSubscription>? Subscriber { get; private set; }
+
+    public Task PublishAsync(string stateJson)
+    {
+        StateJson = stateJson;
+        if (Subscriber is null)
+        {
+            throw new InvalidOperationException("No subscriber was registered.");
+        }
+
+        return Subscriber.Value.OnInstallStateChanged(Deserialise<InstallState>(stateJson));
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+        return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+    {
+        Invocations.Add(identifier);
+        return new ValueTask<TValue>(Invoke<TValue>(identifier, args));
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    private TValue Invoke<TValue>(string identifier, object?[]? args)
+    {
+        switch (identifier)
+        {
+            case "import":
+                ImportedModules.Add((string)args![0]!);
+                return (TValue)(object)this;
+            case "getInstallState":
+                return StateFailure is null ? Deserialise<TValue>(StateJson) : throw StateFailure;
+            case "promptInstall":
+                return (TValue)(object)PromptOutcome;
+            case "subscribeInstallState":
+                return Subscribe<TValue>(args);
+            case "unsubscribeInstallState":
+                UnsubscribedTokens.Add(Convert.ToInt64(args![0]!));
+                return default!;
+            default:
+                throw new InvalidOperationException(identifier);
+        }
+    }
+
+    private TValue Subscribe<TValue>(object?[]? args)
+    {
+        if (SubscribeFailure is not null)
+        {
+            throw SubscribeFailure;
+        }
+
+        Subscriber = (DotNetObjectReference<InstallStateSubscription>)args![0]!;
+        return (TValue)(object)SubscriptionToken;
+    }
+
+    private static TValue Deserialise<TValue>(string json)
+    {
+        return JsonSerializer.Deserialize<TValue>(json, Options)!;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Browser.Install;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Onboarding.Services;
 using FishingLogBook.Web.Features.Profile.Clients;
 using FishingLogBook.Web.Localization;
@@ -275,7 +276,7 @@ public class WhenTestingPreferences
         using var culture = TestCulture.Use(CultureNames.English);
         await using var fixture = CreateFixture(
             ValidPreferences(),
-            installState: new InstallState(false, true, InstallPlatformFamilies.Windows, false),
+            installState: new InstallState(false, true, InstallPlatformFamilies.Desktop, false),
             installResult: InstallResult.Accepted);
         var cut = fixture.Context.Render<OnboardingPage>();
 
@@ -337,9 +338,10 @@ public class WhenTestingPreferences
         context.Services.AddSingleton(preferences);
 
         var install = Substitute.For<IInstallService>();
-        install.GetStateAsync(Arg.Any<CancellationToken>()).Returns(new InstallState(false, false, false, false));
+        install.GetStateAsync(Arg.Any<CancellationToken>()).Returns(InstallState.Unknown);
         context.Services.AddSingleton(install);
         context.Services.AddSingleton(Substitute.For<ILocationService>());
+        context.Services.AddSingleton(Substitute.For<ILoggingService>());
         context.AddAuthorization().SetAuthorized("tester@example.test");
         return context;
     }
@@ -427,10 +429,11 @@ public class WhenTestingPreferences
 
         var install = Substitute.For<IInstallService>();
         install.GetStateAsync(Arg.Any<CancellationToken>())
-            .Returns(installState ?? new InstallState(false, false, InstallPlatformFamilies.Other, false));
+            .Returns(installState ?? InstallState.Unknown);
         install.PromptAsync(Arg.Any<CancellationToken>()).Returns(installResult);
         context.Services.AddSingleton(install);
         context.Services.AddSingleton(Substitute.For<ILocationService>());
+        context.Services.AddSingleton(Substitute.For<ILoggingService>());
         context.AddAuthorization().SetAuthorized("tester@example.test");
         return new Fixture(context, onboarding, preferences, install);
     }


### PR DESCRIPTION
Closes #124

## Root cause found

`InstallState` had **two public constructors** (the record's primary constructor plus a `(bool, bool, bool, bool)` convenience overload). System.Text.Json cannot deserialise such a type, so **every** real interop call threw:

```
System.NotSupportedException : Deserialization of types without a parameterless constructor, a singular
parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute'
is not supported. Type 'FishingLogBook.Web.Browser.Install.InstallState'.
```

`InstallGuidance.RefreshAsync` caught that silently and substituted `Other`, which rendered the vague generic fallback. This explains all the reported real-device behaviour, including the installed Samsung PWA being told to install again — detection never reached Blazor on **any** device. Existing tests missed it because every component test substituted `IInstallService` and the JS suite only exercised JavaScript.

The convenience constructor is removed, and the interop boundary is now covered by tests that perform real JSON deserialisation (`FakeInstallJsRuntime`), so re-introducing a second public constructor fails the build's tests.

## What changed

**Manual guidance is never conditional.** Three MudBlazor expansion panels — **iPhone / iPad**, **Android**, **Computer** — are always rendered, outside every `if`. Detection only chooses which panel starts expanded, and can never hide another. The vague generic-only fallback (`Install_Unsupported`, `Install_Other*`) is gone.

- **iPhone / iPad** — Safari → Share → Add to Home Screen → confirm name → Add → open from Home Screen (5 steps), plus a permanent "No Add to Home Screen option?" section explaining the Safari hand-off for other/in-app browsers. When iOS non-Safari is detected, an additional prominent alert appears, but the advice exists regardless of detection.
- **Android** — ⋮ menu → Install app / Add to Home screen → confirm → open from Home Screen, plus a labelled **Samsung Internet** subsection (Menu → Add page to → Home screen → confirm) that does not depend on detecting Samsung Internet.
- **Computer** — address-bar install control, Chrome's menu route, Edge **Apps → Install this site as an app**, confirm. Desktop detection now covers Windows, macOS, Linux and ChromeOS; previously only Windows was recognised and everything else fell through to the generic screen.

**Runtime fixes**

- `beforeinstallprompt` / `appinstalled` listeners are now registered during bootstrap (`js/bootstrap/app.js`), not on first navigation to the Install page, so an event fired during startup can no longer be missed.
- Captured state lives on a `window.fishingLogBookInstall` store (matching the existing `window.fishingLogBook*` convention) rather than module scope, so it survives SPA navigation and cannot be split across two module instances.
- New `IInstallService.SubscribeAsync` pushes later state changes to the mounted component via `DotNetObjectReference` → `InvokeAsync(StateHasChanged)`, so a prompt or installation arriving after the first state read updates the live page.
- The subscription is disposed cleanly (`unsubscribeInstallState` + `DotNetObjectReference.Dispose`); JS drops subscribers whose callback can no longer be reached.
- Interop failures stay non-blocking but are no longer silent — they log to the existing Web diagnostic path (`ILoggingService`, source `install detection`) and render the **complete** manual guidance rather than generic copy.
- Cancellation during teardown is filtered so navigating away mid-call does not log a spurious error.

**Installed state** — shows **App is installed**, hides the native CTA, does not suggest this device needs installing, and keeps all three panels collapsed as secondary help for other devices. Acceptance of the native prompt stays sticky even if the browser publishes a not-yet-installed state before `appinstalled` fires.

`InstallPlatformFamilies.Windows` became `Desktop`. `IInstallService.cs` was split into one type per file per `blazor.md`.

## Tests

47 new/updated install tests. Notably `WhenTestingBrowserState` renders the real component over the real `InstallService` with a JS runtime that performs genuine JSON deserialisation, closing the gap where the service was substituted in every component test.

- **JS (vitest)** — early capture before any page import; prompt surviving into a second module instance; accepted / dismissed / unavailable / `appinstalled`; standalone + iOS standalone; iPhone, iPad desktop-UA, in-app browsers, Android, Samsung Internet, Windows, macOS, Linux, ChromeOS, unknown; subscriber publish, removal and cleanup; idempotent listener registration.
- **Interop contract** — exact module path (`./js/browser/install.js`) and function names, full deserialised `InstallState` for every platform family, prompt-outcome mapping, subscription routing, disposal, double-disposal, late callback.
- **Component** — all three sections present for every detected and unknown state; detection controls only initial expansion; CTA only with a genuinely captured prompt; prompt arriving late; dismissal; prompt failure; installed transition; interop failure → complete manual guidance; EN/FR copy.

## Validation

```
dotnet format FishingLogBook.sln     clean
dotnet build -c Release              0 warnings, 0 errors
dotnet test FishingLogBook.sln       1220 passed
npm test                             183 passed
npm run test:browser                 27 passed, 1 skipped (pre-existing webkit offline-shell skip)
```

No migrations. No Terraform changes, no Terraform apply. No infrastructure, auth, service-worker or offline-database changes. No manual post-merge steps beyond the normal deployment.

## Manual validation checklist (dev, after deploy)

Automated tests cannot prove real-device installability — please run these. I have **not** performed any physical-device verification.

- [ ] **Samsung, installed PWA launched from Home Screen** → Install page shows **App is installed**, no Install CTA, no suggestion to install this device. *(the specific regression reported)*
- [ ] **Samsung / Android Chrome in-browser** → native **Install app** CTA appears where the browser considers the app installable; accepting installs and the page moves to the installed state.
- [ ] **Android, no native CTA** → Android panel is expanded, ⋮ steps are accurate, Samsung Internet subsection visible.
- [ ] **iPhone / iPad Safari** → iOS panel expanded; Share → Add to Home Screen → Add works; launching from the new icon then shows **App is installed**.
- [ ] **iPhone / iPad non-Safari or in-app browser** → Safari hand-off guidance is visible and actionable; no fake CTA.
- [ ] **Desktop Chrome and Edge** → Computer panel expanded; address-bar and menu routes match the on-screen wording; standalone launch reports installed.
- [ ] **Detection-failure path** → with `js/browser/install.js` blocked in DevTools, the page still shows all three panels with full steps (and Diagnostics records an `install detection` error).

Useful during testing:

```js
await import('/js/browser/install.js').then(m => m.getInstallState())
```

Record `isInstalled`, `canPrompt`, `platformFamily`, `isSafari` alongside what the UI shows.

## Self review

- Issue/AC: PASS — every AC implemented and tested; the generic-only fallback is removed.
- Architecture/CQRS: PASS — N/A (client-only). Interop stays behind `IInstallService`; the component holds no `IJSRuntime`.
- Rules: PASS — `blazor.md` three-file pattern, one type per file, `Browser/` placement, block bodies, no narrating comments; `testing-blazor.md` `{Thing}Tests` leaves with `Base{Thing}Test` and `Received(n)` assertions.
- Security/privacy: PASS — no user data, ids, coordinates or tokens involved; the diagnostic log records only exception type and message.
- Database/migrations: N/A.
- Tests/coverage: PASS — see above; the substituted-service gap is closed by a real-interop suite.
- Browser: N/A (reason) — the Playwright suite is not an authenticated Blazor host, and real installability (`beforeinstallprompt`, `display-mode: standalone`, the OS install dialog) cannot be simulated in CI. Forcing it would need test-only auth or a dual host, which `testing-blazor.md` forbids on a product ticket. Remaining risk is real-device installability only, and it is covered by the manual checklist above. Existing PWA/service-worker browser tests still pass unchanged. No follow-up testing-infrastructure ticket is warranted for this.
- Web/UI/localisation: PASS — EN and FR complete, parity test green, no hard-coded English, panel headers ≥48px tap targets, `<ol>` semantics and `aria-label`s retained.
- Code smells: PASS after fixes.
- CI/deployment: PASS — no manual steps, no infrastructure change.

**Findings discovered during self-review**

1. **BLOCKER** — `InstallState`'s second public constructor made every real interop call throw, which the silent catch converted into the generic page. This was the actual production defect.
2. **SHOULD FIX** — the broad `catch (Exception)` swallowed the above with no trace anywhere, which is why the bug survived. 
3. **SHOULD FIX** — passing the component's `CancellationTokenSource` token into interop meant disposal during an in-flight call would log a spurious `install detection` error.
4. **SHOULD FIX** — a state publish arriving after the user accepted the prompt (before `appinstalled`) could flip the UI back from installed to "install now".
5. **SHOULD FIX** — Blazor's `import` and `app.js`'s `import` resolving to different module instances would silently lose the early-captured prompt.
6. **SHOULD FIX** — `IInstallService.cs` held four types, against `blazor.md`.

**Fixes made**

1. Removed the convenience constructor; added `InstallState.Unknown`; added interop tests that deserialise real JSON so this cannot regress.
2. Interop failures now log to `ILoggingService` and always render the complete manual guidance.
3. Added `catch (OperationCanceledException) when (…IsCancellationRequested)` filters ahead of the general catch in all three interop call sites.
4. `IsInstalled` keeps `_result == Accepted` sticky; covered by `ItShouldKeepTheInstalledStateWhenTheBrowserHasNotConfirmedTheAcceptedInstallYet`.
5. Moved captured state to the `window.fishingLogBookInstall` store; covered by `keeps the captured prompt where every module instance can reach it`.
6. Split into `InstallState.cs`, `InstallResult.cs`, `InstallPlatformFamilies.cs`, `InstallStateSubscription.cs`.

**Remaining deliberate gaps**

- No physical-device verification performed — handed over as the checklist above.
- The teardown-cancellation filter (finding 3) has no automated test: deterministically simulating disposal mid-interop needs a race that `testing-blazor.md` would rightly call brittle, and the only consequence is diagnostic noise.
- `index.html` was not modified. The approved plan listed it, but it already loads `js/bootstrap/app.js` as a deferred module in `<head>` before `blazor.webassembly.js`, so wiring `captureInstallEvents` into `app.js` achieves early capture with a smaller change. Proven behaviourally by `captures a browser install prompt offered before any page asks for it`.
- Six `Onboarding_Install*` resources (`Onboarding_AlreadyInstalled`, `Onboarding_InstallPromptBody`, `Onboarding_InstallAction`, `Onboarding_InstallIos`, `Onboarding_InstallAndroid`, `Onboarding_InstallUnavailable`) are unused. They were already dead before this ticket, superseded by the `Install_*` keys; removing them is unrelated cleanup and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)