### PR TITLE
FLB#126 | detect new CBDF versions and add a safe in-app Update now flow

### DIFF
--- a/src/FishingLogBook.Web/Browser/Update/AppUpdateService.cs
+++ b/src/FishingLogBook.Web/Browser/Update/AppUpdateService.cs
@@ -1,0 +1,177 @@
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Browser.Update;
+
+public sealed class AppUpdateService : IAppUpdateService, IDisposable, IAsyncDisposable
+{
+    private const string ModulePath = "./js/browser/app-update.js";
+    private const string FailureSource = "app update";
+
+    private readonly IJSRuntime _jsRuntime;
+    private readonly ILoggingService _logging;
+
+    private DotNetObjectReference<AppUpdateService>? _reference;
+    private IJSObjectReference? _module;
+    private long _subscriptionToken;
+    private bool _isUpdateReady;
+    private bool _hasFailed;
+    private bool _isActivating;
+    private bool _isStarted;
+
+    public AppUpdateService(IJSRuntime jsRuntime, ILoggingService logging)
+    {
+        _jsRuntime = jsRuntime;
+        _logging = logging;
+    }
+
+    public event Action? StatusChanged;
+
+    public AppUpdateStatus Status
+    {
+        get
+        {
+            if (_isActivating)
+            {
+                return AppUpdateStatus.Activating;
+            }
+
+            if (!_isUpdateReady)
+            {
+                return AppUpdateStatus.Current;
+            }
+
+            return _hasFailed ? AppUpdateStatus.Failed : AppUpdateStatus.Available;
+        }
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_isStarted)
+        {
+            return;
+        }
+
+        _isStarted = true;
+        try
+        {
+            var module = await ImportModuleAsync(cancellationToken);
+            _reference = DotNetObjectReference.Create(this);
+            _subscriptionToken = await module.InvokeAsync<long>(
+                "subscribeUpdateState",
+                cancellationToken,
+                _reference);
+            Apply(await module.InvokeAsync<AppUpdateState>("getUpdateState", cancellationToken));
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await LogFailureAsync(exception);
+        }
+    }
+
+    public async Task ApplyAsync(CancellationToken cancellationToken)
+    {
+        if (!_isUpdateReady || _isActivating)
+        {
+            return;
+        }
+
+        _isActivating = true;
+        _hasFailed = false;
+        StatusChanged?.Invoke();
+
+        try
+        {
+            var module = await ImportModuleAsync(cancellationToken);
+            var requested = await module.InvokeAsync<bool>("applyUpdate", cancellationToken);
+            if (requested)
+            {
+                return;
+            }
+
+            await FailAsync(null);
+        }
+        catch (OperationCanceledException)
+        {
+            _isActivating = false;
+        }
+        catch (Exception exception)
+        {
+            await FailAsync(exception);
+        }
+    }
+
+    [JSInvokable]
+    public void OnUpdateStateChanged(AppUpdateState state)
+    {
+        Apply(state);
+    }
+
+    public void Dispose()
+    {
+        _reference?.Dispose();
+        _reference = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is not null && _reference is not null)
+        {
+            try
+            {
+                await _module.InvokeVoidAsync("unsubscribeUpdateState", _subscriptionToken);
+            }
+            catch (JSDisconnectedException)
+            {
+            }
+            catch (JSException)
+            {
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        Dispose();
+    }
+
+    private void Apply(AppUpdateState state)
+    {
+        if (_isUpdateReady == state.IsUpdateReady)
+        {
+            return;
+        }
+
+        _isUpdateReady = state.IsUpdateReady;
+        StatusChanged?.Invoke();
+    }
+
+    private async Task FailAsync(Exception? exception)
+    {
+        _isActivating = false;
+        _hasFailed = true;
+        StatusChanged?.Invoke();
+        if (exception is not null)
+        {
+            await LogFailureAsync(exception);
+        }
+    }
+
+    private async ValueTask<IJSObjectReference> ImportModuleAsync(CancellationToken cancellationToken)
+    {
+        _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>(
+            "import",
+            cancellationToken,
+            ModulePath);
+        return _module;
+    }
+
+    private Task LogFailureAsync(Exception exception)
+    {
+        return _logging.LogErrorAsync(FailureSource, exception, CancellationToken.None);
+    }
+}

--- a/src/FishingLogBook.Web/Browser/Update/AppUpdateState.cs
+++ b/src/FishingLogBook.Web/Browser/Update/AppUpdateState.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Web.Browser.Update;
+
+public sealed record AppUpdateState(bool IsUpdateReady);

--- a/src/FishingLogBook.Web/Browser/Update/AppUpdateStatus.cs
+++ b/src/FishingLogBook.Web/Browser/Update/AppUpdateStatus.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Web.Browser.Update;
+
+public enum AppUpdateStatus
+{
+    Current,
+    Available,
+    Activating,
+    Failed
+}

