### PR TITLE
FLB#129 | finalise install guidance copy

### DIFF
--- a/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor
+++ b/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor
@@ -46,13 +46,32 @@
                     <MudAlert Severity="Severity.Info" id="install-guidance-ios-browser">@Loc["Install_IosUseSafari"]</MudAlert>
                 }
                 <MudText Typo="Typo.subtitle2" id="install-guidance-ios-heading">@Loc["Install_IosHeading"]</MudText>
-                <ol class="install-steps" id="install-guidance-ios-steps">
-                    <li>@Loc["Install_IosStep1"]</li>
-                    <li>@Loc["Install_IosStep2"]</li>
-                    <li>@Loc["Install_IosStep3"]</li>
-                    <li>@Loc["Install_IosStep4"]</li>
-                    <li>@Loc["Install_IosStep5"]</li>
-                </ol>
+                <div id="install-guidance-ios-steps">
+                    <div class="install-device-section">
+                        <MudText Typo="Typo.subtitle2" id="install-guidance-iphone-heading">@Loc["Install_IphoneHeading"]</MudText>
+                        <ol class="install-steps" id="install-guidance-iphone-steps">
+                            <li>@Loc["Install_IphoneStep1"]</li>
+                            <li>@Loc["Install_IphoneStep2"]</li>
+                            <li>@Loc["Install_IphoneStep3"]</li>
+                            <li>@Loc["Install_IphoneStep4"]</li>
+                            <li>@Loc["Install_IphoneStep5"]</li>
+                            <li>@Loc["Install_IphoneStep6"]</li>
+                            <li>@Loc["Install_IphoneStep7"]</li>
+                            <li>@Loc["Install_IphoneStep8"]</li>
+                        </ol>
+                    </div>
+                    <div class="install-device-section">
+                        <MudText Typo="Typo.subtitle2" id="install-guidance-ipad-heading">@Loc["Install_IpadHeading"]</MudText>
+                        <ol class="install-steps" id="install-guidance-ipad-steps">
+                            <li>@Loc["Install_IpadStep1"]</li>
+                            <li>@Loc["Install_IpadStep2"]</li>
+                            <li>@Loc["Install_IpadStep3"]</li>
+                            <li>@Loc["Install_IpadStep4"]</li>
+                            <li>@Loc["Install_IpadStep5"]</li>
+                            <li>@Loc["Install_IpadStep6"]</li>
+                        </ol>
+                    </div>
+                </div>
                 <MudText Typo="Typo.subtitle2" id="install-guidance-ios-fallback-heading">@Loc["Install_IosFallbackHeading"]</MudText>
                 <MudText id="install-guidance-ios-fallback">@Loc["Install_IosFallbackBody"]</MudText>
             </MudStack>

--- a/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.css
+++ b/src/FishingLogBook.Web/Browser/Install/InstallGuidance.razor.css
@@ -20,6 +20,18 @@
     margin-bottom: 0;
 }
 
