### PR TITLE
Polish update and system status presentation

### DIFF
--- a/src/FishingLogBook.Root/build/root-site.test.mjs
+++ b/src/FishingLogBook.Root/build/root-site.test.mjs
@@ -6,7 +6,7 @@ const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
 
 describe('production root site', () => {
     it('presents the exact brand name', () => {
-        assert.match(html, /<h1>Catch, But Don't Forget<\/h1>/);
+        assert.match(html, /<h1>Catch But Don't Forget<\/h1>/);
     });
 
     it('links to the permanent production PWA origin', () => {

--- a/src/FishingLogBook.Root/index.html
+++ b/src/FishingLogBook.Root/index.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="A private fishing logbook for your catches, photographs and memories.">
-  <title>Catch, But Don't Forget</title>
+  <title>Catch But Don't Forget</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <main>
     <p class="eyebrow">Catch · Release · Remember</p>
-    <h1>Catch, But Don't Forget</h1>
+    <h1>Catch But Don't Forget</h1>
     <p>Keep your catches, photographs and fishing memories together—wherever you fish.</p>
     <a href="https://app.catchbutdontforget.com">Open the app</a>
   </main>

--- a/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor
+++ b/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor
@@ -2,9 +2,9 @@
 
 @if (IsVisible)
 {
-    <MudPaper Class="app-update-banner" Elevation="3" Square="true" role="status" aria-live="polite" id="app-update-banner">
+    <MudPaper Class="app-update-banner" Elevation="1" Outlined="true" role="status" aria-live="polite" id="app-update-banner">
         <div class="app-update-banner-content">
-            <MudIcon Icon="@Icons.Material.Filled.SystemUpdate" Color="Color.Primary" Size="Size.Medium" aria-hidden="true" />
+            <MudIcon Icon="@Icons.Material.Filled.SystemUpdate" Color="Color.Primary" Size="Size.Small" aria-hidden="true" />
             <div class="app-update-banner-text">
                 <MudText Typo="Typo.subtitle1" id="app-update-banner-title">@Title</MudText>
                 <MudText Typo="Typo.body2" Class="mud-text-secondary" id="app-update-banner-body">@Body</MudText>
@@ -14,7 +14,7 @@
         {
             <MudButton Variant="Variant.Filled"
                        Color="Color.Primary"
-                       Size="Size.Large"
+                       Size="Size.Medium"
                        StartIcon="@Icons.Material.Filled.SystemUpdate"
                        OnClick="UpdateAsync"
                        Disabled="IsActivating"

--- a/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor.css
+++ b/src/FishingLogBook.Web/Components/AppUpdateBanner/AppUpdateBanner.razor.css
@@ -1,14 +1,15 @@
 .app-update-banner {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
-    padding: 0.875rem 0.75rem;
+    gap: 0.625rem;
+    margin: 0.75rem;
+    padding: 0.75rem;
 }
 
 .app-update-banner-content {
     align-items: flex-start;
     display: flex;
-    gap: 0.75rem;
+    gap: 0.625rem;
 }
 
 .app-update-banner-text {
@@ -28,7 +29,8 @@
         align-items: center;
         flex-direction: row;
         justify-content: space-between;
-        padding: 0.875rem 1.5rem;
+        margin: 0.75rem 1.5rem;
+        padding: 0.625rem 0.875rem;
     }
 
     .app-update-banner-action {

--- a/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor
+++ b/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor
@@ -1,11 +1,15 @@
 @page "/system-status"
 
-<PageTitle>@Loc["SystemStatus_PageTitle"]</PageTitle>
+<PageTitle>@Loc["App_Name"] - @Loc["SystemStatus_Subtitle"]</PageTitle>
 
 <MudContainer MaxWidth="MaxWidth.Medium" Gutters="false" Class="status-container">
     <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
-        <MudStack Spacing="1" AlignItems="AlignItems.Center">
-            <MudIcon Icon="@Icons.Material.Filled.Phishing" Size="Size.Large" Color="Color.Primary" />
+        <MudStack Spacing="1" AlignItems="AlignItems.Center" Class="status-header" id="system-status-header">
+            <img src="images/brand/brand-mark-transparent.png"
+                 class="status-brand-mark"
+                 alt=""
+                 aria-hidden="true"
+                 id="system-status-brand-mark" />
             <MudText Typo="Typo.h4" Align="Align.Center">@Loc["App_Name"]</MudText>
             <MudText Typo="Typo.subtitle1" Align="Align.Center" Class="mud-text-secondary">@Loc["SystemStatus_Subtitle"]</MudText>
         </MudStack>

--- a/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor
+++ b/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor
@@ -29,14 +29,24 @@
                 <MudText Typo="Typo.h6">@Loc["Build_About"]</MudText>
                 <div id="web-build-information">
                     <MudText Typo="Typo.subtitle1">@Loc["Build_App"]</MudText>
-                    <MudText>@Loc["Build_Version"]: @WebBuild.Version</MudText>
-                    <MudText>@Loc["Build_Commit"]: @WebBuild.Sha</MudText>
-                    <MudText>@Loc["Build_Environment"]: @WebBuild.Environment</MudText>
+                    <div class="status-metadata">
+                        <MudText Class="status-metadata-label">@Loc["Build_Version"]</MudText>
+                        <MudText>@WebBuild.Version</MudText>
+                        <MudText Class="status-metadata-label">@Loc["Build_Commit"]</MudText>
+                        <MudText Class="status-metadata-value">@WebBuild.Sha</MudText>
+                        <MudText Class="status-metadata-label">@Loc["Build_Environment"]</MudText>
+                        <MudText>@WebBuild.Environment</MudText>
+                    </div>
                 </div>
                 <MudDivider />
-                <div id="update-information">
-                    <MudText Typo="Typo.subtitle1">@Loc["Update_StatusLabel"]</MudText>
-                    <MudText id="update-status">@UpdateStatusText</MudText>
+                <div class="status-update" id="update-information">
+                    <div class="status-update-summary">
+                        <MudIcon Icon="@Icons.Material.Filled.SystemUpdate" Color="Color.Primary" Size="Size.Small" aria-hidden="true" />
+                        <div>
+                            <MudText Typo="Typo.subtitle1">@Loc["Update_StatusLabel"]</MudText>
+                            <MudText Class="mud-text-secondary" id="update-status">@UpdateStatusText</MudText>
+                        </div>
+                    </div>
                     @if (CanUpdate)
                     {
                         <MudButton Variant="Variant.Filled"
@@ -57,9 +67,14 @@
                     }
                     else
                     {
-                        <MudText>@Loc["Build_Version"]: @_apiBuild.Version</MudText>
-                        <MudText>@Loc["Build_Commit"]: @_apiBuild.Sha</MudText>
-                        <MudText>@Loc["Build_Environment"]: @_apiBuild.Environment</MudText>
+                        <div class="status-metadata">
+                            <MudText Class="status-metadata-label">@Loc["Build_Version"]</MudText>
+                            <MudText>@_apiBuild.Version</MudText>
+                            <MudText Class="status-metadata-label">@Loc["Build_Commit"]</MudText>
+                            <MudText Class="status-metadata-value">@_apiBuild.Sha</MudText>
+                            <MudText Class="status-metadata-label">@Loc["Build_Environment"]</MudText>
+                            <MudText>@_apiBuild.Environment</MudText>
+                        </div>
                     }
                 </div>
             </MudStack>

--- a/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor.css
+++ b/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor.css
@@ -2,6 +2,12 @@
     padding-top: 2rem;
 }
 
+.status-brand-mark {
+    height: 2.75rem;
+    object-fit: contain;
+    width: 2.75rem;
+}
+
 .status-row {
     width: 100%;
 }

--- a/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor.css
+++ b/src/FishingLogBook.Web/Features/SystemStatus/Pages/SystemStatus/SystemStatus.razor.css
@@ -8,6 +8,42 @@
     width: 2.75rem;
 }
 
+.status-metadata {
+    display: grid;
+    gap: 0.125rem 0.75rem;
+    grid-template-columns: max-content minmax(0, 1fr);
+    margin-top: 0.25rem;
+}
+
+.status-metadata-label {
+    font-weight: 600;
+}
+
+.status-metadata-value {
+    overflow-wrap: anywhere;
+}
+
+.status-update {
+    align-items: stretch;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.status-update-summary {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.625rem;
+}
+
+@media (min-width: 600px) {
+    .status-update {
+        align-items: center;
+        flex-direction: row;
+        justify-content: space-between;
+    }
+}
+
 .status-row {
     width: 100%;
 }

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -13,7 +13,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="App_Name" xml:space="preserve">
-    <value>Catch, But Don’t Forget</value>
+    <value>Catch But Don’t Forget</value>
   </data>
   <data name="SystemStatus_PageTitle" xml:space="preserve">
     <value>FishingLogBook - État du système</value>
@@ -619,10 +619,10 @@
     <value>Réessayer</value>
   </data>
   <data name="Common_Loading" xml:space="preserve"><value>Chargement</value></data>
-  <data name="Brand_LogoAlt" xml:space="preserve"><value>Catch, But Don’t Forget — Catch · Release · Remember</value></data>
+  <data name="Brand_LogoAlt" xml:space="preserve"><value>Catch But Don’t Forget — Catch · Release · Remember</value></data>
   <data name="Onboarding_PageTitle" xml:space="preserve"><value>Bienvenue</value></data>
   <data name="Onboarding_WelcomeStep" xml:space="preserve"><value>Bienvenue</value></data>
-  <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>Bienvenue dans Catch, But Don’t Forget</value></data>
+  <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>Bienvenue dans Catch But Don’t Forget</value></data>
   <data name="Onboarding_WelcomeBody" xml:space="preserve"><value>Catch · Release · Remember. Configurez votre carnet de pêche privé, utilisable hors ligne, en une minute environ.</value></data>
   <data name="Onboarding_PreferencesStep" xml:space="preserve"><value>Préférences</value></data>
   <data name="Onboarding_PreferencesTitle" xml:space="preserve"><value>Définissez vos préférences de pêche</value></data>
@@ -649,7 +649,7 @@
   <data name="Action_NotNow" xml:space="preserve"><value>Pas maintenant</value></data>
   <data name="Action_Back" xml:space="preserve"><value>Retour</value></data>
   <data name="Action_Next" xml:space="preserve"><value>Suivant</value></data>
-  <data name="Landing_PageTitle" xml:space="preserve"><value>Catch, But Don’t Forget</value></data>
+  <data name="Landing_PageTitle" xml:space="preserve"><value>Catch But Don’t Forget</value></data>
   <data name="Landing_Tagline" xml:space="preserve"><value>Catch · Release · Remember</value></data>
   <data name="Landing_Heading" xml:space="preserve"><value>Votre carnet de pêche privé</value></data>
   <data name="Landing_Introduction" xml:space="preserve"><value>Conservez chaque prise, photo et souvenir au même endroit, où que vous pêchiez.</value></data>
@@ -721,7 +721,7 @@
   <data name="Build_Commit" xml:space="preserve"><value>Build</value></data>
   <data name="Build_Environment" xml:space="preserve"><value>Environnement</value></data>
   <data name="Build_Unavailable" xml:space="preserve"><value>Indisponible</value></data>
-  <data name="Update_BannerTitle" xml:space="preserve"><value>Nouvelle version de CBDF disponible</value></data>
+  <data name="Update_BannerTitle" xml:space="preserve"><value>Nouvelle version disponible</value></data>
   <data name="Update_BannerBody" xml:space="preserve"><value>Obtenez les derniers correctifs et nouveautés.</value></data>
   <data name="Update_Action" xml:space="preserve"><value>Mettre à jour</value></data>
   <data name="Update_ActivatingTitle" xml:space="preserve"><value>Mise à jour en cours</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -13,7 +13,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="App_Name" xml:space="preserve">
-    <value>Catch, But Don’t Forget</value>
+    <value>Catch But Don’t Forget</value>
   </data>
   <data name="SystemStatus_PageTitle" xml:space="preserve">
     <value>FishingLogBook - System Status</value>
@@ -619,10 +619,10 @@
     <value>Try again</value>
   </data>
   <data name="Common_Loading" xml:space="preserve"><value>Loading</value></data>
-  <data name="Brand_LogoAlt" xml:space="preserve"><value>Catch, But Don’t Forget — Catch · Release · Remember</value></data>
+  <data name="Brand_LogoAlt" xml:space="preserve"><value>Catch But Don’t Forget — Catch · Release · Remember</value></data>
   <data name="Onboarding_PageTitle" xml:space="preserve"><value>Welcome</value></data>
   <data name="Onboarding_WelcomeStep" xml:space="preserve"><value>Welcome</value></data>
-  <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>Welcome to Catch, But Don’t Forget</value></data>
+  <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>Welcome to Catch But Don’t Forget</value></data>
   <data name="Onboarding_WelcomeBody" xml:space="preserve"><value>Catch · Release · Remember. Set up your private, offline-friendly fishing logbook in about a minute.</value></data>
   <data name="Onboarding_PreferencesStep" xml:space="preserve"><value>Preferences</value></data>
   <data name="Onboarding_PreferencesTitle" xml:space="preserve"><value>Set your fishing preferences</value></data>
@@ -649,7 +649,7 @@
   <data name="Action_NotNow" xml:space="preserve"><value>Not now</value></data>
   <data name="Action_Back" xml:space="preserve"><value>Back</value></data>
   <data name="Action_Next" xml:space="preserve"><value>Next</value></data>
-  <data name="Landing_PageTitle" xml:space="preserve"><value>Catch, But Don’t Forget</value></data>
+  <data name="Landing_PageTitle" xml:space="preserve"><value>Catch But Don’t Forget</value></data>
   <data name="Landing_Tagline" xml:space="preserve"><value>Catch · Release · Remember</value></data>
   <data name="Landing_Heading" xml:space="preserve"><value>Your private fishing logbook</value></data>
   <data name="Landing_Introduction" xml:space="preserve"><value>Keep every catch, photograph and memory together—wherever you fish.</value></data>
@@ -721,7 +721,7 @@
   <data name="Build_Commit" xml:space="preserve"><value>Build</value></data>
   <data name="Build_Environment" xml:space="preserve"><value>Environment</value></data>
   <data name="Build_Unavailable" xml:space="preserve"><value>Unavailable</value></data>
-  <data name="Update_BannerTitle" xml:space="preserve"><value>New CBDF version available</value></data>
+  <data name="Update_BannerTitle" xml:space="preserve"><value>New version available</value></data>
   <data name="Update_BannerBody" xml:space="preserve"><value>Get the latest fixes and features.</value></data>
   <data name="Update_Action" xml:space="preserve"><value>Update now</value></data>
   <data name="Update_ActivatingTitle" xml:space="preserve"><value>Updating</value></data>

--- a/src/FishingLogBook.Web/vitest.config.js
+++ b/src/FishingLogBook.Web/vitest.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
     test: {
         environment: 'jsdom',
         setupFiles: ['./vitest.setup.js'],
-        include: ['./wwwroot/js/**/*.test.js'],
+        include: ['./wwwroot/js/**/*.test.js', './wwwroot/manifest.test.js'],
         fileParallelism: false,
         pool: 'forks',
         singleFork: true,

--- a/src/FishingLogBook.Web/wwwroot/index.html
+++ b/src/FishingLogBook.Web/wwwroot/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>Catch, But Don’t Forget</title>
+    <title>Catch But Don’t Forget</title>
     <base href="/" />
     <link rel="preload" id="webassembly" />
     <link rel="stylesheet" href="_content/MudBlazor/MudBlazor.min.css" />

--- a/src/FishingLogBook.Web/wwwroot/manifest.test.js
+++ b/src/FishingLogBook.Web/wwwroot/manifest.test.js
@@ -7,7 +7,7 @@ describe('web app manifest', () => {
         const root = resolve(import.meta.dirname);
         const manifest = JSON.parse(readFileSync(resolve(root, 'manifest.webmanifest'), 'utf8'));
 
-        expect(manifest.name).toBe('Catch, But Don’t Forget');
+        expect(manifest.name).toBe('Catch But Don’t Forget');
         expect(manifest.icons).toEqual(expect.arrayContaining([
             expect.objectContaining({ src: 'icon-192.png', sizes: '192x192' }),
             expect.objectContaining({ src: 'icon-512.png', sizes: '512x512' })

--- a/src/FishingLogBook.Web/wwwroot/manifest.webmanifest
+++ b/src/FishingLogBook.Web/wwwroot/manifest.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "Catch, But Don’t Forget",
+  "name": "Catch But Don’t Forget",
   "short_name": "Catch Logbook",
   "id": "./",
   "start_url": "./",

--- a/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/WhenTestingRender.cs
@@ -46,7 +46,7 @@ public class WhenTestingRender : BaseAppUpdateBannerTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#app-update-banner-title").TextContent
-                .Should().Contain("New CBDF version available");
+                .Should().Contain("New version available");
             cut.Find("#app-update-banner-body").TextContent
                 .Should().Contain("Get the latest fixes and features.");
             cut.Find("#app-update-banner-action").TextContent.Should().Contain("Update now");
@@ -110,6 +110,7 @@ public class WhenTestingRender : BaseAppUpdateBannerTest
         {
             var banner = cut.Find("#app-update-banner").TextContent;
             banner.Should().NotContainAny(
+                "CBDF",
                 "service worker",
                 "cache",
                 "hard refresh",
@@ -133,7 +134,7 @@ public class WhenTestingRender : BaseAppUpdateBannerTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#app-update-banner-title").TextContent
-                .Should().Contain("Nouvelle version de CBDF disponible");
+                .Should().Contain("Nouvelle version disponible");
             cut.Find("#app-update-banner-action").TextContent.Should().Contain("Mettre à jour");
         });
     }

--- a/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/WhenTestingUpdate.cs
+++ b/tests/FishingLogBook.Web.Tests/Components/AppUpdateBannerTests/WhenTestingUpdate.cs
@@ -62,7 +62,7 @@ public class WhenTestingUpdate : BaseAppUpdateBannerTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#app-update-banner-title").TextContent
-                .Should().Contain("New CBDF version available");
+                .Should().Contain("New version available");
             cut.Find("#app-update-banner-action").Should().NotBeNull();
         });
     }

--- a/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Pages/SystemStatusTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Pages/SystemStatusTests/WhenTestingRender.cs
@@ -13,6 +13,30 @@ namespace FishingLogBook.Web.Tests.Features.SystemStatus.Pages.SystemStatusTests
 public class WhenTestingRender : BaseSystemStatusTest
 {
     [Fact]
+    public async Task ItShouldShowTheCurrentBrandHeader()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var statusClient = Substitute.For<ISystemStatusClient>();
+        await using var context = CreateContext(statusClient);
+
+        // Act
+        var cut = context.Render<SystemStatusPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            var header = cut.Find("#system-status-header");
+            header.TextContent.Should().Contain("Catch But Don’t Forget");
+            header.TextContent.Should().Contain("System status");
+            header.TextContent.Should().NotContain("Catch, But Don’t Forget");
+            cut.Find("#system-status-brand-mark").GetAttribute("src")
+                .Should().Be("images/brand/brand-mark-transparent.png");
+            header.QuerySelectorAll(".mud-icon-root").Should().BeEmpty();
+        });
+    }
+
+    [Fact]
     public async Task ItShouldShowOnlineWhenApiAndDatabaseAreHealthy()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Pages/SystemStatusTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Pages/SystemStatusTests/WhenTestingRender.cs
@@ -61,6 +61,8 @@ public class WhenTestingRender : BaseSystemStatusTest
             cut.Find("#status-row-database").TextContent.Should().Contain("FishingLogBook database online");
             cut.Find("#web-build-information").TextContent.Should().Contain("web1234");
             cut.Find("#api-build-information").TextContent.Should().Contain("api5678");
+            cut.FindAll("#web-build-information .status-metadata").Should().ContainSingle();
+            cut.FindAll("#api-build-information .status-metadata").Should().ContainSingle();
         });
         await statusClient.Received(1).GetApiHealthAsync(Arg.Any<CancellationToken>());
         await statusClient.Received(1).GetBuildMetadataAsync(Arg.Any<CancellationToken>());

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingMenu.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingMenu.cs
@@ -30,7 +30,7 @@ public class WhenTestingMenu : BaseMainLayoutTest
         cut.Find("#home-nav-link").GetAttribute("href").Should().Be("/");
         cut.Find("#app-brand-mark").GetAttribute("src").Should().Be("images/brand/brand-mark-transparent.png");
         cut.Find("#app-brand-mark").GetAttribute("src").Should().NotBe("icon-192.png");
-        cut.Find("#app-brand-name").TextContent.Should().Be("Catch, But Don’t Forget");
+        cut.Find("#app-brand-name").TextContent.Should().Be("Catch But Don’t Forget");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingUpdateBanner.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingUpdateBanner.cs
@@ -61,7 +61,7 @@ public class WhenTestingUpdateBanner : BaseMainLayoutTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#app-update-banner-title").TextContent
-                .Should().Contain("New CBDF version available");
+                .Should().Contain("New version available");
             cut.Find("#app-update-banner-action").TextContent.Should().Contain("Update now");
             cut.Markup.IndexOf("app-update-banner", StringComparison.Ordinal)
                 .Should().BeLessThan(cut.Markup.IndexOf("app-shell-content", StringComparison.Ordinal));

--- a/tests/FishingLogBook.Web.Tests/Localization/UiStringsTests/WhenTestingResourceParity.cs
+++ b/tests/FishingLogBook.Web.Tests/Localization/UiStringsTests/WhenTestingResourceParity.cs
@@ -62,6 +62,29 @@ public class WhenTestingResourceParity
         });
     }
 
+    [Fact]
+    public void ItShouldUseTheCanonicalProductNameInUserFacingResources()
+    {
+        // Arrange
+        var manager = new ResourceManager(typeof(UiStrings));
+        var english = manager.GetResourceSet(new CultureInfo(CultureNames.English), true, false);
+        var french = manager.GetResourceSet(new CultureInfo(CultureNames.French), true, false);
+
+        // Act
+        var appName = manager.GetString("App_Name", new CultureInfo(CultureNames.English));
+        var userFacingValues = AllValues(english)
+            .Concat(AllValues(french))
+            .ToArray();
+
+        // Assert
+        appName.Should().Be("Catch But Don’t Forget");
+        userFacingValues.Should().AllSatisfy(value =>
+        {
+            value.Should().NotContain("Catch, But Don’t Forget");
+            value.Should().NotContain("CBDF");
+        });
+    }
+
     private static IReadOnlyCollection<string> Keys(ResourceSet? set)
     {
         return set is null
@@ -75,6 +98,14 @@ public class WhenTestingResourceParity
             ? []
             : [.. set.Cast<System.Collections.DictionaryEntry>()
                 .Where(entry => ((string)entry.Key).StartsWith("Install_", StringComparison.Ordinal))
+                .Select(entry => (string)entry.Value!)];
+    }
+
+    private static IReadOnlyCollection<string> AllValues(ResourceSet? set)
+    {
+        return set is null
+            ? []
+            : [.. set.Cast<System.Collections.DictionaryEntry>()
                 .Select(entry => (string)entry.Value!)];
     }
 }


### PR DESCRIPTION
## Summary

- restyle the existing global update banner as a compact responsive MudBlazor notice
- replace the obsolete System Status hook icon with the existing small brand mark
- tidy the About build metadata into aligned label/value rows and make its update status responsive
- correct the shared app name, PWA metadata, and root-site user-facing comma variants to **Catch But Don’t Forget**
- remove the internal CBDF abbreviation from update copy in English and French
- make the existing manifest test part of the normal JavaScript suite

## Scope

Presentation, branding, and copy only. No update service, service-worker lifecycle, waiting-worker, activation, reload, install detection, authentication, IndexedDB, offline cache, or feature-page behaviour was changed.

## Validation

- Focused Web component/localisation tests: **47 passed**
- `dotnet format FishingLogBook.sln --no-restore`: completed
- Release build: **succeeded, 0 warnings, 0 errors**
- Full non-container .NET tests:
  - Web: **664 passed**
  - API: **149 passed**
  - Application: **298 passed**
  - Shared: **18 passed**
  - Db.Migrations: **10 passed**
  - Infrastructure unit tests: **14 passed**
- Infrastructure PostgreSQL/Testcontainers: **103 could not run** because Docker access to `npipe://./pipe/docker_engine` is unavailable in this environment
- JavaScript/Vitest: **210 passed across 24 files**
- Root-site branding tests: **2 passed**
- Browser/Playwright: **27 passed, 1 existing WebKit offline-shell skip**

## Self review

- Issue/AC: PASS — requested banner, branding, product-name, localisation, and focused test outcomes are covered
- Architecture/CQRS: PASS — presentation/resource changes only; update behaviour remains behind the existing service
- Rules: PASS — scoped Blazor/localisation/test conventions followed
- Security/privacy: PASS — no security or privacy surface changed
- Database/migrations: N/A
- Tests/coverage: PASS — banner visibility/action/current state, branding, logo asset, product name, and EN/FR parity covered
- Browser: PASS for unchanged PWA behaviour; visual spacing remains appropriate for manual review after deployment
- Web/UI/localisation: PASS — EN/FR parity maintained and no user-facing CBDF/legacy comma wording remains
- Code smells: PASS — no new abstraction or duplicated product-name constant
- CI/deployment: PASS — no migration, Terraform, secret, or manual infrastructure step

### Findings discovered during self-review

1. The existing `manifest.test.js` was outside the Vitest include pattern and therefore did not run.

### Fixes made

1. Added only the existing manifest test to the configured Vitest include list; the final normal suite now runs and passes it.

### Remaining deliberate gaps

- The compact responsive presentation is covered at component/CSS level but should receive the normal visual check after deployment.
- PostgreSQL/Testcontainers validation remains unavailable locally because Docker is inaccessible; CI can run it.