--- a/src/FishingLogBook.Web/Browser/Update/IAppUpdateService.cs
+++ b/src/FishingLogBook.Web/Browser/Update/IAppUpdateService.cs
@@ -1,0 +1,12 @@
+namespace FishingLogBook.Web.Browser.Update;
+
+public interface IAppUpdateService
+{
+    AppUpdateStatus Status { get; }
+
+    event Action? StatusChanged;
+
+    Task StartAsync(CancellationToken cancellationToken);
+
+    Task ApplyAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor
+++ b/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor
@@ -1,0 +1,28 @@
+@namespace FishingLogBook.Web.Components.AppUpdateBanner
+
+@if (IsVisible)
+{
+    <MudPaper Class="app-update-banner" Elevation="3" Square="true" role="status" aria-live="polite" id="app-update-banner">
+        <div class="app-update-banner-content">
+            <MudIcon Icon="@Icons.Material.Filled.SystemUpdate" Color="Color.Primary" Size="Size.Medium" aria-hidden="true" />
+            <div class="app-update-banner-text">
+                <MudText Typo="Typo.subtitle1" id="app-update-banner-title">@Title</MudText>
+                <MudText Typo="Typo.body2" Class="mud-text-secondary" id="app-update-banner-body">@Body</MudText>
+            </div>
+        </div>
+        @if (ShowAction)
+        {
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       Size="Size.Large"
+                       StartIcon="@Icons.Material.Filled.SystemUpdate"
+                       OnClick="UpdateAsync"
+                       Disabled="IsActivating"
+                       Class="app-update-banner-action"
+                       aria-label="@Loc["Update_Action"]"
+                       id="app-update-banner-action">
+                @Loc["Update_Action"]
+            </MudButton>
+        }
+    </MudPaper>
+}

--- a/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor.cs
+++ b/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor.cs
@@ -1,0 +1,79 @@
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Components.AppUpdateBanner;
+
+public partial class AppUpdateBanner : ComponentBase, IDisposable
+{
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    [Inject]
+    private IAppUpdateService AppUpdate { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool IsVisible => AppUpdate.Status != AppUpdateStatus.Current;
+
+    private bool IsActivating => AppUpdate.Status == AppUpdateStatus.Activating;
+
+    private bool ShowAction => AppUpdate.Status is AppUpdateStatus.Available or AppUpdateStatus.Failed;
+
+    private string Title
+    {
+        get
+        {
+            return AppUpdate.Status switch
+            {
+                AppUpdateStatus.Activating => Loc["Update_ActivatingTitle"],
+                AppUpdateStatus.Failed => Loc["Update_FailedTitle"],
+                _ => Loc["Update_BannerTitle"]
+            };
+        }
+    }
+
+    private string Body
+    {
+        get
+        {
+            return AppUpdate.Status switch
+            {
+                AppUpdateStatus.Activating => Loc["Update_ActivatingBody"],
+                AppUpdateStatus.Failed => Loc["Update_FailedBody"],
+                _ => Loc["Update_BannerBody"]
+            };
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        AppUpdate.StatusChanged += OnStatusChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await AppUpdate.StartAsync(_cancellationTokenSource.Token);
+        }
+    }
+
+    public void Dispose()
+    {
+        AppUpdate.StatusChanged -= OnStatusChanged;
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+
+    private async Task UpdateAsync()
+    {
+        await AppUpdate.ApplyAsync(_cancellationTokenSource.Token);
+    }
+
+    private void OnStatusChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+}

--- a/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor.css
+++ b/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor.css
@@ -1,0 +1,38 @@
+.app-update-banner {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.875rem 0.75rem;
+}
+
+.app-update-banner-content {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.75rem;
+}
+
+.app-update-banner-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+}
+
+.app-update-banner-action {
+    min-height: 2.75rem;
+    width: 100%;
+}
+
+@media (min-width: 600px) {
+    .app-update-banner {
+        align-items: center;
+        flex-direction: row;
+        justify-content: space-between;
+        padding: 0.875rem 1.5rem;
+    }
+
+    .app-update-banner-action {
+        flex-shrink: 0;
+        width: auto;
+    }
+}

--- a/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor
+++ b/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor
@@ -30,6 +30,21 @@
                     <MudText>@Loc["Build_Environment"]: @WebBuild.Environment</MudText>
                 </div>
                 <MudDivider />
+                <div id="update-information">
+                    <MudText Typo="Typo.subtitle1">@Loc["Update_StatusLabel"]</MudText>
+                    <MudText id="update-status">@UpdateStatusText</MudText>
+                    @if (CanUpdate)
+                    {
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.SystemUpdate"
+                                   OnClick="UpdateAsync"
+                                   id="update-now-button">
+                            @Loc["Update_Action"]
+                        </MudButton>
+                    }
+                </div>
+                <MudDivider />
                 <div id="api-build-information">
                     <MudText Typo="Typo.subtitle1">@Loc["Build_Api"]</MudText>
                     @if (_apiBuild is null)

--- a/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor.cs
+++ b/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor.cs
@@ -1,6 +1,7 @@
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Browser.Update;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.SystemStatus.Clients;
 using FishingLogBook.Web.Features.SystemStatus.Models;
@@ -33,9 +34,39 @@ public partial class SystemStatus : ComponentBase, IDisposable
     [Inject]
     private BuildMetadataConfig WebBuild { get; set; } = default!;
 
+    [Inject]
+    private IAppUpdateService AppUpdate { get; set; } = default!;
+
+    private bool CanUpdate => AppUpdate.Status is AppUpdateStatus.Available or AppUpdateStatus.Failed;
+
+    private string UpdateStatusText
+    {
+        get
+        {
+            return AppUpdate.Status switch
+            {
+                AppUpdateStatus.Current => Loc["Update_StatusCurrent"],
+                AppUpdateStatus.Activating => Loc["Update_ActivatingTitle"],
+                AppUpdateStatus.Failed => Loc["Update_FailedTitle"],
+                _ => Loc["Update_StatusAvailable"]
+            };
+        }
+    }
+
     protected override async Task OnInitializedAsync()
     {
+        AppUpdate.StatusChanged += OnUpdateStatusChanged;
         await RefreshAsync();
+    }
+
+    private async Task UpdateAsync()
+    {
+        await AppUpdate.ApplyAsync(_cancellationTokenSource.Token);
+    }
+
+    private void OnUpdateStatusChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private async Task RefreshAsync()
@@ -116,6 +147,7 @@ public partial class SystemStatus : ComponentBase, IDisposable
 
     public void Dispose()
     {
+        AppUpdate.StatusChanged -= OnUpdateStatusChanged;
         _cancellationTokenSource.Cancel();
         _cancellationTokenSource.Dispose();
     }

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
@@ -57,7 +57,11 @@
         </Authorized>
     </AuthorizeView>
     <MudMainContent>
-        <AppUpdateBanner />
+        <AuthorizeView>
+            <Authorized>
+                <AppUpdateBanner />
+            </Authorized>
+        </AuthorizeView>
         <div class="app-shell-content" id="app-shell-content">
             <AppErrorBoundary>
                 @Body

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
@@ -57,6 +57,7 @@
         </Authorized>
     </AuthorizeView>
     <MudMainContent>
+        <AppUpdateBanner />
         <div class="app-shell-content" id="app-shell-content">
             <AppErrorBoundary>
                 @Body

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -710,4 +710,14 @@
   <data name="Build_Commit" xml:space="preserve"><value>Build</value></data>
   <data name="Build_Environment" xml:space="preserve"><value>Environnement</value></data>
   <data name="Build_Unavailable" xml:space="preserve"><value>Indisponible</value></data>
+  <data name="Update_BannerTitle" xml:space="preserve"><value>Nouvelle version de CBDF disponible</value></data>
+  <data name="Update_BannerBody" xml:space="preserve"><value>Obtenez les derniers correctifs et nouveautés.</value></data>
+  <data name="Update_Action" xml:space="preserve"><value>Mettre à jour</value></data>
+  <data name="Update_ActivatingTitle" xml:space="preserve"><value>Mise à jour en cours</value></data>
+  <data name="Update_ActivatingBody" xml:space="preserve"><value>L’application va rouvrir sur la nouvelle version dans un instant.</value></data>
+  <data name="Update_FailedTitle" xml:space="preserve"><value>La mise à jour n’a pas pu être effectuée</value></data>
+  <data name="Update_FailedBody" xml:space="preserve"><value>Vous pouvez continuer à utiliser l’application normalement et réessayer.</value></data>
+  <data name="Update_StatusLabel" xml:space="preserve"><value>Mise à jour</value></data>
+  <data name="Update_StatusCurrent" xml:space="preserve"><value>À jour</value></data>
+  <data name="Update_StatusAvailable" xml:space="preserve"><value>Nouvelle version disponible</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -710,4 +710,14 @@
   <data name="Build_Commit" xml:space="preserve"><value>Build</value></data>
   <data name="Build_Environment" xml:space="preserve"><value>Environment</value></data>
   <data name="Build_Unavailable" xml:space="preserve"><value>Unavailable</value></data>
+  <data name="Update_BannerTitle" xml:space="preserve"><value>New CBDF version available</value></data>
+  <data name="Update_BannerBody" xml:space="preserve"><value>Get the latest fixes and features.</value></data>
+  <data name="Update_Action" xml:space="preserve"><value>Update now</value></data>
+  <data name="Update_ActivatingTitle" xml:space="preserve"><value>Updating</value></data>
+  <data name="Update_ActivatingBody" xml:space="preserve"><value>The app will reopen on the new version in a moment.</value></data>
+  <data name="Update_FailedTitle" xml:space="preserve"><value>Update could not be completed</value></data>
+  <data name="Update_FailedBody" xml:space="preserve"><value>You can keep using the app as normal and try again.</value></data>
+  <data name="Update_StatusLabel" xml:space="preserve"><value>Update</value></data>
+  <data name="Update_StatusCurrent" xml:space="preserve"><value>Up to date</value></data>
+  <data name="Update_StatusAvailable" xml:space="preserve"><value>New version available</value></data>
 </root>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using FishingLogBook.Web.Browser.Install;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Browser.Update;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
@@ -67,6 +68,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<INetworkService, NetworkService>();
         services.AddScoped<ILocationService, LocationService>();
         services.AddScoped<IInstallService, InstallService>();
+        services.AddScoped<IAppUpdateService, AppUpdateService>();
         services.AddScoped<IOnboardingService, OnboardingService>();
         services.AddScoped<ITimeService, TimeService>();
         services.AddScoped<ICatchStore, IndexedDbCatchStore>();

--- a/src/FishingLogBook.Web/_Imports.razor
+++ b/src/FishingLogBook.Web/_Imports.razor
@@ -16,6 +16,7 @@
 @using FishingLogBook.Web.Browser.Network
 @using FishingLogBook.Web.Common
 @using FishingLogBook.Web.Components.AppErrorBoundary
+@using FishingLogBook.Web.Components.AppUpdateBanner
 @using FishingLogBook.Web.Components.LanguageSwitcher
 @using FishingLogBook.Web.Features.Authentication.Components.UserMenu
 @using FishingLogBook.Web.Features.Authentication.Components.RedirectToLogin

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
@@ -117,6 +117,10 @@ function createWorker({ assets = [], cacheKeys = [], match, fetch: fetchImplemen
         return activation;
     }
 
+    function dispatchMessage(data) {
+        listeners.message({ data });
+    }
+
     return {
         cache,
         cacheDelete,
@@ -124,6 +128,7 @@ function createWorker({ assets = [], cacheKeys = [], match, fetch: fetchImplemen
         dispatchActivate,
         dispatchFetch,
         dispatchInstall,
+        dispatchMessage,
         fetch,
         recoveryCache,
         serviceWorker
@@ -159,7 +164,66 @@ describe('published service worker', () => {
 
         expect(worker.cache.put).toHaveBeenCalledTimes(2);
         expect(worker.cacheDelete).not.toHaveBeenCalled();
+    });
+
+    it('waits for the running app instead of taking over as soon as it is installed', async () => {
+        const worker = createWorker({
+            assets: [{ url: '_framework/app.wasm' }],
+            fetch: async request => new TestResponse(request.url)
+        });
+
+        await worker.dispatchInstall();
+
+        expect(worker.serviceWorker.skipWaiting).not.toHaveBeenCalled();
+    });
+
+    it('takes over only when the running app asks it to', () => {
+        const worker = createWorker();
+
+        worker.dispatchMessage({ type: 'SomethingElse' });
+        expect(worker.serviceWorker.skipWaiting).not.toHaveBeenCalled();
+
+        worker.dispatchMessage({ type: 'SkipWaiting' });
+
         expect(worker.serviceWorker.skipWaiting).toHaveBeenCalledOnce();
+    });
+
+    it('ignores a message without data', () => {
+        const worker = createWorker();
+
+        expect(() => worker.dispatchMessage(null)).not.toThrow();
+        expect(worker.serviceWorker.skipWaiting).not.toHaveBeenCalled();
+    });
+
+    it('leaves the reload to the app when the app requested the takeover', async () => {
+        const navigate = vi.fn(async () => undefined);
+        const worker = createWorker({
+            cacheKeys: ['offline-cache-previous', 'offline-cache-test']
+        });
+        worker.serviceWorker.clients.matchAll.mockResolvedValue([
+            { url: 'https://app.test/', navigate }
+        ]);
+
+        worker.dispatchMessage({ type: 'SkipWaiting' });
+        await worker.dispatchActivate();
+
+        expect(navigate).not.toHaveBeenCalled();
+        expect(worker.cacheDelete).toHaveBeenCalledOnce();
+        expect(worker.cacheDelete).toHaveBeenCalledWith('offline-cache-previous');
+        expect(worker.serviceWorker.clients.claim).toHaveBeenCalledOnce();
+    });
+
+    it('never deletes application data when a replacement activates', async () => {
+        const worker = createWorker({
+            cacheKeys: ['offline-cache-previous', 'offline-cache-test']
+        });
+
+        worker.dispatchMessage({ type: 'SkipWaiting' });
+        await worker.dispatchActivate();
+
+        expect(worker.cacheDelete).not.toHaveBeenCalledWith('service-worker-recovery');
+        expect(worker.cacheDelete.mock.calls.every(call => call[0].startsWith('offline-cache-')))
+            .toBe(true);
     });
 
     it('reloads existing controlled clients once after a complete replacement activates', async () => {

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.js
@@ -1,3 +1,5 @@
+import { trackAppUpdates } from '../browser/app-update.js';
+
 const epoch = '20260821-pre-onboarding-startup';
 
 export function listenForServiceWorkerErrors(targetWindow = window) {
@@ -15,13 +17,15 @@ export async function registerServiceWorker(targetWindow = window) {
     } catch { /* ignore */ }
 
     try {
-        await targetWindow.navigator.serviceWorker.register(
+        const registration = await targetWindow.navigator.serviceWorker.register(
             'service-worker.js',
             { updateViaCache: 'none' });
 
         if (epochChanged) {
             targetWindow.localStorage.setItem('flb-sw-epoch', epoch);
         }
+
+        trackAppUpdates(targetWindow, registration);
     } catch (error) {
         targetWindow.console.error('[FLB] ServiceWorkerRegistrationError', error);
     }

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-registration.test.js
@@ -117,4 +117,22 @@ describe('service worker registration', () => {
     it('does nothing when the browser has no service worker API', () => {
         expect(() => listenForServiceWorkerErrors({ navigator: {} })).not.toThrow();
     });
+
+    it('reports an update that was already waiting when the app started', async () => {
+        vi.resetModules();
+        const registration = await import('./service-worker-registration.js');
+        const update = await import('../browser/app-update.js');
+        const targetWindow = createTargetWindow({ epoch: currentEpoch });
+        const waiting = { postMessage: vi.fn(), addEventListener: vi.fn() };
+        targetWindow.navigator.serviceWorker.controller = {};
+        targetWindow.navigator.serviceWorker.register = vi.fn(async () => ({
+            waiting,
+            update: vi.fn(async () => undefined),
+            addEventListener: vi.fn()
+        }));
+
+        await registration.registerServiceWorker(targetWindow);
+
+        expect(update.getUpdateState()).toEqual({ isUpdateReady: true });
+    });
 });

--- a/src/FishingLogBook.Web/wwwroot/js/browser/app-update.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/app-update.js
@@ -1,0 +1,166 @@
+let trackedWindow;
+
+export function trackAppUpdates(targetWindow, registration) {
+    trackedWindow = targetWindow;
+    const state = store(targetWindow);
+    if (!registration) {
+        return;
+    }
+
+    state.registration = registration;
+    observeController(targetWindow);
+    observeVisibility(targetWindow);
+    adopt(targetWindow, registration.waiting);
+    registration.addEventListener?.('updatefound', () => observeInstalling(targetWindow, registration));
+    observeInstalling(targetWindow, registration);
+    checkForUpdate(targetWindow);
+}
+
+export function getUpdateState() {
+    return currentState(activeWindow());
+}
+
+export function subscribeUpdateState(subscriber) {
+    const state = store(activeWindow());
+    state.nextToken += 1;
+    state.subscribers.set(state.nextToken, subscriber);
+    return state.nextToken;
+}
+
+export function unsubscribeUpdateState(token) {
+    store(activeWindow()).subscribers.delete(token);
+}
+
+export async function applyUpdate() {
+    const targetWindow = activeWindow();
+    const state = store(targetWindow);
+    if (state.applying || !state.waiting) {
+        return false;
+    }
+
+    state.applying = true;
+    try {
+        state.waiting.postMessage({ type: 'SkipWaiting' });
+        return true;
+    } catch {
+        state.applying = false;
+        return false;
+    }
+}
+
+export async function checkForUpdate(targetWindow = activeWindow()) {
+    const state = store(targetWindow);
+    if (!state.registration || targetWindow.navigator?.onLine === false) {
+        return;
+    }
+
+    try {
+        await state.registration.update();
+    } catch { /* an unreachable network must never look like an update */ }
+}
+
+function activeWindow() {
+    return trackedWindow ?? window;
+}
+
+function store(targetWindow) {
+    if (!targetWindow.fishingLogBookUpdate) {
+        targetWindow.fishingLogBookUpdate = {
+            registration: undefined,
+            waiting: undefined,
+            applying: false,
+            reloaded: false,
+            observingController: false,
+            observingVisibility: false,
+            nextToken: 0,
+            subscribers: new Map()
+        };
+    }
+
+    return targetWindow.fishingLogBookUpdate;
+}
+
+function currentState(targetWindow) {
+    return { isUpdateReady: Boolean(store(targetWindow).waiting) };
+}
+
+function observeInstalling(targetWindow, registration) {
+    const installing = registration.installing;
+    if (!installing) {
+        return;
+    }
+
+    installing.addEventListener?.('statechange', () => {
+        if (installing.state === 'installed') {
+            adopt(targetWindow, registration.waiting || installing);
+        }
+    });
+}
+
+function adopt(targetWindow, worker) {
+    const state = store(targetWindow);
+    if (!worker || state.waiting === worker) {
+        return;
+    }
+
+    if (!targetWindow.navigator?.serviceWorker?.controller) {
+        return;
+    }
+
+    state.waiting = worker;
+    publish(targetWindow);
+}
+
+function observeController(targetWindow) {
+    const state = store(targetWindow);
+    if (state.observingController) {
+        return;
+    }
+
+    state.observingController = true;
+    targetWindow.navigator.serviceWorker.addEventListener?.('controllerchange', () => {
+        if (!state.applying || state.reloaded) {
+            return;
+        }
+
+        state.reloaded = true;
+        targetWindow.location.reload();
+    });
+}
+
+function observeVisibility(targetWindow) {
+    const state = store(targetWindow);
+    if (state.observingVisibility || !targetWindow.document?.addEventListener) {
+        return;
+    }
+
+    state.observingVisibility = true;
+    targetWindow.document.addEventListener('visibilitychange', () => {
+        if (targetWindow.document.visibilityState === 'visible') {
+            checkForUpdate(targetWindow);
+        }
+    });
+}
+
+function publish(targetWindow) {
+    const state = store(targetWindow);
+    if (state.subscribers.size === 0) {
+        return;
+    }
+
+    const current = currentState(targetWindow);
+    for (const [token, subscriber] of [...state.subscribers]) {
+        notify(state, token, subscriber, current);
+    }
+}
+
+function notify(state, token, subscriber, current) {
+    try {
+        const pending = subscriber.invokeMethodAsync('OnUpdateStateChanged', current);
+        if (typeof pending?.catch === 'function') {
+            pending.catch(() => state.subscribers.delete(token));
+        }
+    } catch {
+        state.subscribers.delete(token);
+    }
+}

--- a/src/FishingLogBook.Web/wwwroot/js/browser/app-update.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/app-update.test.js
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function createWorker() {
+    return { postMessage: vi.fn(), state: 'installed', addEventListener: vi.fn() };
+}
+
+function createRegistration({ waiting, installing } = {}) {
+    const listeners = {};
+    return {
+        waiting,
+        installing,
+        update: vi.fn(async () => undefined),
+        unregister: vi.fn(async () => true),
+        addEventListener: (type, listener) => { listeners[type] = listener; },
+        raise: (type) => listeners[type]?.()
+    };
+}
+
+function createWindow({ controller = {}, onLine = true } = {}) {
+    const controllerListeners = [];
+    const documentListeners = {};
+    return {
+        navigator: {
+            onLine,
+            serviceWorker: {
+                controller,
+                addEventListener: (type, listener) => {
+                    if (type === 'controllerchange') {
+                        controllerListeners.push(listener);
+                    }
+                }
+            }
+        },
+        document: {
+            visibilityState: 'visible',
+            addEventListener: (type, listener) => { documentListeners[type] = listener; }
+        },
+        location: { reload: vi.fn() },
+        caches: { delete: vi.fn(), keys: vi.fn() },
+        indexedDB: { deleteDatabase: vi.fn() },
+        localStorage: { clear: vi.fn(), removeItem: vi.fn() },
+        sessionStorage: { clear: vi.fn() },
+        raiseControllerChange: () => controllerListeners.forEach(listener => listener()),
+        raiseVisible: () => documentListeners.visibilitychange?.()
+    };
+}
+
+let update;
+
+beforeEach(async () => {
+    vi.resetModules();
+    update = await import('./app-update.js');
+});
+
+describe('app update detection', () => {
+    it('reports no update when the service worker is not registered', () => {
+        const targetWindow = createWindow();
+
+        update.trackAppUpdates(targetWindow, undefined);
+
+        expect(update.getUpdateState()).toEqual({ isUpdateReady: false });
+    });
+
+    it('reports no update when nothing is waiting', () => {
+        const targetWindow = createWindow();
+
+        update.trackAppUpdates(targetWindow, createRegistration());
+
+        expect(getState(targetWindow)).toEqual({ isUpdateReady: false });
+    });
+
+    it('does not fabricate an update when the update check fails offline', async () => {
+        const targetWindow = createWindow({ onLine: false });
+        const registration = createRegistration();
+
+        update.trackAppUpdates(targetWindow, registration);
+        await update.checkForUpdate(targetWindow);
+
+        expect(registration.update).not.toHaveBeenCalled();
+        expect(getState(targetWindow)).toEqual({ isUpdateReady: false });
+    });
+
+    it('does not fabricate an update when the network rejects the update check', async () => {
+        const targetWindow = createWindow();
+        const registration = createRegistration();
+        registration.update = vi.fn(async () => { throw new TypeError('Failed to fetch'); });
+
+        update.trackAppUpdates(targetWindow, registration);
+        await update.checkForUpdate(targetWindow);
+
+        expect(getState(targetWindow)).toEqual({ isUpdateReady: false });
+    });
+
+    it('does not treat a first installation without a controller as an update', () => {
+        const targetWindow = createWindow({ controller: null });
+
+        update.trackAppUpdates(targetWindow, createRegistration({ waiting: createWorker() }));
+
+        expect(getState(targetWindow)).toEqual({ isUpdateReady: false });
+    });
+
+    it('reports a worker that was already waiting when the app started', () => {
+        const targetWindow = createWindow();
+
+        update.trackAppUpdates(targetWindow, createRegistration({ waiting: createWorker() }));
+
+        expect(getState(targetWindow)).toEqual({ isUpdateReady: true });
+    });
+
+    it('reports an update that finishes installing after startup', () => {
+        const targetWindow = createWindow();
+        const installing = createWorker();
+        installing.state = 'installing';
+        const registration = createRegistration({ installing });
+
+        update.trackAppUpdates(targetWindow, registration);
+        installing.state = 'installed';
+        raiseStateChange(installing);
+
+        expect(getState(targetWindow)).toEqual({ isUpdateReady: true });
+    });
+
+    it('checks for a new version when the app becomes visible again', () => {
+        const targetWindow = createWindow();
+        const registration = createRegistration();
+
+        update.trackAppUpdates(targetWindow, registration);
+        registration.update.mockClear();
+        targetWindow.raiseVisible();
+
+        expect(registration.update).toHaveBeenCalledOnce();
+    });
+});
+
+describe('app update activation', () => {
+    it('does nothing when no update is waiting', async () => {
+        const targetWindow = createWindow();
+        update.trackAppUpdates(targetWindow, createRegistration());
+
+        await expect(update.applyUpdate()).resolves.toBe(false);
+
+        expect(targetWindow.location.reload).not.toHaveBeenCalled();
+    });
+
+    it('asks the waiting worker to take over', async () => {
+        const targetWindow = createWindow();
+        const waiting = createWorker();
+        update.trackAppUpdates(targetWindow, createRegistration({ waiting }));
+
+        await expect(update.applyUpdate()).resolves.toBe(true);
+
+        expect(waiting.postMessage).toHaveBeenCalledOnce();
+        expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SkipWaiting' });
+        expect(targetWindow.location.reload).not.toHaveBeenCalled();
+    });
+
+    it('reloads once when the new worker takes control', async () => {
+        const targetWindow = createWindow();
+        update.trackAppUpdates(targetWindow, createRegistration({ waiting: createWorker() }));
+        await update.applyUpdate();
+
+        targetWindow.raiseControllerChange();
+        targetWindow.raiseControllerChange();
+        targetWindow.raiseControllerChange();
+
+        expect(targetWindow.location.reload).toHaveBeenCalledOnce();
+    });
+
+    it('does not reload on a controller change the app did not request', () => {
+        const targetWindow = createWindow();
+        update.trackAppUpdates(targetWindow, createRegistration({ waiting: createWorker() }));
+
+        targetWindow.raiseControllerChange();
+
+        expect(targetWindow.location.reload).not.toHaveBeenCalled();
+    });
+
+    it('ignores repeated activation requests', async () => {
+        const targetWindow = createWindow();
+        const waiting = createWorker();
+        update.trackAppUpdates(targetWindow, createRegistration({ waiting }));
+
+        await update.applyUpdate();
+        await expect(update.applyUpdate()).resolves.toBe(false);
+        await expect(update.applyUpdate()).resolves.toBe(false);
+
+        expect(waiting.postMessage).toHaveBeenCalledOnce();
+    });
+
+    it('reports failure when the waiting worker cannot be reached', async () => {
+        const targetWindow = createWindow();
+        const waiting = createWorker();
+        waiting.postMessage = vi.fn(() => { throw new Error('worker is gone'); });
+        update.trackAppUpdates(targetWindow, createRegistration({ waiting }));
+
+        await expect(update.applyUpdate()).resolves.toBe(false);
+
+        expect(targetWindow.location.reload).not.toHaveBeenCalled();
+    });
+
+    it('never deletes application data as part of updating', async () => {
+        const targetWindow = createWindow();
+        update.trackAppUpdates(targetWindow, createRegistration({ waiting: createWorker() }));
+
+        await update.applyUpdate();
+        targetWindow.raiseControllerChange();
+
+        expect(targetWindow.caches.delete).not.toHaveBeenCalled();
+        expect(targetWindow.caches.keys).not.toHaveBeenCalled();
+        expect(targetWindow.indexedDB.deleteDatabase).not.toHaveBeenCalled();
+        expect(targetWindow.localStorage.clear).not.toHaveBeenCalled();
+        expect(targetWindow.localStorage.removeItem).not.toHaveBeenCalled();
+        expect(targetWindow.sessionStorage.clear).not.toHaveBeenCalled();
+    });
+
+    it('never unregisters the service worker as part of updating', async () => {
+        const targetWindow = createWindow();
+        const registration = createRegistration({ waiting: createWorker() });
+        update.trackAppUpdates(targetWindow, registration);
+
+        await update.applyUpdate();
+        targetWindow.raiseControllerChange();
+
+        expect(registration.unregister).not.toHaveBeenCalled();
+    });
+});
+
+describe('app update subscriptions', () => {
+    it('publishes when an update becomes ready after the first state read', () => {
+        const targetWindow = createWindow();
+        const installing = createWorker();
+        installing.state = 'installing';
+        const registration = createRegistration({ installing });
+        update.trackAppUpdates(targetWindow, registration);
+        const subscriber = { invokeMethodAsync: vi.fn(() => Promise.resolve()) };
+        const token = update.subscribeUpdateState(subscriber);
+
+        installing.state = 'installed';
+        raiseStateChange(installing);
+
+        expect(subscriber.invokeMethodAsync).toHaveBeenCalledOnce();
+        expect(subscriber.invokeMethodAsync).toHaveBeenCalledWith(
+            'OnUpdateStateChanged',
+            { isUpdateReady: true });
+        update.unsubscribeUpdateState(token);
+    });
+
+    it('publishes the same update only once', () => {
+        const targetWindow = createWindow();
+        const waiting = createWorker();
+        const registration = createRegistration({ installing: waiting });
+        update.trackAppUpdates(targetWindow, registration);
+        const subscriber = { invokeMethodAsync: vi.fn(() => Promise.resolve()) };
+        const token = update.subscribeUpdateState(subscriber);
+
+        raiseStateChange(waiting);
+        raiseStateChange(waiting);
+        registration.raise('updatefound');
+        raiseStateChange(waiting);
+
+        expect(subscriber.invokeMethodAsync).toHaveBeenCalledOnce();
+        update.unsubscribeUpdateState(token);
+    });
+
+    it('stops publishing to a subscriber that has been removed', () => {
+        const targetWindow = createWindow();
+        const installing = createWorker();
+        installing.state = 'installing';
+        update.trackAppUpdates(targetWindow, createRegistration({ installing }));
+        const subscriber = { invokeMethodAsync: vi.fn(() => Promise.resolve()) };
+        const token = update.subscribeUpdateState(subscriber);
+        update.unsubscribeUpdateState(token);
+
+        installing.state = 'installed';
+        raiseStateChange(installing);
+
+        expect(subscriber.invokeMethodAsync).not.toHaveBeenCalled();
+    });
+
+    it('drops a subscriber whose callback can no longer be reached', async () => {
+        const targetWindow = createWindow();
+        const installing = createWorker();
+        installing.state = 'installing';
+        update.trackAppUpdates(targetWindow, createRegistration({ installing }));
+        const subscriber = {
+            invokeMethodAsync: vi.fn(() => Promise.reject(new Error('disposed')))
+        };
+        update.subscribeUpdateState(subscriber);
+
+        installing.state = 'installed';
+        raiseStateChange(installing);
+        await Promise.resolve();
+
+        expect(subscriber.invokeMethodAsync).toHaveBeenCalledOnce();
+        expect(store(targetWindow).subscribers.size).toBe(0);
+    });
+});
+
+function raiseStateChange(worker) {
+    worker.addEventListener.mock.calls
+        .filter(call => call[0] === 'statechange')
+        .forEach(call => call[1]());
+}
+
+function store(targetWindow) {
+    return targetWindow.fishingLogBookUpdate;
+}
+
+function getState(targetWindow) {
+    return { isUpdateReady: Boolean(store(targetWindow).waiting) };
+}

--- a/src/FishingLogBook.Web/wwwroot/service-worker.published.js
+++ b/src/FishingLogBook.Web/wwwroot/service-worker.published.js
@@ -17,6 +17,12 @@ self.addEventListener('fetch', event => {
 
     event.respondWith(onFetch(event));
 });
+self.addEventListener('message', event => {
+    if (event.data?.type === 'SkipWaiting') {
+        activationRequestedByClient = true;
+        self.skipWaiting();
+    }
+});
 self.addEventListener('error', event => notifyServiceWorkerError(event.message || 'error'));
 self.addEventListener('unhandledrejection', event => notifyServiceWorkerError(String(event.reason || 'unhandledrejection')));
 
@@ -24,6 +30,11 @@ const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
 const recoveryCacheName = 'service-worker-recovery';
 const recoveryKey = 'pre-onboarding-startup-20260821';
+
+// A replacement worker stays in `waiting` until the running app asks to activate it, so the
+// user chooses when to move to the new build (FLB#126). The client reloads itself once the
+// controller changes, so activation requested this way must not also navigate clients.
+let activationRequestedByClient = false;
 const offlineAssetsInclude = [ /\.dll$/, /\.pdb$/, /\.wasm/, /\.html/, /\.js$/, /\.json$/, /\.css$/, /\.woff$/, /\.woff2$/, /\.png$/, /\.jpe?g$/, /\.gif$/, /\.ico$/, /\.svg$/, /\.blat$/, /\.dat$/, /\.webmanifest$/ ];
 const offlineAssetsExclude = [ /^service-worker\.js$/, /\/_redirects$/, /\/_headers$/, /\.test\.js$/ ];
 
@@ -42,7 +53,6 @@ async function onInstall(event) {
 
     await Promise.all(assetsRequests.map(request => cacheUnredirected(cache, request)));
     await cacheAppShell(cache);
-    await self.skipWaiting();
 }
 
 async function onActivate(event) {
@@ -56,7 +66,7 @@ async function onActivate(event) {
         .filter(key => key.startsWith(cacheNamePrefix) && key !== cacheName)
         .map(key => caches.delete(key)));
 
-    if (hasPreviousAppShell) {
+    if (hasPreviousAppShell && !activationRequestedByClient) {
         await reloadClientsOnce();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Browser/Update/AppUpdateServiceTests/BaseAppUpdateServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Update/AppUpdateServiceTests/BaseAppUpdateServiceTest.cs
@@ -1,0 +1,18 @@
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Tests.Browser.Update.TestSupport;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Update.AppUpdateServiceTests;
+
+public class BaseAppUpdateServiceTest
+{
+    protected const string ModulePath = "./js/browser/app-update.js";
+
+    protected static AppUpdateService CreateService(
+        FakeAppUpdateJsRuntime jsRuntime,
+        ILoggingService? logging = null)
+    {
+        return new AppUpdateService(jsRuntime, logging ?? Substitute.For<ILoggingService>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Update/AppUpdateServiceTests/WhenTestingApply.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Update/AppUpdateServiceTests/WhenTestingApply.cs
@@ -1,0 +1,110 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Tests.Browser.Update.TestSupport;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Update.AppUpdateServiceTests;
+
+public class WhenTestingApply : BaseAppUpdateServiceTest
+{
+    [Fact]
+    public async Task ItShouldDoNothingWhenNoUpdateIsWaiting()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.NoUpdateJson };
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+
+        // Act
+        await sut.ApplyAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Current);
+        js.Invocations.Should().NotContain("applyUpdate");
+    }
+
+    [Fact]
+    public async Task ItShouldStayUsableWhenActivationIsRefused()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime
+        {
+            StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson,
+            ApplyAccepted = false
+        };
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+
+        // Act
+        await sut.ApplyAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Failed);
+        js.Invocations.Should().Contain("applyUpdate");
+    }
+
+    [Fact]
+    public async Task ItShouldStayUsableWhenActivationThrows()
+    {
+        // Arrange
+        var logging = Substitute.For<ILoggingService>();
+        var js = new FakeAppUpdateJsRuntime
+        {
+            StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson,
+            ApplyFailure = new InvalidOperationException("worker is gone")
+        };
+        var sut = CreateService(js, logging);
+        await sut.StartAsync(CancellationToken.None);
+
+        // Act
+        await sut.ApplyAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Failed);
+        await logging.Received(1).LogErrorAsync(
+            "app update",
+            Arg.Is<Exception>(exception => exception.Message == "worker is gone"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRequestActivationOnlyOnceWhileActivating()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson };
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+
+        // Act
+        await sut.ApplyAsync(CancellationToken.None);
+        await sut.ApplyAsync(CancellationToken.None);
+        await sut.ApplyAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Activating);
+        js.Invocations.Count(invocation => invocation == "applyUpdate").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldAllowARetryAfterAFailedActivation()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime
+        {
+            StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson,
+            ApplyAccepted = false
+        };
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+        await sut.ApplyAsync(CancellationToken.None);
+        js.ApplyAccepted = true;
+
+        // Act
+        await sut.ApplyAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Activating);
+        js.Invocations.Count(invocation => invocation == "applyUpdate").Should().Be(2);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Update/AppUpdateServiceTests/WhenTestingStart.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Update/AppUpdateServiceTests/WhenTestingStart.cs
@@ -1,0 +1,97 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Tests.Browser.Update.TestSupport;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Update.AppUpdateServiceTests;
+
+public class WhenTestingStart : BaseAppUpdateServiceTest
+{
+    [Fact]
+    public async Task ItShouldStayUsableWhenTheBrowserModuleFails()
+    {
+        // Arrange
+        var logging = Substitute.For<ILoggingService>();
+        var js = new FakeAppUpdateJsRuntime
+        {
+            StateFailure = new InvalidOperationException("module unavailable")
+        };
+        var sut = CreateService(js, logging);
+
+        // Act
+        await sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Current);
+        await logging.Received(1).LogErrorAsync(
+            "app update",
+            Arg.Is<Exception>(exception => exception.Message == "module unavailable"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportNoUpdateWhenNothingIsWaiting()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.NoUpdateJson };
+        var sut = CreateService(js);
+
+        // Act
+        await sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Current);
+        js.ImportedModules.Should().Equal(ModulePath);
+        js.Invocations.Should().Equal("import", "subscribeUpdateState", "getUpdateState");
+    }
+
+    [Fact]
+    public async Task ItShouldReportAnUpdateThatIsAlreadyWaiting()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson };
+        var sut = CreateService(js);
+        var notifications = 0;
+        sut.StatusChanged += () => notifications++;
+
+        // Act
+        await sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Available);
+        notifications.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldOnlySubscribeOnceAcrossRepeatedStarts()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson };
+        var sut = CreateService(js);
+
+        // Act
+        await sut.StartAsync(CancellationToken.None);
+        await sut.StartAsync(CancellationToken.None);
+        await sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Available);
+        js.Invocations.Should().Equal("import", "subscribeUpdateState", "getUpdateState");
+    }
+
+    [Fact]
+    public async Task ItShouldReleaseTheBrowserSubscriptionWhenDisposed()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime();
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+
+        // Act
+        await sut.DisposeAsync();
+
+        // Assert
+        js.UnsubscribedTokens.Should().Equal(js.SubscriptionToken);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Update/AppUpdateServiceTests/WhenTestingStateChange.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Update/AppUpdateServiceTests/WhenTestingStateChange.cs
@@ -1,0 +1,82 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Tests.Browser.Update.TestSupport;
+
+namespace FishingLogBook.Web.Tests.Browser.Update.AppUpdateServiceTests;
+
+public class WhenTestingStateChange : BaseAppUpdateServiceTest
+{
+    [Fact]
+    public async Task ItShouldReportAnUpdateThatArrivesAfterStartup()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.NoUpdateJson };
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+        var notifications = 0;
+        sut.StatusChanged += () => notifications++;
+
+        // Act
+        js.Publish(FakeAppUpdateJsRuntime.UpdateReadyJson);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Available);
+        notifications.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldNotRaiseAgainForTheSameUpdate()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.NoUpdateJson };
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+        var notifications = 0;
+        sut.StatusChanged += () => notifications++;
+
+        // Act
+        js.Publish(FakeAppUpdateJsRuntime.UpdateReadyJson);
+        js.Publish(FakeAppUpdateJsRuntime.UpdateReadyJson);
+        js.Publish(FakeAppUpdateJsRuntime.UpdateReadyJson);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Available);
+        notifications.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldNotKeepOfferingARetryOnceTheWaitingUpdateHasGone()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime
+        {
+            StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson,
+            ApplyAccepted = false
+        };
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+        await sut.ApplyAsync(CancellationToken.None);
+        sut.Status.Should().Be(AppUpdateStatus.Failed);
+
+        // Act
+        js.Publish(FakeAppUpdateJsRuntime.NoUpdateJson);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Current);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnToCurrentWhenTheWaitingUpdateDisappears()
+    {
+        // Arrange
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson };
+        var sut = CreateService(js);
+        await sut.StartAsync(CancellationToken.None);
+
+        // Act
+        js.Publish(FakeAppUpdateJsRuntime.NoUpdateJson);
+
+        // Assert
+        sut.Status.Should().Be(AppUpdateStatus.Current);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Update/TestSupport/FakeAppUpdateJsRuntime.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Update/TestSupport/FakeAppUpdateJsRuntime.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using FishingLogBook.Web.Browser.Update;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Tests.Browser.Update.TestSupport;
+
+public sealed class FakeAppUpdateJsRuntime : IJSRuntime, IJSObjectReference
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    public const string NoUpdateJson = """{"isUpdateReady":false}""";
+    public const string UpdateReadyJson = """{"isUpdateReady":true}""";
+
+    public string StateJson { get; set; } = NoUpdateJson;
+
+    public bool ApplyAccepted { get; set; } = true;
+
+    public long SubscriptionToken { get; set; } = 9;
+
+    public Exception? StateFailure { get; set; }
+
+    public Exception? ApplyFailure { get; set; }
+
+    public List<string> ImportedModules { get; } = [];
+
+    public List<string> Invocations { get; } = [];
+
+    public List<long> UnsubscribedTokens { get; } = [];
+
+    public DotNetObjectReference<AppUpdateService>? Subscriber { get; private set; }
+
+    public void Publish(string stateJson)
+    {
+        StateJson = stateJson;
+        if (Subscriber is null)
+        {
+            throw new InvalidOperationException("No subscriber was registered.");
+        }
+
+        Subscriber.Value.OnUpdateStateChanged(Deserialise<AppUpdateState>(stateJson));
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+        return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+    {
+        Invocations.Add(identifier);
+        return new ValueTask<TValue>(Invoke<TValue>(identifier, args));
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    private TValue Invoke<TValue>(string identifier, object?[]? args)
+    {
+        switch (identifier)
+        {
+            case "import":
+                ImportedModules.Add((string)args![0]!);
+                return (TValue)(object)this;
+            case "getUpdateState":
+                return StateFailure is null ? Deserialise<TValue>(StateJson) : throw StateFailure;
+            case "subscribeUpdateState":
+                Subscriber = (DotNetObjectReference<AppUpdateService>)args![0]!;
+                return (TValue)(object)SubscriptionToken;
+            case "applyUpdate":
+                return ApplyFailure is null
+                    ? (TValue)(object)ApplyAccepted
+                    : throw ApplyFailure;
+            case "unsubscribeUpdateState":
+                UnsubscribedTokens.Add(Convert.ToInt64(args![0]!));
+                return default!;
+            default:
+                throw new InvalidOperationException(identifier);
+        }
+    }
+
+    private static TValue Deserialise<TValue>(string json)
+    {
+        return JsonSerializer.Deserialize<TValue>(json, Options)!;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/BaseAppUpdateBannerTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/BaseAppUpdateBannerTest.cs
@@ -1,0 +1,47 @@
+using Bunit;
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Browser.Update.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Components.AppUpdateBannerTests;
+
+public class BaseAppUpdateBannerTest
+{
+    protected static IAppUpdateService CreateService(AppUpdateStatus status)
+    {
+        var service = Substitute.For<IAppUpdateService>();
+        service.Status.Returns(status);
+        return service;
+    }
+
+    protected static BunitContext CreateContext(IAppUpdateService service)
+    {
+        var context = CreateContext();
+        context.Services.AddSingleton(service);
+        return context;
+    }
+
+    protected static BunitContext CreateBrowserContext(FakeAppUpdateJsRuntime jsRuntime)
+    {
+        var context = CreateContext();
+        context.Services.AddSingleton<IJSRuntime>(jsRuntime);
+        context.Services.AddSingleton<IAppUpdateService>(
+            new AppUpdateService(jsRuntime, Substitute.For<FishingLogBook.Web.Features.Diagnostics.Services.ILoggingService>()));
+        return context;
+    }
+
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddTransient<MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/WhenTestingRender.cs
@@ -1,0 +1,140 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Components.AppUpdateBanner;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Components.AppUpdateBannerTests;
+
+public class WhenTestingRender : BaseAppUpdateBannerTest
+{
+    [Fact]
+    public async Task ItShouldTakeNoSpaceWhileTheAppIsCurrent()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(AppUpdateStatus.Current);
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<AppUpdateBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Markup.Trim().Should().BeEmpty();
+            cut.FindAll("#app-update-banner").Should().BeEmpty();
+            cut.FindAll("#app-update-banner-action").Should().BeEmpty();
+        });
+        await service.Received(1).StartAsync(Arg.Any<CancellationToken>());
+        await service.DidNotReceive().ApplyAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOfferTheUpdateWhenANewVersionIsWaiting()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<AppUpdateBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#app-update-banner-title").TextContent
+                .Should().Contain("New CBDF version available");
+            cut.Find("#app-update-banner-body").TextContent
+                .Should().Contain("Get the latest fixes and features.");
+            cut.Find("#app-update-banner-action").TextContent.Should().Contain("Update now");
+        });
+        await service.Received(1).StartAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferTheUpdateWhileItIsActivating()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(AppUpdateStatus.Activating);
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<AppUpdateBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#app-update-banner").Should().NotBeNull();
+            cut.FindAll("#app-update-banner-action").Should().BeEmpty();
+            cut.Find("#app-update-banner-body").TextContent.Should().Contain("reopen");
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldLeaveTheAppUsableAfterAFailedUpdate()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(AppUpdateStatus.Failed);
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<AppUpdateBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#app-update-banner-body").TextContent
+                .Should().Contain("keep using the app");
+            cut.Find("#app-update-banner-action").Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldNotMentionBrowserInternals()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<AppUpdateBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            var banner = cut.Find("#app-update-banner").TextContent;
+            banner.Should().NotContainAny(
+                "service worker",
+                "cache",
+                "hard refresh",
+                "waiting worker",
+                "SHA");
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchGuidance()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var service = CreateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(service);
+
+        // Act
+        var cut = context.Render<AppUpdateBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#app-update-banner-title").TextContent
+                .Should().Contain("Nouvelle version de CBDF disponible");
+            cut.Find("#app-update-banner-action").TextContent.Should().Contain("Mettre à jour");
+        });
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/WhenTestingUpdate.cs
+++ b/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/WhenTestingUpdate.cs
@@ -1,0 +1,114 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Components.AppUpdateBanner;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Browser.Update.TestSupport;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Components.AppUpdateBannerTests;
+
+public class WhenTestingUpdate : BaseAppUpdateBannerTest
+{
+    [Fact]
+    public async Task ItShouldAskTheSharedServiceToUpdate()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var service = CreateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(service);
+        var cut = context.Render<AppUpdateBanner>();
+        cut.WaitForAssertion(() => cut.Find("#app-update-banner-action"));
+
+        // Act
+        await cut.Find("#app-update-banner-action").ClickAsync();
+
+        // Assert
+        await service.Received(1).ApplyAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotStartMoreThanOneUpdateFromRepeatedTaps()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson };
+        await using var context = CreateBrowserContext(js);
+        var cut = context.Render<AppUpdateBanner>();
+        cut.WaitForAssertion(() => cut.Find("#app-update-banner-action"));
+
+        // Act
+        await cut.Find("#app-update-banner-action").ClickAsync();
+        cut.WaitForAssertion(() => cut.FindAll("#app-update-banner-action").Should().BeEmpty());
+
+        // Assert
+        js.Invocations.Count(invocation => invocation == "applyUpdate").Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldOfferTheUpdateWhenTheBrowserFindsOneAfterTheFirstRender()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.NoUpdateJson };
+        await using var context = CreateBrowserContext(js);
+        var cut = context.Render<AppUpdateBanner>();
+        cut.WaitForAssertion(() => cut.FindAll("#app-update-banner").Should().BeEmpty());
+
+        // Act
+        js.Publish(FakeAppUpdateJsRuntime.UpdateReadyJson);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#app-update-banner-title").TextContent
+                .Should().Contain("New CBDF version available");
+            cut.Find("#app-update-banner-action").Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldActivateTheWaitingVersionThroughTheBrowser()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var js = new FakeAppUpdateJsRuntime { StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson };
+        await using var context = CreateBrowserContext(js);
+        var cut = context.Render<AppUpdateBanner>();
+        cut.WaitForAssertion(() => cut.Find("#app-update-banner-action"));
+
+        // Act
+        await cut.Find("#app-update-banner-action").ClickAsync();
+
+        // Assert
+        js.ImportedModules.Should().Contain("./js/browser/app-update.js");
+        js.Invocations.Should().Contain("applyUpdate");
+        cut.WaitForAssertion(() =>
+            cut.Find("#app-update-banner-body").TextContent.Should().Contain("reopen"));
+    }
+
+    [Fact]
+    public async Task ItShouldKeepManualUseAvailableWhenActivationFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var js = new FakeAppUpdateJsRuntime
+        {
+            StateJson = FakeAppUpdateJsRuntime.UpdateReadyJson,
+            ApplyAccepted = false
+        };
+        await using var context = CreateBrowserContext(js);
+        var cut = context.Render<AppUpdateBanner>();
+        cut.WaitForAssertion(() => cut.Find("#app-update-banner-action"));
+
+        // Act
+        await cut.Find("#app-update-banner-action").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#app-update-banner-body").TextContent.Should().Contain("keep using the app");
+            cut.Find("#app-update-banner-action").Should().NotBeNull();
+        });
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Pages/SystemStatusTests/BaseSystemStatusTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Pages/SystemStatusTests/BaseSystemStatusTest.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Browser.Update;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.SystemStatus.Clients;
 using FishingLogBook.Web.Localization;