+#install-guidance-ios-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.install-device-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
 .install-guidance ::deep .mud-expand-panel-header {
     min-height: 3rem;
     padding-top: 0.75rem;

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -663,33 +663,44 @@
   <data name="Modal_ShowingLimited" xml:space="preserve"><value>Affichage de {0} sur {1} {2}. Recherchez pour en trouver davantage.</value></data>
   <data name="Modal_Species" xml:space="preserve"><value>espèces</value></data>
   <data name="Modal_FishingMethods" xml:space="preserve"><value>méthodes de pêche</value></data>
-  <data name="Install_Title" xml:space="preserve"><value>Installer Catch, But Don’t Forget</value></data>
+  <data name="Install_Title" xml:space="preserve"><value>Installer Catch But Don’t Forget</value></data>
   <data name="Install_Benefit" xml:space="preserve"><value>Installez l’application pour y accéder rapidement depuis votre appareil et profiter d’une expérience plus fiable lorsque vous pêchez.</value></data>
   <data name="Install_NativeAvailable" xml:space="preserve"><value>Votre navigateur peut installer l’application pour vous.</value></data>
   <data name="Install_Action" xml:space="preserve"><value>Installer l’application</value></data>
   <data name="Install_Dismissed" xml:space="preserve"><value>L’application n’a pas été installée. Vous pouvez réessayer ou suivre les étapes correspondant à votre appareil ci-dessous.</value></data>
   <data name="Install_ManualIntro" xml:space="preserve"><value>Choisissez votre appareil ci-dessous pour obtenir les étapes détaillées.</value></data>
   <data name="Install_InstalledTitle" xml:space="preserve"><value>L’application est installée</value></data>
-  <data name="Install_InstalledBody" xml:space="preserve"><value>Vous utilisez l’application installée. Ouvrez Catch, But Don’t Forget depuis votre écran d’accueil chaque fois que vous partez pêcher.</value></data>
-  <data name="Install_InstalledDesktop" xml:space="preserve"><value>Vous utilisez l’application installée. Ouvrez Catch, But Don’t Forget depuis le menu Démarrer, le Dock ou votre liste d’applications, et épinglez-la où vous le souhaitez.</value></data>
+  <data name="Install_InstalledBody" xml:space="preserve"><value>Vous utilisez l’application installée. Ouvrez l’application Catch But Don’t Forget depuis votre écran d’accueil chaque fois que vous partez pêcher.</value></data>
+  <data name="Install_InstalledDesktop" xml:space="preserve"><value>Vous utilisez l’application installée. Ouvrez l’application Catch But Don’t Forget depuis le menu Démarrer, le Dock ou votre liste d’applications, et épinglez-la où vous le souhaitez.</value></data>
   <data name="Install_InstalledOtherDevices" xml:space="preserve"><value>Vous installez l’application sur un autre téléphone, une tablette ou un ordinateur ? Les étapes pour chaque appareil se trouvent ci-dessous.</value></data>
   <data name="Install_IosPanel" xml:space="preserve"><value>iPhone / iPad</value></data>
   <data name="Install_AndroidPanel" xml:space="preserve"><value>Android</value></data>
   <data name="Install_ComputerPanel" xml:space="preserve"><value>Ordinateur</value></data>
   <data name="Install_IosHeading" xml:space="preserve"><value>Ajouter l’application à l’écran d’accueil</value></data>
-  <data name="Install_IosUseSafari" xml:space="preserve"><value>Vous n’utilisez pas Safari. Ouvrez d’abord Catch, But Don’t Forget dans Safari, puis suivez les étapes ci-dessous.</value></data>
-  <data name="Install_IosStep1" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget dans Safari.</value></data>
-  <data name="Install_IosStep2" xml:space="preserve"><value>Touchez Partager, le carré avec une flèche vers le haut.</value></data>
-  <data name="Install_IosStep3" xml:space="preserve"><value>Faites défiler la liste et choisissez Sur l’écran d’accueil.</value></data>
-  <data name="Install_IosStep4" xml:space="preserve"><value>Vérifiez le nom proposé pour l’application, puis touchez Ajouter.</value></data>
-  <data name="Install_IosStep5" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget depuis sa nouvelle icône sur l’écran d’accueil.</value></data>
+  <data name="Install_IosUseSafari" xml:space="preserve"><value>Vous n’utilisez pas Safari. Ouvrez d’abord Catch But Don’t Forget dans Safari, puis suivez les étapes ci-dessous.</value></data>
+  <data name="Install_IphoneHeading" xml:space="preserve"><value>iPhone</value></data>
+  <data name="Install_IphoneStep1" xml:space="preserve"><value>Ouvrez Catch But Don’t Forget dans Safari.</value></data>
+  <data name="Install_IphoneStep2" xml:space="preserve"><value>Touchez ⋯ Plus dans la barre d’outils de Safari.</value></data>
+  <data name="Install_IphoneStep3" xml:space="preserve"><value>Touchez Partager.</value></data>
+  <data name="Install_IphoneStep4" xml:space="preserve"><value>Si le bouton Partager est déjà visible dans votre présentation Safari, vous pouvez le toucher directement.</value></data>
+  <data name="Install_IphoneStep5" xml:space="preserve"><value>Choisissez Sur l’écran d’accueil.</value></data>
+  <data name="Install_IphoneStep6" xml:space="preserve"><value>Si Safari affiche Ouvrir comme app web, vérifiez que l’option est activée.</value></data>
+  <data name="Install_IphoneStep7" xml:space="preserve"><value>Touchez Ajouter.</value></data>
+  <data name="Install_IphoneStep8" xml:space="preserve"><value>Ouvrez l’application Catch But Don’t Forget depuis la nouvelle icône sur l’écran d’accueil.</value></data>
+  <data name="Install_IpadHeading" xml:space="preserve"><value>iPad</value></data>
+  <data name="Install_IpadStep1" xml:space="preserve"><value>Ouvrez Catch But Don’t Forget dans Safari.</value></data>
+  <data name="Install_IpadStep2" xml:space="preserve"><value>Touchez Partager dans la barre d’outils supérieure.</value></data>
+  <data name="Install_IpadStep3" xml:space="preserve"><value>Choisissez Sur l’écran d’accueil. Si Safari l’affiche dans Plus, ouvrez d’abord Plus.</value></data>
+  <data name="Install_IpadStep4" xml:space="preserve"><value>Si Safari affiche Ouvrir comme app web, vérifiez que l’option est activée.</value></data>
+  <data name="Install_IpadStep5" xml:space="preserve"><value>Touchez Ajouter.</value></data>
+  <data name="Install_IpadStep6" xml:space="preserve"><value>Ouvrez l’application Catch But Don’t Forget depuis votre écran d’accueil.</value></data>
   <data name="Install_IosFallbackHeading" xml:space="preserve"><value>Aucune option Sur l’écran d’accueil ?</value></data>
-  <data name="Install_IosFallbackBody" xml:space="preserve"><value>Vous avez probablement ouvert la page dans un autre navigateur, ou dans une autre application comme une messagerie. Choisissez Ouvrir dans Safari si l’option est proposée, ou copiez l’adresse web, collez-la dans Safari, puis suivez les cinq étapes ci-dessus.</value></data>
+  <data name="Install_IosFallbackBody" xml:space="preserve"><value>Vous avez probablement ouvert la page dans un autre navigateur, ou dans une autre application comme une messagerie. Choisissez Ouvrir dans Safari si l’option est proposée, ou copiez l’adresse web, collez-la dans Safari, puis suivez les étapes iPhone ou iPad ci-dessus.</value></data>
   <data name="Install_AndroidHeading" xml:space="preserve"><value>Installer avec Chrome ou un autre navigateur Chromium</value></data>
   <data name="Install_AndroidStep1" xml:space="preserve"><value>Ouvrez le menu du navigateur, les trois points (⋮) en haut de l’écran.</value></data>
   <data name="Install_AndroidStep2" xml:space="preserve"><value>Choisissez Installer l’application, ou Ajouter à l’écran d’accueil selon le libellé affiché.</value></data>
   <data name="Install_AndroidStep3" xml:space="preserve"><value>Confirmez l’installation lorsque le navigateur vous le demande.</value></data>
-  <data name="Install_AndroidStep4" xml:space="preserve"><value>Ouvrez Catch, But Don’t Forget depuis sa nouvelle icône sur l’écran d’accueil.</value></data>
+  <data name="Install_AndroidStep4" xml:space="preserve"><value>Ouvrez l’application Catch But Don’t Forget depuis sa nouvelle icône sur l’écran d’accueil.</value></data>
   <data name="Install_SamsungHeading" xml:space="preserve"><value>Samsung Internet</value></data>
   <data name="Install_SamsungStep1" xml:space="preserve"><value>Ouvrez le menu du navigateur en bas de l’écran.</value></data>
   <data name="Install_SamsungStep2" xml:space="preserve"><value>Choisissez Ajouter la page à.</value></data>
@@ -698,7 +709,7 @@
   <data name="Install_ComputerStep1" xml:space="preserve"><value>Dans Chrome ou Edge, recherchez l’icône d’installation à droite de la barre d’adresse et sélectionnez-la.</value></data>
   <data name="Install_ComputerStep2" xml:space="preserve"><value>Aucune icône dans Chrome ? Ouvrez le menu du navigateur (⋮), puis choisissez Diffuser, enregistrer et partager, puis Installer la page en tant qu’application.</value></data>
   <data name="Install_ComputerStep3" xml:space="preserve"><value>Dans Edge, ouvrez le menu du navigateur, puis choisissez Applications, puis Installer ce site en tant qu’application.</value></data>
-  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirmez l’installation, puis ouvrez Catch, But Don’t Forget depuis le menu Démarrer, le Dock ou votre liste d’applications.</value></data>
+  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirmez l’installation, puis ouvrez l’application Catch But Don’t Forget depuis le menu Démarrer, le Dock ou votre liste d’applications.</value></data>
   <data name="Install_Later" xml:space="preserve"><value>L’installation est facultative. Vous pouvez continuer et retrouver ces instructions plus tard depuis le menu de l’application.</value></data>
   <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choisissez au moins une méthode de pêche.</value></data>
   <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choisissez au moins une espèce pour {0}.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -663,33 +663,44 @@
   <data name="Modal_ShowingLimited" xml:space="preserve"><value>Showing {0} of {1} {2}. Search to find more.</value></data>
   <data name="Modal_Species" xml:space="preserve"><value>species</value></data>
   <data name="Modal_FishingMethods" xml:space="preserve"><value>fishing methods</value></data>
-  <data name="Install_Title" xml:space="preserve"><value>Install Catch, But Don’t Forget</value></data>
+  <data name="Install_Title" xml:space="preserve"><value>Install Catch But Don’t Forget</value></data>
   <data name="Install_Benefit" xml:space="preserve"><value>Install the app for quick access from your device and a more reliable experience when you are out fishing.</value></data>
   <data name="Install_NativeAvailable" xml:space="preserve"><value>Your browser can install the app for you.</value></data>
   <data name="Install_Action" xml:space="preserve"><value>Install app</value></data>
   <data name="Install_Dismissed" xml:space="preserve"><value>The app was not installed. You can try again, or follow the steps for your device below.</value></data>
   <data name="Install_ManualIntro" xml:space="preserve"><value>Choose your device below for step-by-step instructions.</value></data>
   <data name="Install_InstalledTitle" xml:space="preserve"><value>App is installed</value></data>
-  <data name="Install_InstalledBody" xml:space="preserve"><value>You are using the installed app. Open Catch, But Don’t Forget from your Home Screen whenever you go fishing.</value></data>
-  <data name="Install_InstalledDesktop" xml:space="preserve"><value>You are using the installed app. Open Catch, But Don’t Forget from your Start menu, Dock or app list, and pin it where convenient.</value></data>
+  <data name="Install_InstalledBody" xml:space="preserve"><value>You are using the installed app. Open the Catch But Don’t Forget app from your Home Screen whenever you go fishing.</value></data>
+  <data name="Install_InstalledDesktop" xml:space="preserve"><value>You are using the installed app. Open the Catch But Don’t Forget app from your Start menu, Dock or app list, and pin it where convenient.</value></data>
   <data name="Install_InstalledOtherDevices" xml:space="preserve"><value>Installing on another phone, tablet or computer? The steps for every device are below.</value></data>
   <data name="Install_IosPanel" xml:space="preserve"><value>iPhone / iPad</value></data>
   <data name="Install_AndroidPanel" xml:space="preserve"><value>Android</value></data>
   <data name="Install_ComputerPanel" xml:space="preserve"><value>Computer</value></data>
   <data name="Install_IosHeading" xml:space="preserve"><value>Add the app to your Home Screen</value></data>
-  <data name="Install_IosUseSafari" xml:space="preserve"><value>You are not using Safari. Open Catch, But Don’t Forget in Safari first, then follow the steps below.</value></data>
-  <data name="Install_IosStep1" xml:space="preserve"><value>Open Catch, But Don’t Forget in Safari.</value></data>
-  <data name="Install_IosStep2" xml:space="preserve"><value>Tap Share, the square with an arrow pointing up.</value></data>
-  <data name="Install_IosStep3" xml:space="preserve"><value>Scroll down the list and choose Add to Home Screen.</value></data>
-  <data name="Install_IosStep4" xml:space="preserve"><value>Check the name shown for the app, then tap Add.</value></data>
-  <data name="Install_IosStep5" xml:space="preserve"><value>Open Catch, But Don’t Forget from its new Home Screen icon.</value></data>
+  <data name="Install_IosUseSafari" xml:space="preserve"><value>You are not using Safari. Open Catch But Don’t Forget in Safari first, then follow the steps below.</value></data>
+  <data name="Install_IphoneHeading" xml:space="preserve"><value>iPhone</value></data>
+  <data name="Install_IphoneStep1" xml:space="preserve"><value>Open Catch But Don’t Forget in Safari.</value></data>
+  <data name="Install_IphoneStep2" xml:space="preserve"><value>Tap ⋯ More in the Safari toolbar.</value></data>
+  <data name="Install_IphoneStep3" xml:space="preserve"><value>Tap Share.</value></data>
+  <data name="Install_IphoneStep4" xml:space="preserve"><value>If a Share button is already visible in your Safari layout, you can tap it directly instead.</value></data>
+  <data name="Install_IphoneStep5" xml:space="preserve"><value>Choose Add to Home Screen.</value></data>
+  <data name="Install_IphoneStep6" xml:space="preserve"><value>If Safari shows Open as Web App, make sure it is enabled.</value></data>
+  <data name="Install_IphoneStep7" xml:space="preserve"><value>Tap Add.</value></data>
+  <data name="Install_IphoneStep8" xml:space="preserve"><value>Open the Catch But Don’t Forget app from the new Home Screen icon.</value></data>
+  <data name="Install_IpadHeading" xml:space="preserve"><value>iPad</value></data>
+  <data name="Install_IpadStep1" xml:space="preserve"><value>Open Catch But Don’t Forget in Safari.</value></data>
+  <data name="Install_IpadStep2" xml:space="preserve"><value>Tap Share in the top toolbar.</value></data>
+  <data name="Install_IpadStep3" xml:space="preserve"><value>Choose Add to Home Screen. If Safari shows it through More, open More first.</value></data>
+  <data name="Install_IpadStep4" xml:space="preserve"><value>If Safari shows Open as Web App, make sure it is enabled.</value></data>
+  <data name="Install_IpadStep5" xml:space="preserve"><value>Tap Add.</value></data>
+  <data name="Install_IpadStep6" xml:space="preserve"><value>Open the Catch But Don’t Forget app from your Home Screen.</value></data>
   <data name="Install_IosFallbackHeading" xml:space="preserve"><value>No Add to Home Screen option?</value></data>
-  <data name="Install_IosFallbackBody" xml:space="preserve"><value>You have probably opened the page in another browser, or inside another app such as a messaging app. Choose Open in Safari if it is offered, or copy the web address, paste it into Safari, then follow the five steps above.</value></data>
+  <data name="Install_IosFallbackBody" xml:space="preserve"><value>You have probably opened the page in another browser, or inside another app such as a messaging app. Choose Open in Safari if it is offered, or copy the web address, paste it into Safari, then follow the iPhone or iPad steps above.</value></data>
   <data name="Install_AndroidHeading" xml:space="preserve"><value>Install with Chrome or another Chromium browser</value></data>
   <data name="Install_AndroidStep1" xml:space="preserve"><value>Open the browser menu, the three dots (⋮) at the top of the screen.</value></data>
   <data name="Install_AndroidStep2" xml:space="preserve"><value>Choose Install app, or Add to Home screen if that is the wording you see.</value></data>
   <data name="Install_AndroidStep3" xml:space="preserve"><value>Confirm the installation when your browser asks.</value></data>
-  <data name="Install_AndroidStep4" xml:space="preserve"><value>Open Catch, But Don’t Forget from its new Home Screen icon.</value></data>
+  <data name="Install_AndroidStep4" xml:space="preserve"><value>Open the Catch But Don’t Forget app from its new Home Screen icon.</value></data>
   <data name="Install_SamsungHeading" xml:space="preserve"><value>Samsung Internet</value></data>
   <data name="Install_SamsungStep1" xml:space="preserve"><value>Open the browser menu at the bottom of the screen.</value></data>
   <data name="Install_SamsungStep2" xml:space="preserve"><value>Choose Add page to.</value></data>
@@ -698,7 +709,7 @@
   <data name="Install_ComputerStep1" xml:space="preserve"><value>In Chrome or Edge, look for the install icon at the right-hand end of the address bar and select it.</value></data>
   <data name="Install_ComputerStep2" xml:space="preserve"><value>No icon in Chrome? Open the browser menu (⋮), then choose Cast, save and share, then Install page as app.</value></data>
   <data name="Install_ComputerStep3" xml:space="preserve"><value>In Edge, open the browser menu, then choose Apps, then Install this site as an app.</value></data>
-  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirm the installation, then open Catch, But Don’t Forget from your Start menu, Dock or app list.</value></data>
+  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirm the installation, then open the Catch But Don’t Forget app from your Start menu, Dock or app list.</value></data>
   <data name="Install_Later" xml:space="preserve"><value>Installation is optional. You can continue now and find this guidance again from the app menu.</value></data>
   <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choose at least one fishing method.</value></data>
   <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choose at least one species for {0}.</value></data>

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingBrowserState.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingBrowserState.cs
@@ -34,7 +34,8 @@ public class WhenTestingBrowserState : BaseInstallGuidanceTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-iphone-steps").Children.Should().HaveCount(8);
+            cut.Find("#install-guidance-ipad-steps").Children.Should().HaveCount(6);
             cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
             cut.Find("#install-guidance-computer-steps").Children.Should().HaveCount(4);
             cut.FindAll("#install-guidance-action").Should().BeEmpty();

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingInstall.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingInstall.cs
@@ -33,7 +33,8 @@ public class WhenTestingInstall : BaseInstallGuidanceTest
         {
             cut.FindAll("#install-guidance-action").Should().BeEmpty();
             cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
-            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-iphone-steps").Children.Should().HaveCount(8);
+            cut.Find("#install-guidance-ipad-steps").Children.Should().HaveCount(6);
             cut.Find("#install-guidance-computer-steps").Children.Should().HaveCount(4);
         });
         await service.Received(1).PromptAsync(Arg.Any<CancellationToken>());