@@ -14,13 +15,16 @@ public class BaseSystemStatusTest
 {
     // MudBlazor registers IAsyncDisposable-only services, so the context must be created
     // per test and disposed with `await using` (never inherit BunitContext on the class).
-    protected static BunitContext CreateContext(ISystemStatusClient statusClient)
+    protected static BunitContext CreateContext(
+        ISystemStatusClient statusClient,
+        IAppUpdateService? appUpdate = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
         context.Services.AddSingleton(statusClient);
+        context.Services.AddSingleton(appUpdate ?? CreateUpdateService(AppUpdateStatus.Current));
         context.Services.AddSingleton(new BuildMetadataConfig
         {
             Version = "0.1.0",
@@ -31,5 +35,12 @@ public class BaseSystemStatusTest
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
 
         return context;
+    }
+
+    protected static IAppUpdateService CreateUpdateService(AppUpdateStatus status)
+    {
+        var service = Substitute.For<IAppUpdateService>();
+        service.Status.Returns(status);
+        return service;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Pages/SystemStatusTests/WhenTestingUpdateStatus.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Pages/SystemStatusTests/WhenTestingUpdateStatus.cs
@@ -1,0 +1,121 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Components.AppUpdateBanner;
+using FishingLogBook.Web.Features.SystemStatus.Clients;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using SystemStatusPage = FishingLogBook.Web.Features.SystemStatus.Pages.SystemStatus.SystemStatus;
+
+namespace FishingLogBook.Web.Tests.Features.SystemStatus.Pages.SystemStatusTests;
+
+public class WhenTestingUpdateStatus : BaseSystemStatusTest
+{
+    [Fact]
+    public async Task ItShouldReportBeingUpToDateWithoutOfferingAnUpdate()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var appUpdate = CreateUpdateService(AppUpdateStatus.Current);
+        await using var context = CreateContext(CreateStatusClient(), appUpdate);
+
+        // Act
+        var cut = context.Render<SystemStatusPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#update-status").TextContent.Should().Contain("Up to date");
+            cut.FindAll("#update-now-button").Should().BeEmpty();
+        });
+        await appUpdate.DidNotReceive().ApplyAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOfferTheUpdateWhenANewVersionIsWaiting()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var appUpdate = CreateUpdateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(CreateStatusClient(), appUpdate);
+
+        // Act
+        var cut = context.Render<SystemStatusPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#update-status").TextContent.Should().Contain("New version available");
+            cut.Find("#update-now-button").TextContent.Should().Contain("Update now");
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldPreserveTheExistingBuildInformation()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(CreateStatusClient());
+
+        // Act
+        var cut = context.Render<SystemStatusPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#web-build-information").TextContent
+                .Should().Contain("0.1.0").And.Contain("web1234").And.Contain("prod");
+            cut.Find("#update-information").Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldAskTheSharedServiceToUpdate()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var appUpdate = CreateUpdateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(CreateStatusClient(), appUpdate);
+        var cut = context.Render<SystemStatusPage>();
+        cut.WaitForAssertion(() => cut.Find("#update-now-button"));
+
+        // Act
+        await cut.Find("#update-now-button").ClickAsync();
+
+        // Assert
+        await appUpdate.Received(1).ApplyAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReadTheSameUpdateStateAsTheGlobalBanner()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var appUpdate = CreateUpdateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(CreateStatusClient(), appUpdate);
+        var page = context.Render<SystemStatusPage>();
+        var banner = context.Render<AppUpdateBanner>();
+        page.WaitForAssertion(() => page.Find("#update-now-button"));
+        banner.WaitForAssertion(() => banner.Find("#app-update-banner-action"));
+
+        // Act
+        await banner.Find("#app-update-banner-action").ClickAsync();
+        await page.Find("#update-now-button").ClickAsync();
+
+        // Assert
+        await appUpdate.Received(2).ApplyAsync(Arg.Any<CancellationToken>());
+        context.Services.GetService(typeof(IAppUpdateService)).Should().BeSameAs(appUpdate);
+    }
+
+    private static ISystemStatusClient CreateStatusClient()
+    {
+        var client = Substitute.For<ISystemStatusClient>();
+        client.GetApiHealthAsync(Arg.Any<CancellationToken>()).Returns(new HealthDto("Healthy"));
+        client.GetDatabaseStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new DatabaseTestDto("Healthy", "flb"));
+        client.GetBuildMetadataAsync(Arg.Any<CancellationToken>())
+            .Returns(new BuildMetadataDto("2.0.0", "api9999", "prod", null));
+        return client;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
@@ -1,5 +1,6 @@
 using Bunit;
 using Bunit.TestDoubles;
+using FishingLogBook.Web.Browser.Update;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
 using FishingLogBook.Web.Features.Catch.Offline;
@@ -56,6 +57,7 @@ public class BaseMainLayoutTest
         context.Services.AddSingleton(
             diagnosticSynchroniser ?? Substitute.For<IDiagnosticSynchroniser>());
         context.Services.AddSingleton(Substitute.For<ILoggingService>());
+        context.Services.AddSingleton(Substitute.For<IAppUpdateService>());
         context.Services.AddSingleton(profileSummary ?? QuietProfileSummary());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
@@ -25,7 +25,8 @@ public class BaseMainLayoutTest
         bool isAuthenticated = false,
         ICatchSynchroniser? catchSynchroniser = null,
         IDiagnosticSynchroniser? diagnosticSynchroniser = null,
-        IProfileSummaryProvider? profileSummary = null)
+        IProfileSummaryProvider? profileSummary = null,
+        IAppUpdateService? appUpdate = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -57,7 +58,7 @@ public class BaseMainLayoutTest
         context.Services.AddSingleton(
             diagnosticSynchroniser ?? Substitute.For<IDiagnosticSynchroniser>());
         context.Services.AddSingleton(Substitute.For<ILoggingService>());
-        context.Services.AddSingleton(Substitute.For<IAppUpdateService>());
+        context.Services.AddSingleton(appUpdate ?? Substitute.For<IAppUpdateService>());
         context.Services.AddSingleton(profileSummary ?? QuietProfileSummary());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingUpdateBanner.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingUpdateBanner.cs
@@ -1,0 +1,78 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Browser.Update;
+using FishingLogBook.Web.Layouts.MainLayout;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Layouts.MainLayoutTests;
+
+public class WhenTestingUpdateBanner : BaseMainLayoutTest
+{
+    [Fact]
+    public async Task ItShouldNotShowTheUpdateBannerToAnUnauthenticatedVisitor()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var appUpdate = CreateUpdateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(isAuthenticated: false, appUpdate: appUpdate);
+
+        // Act
+        var cut = context.Render<MainLayout>();
+
+        // Assert
+        cut.FindAll("#app-update-banner").Should().BeEmpty();
+        cut.FindAll("#app-update-banner-action").Should().BeEmpty();
+        await appUpdate.DidNotReceive().StartAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldTakeNoLayoutSpaceWhileTheAppIsCurrent()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var appUpdate = CreateUpdateService(AppUpdateStatus.Current);
+        await using var context = CreateContext(isAuthenticated: true, appUpdate: appUpdate);
+
+        // Act
+        var cut = context.Render<MainLayout>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.FindAll("#app-update-banner").Should().BeEmpty();
+            cut.Find("#app-shell-content").Should().NotBeNull();
+        });
+        await appUpdate.Received(1).StartAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheUpdateBannerAboveThePageContentForASignedInAngler()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var appUpdate = CreateUpdateService(AppUpdateStatus.Available);
+        await using var context = CreateContext(isAuthenticated: true, appUpdate: appUpdate);
+
+        // Act
+        var cut = context.Render<MainLayout>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#app-update-banner-title").TextContent
+                .Should().Contain("New CBDF version available");
+            cut.Find("#app-update-banner-action").TextContent.Should().Contain("Update now");
+            cut.Markup.IndexOf("app-update-banner", StringComparison.Ordinal)
+                .Should().BeLessThan(cut.Markup.IndexOf("app-shell-content", StringComparison.Ordinal));
+        });
+        await appUpdate.Received(1).StartAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static IAppUpdateService CreateUpdateService(AppUpdateStatus status)
+    {
+        var service = Substitute.For<IAppUpdateService>();
+        service.Status.Returns(status);
+        return service;
+    }
+}