@@ -62,7 +63,8 @@ public class WhenTestingInstall : BaseInstallGuidanceTest
             cut.Find("#install-guidance-dismissed").TextContent.Should().Contain("not installed");
             cut.Find("#install-guidance-action").Should().NotBeNull();
             cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
-            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-iphone-steps").Children.Should().HaveCount(8);
+            cut.Find("#install-guidance-ipad-steps").Children.Should().HaveCount(6);
         });
         await service.Received(1).PromptAsync(Arg.Any<CancellationToken>());
         await service.Received(2).GetStateAsync(Arg.Any<CancellationToken>());

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingRender.cs
@@ -26,7 +26,8 @@ public class WhenTestingRender : BaseInstallGuidanceTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-iphone-steps").Children.Should().HaveCount(8);
+            cut.Find("#install-guidance-ipad-steps").Children.Should().HaveCount(6);
             cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
             cut.Find("#install-guidance-samsung-steps").Children.Should().HaveCount(3);
             cut.Find("#install-guidance-computer-steps").Children.Should().HaveCount(4);
@@ -83,8 +84,14 @@ public class WhenTestingRender : BaseInstallGuidanceTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#install-guidance-ios-panel").TextContent.Should().Contain("iPhone / iPad");
-            cut.Find("#install-guidance-ios-steps").TextContent.Should()
-                .Contain("Safari").And.Contain("Share").And.Contain("Add to Home Screen");
+            cut.Find("#install-guidance-iphone-steps").TextContent.Should()
+                .Contain("More").And.Contain("Share").And.Contain("Add to Home Screen")
+                .And.Contain("Open as Web App").And.Contain("Tap Add")
+                .And.Contain("Share button is already visible")
+                .And.Contain("Catch But Don’t Forget app");
+            cut.Find("#install-guidance-ipad-steps").TextContent.Should()
+                .Contain("Share in the top toolbar").And.Contain("Add to Home Screen")
+                .And.Contain("Open as Web App").And.Contain("Catch But Don’t Forget app");
             cut.Find("#install-guidance-ios-fallback").TextContent.Should().Contain("Open in Safari");
             cut.Find("#install-guidance-android-steps").TextContent.Should()
                 .Contain("⋮").And.Contain("Install app").And.Contain("Add to Home screen");
@@ -144,7 +151,10 @@ public class WhenTestingRender : BaseInstallGuidanceTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#install-guidance-ios-browser").TextContent.Should().Contain("Safari");
-            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-ios-fallback").TextContent.Should()
+                .Contain("Open in Safari").And.Contain("copy the web address");
+            cut.Find("#install-guidance-iphone-steps").Children.Should().HaveCount(8);
+            cut.Find("#install-guidance-ipad-steps").Children.Should().HaveCount(6);
         });
         await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
     }
@@ -184,7 +194,8 @@ public class WhenTestingRender : BaseInstallGuidanceTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#install-guidance-installed").TextContent.Should().Contain("App is installed");
+            cut.Find("#install-guidance-installed").TextContent.Should()
+                .Contain("App is installed").And.Contain("Catch But Don’t Forget app");
             cut.Find("#install-guidance-other-devices").TextContent.Should().Contain("another phone");
             cut.FindAll("#install-guidance-action").Should().BeEmpty();
             cut.FindAll("#install-guidance-benefit").Should().BeEmpty();
@@ -209,7 +220,8 @@ public class WhenTestingRender : BaseInstallGuidanceTest
 
         // Assert
         cut.WaitForAssertion(() =>
-            cut.Find("#install-guidance-installed").TextContent.Should().Contain("Start menu"));
+            cut.Find("#install-guidance-installed").TextContent.Should()
+                .Contain("Catch But Don’t Forget app").And.Contain("Start menu"));
         await service.Received(1).GetStateAsync(Arg.Any<CancellationToken>());
     }
 