### PR DESCRIPTION
Closes #126

> **Not yet production-safe.** The service-worker lifecycle change is not cleared for production until the dev physical-device matrix at the bottom of this description is completed, iPhone/iPad included. Automated coverage cannot stage a real waiting worker on a real device.

## Application-level integration (deliberately minimal)

Exactly two pieces:

1. `<AppUpdateBanner />` in `MainLayout`, gated to signed-in anglers.
2. One app-scoped `IAppUpdateService`.

**No feature page injects or references the update service.** Record Catch, Edit Catch, Profile and every other page are untouched — `git diff` shows no change under `Features/Catch/` or `Features/Profile/`. There is no dirty-form or update awareness anywhere outside the banner.

The About/System Status row from the first revision has been **removed**. It added a second `StatusChanged` subscribe/unsubscribe lifecycle, a threaded parameter through `BaseSystemStatusTest`, and a duplicate update affordance, for little user value given the banner is global and unmissable. About keeps its existing version/SHA/environment output, unchanged. `IAppUpdateService` now has exactly one consumer.

---

## Service-worker lifecycle review

The entire change to `service-worker.published.js` is four hunks — one removal, one added condition, and two additions:

```diff
+self.addEventListener('message', event => {
+    if (event.data?.type === 'SkipWaiting') {
+        activationRequestedByClient = true;
+        self.skipWaiting();
+    }
+});
+let activationRequestedByClient = false;

 async function onInstall(event) {
     await Promise.all(assetsRequests.map(request => cacheUnredirected(cache, request)));
     await cacheAppShell(cache);
-    await self.skipWaiting();
 }

-    if (hasPreviousAppShell) {
+    if (hasPreviousAppShell && !activationRequestedByClient) {
         await reloadClientsOnce();
     }
```