@@ -255,8 +267,11 @@ public class WhenTestingRender : BaseInstallGuidanceTest
         {
             cut.Find("#install-guidance-title").TextContent.Should().Contain("Installer");
             cut.Find("#install-guidance-computer-panel").TextContent.Should().Contain("Ordinateur");
-            cut.Find("#install-guidance-ios-steps").TextContent.Should()
-                .Contain("Safari").And.Contain("Partager").And.Contain("Sur l’écran d’accueil");
+            cut.Find("#install-guidance-iphone-steps").TextContent.Should()
+                .Contain("Safari").And.Contain("Plus").And.Contain("Partager")
+                .And.Contain("Sur l’écran d’accueil").And.Contain("Ouvrir comme app web");
+            cut.Find("#install-guidance-ipad-steps").TextContent.Should()
+                .Contain("barre d’outils supérieure").And.Contain("Sur l’écran d’accueil");
             cut.Find("#install-guidance-android-steps").TextContent.Should()
                 .Contain("Installer l’application");
             cut.Find("#install-guidance-samsung-steps").TextContent.Should()

--- a/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingStateChange.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Install/InstallGuidanceTests/WhenTestingStateChange.cs
@@ -27,7 +27,8 @@ public class WhenTestingStateChange : BaseInstallGuidanceTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#install-guidance-android-steps").Children.Should().HaveCount(4);
-            cut.Find("#install-guidance-ios-steps").Children.Should().HaveCount(5);
+            cut.Find("#install-guidance-iphone-steps").Children.Should().HaveCount(8);
+            cut.Find("#install-guidance-ipad-steps").Children.Should().HaveCount(6);
             cut.Find("#install-guidance-computer-steps").Children.Should().HaveCount(4);
         });
         await logging.Received(1).LogErrorAsync(

--- a/tests/FishingLogBook.Web.Tests/Localization/UiStringsTests/WhenTestingResourceParity.cs
+++ b/tests/FishingLogBook.Web.Tests/Localization/UiStringsTests/WhenTestingResourceParity.cs
@@ -40,10 +40,41 @@ public class WhenTestingResourceParity
         avatar.Should().Be("Votre photo de profil");
     }
 
+    [Fact]
+    public void ItShouldKeepInstallCopyFreeOfLegacyProductWording()
+    {
+        // Arrange
+        var manager = new ResourceManager(typeof(UiStrings));
+        var english = manager.GetResourceSet(new CultureInfo(CultureNames.English), true, false);
+        var french = manager.GetResourceSet(new CultureInfo(CultureNames.French), true, false);
+
+        // Act
+        var installValues = Values(english)
+            .Concat(Values(french))
+            .ToArray();
+
+        // Assert
+        installValues.Should().NotBeEmpty();
+        installValues.Should().AllSatisfy(value =>
+        {
+            value.Should().NotContain("Catch, But Don’t Forget");
+            value.Should().NotContain("CBDF");
+        });
+    }
+
     private static IReadOnlyCollection<string> Keys(ResourceSet? set)
     {
         return set is null
             ? []
             : [.. set.Cast<System.Collections.DictionaryEntry>().Select(entry => (string)entry.Key)];
+    }
+
+    private static IReadOnlyCollection<string> Values(ResourceSet? set)
+    {
+        return set is null
+            ? []
+            : [.. set.Cast<System.Collections.DictionaryEntry>()
+                .Where(entry => ((string)entry.Key).StartsWith("Install_", StringComparison.Ordinal))
+                .Select(entry => (string)entry.Value!)];
     }
 }


### PR DESCRIPTION
## Summary

- finalise the shared Install guidance copy with the correct product name, **Catch But Don’t Forget**
- provide distinct, actionable iPhone and iPad Safari instructions
- clarify installed-app wording across iOS, Android, Samsung Internet, and computer guidance
- preserve the non-Safari handoff instructions and complete English/French localisation parity
- add focused component and localisation coverage for the revised copy

## Scope

This is a copy/UI-only follow-up. It does not change install detection, `beforeinstallprompt`, installed-state detection, JavaScript interop, service-worker behaviour, offline caching, authentication, or PWA architecture.

## Validation

- Focused Install/localisation tests: **34 passed**
- Release build: **succeeded, 0 warnings, 0 errors**
- JavaScript/PWA tests: **183 passed**
- Browser tests: **27 passed, 1 existing WebKit offline-shell skip**
- Full .NET suite: all non-container tests passed; Infrastructure integration tests requiring Testcontainers could not run because Docker was unavailable (`npipe://./pipe/docker_engine`)

## Self-review

- Acceptance criteria: PASS
- Architecture/scope discipline: PASS
- EN/FR localisation parity: PASS
- Security, persistence, authentication, and PWA runtime impact: none
- Blocking or required findings: none

Closes #129