### Behaviours that are unchanged

| Behaviour | Why it is unchanged | Pinned by |
|---|---|---|
| **First install** | A newly installed worker enters `waiting` **only if an active worker already exists**. On a genuine first install there is none, so it goes `installed → activating → activated` on its own; `skipWaiting()` was a no-op there. Install still caches every matching asset plus the shell before resolving, and still rejects on partial failure so a broken worker never activates. | `takes control on a first installation without being asked`, `activates only after the complete app shell and framework assets are cached`, `rejects a partial installation and preserves the active worker` |
| **First offline launch** | Depends on `onInstall` populating `offline-cache-<version>` and `clients.claim()` taking control. Both unchanged. `cacheAppShell` still throws if the shell cannot be cached. | `takes control on a first installation without being asked`, `serves an alternate cached shell while offline` |
| **Existing cached-shell startup** | `onFetch` is **byte-for-byte untouched** — cache-first navigation, `matchIndexHtml` candidate fallbacks, `withoutRedirect` normalisation (dotnet/aspnetcore#33872 / Cloudflare 308), `service-worker.js` and `service-worker-assets.js` always from network. | `serves the cached app shell for a route navigation without using the network`, `fetches and caches the root app shell when a navigation cache entry is missing`, `normalizes a redirected network app shell before caching and returning it`, `always fetches service-worker scripts from the network` |
| **Cross-origin passthrough (FLB#74, R2 presigned photo URLs)** | The `fetch` listener's origin guard is untouched. | `does not intercept cross-origin requests` |
| **Recovery-cache behaviour** | `reloadClientsOnce()`'s body is untouched: same `service-worker-recovery` cache, same one-time `pre-onboarding-startup-20260821` key, same `/authentication/` client filter, same once-ever semantics. Only its *trigger condition* narrowed (below). | `reloads existing controlled clients once after a complete replacement activates`, `does not replay authentication callback URLs during migration`, `does not reload clients on a first service worker installation` |
| **Activation cache cleanup** | `onActivate` still computes `hasPreviousAppShell` before deleting, then deletes only `offline-cache-*` keys that are not the current one. The recovery cache is never deleted. | `does not touch the recovery cache while cleaning up old app shells`, `never deletes application data when a replacement activates` |
| **`clients.claim()`** | Still called unconditionally at the top of `onActivate`, on every activation regardless of how it was triggered. | `claims its clients on every activation however it was triggered` |
| **iOS Safari / Home Screen PWA startup** | Startup is served by the *already active* worker through `onFetch`, which did not change. First install on iOS has no prior controller, so it activates immediately as before. Nothing in the change is conditional on platform or user agent. | the `onFetch` tests above |
| **iPhone offline catches** | Catches live in IndexedDB. The service worker never touches IndexedDB, and this change adds no storage call of any kind. | `Catch IndexedDB` browser suite (unchanged, still green) |

### Behaviours intentionally changed

| # | Before | After | Consequence |
|---|---|---|---|
| 1 | A replacement worker called `skipWaiting()` at the end of `install`, so it activated as soon as it finished caching. | It stays in `waiting` until the running app posts `{ type: 'SkipWaiting' }`. | **This is the feature.** A returning user now stays on their current build until they tap **Update now**, instead of being switched automatically. |
| 2 | On any activation where a previous app-shell cache existed, `reloadClientsOnce()` force-navigated open clients (once ever, via the recovery key). | Same, **except** when the app itself requested activation — then the client reloads itself on `controllerchange`. | Honours "reload exactly once". Browser-initiated activation keeps the old recovery behaviour untouched. |
| 3 | No `message` listener. | Handles `SkipWaiting` only; any other or absent payload is ignored. | Purely additive. |

### Two honest consequences of change 1, both iOS-relevant

- **Users can now stay on an old build indefinitely** if they never tap **Update now**. Previously every deploy eventually auto-switched them. This is the intended trade (user control) but it is a real behavioural shift, and it matters most on iOS where the app is often long-lived in the background.
- **Two app-shell caches coexist for longer.** Peak storage is unchanged (both caches always existed during install), but the *duration* at peak is now user-controlled rather than seconds. On iOS, where quotas are tighter and eviction is aggressive, a waiting update left untapped for a long time keeps `offline-cache-<old>` and `offline-cache-<new>` alive together. Worth watching on the device matrix.

### What automated tests can and cannot prove here

The Playwright suite uses its **own** minimal worker in `BrowserTests/harness/pwa/service-worker.js` — it never loads `service-worker.published.js`. The only automated coverage of the real worker is `service-worker-published.test.js`, which runs the actual script in a `node:vm` context with faked `caches`/`clients`/`fetch`. That proves the lifecycle logic; it cannot prove real-browser installability, iOS activation timing, or storage eviction. Hence the blocker note at the top.

---

## Update tracking is non-blocking by construction

- `registerServiceWorker()` is invoked un-awaited from `index.html` (pinned by the existing `index-startup.test.js` assertion that there is no `await registerServiceWorker();`), so nothing in this path can delay Blazor start.
- `trackAppUpdates` is now called through its own `startUpdateTracking` wrapper with a dedicated `try/catch`, so a tracking fault logs `ServiceWorkerUpdateTrackingError` and can neither be mistaken for a registration failure nor abort anything.
- `checkForUpdate` never propagates: it returns early when there is no registration or `navigator.onLine === false`, swallows `registration.update()` rejections, and is called un-awaited so a slow or hanging network check cannot delay startup.
- A concurrent-check guard stops repeated foregrounding (common for an installed iOS PWA, and every check is a real network fetch because of `updateViaCache: 'none'`) from piling up requests.
- An `installed` worker is only treated as an update when `navigator.serviceWorker.controller` already exists, so a first install can never raise a spurious banner.

Pinned by: `still registers when update tracking throws`, `does not wait on the update check before returning`, `does not block application startup when service worker registration fails`, `does not fabricate an update when the update check fails offline`, `does not fabricate an update when the network rejects the update check`, `does not treat a first installation without a controller as an update`, `does not pile up update checks when the app is foregrounded repeatedly`.

---

## How the flow works

1. `service-worker-registration.js` hands the registration to `trackAppUpdates`, so a worker already waiting at startup is seen.
2. The tracker watches `registration.waiting` and `updatefound` → `statechange` → `installed`, and re-checks on startup and on visibility-visible.
3. State lives on a `window.fishingLogBookUpdate` store (the existing `window.fishingLogBook*` convention) and reaches `AppUpdateService` over a `DotNetObjectReference`.
4. **Update now** posts `{ type: 'SkipWaiting' }`, then reloads once on `controllerchange` behind a `reloading` guard.

Races covered: repeated events publish once; repeated taps post once; multiple `controllerchange` events reload once; an unrequested `controllerchange` never reloads; an unreachable worker fails safe.

## UX

`MudPaper` in `MainLayout` inside `MudMainContent`, directly below the AppBar and above `.app-shell-content`. Renders **nothing** when current (asserted empty markup), stacks with a full-width CTA under 600px, `role="status"` / `aria-live="polite"`, ≥44px target. Gated by `AuthorizeView`/`Authorized` like the existing menu button and drawer — an unauthenticated visitor never sees it and `StartAsync` is not called.

## Data safety

No `caches.delete(...)`, `indexedDB.deleteDatabase`, `registration.unregister()`, `localStorage.clear()`, `sessionStorage.clear()` or site-data clearing anywhere in this change. Asset replacement is the pre-existing versioned-cache lifecycle, which removes only its own stale `offline-cache-*` keys. Tests assert the destructive APIs are never called and that only `offline-cache-`-prefixed keys are ever removed.

## Validation

```
dotnet format FishingLogBook.sln     clean
dotnet build -c Release              0 warnings, 0 errors
dotnet test FishingLogBook.sln       1248 passed
npm test                             215 passed
npm run test:browser                 27 passed, 1 skipped (pre-existing webkit offline-shell skip)
```

No migrations, no Terraform, no infrastructure changes.

---

## Dev physical-device matrix — required before this is production-safe

**Cannot be reproduced with `dotnet run`.** The dev worker is `self.addEventListener('fetch', () => { })`, a no-op with no update lifecycle. This needs **two successive deploys to the dev environment**.

I have performed **no** device testing.

### Regression first — prove the old behaviour still works (blocker)

Before testing the new flow, on a **clean install** of the newer build:

- [ ] **iPhone/iPad, first install from Safari** → Add to Home Screen, launch, app loads.
- [ ] **iPhone/iPad, first offline launch** → enable Airplane mode, launch from Home Screen, app shell loads and previously logged catches are listed.
- [ ] **iPhone/iPad, log a catch offline** → saves locally, appears in Catches, still there after force-quit and relaunch.
- [ ] **iPhone/iPad, catch photographs** still load offline and online.
- [ ] Same four checks on **Samsung/Android** and **desktop Chrome/Edge**.
- [ ] DevTools → Application → Service Workers shows the worker **activated** after first install, with no waiting worker.

### Then the update flow

1. Install the **older** dev build; note the Web version/SHA in About; log a couple of catches.
2. Deploy the **newer** dev build.
3. Return to the installed app (background/foreground, or relaunch). The banner should appear below the header: **New CBDF version available / Get the latest fixes and features. / Update now**.
4. Navigate between Catches, Record catch and Profile — the banner must persist.
5. Tap **Update now** → app reloads **exactly once** (watch DevTools Network / the SW panel; no reload loop).
6. About shows the **new** version/SHA; banner gone.

- [ ] Samsung / Android installed PWA — primary case.
- [ ] Android Chrome in-browser.
- [ ] iPhone / iPad installed PWA — record what actually happens; iOS activation timing is less predictable and it is the platform this change most needs proving on.
- [ ] Desktop Chrome and Edge, installed and in-browser.

### Straight after updating

- [ ] All previously logged offline catches still present.
- [ ] Anything queued for sync still queued — not lost, not duplicated.
- [ ] Photographs still load.
- [ ] Still signed in.
- [ ] DevTools → Application → Storage still shows the IndexedDB databases with their records.
- [ ] Only one `offline-cache-*` entry remains under Cache Storage once the update has activated.

### Offline

- [ ] Network off, relaunch installed app → starts and shows catches.
- [ ] Log a catch offline → unaffected.
- [ ] With no network, **no** banner appears.

### Leaving an update untapped (the new storage consequence)

- [ ] With a waiting update, confirm two `offline-cache-*` entries exist and the app keeps working normally offline.
- [ ] Leave it untapped for a while on iOS and confirm offline launch still works — this is the eviction risk called out above.

**Useful during testing**

```js
await import('/js/browser/app-update.js').then(m => m.getUpdateState())
```

`{ isUpdateReady: true }` should coincide with the banner being visible.

---

## Self review

- Issue/AC: PASS except the two documented divergences below.
- Architecture: PASS — one banner, one app-scoped service, one consumer. No feature-page coupling.
- Rules: PASS — `blazor.md` three-file component, `Browser/` for a browser API, root `Components/` for shared UI, block bodies; `testing-blazor.md` `{Thing}Tests` leaves with `Base{Thing}Test` and `Received(n)`. The two worker comments explain non-obvious lifecycle constraints, which the comment rule permits.
- Security/privacy: PASS — no user data, ids, coordinates or tokens; auth/session untouched; diagnostics record only exception type and message.
- Database/migrations: N/A.
- Tests/coverage: PASS.
- Browser: N/A (reason) — the Playwright harness uses its own worker and cannot stage two published deploys or a real waiting worker; forcing it would need test-only auth or a dual host, which `testing-blazor.md` forbids on a product ticket. Compensating coverage is the VM-executed real-worker suite plus the real-interop C# suite. Residual risk is real-device lifecycle timing and iOS storage pressure, covered by the matrix above.
- Web/UI/localisation: PASS — EN/FR complete, parity green, no service-worker/cache/refresh/SHA wording in user copy (asserted), `role="status"`, ≥44px CTA.
- Code smells: PASS after fixes.
- CI/deployment: PASS.

**Findings fixed during review**

1. **BLOCKER** — `skipWaiting()` in `onInstall` meant no worker ever waited; user-controlled activation was impossible.
2. **BLOCKER** — `reloadClientsOnce()` plus the client's own `controllerchange` reload would reload twice.
3. **BLOCKER** — `AppUpdateService` was `IAsyncDisposable`-only, throwing on synchronous container disposal and breaking the existing DI guard test (the MudBlazor hazard `testing-blazor.md` documents). Now implements both.
4. **SHOULD FIX** — `Status` returned `Failed` after the waiting update had gone, leaving a retry button that could do nothing. Reordered; covered by a test.
5. **SHOULD FIX** — `app-update.js` had two notions of "the window", splitting state between the tracked window and the global. Found by a failing test.
6. **SHOULD FIX** — a tracking fault was reported as `ServiceWorkerRegistrationError`. Now isolated with its own wrapper and error name.
7. **SHOULD FIX** — repeated foregrounding fired unbounded `registration.update()` network calls. Concurrent-check guard added.
8. **SHOULD FIX** — the About row added a second lifecycle subscription for little value. Removed.
9. **SHOULD FIX** — `var activationRequestedByClient` in an otherwise `const`/`let` file. Changed to `let`.

**Deliberate divergences from #126 — please confirm**

- **No unsaved-catch protection.** Per your instruction that the update stays self-contained and no feature page gains update awareness, the issue's dirty-work guard and `Blocked` state are not implemented. **Consequence: tapping Update now while entering a catch reloads and discards unsaved photographs.** User-initiated rather than silent, and the banner is passive until tapped, but the AC is not met. Clean follow-up ticket if wanted.
- **No activation watchdog.** If a worker accepts `SkipWaiting` but never activates, the banner stays on "Updating…" until a manual refresh. A timer would need injected time to test deterministically; judged not worth it for what implies a broken browser lifecycle.

**Remaining deliberate gaps**

- No physical-device verification performed — handed over as the matrix above.
- `checkForUpdate` is exported but not called from C#; used internally (startup, visibility) and by tests, kept exported as part of a coherent module API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)