### PR TITLE
FLB#132 | Add disposable offline WebAuthn capability probe

### DIFF
--- a/src/FishingLogBook.Web/Features/Diagnostics/Components/ProbeResultRow/ProbeResultRow.razor
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Components/ProbeResultRow/ProbeResultRow.razor
@@ -1,0 +1,4 @@
+<div class="probe-result-row">
+    <MudText Typo="Typo.body2" Class="probe-result-label">@Label</MudText>
+    <MudText Typo="Typo.body2">@Value</MudText>
+</div>

--- a/src/FishingLogBook.Web/Features/Diagnostics/Components/ProbeResultRow/ProbeResultRow.razor.cs
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Components/ProbeResultRow/ProbeResultRow.razor.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Components;
+
+namespace FishingLogBook.Web.Features.Diagnostics.Components.ProbeResultRow;
+
+public partial class ProbeResultRow : ComponentBase
+{
+    [Parameter, EditorRequired]
+    public string Label { get; set; } = string.Empty;
+
+    [Parameter, EditorRequired]
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/FishingLogBook.Web/Features/Diagnostics/Components/ProbeResultRow/ProbeResultRow.razor.css
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Components/ProbeResultRow/ProbeResultRow.razor.css
@@ -1,0 +1,10 @@
+.probe-result-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    padding: 0.35rem 0;
+}
+
+.probe-result-label {
+    color: var(--mud-palette-text-secondary);
+}

--- a/src/FishingLogBook.Web/Features/Diagnostics/Models/WebAuthnCapabilityProbeResultModel.cs
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Models/WebAuthnCapabilityProbeResultModel.cs
@@ -1,0 +1,30 @@
+namespace FishingLogBook.Web.Features.Diagnostics.Models;
+
+public sealed record WebAuthnCapabilityProbeResultModel
+{
+    public bool WebAuthnAvailable { get; init; }
+
+    public bool? PlatformAuthenticatorAvailable { get; init; }
+
+    public bool IsOnlineAtInvocation { get; init; }
+
+    public bool HasProbeMetadata { get; init; }
+
+    public bool CredentialCreated { get; init; }
+
+    public bool? CreatePrfEnabled { get; init; }
+
+    public bool CreatePrfResultReturned { get; init; }
+
+    public bool GetSucceeded { get; init; }
+
+    public bool UserVerified { get; init; }
+
+    public bool GetPrfExtensionReported { get; init; }
+
+    public bool GetPrfResultReturned { get; init; }
+
+    public bool TestPayloadVerified { get; init; }
+
+    public string Outcome { get; init; } = "unknown";
+}

--- a/src/FishingLogBook.Web/Features/Diagnostics/Pages/DiagnosticsInspector/DiagnosticsInspector.razor
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Pages/DiagnosticsInspector/DiagnosticsInspector.razor
@@ -39,6 +39,14 @@
                    id="retry-diagnostics-probe-button">
             @Loc["Diagnostics_RetryProbe"]
         </MudButton>
+        <MudButton Variant="Variant.Outlined"
+                   Color="Color.Secondary"
+                   FullWidth="true"
+                   Href="/diagnostics/webauthn-capability-probe"
+                   StartIcon="@Icons.Material.Filled.Fingerprint"
+                   id="webauthn-capability-probe-link">
+            @Loc["WebAuthnProbe_OpenAction"]
+        </MudButton>
         @if (ShowEmptyQueue)
         {
             <MudText Typo="Typo.body2" Class="mud-text-secondary" id="diagnostic-queue-empty">

--- a/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor
@@ -1,0 +1,101 @@
+@page "/diagnostics/webauthn-capability-probe"
+@using FishingLogBook.Web.Features.Diagnostics.Components.ProbeResultRow
+
+<PageTitle>@Loc["WebAuthnProbe_PageTitle"]</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Gutters="false" Class="webauthn-probe">
+    <MudStack Spacing="3">
+        <MudText Typo="Typo.h5" id="webauthn-probe-title">@Loc["WebAuthnProbe_Title"]</MudText>
+        <MudAlert Severity="Severity.Info" Dense="true" id="webauthn-probe-scope">
+            @Loc["WebAuthnProbe_Scope"]
+        </MudAlert>
+
+        <MudPaper Class="pa-4" Outlined="true">
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.h6">@Loc["WebAuthnProbe_ProvisionTitle"]</MudText>
+                <MudText Typo="Typo.body2">@Loc["WebAuthnProbe_ProvisionBody"]</MudText>
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.Fingerprint"
+                           Disabled="@_isBusy"
+                           OnClick="ProvisionAsync"
+                           id="provision-webauthn-probe-button">
+                    @Loc["WebAuthnProbe_ProvisionAction"]
+                </MudButton>
+                @if (_provisionResult is not null)
+                {
+                    <div id="webauthn-provision-results">
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_WebAuthnAvailable"]" Value="@BooleanLabel(_provisionResult.WebAuthnAvailable)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PlatformAvailable"]" Value="@NullableBooleanLabel(_provisionResult.PlatformAuthenticatorAvailable)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_CreateSucceeded"]" Value="@BooleanLabel(_provisionResult.CredentialCreated)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_CreatePrfEnabled"]" Value="@NullableBooleanLabel(_provisionResult.CreatePrfEnabled)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_CreatePrfResult"]" Value="@BooleanLabel(_provisionResult.CreatePrfResultReturned)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_Outcome"]" Value="@OutcomeLabel(_provisionResult.Outcome)" />
+                    </div>
+                }
+                <MudButton Variant="Variant.Outlined"
+                           Color="Color.Primary"
+                           StartIcon="@Icons.Material.Filled.VerifiedUser"
+                           Disabled="@(_isBusy || _status?.HasProbeMetadata != true)"
+                           OnClick="VerifyOnlineAsync"
+                           id="verify-online-webauthn-probe-button">
+                    @Loc["WebAuthnProbe_VerifyOnlineAction"]
+                </MudButton>
+                @if (_onlineVerificationResult is not null)
+                {
+                    <div id="webauthn-online-verification-results">
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_ImmediateGetSucceeded"]" Value="@BooleanLabel(_onlineVerificationResult.GetSucceeded)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_UserVerified"]" Value="@BooleanLabel(_onlineVerificationResult.UserVerified)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_GetPrfReported"]" Value="@BooleanLabel(_onlineVerificationResult.GetPrfExtensionReported)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_GetPrfResult"]" Value="@BooleanLabel(_onlineVerificationResult.GetPrfResultReturned)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PayloadVerified"]" Value="@BooleanLabel(_onlineVerificationResult.TestPayloadVerified)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_Outcome"]" Value="@OutcomeLabel(_onlineVerificationResult.Outcome)" />
+                    </div>
+                }
+            </MudStack>
+        </MudPaper>
+
+        <MudPaper Class="pa-4" Outlined="true">
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.h6">@Loc["WebAuthnProbe_OfflineTitle"]</MudText>
+                <MudText Typo="Typo.body2">@Loc["WebAuthnProbe_OfflineBody"]</MudText>
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Secondary"
+                           StartIcon="@Icons.Material.Filled.LockOpen"
+                           Disabled="@(_isBusy || _status?.HasProbeMetadata != true)"
+                           OnClick="TestOfflineUnlockAsync"
+                           id="test-offline-webauthn-button">
+                    @Loc["WebAuthnProbe_OfflineAction"]
+                </MudButton>
+                @if (_offlineResult is not null)
+                {
+                    <div id="webauthn-offline-results">
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_OfflineAtInvocation"]" Value="@BooleanLabel(!_offlineResult.IsOnlineAtInvocation)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_GetSucceeded"]" Value="@BooleanLabel(_offlineResult.GetSucceeded)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_UserVerified"]" Value="@BooleanLabel(_offlineResult.UserVerified)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_GetPrfReported"]" Value="@BooleanLabel(_offlineResult.GetPrfExtensionReported)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_GetPrfResult"]" Value="@BooleanLabel(_offlineResult.GetPrfResultReturned)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PayloadVerified"]" Value="@BooleanLabel(_offlineResult.TestPayloadVerified)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_Outcome"]" Value="@OutcomeLabel(_offlineResult.Outcome)" />
+                    </div>
+                }
+            </MudStack>
+        </MudPaper>
+
+        <MudAlert Severity="Severity.Warning" Dense="true" id="webauthn-probe-cleanup-note">
+            @Loc["WebAuthnProbe_CleanupNote"]
+        </MudAlert>
+        <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2">
+            <MudButton Variant="Variant.Text" Href="/" id="leave-webauthn-probe-button">
+                @Loc["WebAuthnProbe_LeaveAction"]
+            </MudButton>
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Error"
+                       Disabled="@(_isBusy || _status?.HasProbeMetadata != true)"
+                       OnClick="RemoveMetadataAsync"
+                       id="remove-webauthn-probe-metadata-button">
+                @Loc["WebAuthnProbe_RemoveMetadataAction"]
+            </MudButton>
+        </MudStack>
+    </MudStack>
+</MudContainer>

--- a/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor.cs
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor.cs
@@ -1,0 +1,99 @@
+using FishingLogBook.Web.Features.Diagnostics.Models;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Diagnostics.Pages.WebAuthnCapabilityProbe;
+
+public partial class WebAuthnCapabilityProbe : ComponentBase
+{
+    [Inject]
+    private IWebAuthnCapabilityProbeService Probe { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private WebAuthnCapabilityProbeResultModel? _status;
+    private WebAuthnCapabilityProbeResultModel? _provisionResult;
+    private WebAuthnCapabilityProbeResultModel? _onlineVerificationResult;
+    private WebAuthnCapabilityProbeResultModel? _offlineResult;
+    private bool _isBusy;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _status = await Probe.GetStatusAsync(CancellationToken.None);
+    }
+
+    private async Task ProvisionAsync()
+    {
+        _isBusy = true;
+        try
+        {
+            _provisionResult = await Probe.ProvisionAsync(CancellationToken.None);
+            _status = _provisionResult;
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private async Task TestOfflineUnlockAsync()
+    {
+        _isBusy = true;
+        try
+        {
+            _offlineResult = await Probe.TestOfflineUnlockAsync(CancellationToken.None);
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private async Task VerifyOnlineAsync()
+    {
+        _isBusy = true;
+        try
+        {
+            _onlineVerificationResult = await Probe.VerifyOnlineAsync(CancellationToken.None);
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private async Task RemoveMetadataAsync()
+    {
+        _isBusy = true;
+        try
+        {
+            await Probe.RemoveMetadataAsync(CancellationToken.None);
+            _status = await Probe.GetStatusAsync(CancellationToken.None);
+            _provisionResult = null;
+            _onlineVerificationResult = null;
+            _offlineResult = null;
+        }
+        finally
+        {
+            _isBusy = false;
+        }
+    }
+
+    private string BooleanLabel(bool value)
+    {
+        return value ? Loc["WebAuthnProbe_Yes"] : Loc["WebAuthnProbe_No"];
+    }
+
+    private string NullableBooleanLabel(bool? value)
+    {
+        return value.HasValue ? BooleanLabel(value.Value) : Loc["WebAuthnProbe_NotReported"];
+    }
+
+    private string OutcomeLabel(string outcome)
+    {
+        return Loc[$"WebAuthnProbe_Outcome_{outcome}"];
+    }
+}

--- a/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor.css
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor.css
@@ -1,0 +1,3 @@
+.webauthn-probe {
+    padding-bottom: 1rem;
+}

--- a/src/FishingLogBook.Web/Features/Diagnostics/Services/IWebAuthnCapabilityProbeService.cs
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Services/IWebAuthnCapabilityProbeService.cs
@@ -1,0 +1,18 @@
+using FishingLogBook.Web.Features.Diagnostics.Models;
+
+namespace FishingLogBook.Web.Features.Diagnostics.Services;
+
+public interface IWebAuthnCapabilityProbeService
+{
+    Task<bool> HasMetadataAsync(CancellationToken cancellationToken);
+
+    Task<WebAuthnCapabilityProbeResultModel> GetStatusAsync(CancellationToken cancellationToken);
+
+    Task<WebAuthnCapabilityProbeResultModel> ProvisionAsync(CancellationToken cancellationToken);
+
+    Task<WebAuthnCapabilityProbeResultModel> VerifyOnlineAsync(CancellationToken cancellationToken);
+
+    Task<WebAuthnCapabilityProbeResultModel> TestOfflineUnlockAsync(CancellationToken cancellationToken);
+
+    Task RemoveMetadataAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Diagnostics/Services/WebAuthnCapabilityProbeService.cs
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Services/WebAuthnCapabilityProbeService.cs
@@ -1,0 +1,59 @@
+using FishingLogBook.Web.Features.Diagnostics.Models;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Features.Diagnostics.Services;
+
+public sealed class WebAuthnCapabilityProbeService : IWebAuthnCapabilityProbeService
+{
+    private const string ModulePath = "./js/browser/webauthn-capability-probe.js";
+    private readonly IJSRuntime _jsRuntime;
+
+    public WebAuthnCapabilityProbeService(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task<bool> HasMetadataAsync(CancellationToken cancellationToken)
+    {
+        var module = await ImportModuleAsync(cancellationToken);
+        return await module.InvokeAsync<bool>("hasProbeMetadata", cancellationToken);
+    }
+
+    public async Task<WebAuthnCapabilityProbeResultModel> GetStatusAsync(CancellationToken cancellationToken)
+    {
+        var module = await ImportModuleAsync(cancellationToken);
+        return await module.InvokeAsync<WebAuthnCapabilityProbeResultModel>("getProbeStatus", cancellationToken);
+    }
+
+    public async Task<WebAuthnCapabilityProbeResultModel> ProvisionAsync(CancellationToken cancellationToken)
+    {
+        var module = await ImportModuleAsync(cancellationToken);
+        return await module.InvokeAsync<WebAuthnCapabilityProbeResultModel>("provisionTestCredential", cancellationToken);
+    }
+
+    public async Task<WebAuthnCapabilityProbeResultModel> TestOfflineUnlockAsync(
+        CancellationToken cancellationToken)
+    {
+        var module = await ImportModuleAsync(cancellationToken);
+        return await module.InvokeAsync<WebAuthnCapabilityProbeResultModel>("testOfflineUnlock", cancellationToken);
+    }
+
+    public async Task<WebAuthnCapabilityProbeResultModel> VerifyOnlineAsync(CancellationToken cancellationToken)
+    {
+        var module = await ImportModuleAsync(cancellationToken);
+        return await module.InvokeAsync<WebAuthnCapabilityProbeResultModel>(
+            "verifyOnlineCredential",
+            cancellationToken);
+    }
+
+    public async Task RemoveMetadataAsync(CancellationToken cancellationToken)
+    {
+        var module = await ImportModuleAsync(cancellationToken);
+        await module.InvokeVoidAsync("removeProbeMetadata", cancellationToken);
+    }
+
+    private ValueTask<IJSObjectReference> ImportModuleAsync(CancellationToken cancellationToken)
+    {
+        return _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+    }
+}

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
@@ -31,6 +31,16 @@ else if (_isAnonymous)
                 <MudStack Spacing="2" Class="landing-actions">
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginCreateAccount" id="landing-create-account">@Loc["Auth_CreateAccount"]</MudButton>
                     <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginSignIn" id="landing-sign-in">@Loc["Auth_SignIn"]</MudButton>
+                    @if (_showWebAuthnProbeAction)
+                    {
+                        <MudButton Variant="Variant.Text"
+                                   Color="Color.Secondary"
+                                   FullWidth="true"
+                                   OnClick="OpenWebAuthnProbe"
+                                   id="landing-webauthn-probe-action">
+                            @Loc["WebAuthnProbe_OfflineAction"]
+                        </MudButton>
+                    }
                 </MudStack>
             </MudStack>
         </MudContainer>

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
@@ -1,9 +1,11 @@
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Onboarding.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.Extensions.Localization;
+using Microsoft.JSInterop;
 
 namespace FishingLogBook.Web.Features.Onboarding.Pages.Landing;
 
@@ -12,14 +14,25 @@ public partial class Landing : ComponentBase, IDisposable
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private bool _isResolvingAuthentication = true;
     private bool _isAnonymous;
+    private bool _showWebAuthnProbeAction;
 
     [Inject] private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
     [Inject] private IOnboardingService Onboarding { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+    [Inject] private IWebAuthnCapabilityProbeService WebAuthnProbe { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        try
+        {
+            _showWebAuthnProbeAction = await WebAuthnProbe.HasMetadataAsync(_cancellationTokenSource.Token);
+        }
+        catch (JSException)
+        {
+            _showWebAuthnProbeAction = false;
+        }
+
         var authentication = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         if (authentication.User.Identity?.IsAuthenticated != true)
         {
@@ -40,6 +53,11 @@ public partial class Landing : ComponentBase, IDisposable
     private void BeginSignIn()
     {
         Navigation.NavigateToLogin("authentication/login");
+    }
+
+    private void OpenWebAuthnProbe()
+    {
+        Navigation.NavigateTo("/diagnostics/webauthn-capability-probe");
     }
 
     public void Dispose()

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -731,4 +731,44 @@
   <data name="Update_StatusLabel" xml:space="preserve"><value>Mise à jour</value></data>
   <data name="Update_StatusCurrent" xml:space="preserve"><value>À jour</value></data>
   <data name="Update_StatusAvailable" xml:space="preserve"><value>Nouvelle version disponible</value></data>
+  <data name="WebAuthnProbe_PageTitle" xml:space="preserve"><value>Test de capacité WebAuthn</value></data>
+  <data name="WebAuthnProbe_Title" xml:space="preserve"><value>Test de capacité de déverrouillage hors ligne</value></data>
+  <data name="WebAuthnProbe_Scope" xml:space="preserve"><value>Ce diagnostic temporaire vérifie uniquement l’authentification de l’appareil. Il ne peut pas vous connecter, accéder aux données de pêche ni appeler l’API.</value></data>
+  <data name="WebAuthnProbe_ProvisionTitle" xml:space="preserve"><value>Configurer en ligne</value></data>
+  <data name="WebAuthnProbe_ProvisionBody" xml:space="preserve"><value>Effectuez ce test dans l’application installée lorsque vous êtes en ligne. Créez d’abord l’identifiant de test, puis appuyez sur Vérifier l’identifiant en ligne afin que chaque authentification de l’appareil ait sa propre action explicite.</value></data>
+  <data name="WebAuthnProbe_ProvisionAction" xml:space="preserve"><value>Configurer l’identifiant de test</value></data>
+  <data name="WebAuthnProbe_VerifyOnlineAction" xml:space="preserve"><value>Vérifier l’identifiant en ligne</value></data>
+  <data name="WebAuthnProbe_OfflineTitle" xml:space="preserve"><value>Tester après un démarrage à froid hors ligne</value></data>
+  <data name="WebAuthnProbe_OfflineBody" xml:space="preserve"><value>Fermez complètement l’application installée, activez le mode Avion, rouvrez-la depuis son icône, revenez ici depuis l’accueil, puis appuyez sur le bouton. L’authentification de l’appareil ne démarre jamais automatiquement.</value></data>
+  <data name="WebAuthnProbe_OfflineAction" xml:space="preserve"><value>Tester le déverrouillage hors ligne</value></data>
+  <data name="WebAuthnProbe_OpenAction" xml:space="preserve"><value>Ouvrir le test de déverrouillage de l’appareil</value></data>
+  <data name="WebAuthnProbe_CleanupNote" xml:space="preserve"><value>La suppression des métadonnées du test retire uniquement les valeurs de test inoffensives de l’application. La clé d’accès de test devra peut-être être supprimée manuellement dans Mots de passe Apple, Google Password Manager ou les réglages d’identifiants de votre appareil.</value></data>
+  <data name="WebAuthnProbe_RemoveMetadataAction" xml:space="preserve"><value>Supprimer les métadonnées du test</value></data>
+  <data name="WebAuthnProbe_LeaveAction" xml:space="preserve"><value>Quitter le test</value></data>
+  <data name="WebAuthnProbe_WebAuthnAvailable" xml:space="preserve"><value>API WebAuthn disponible</value></data>
+  <data name="WebAuthnProbe_PlatformAvailable" xml:space="preserve"><value>Authentificateur de plateforme disponible</value></data>
+  <data name="WebAuthnProbe_CreateSucceeded" xml:space="preserve"><value>CREATE réussi</value></data>
+  <data name="WebAuthnProbe_CreatePrfEnabled" xml:space="preserve"><value>PRF activée lors de CREATE</value></data>
+  <data name="WebAuthnProbe_CreatePrfResult" xml:space="preserve"><value>Résultat PRF lors de CREATE</value></data>
+  <data name="WebAuthnProbe_ImmediateGetSucceeded" xml:space="preserve"><value>GET immédiat réussi</value></data>
+  <data name="WebAuthnProbe_GetSucceeded" xml:space="preserve"><value>GET réussi</value></data>
+  <data name="WebAuthnProbe_UserVerified" xml:space="preserve"><value>Vérification de l’utilisateur confirmée</value></data>
+  <data name="WebAuthnProbe_GetPrfReported" xml:space="preserve"><value>Extension PRF indiquée lors de GET</value></data>
+  <data name="WebAuthnProbe_GetPrfResult" xml:space="preserve"><value>Résultat PRF lors de GET</value></data>
+  <data name="WebAuthnProbe_PayloadVerified" xml:space="preserve"><value>Contenu inoffensif déchiffré</value></data>
+  <data name="WebAuthnProbe_OfflineAtInvocation" xml:space="preserve"><value>Hors ligne lors du lancement</value></data>
+  <data name="WebAuthnProbe_Outcome" xml:space="preserve"><value>Résultat</value></data>
+  <data name="WebAuthnProbe_Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="WebAuthnProbe_No" xml:space="preserve"><value>Non</value></data>
+  <data name="WebAuthnProbe_NotReported" xml:space="preserve"><value>Non indiqué</value></data>
+  <data name="WebAuthnProbe_Outcome_unknown" xml:space="preserve"><value>Non exécuté</value></data>
+  <data name="WebAuthnProbe_Outcome_ready" xml:space="preserve"><value>Prêt</value></data>
+  <data name="WebAuthnProbe_Outcome_unsupported" xml:space="preserve"><value>WebAuthn n’est pas pris en charge</value></data>
+  <data name="WebAuthnProbe_Outcome_platform-unavailable" xml:space="preserve"><value>Aucun authentificateur de plateforme n’est disponible</value></data>
+  <data name="WebAuthnProbe_Outcome_provisioned" xml:space="preserve"><value>Configuration terminée</value></data>
+  <data name="WebAuthnProbe_Outcome_verified-online" xml:space="preserve"><value>Vérification en ligne terminée</value></data>
+  <data name="WebAuthnProbe_Outcome_retrieved" xml:space="preserve"><value>Récupération de l’identifiant terminée</value></data>
+  <data name="WebAuthnProbe_Outcome_missing-metadata" xml:space="preserve"><value>Aucune métadonnée de test n’est enregistrée</value></data>
+  <data name="WebAuthnProbe_Outcome_cancelled" xml:space="preserve"><value>L’authentification de l’appareil a été annulée</value></data>
+  <data name="WebAuthnProbe_Outcome_failed" xml:space="preserve"><value>Le test de capacité a échoué</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -731,4 +731,44 @@
   <data name="Update_StatusLabel" xml:space="preserve"><value>Update</value></data>
   <data name="Update_StatusCurrent" xml:space="preserve"><value>Up to date</value></data>
   <data name="Update_StatusAvailable" xml:space="preserve"><value>New version available</value></data>
+  <data name="WebAuthnProbe_PageTitle" xml:space="preserve"><value>WebAuthn capability probe</value></data>
+  <data name="WebAuthnProbe_Title" xml:space="preserve"><value>Offline device unlock capability probe</value></data>
+  <data name="WebAuthnProbe_Scope" xml:space="preserve"><value>This disposable diagnostic checks device authentication only. It cannot sign you in, access fishing data or call the API.</value></data>
+  <data name="WebAuthnProbe_ProvisionTitle" xml:space="preserve"><value>Provision while online</value></data>
+  <data name="WebAuthnProbe_ProvisionBody" xml:space="preserve"><value>Run this inside the installed app while online. First create the test credential, then tap Verify online credential so each device-authentication request has its own explicit action.</value></data>
+  <data name="WebAuthnProbe_ProvisionAction" xml:space="preserve"><value>Provision test credential</value></data>
+  <data name="WebAuthnProbe_VerifyOnlineAction" xml:space="preserve"><value>Verify online credential</value></data>
+  <data name="WebAuthnProbe_OfflineTitle" xml:space="preserve"><value>Test after a cold offline start</value></data>
+  <data name="WebAuthnProbe_OfflineBody" xml:space="preserve"><value>Kill the installed app, enable Airplane Mode, reopen it from the app icon, return here from Landing, then tap the button. Device authentication never starts automatically.</value></data>
+  <data name="WebAuthnProbe_OfflineAction" xml:space="preserve"><value>Test offline device unlock</value></data>
+  <data name="WebAuthnProbe_OpenAction" xml:space="preserve"><value>Open device unlock capability probe</value></data>
+  <data name="WebAuthnProbe_CleanupNote" xml:space="preserve"><value>Removing probe metadata removes only this app’s harmless test values. The test passkey may need to be removed manually from Apple Passwords, Google Password Manager or your device credential settings.</value></data>
+  <data name="WebAuthnProbe_RemoveMetadataAction" xml:space="preserve"><value>Remove probe metadata</value></data>
+  <data name="WebAuthnProbe_LeaveAction" xml:space="preserve"><value>Leave probe</value></data>
+  <data name="WebAuthnProbe_WebAuthnAvailable" xml:space="preserve"><value>WebAuthn API available</value></data>
+  <data name="WebAuthnProbe_PlatformAvailable" xml:space="preserve"><value>Platform authenticator available</value></data>
+  <data name="WebAuthnProbe_CreateSucceeded" xml:space="preserve"><value>CREATE succeeded</value></data>
+  <data name="WebAuthnProbe_CreatePrfEnabled" xml:space="preserve"><value>PRF enabled on CREATE</value></data>
+  <data name="WebAuthnProbe_CreatePrfResult" xml:space="preserve"><value>PRF result on CREATE</value></data>
+  <data name="WebAuthnProbe_ImmediateGetSucceeded" xml:space="preserve"><value>Immediate GET succeeded</value></data>
+  <data name="WebAuthnProbe_GetSucceeded" xml:space="preserve"><value>GET succeeded</value></data>
+  <data name="WebAuthnProbe_UserVerified" xml:space="preserve"><value>User verification true</value></data>
+  <data name="WebAuthnProbe_GetPrfReported" xml:space="preserve"><value>PRF extension reported on GET</value></data>
+  <data name="WebAuthnProbe_GetPrfResult" xml:space="preserve"><value>PRF result on GET</value></data>
+  <data name="WebAuthnProbe_PayloadVerified" xml:space="preserve"><value>Harmless payload decrypted</value></data>
+  <data name="WebAuthnProbe_OfflineAtInvocation" xml:space="preserve"><value>Offline at invocation</value></data>
+  <data name="WebAuthnProbe_Outcome" xml:space="preserve"><value>Outcome</value></data>
+  <data name="WebAuthnProbe_Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="WebAuthnProbe_No" xml:space="preserve"><value>No</value></data>
+  <data name="WebAuthnProbe_NotReported" xml:space="preserve"><value>Not reported</value></data>
+  <data name="WebAuthnProbe_Outcome_unknown" xml:space="preserve"><value>Not run</value></data>
+  <data name="WebAuthnProbe_Outcome_ready" xml:space="preserve"><value>Ready</value></data>
+  <data name="WebAuthnProbe_Outcome_unsupported" xml:space="preserve"><value>WebAuthn is not supported</value></data>
+  <data name="WebAuthnProbe_Outcome_platform-unavailable" xml:space="preserve"><value>No platform authenticator is available</value></data>
+  <data name="WebAuthnProbe_Outcome_provisioned" xml:space="preserve"><value>Provisioning completed</value></data>
+  <data name="WebAuthnProbe_Outcome_verified-online" xml:space="preserve"><value>Online verification completed</value></data>
+  <data name="WebAuthnProbe_Outcome_retrieved" xml:space="preserve"><value>Credential retrieval completed</value></data>
+  <data name="WebAuthnProbe_Outcome_missing-metadata" xml:space="preserve"><value>No probe metadata is stored</value></data>
+  <data name="WebAuthnProbe_Outcome_cancelled" xml:space="preserve"><value>Device authentication was cancelled</value></data>
+  <data name="WebAuthnProbe_Outcome_failed" xml:space="preserve"><value>The capability check failed</value></data>
 </root>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IDiagnosticEventStore, IndexedDbDiagnosticEventStore>();
         services.AddScoped<IDiagnosticLogger, DiagnosticLogger>();
         services.AddScoped<IDiagnosticSynchroniser, DiagnosticSynchroniser>();
+        services.AddScoped<IWebAuthnCapabilityProbeService, WebAuthnCapabilityProbeService>();
         services.AddLocalization();
         services.AddScoped<ICatalogueLocalizer, CatalogueLocalizer>();
         services.AddScoped<ICultureService, CultureService>();

--- a/src/FishingLogBook.Web/wwwroot/js/browser/webauthn-capability-probe.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/webauthn-capability-probe.js
@@ -1,0 +1,333 @@
+const storageKey = 'fishingLogBook.webAuthnCapabilityProbe.v1';
+const payload = new TextEncoder().encode('cbdf-webauthn-capability-probe');
+
+const outcomes = Object.freeze({
+    unknown: 'unknown',
+    ready: 'ready',
+    unsupported: 'unsupported',
+    platformUnavailable: 'platform-unavailable',
+    provisioned: 'provisioned',
+    verifiedOnline: 'verified-online',
+    retrieved: 'retrieved',
+    missingMetadata: 'missing-metadata',
+    cancelled: 'cancelled',
+    failed: 'failed'
+});
+
+function emptyResult(outcome = outcomes.unknown) {
+    return {
+        webAuthnAvailable: isWebAuthnAvailable(),
+        platformAuthenticatorAvailable: null,
+        isOnlineAtInvocation: navigator.onLine,
+        hasProbeMetadata: hasProbeMetadata(),
+        credentialCreated: false,
+        createPrfEnabled: null,
+        createPrfResultReturned: false,
+        getSucceeded: false,
+        userVerified: false,
+        getPrfExtensionReported: false,
+        getPrfResultReturned: false,
+        testPayloadVerified: false,
+        outcome
+    };
+}
+
+function isWebAuthnAvailable() {
+    return typeof PublicKeyCredential !== 'undefined'
+        && typeof navigator.credentials?.create === 'function'
+        && typeof navigator.credentials?.get === 'function';
+}
+
+export function hasProbeMetadata() {
+    return localStorage.getItem(storageKey) !== null;
+}
+
+async function platformAuthenticatorAvailable() {
+    if (!isWebAuthnAvailable()
+        || typeof PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable !== 'function') {
+        return null;
+    }
+
+    return await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+}
+
+function randomBytes(length) {
+    return crypto.getRandomValues(new Uint8Array(length));
+}
+
+function toBase64Url(value) {
+    let binary = '';
+    for (const byte of new Uint8Array(value)) {
+        binary += String.fromCharCode(byte);
+    }
+
+    return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function fromBase64Url(value) {
+    const padded = value.replaceAll('-', '+').replaceAll('_', '/')
+        .padEnd(Math.ceil(value.length / 4) * 4, '=');
+    const binary = atob(padded);
+    return Uint8Array.from(binary, character => character.charCodeAt(0));
+}
+
+function getPrfDetails(credential) {
+    const prf = credential.getClientExtensionResults?.().prf;
+    const first = prf?.results?.first;
+    return {
+        reported: prf !== undefined,
+        enabled: typeof prf?.enabled === 'boolean' ? prf.enabled : null,
+        result: first instanceof ArrayBuffer
+            ? new Uint8Array(first)
+            : ArrayBuffer.isView(first)
+                ? new Uint8Array(first.buffer, first.byteOffset, first.byteLength)
+                : null
+    };
+}
+
+function userVerified(assertion) {
+    const authenticatorData = new Uint8Array(assertion.response.authenticatorData);
+    return authenticatorData.length > 32 && (authenticatorData[32] & 0x04) !== 0;
+}
+
+function readMetadata() {
+    const stored = localStorage.getItem(storageKey);
+    if (stored === null) {
+        return null;
+    }
+
+    try {
+        const metadata = JSON.parse(stored);
+        if (metadata.version !== 1
+            || typeof metadata.credentialId !== 'string'
+            || typeof metadata.prfSalt !== 'string') {
+            return null;
+        }
+
+        return metadata;
+    } catch {
+        return null;
+    }
+}
+
+function writeMetadata(metadata) {
+    localStorage.setItem(storageKey, JSON.stringify(metadata));
+}
+
+async function createPayloadEnvelope(prfResult) {
+    const key = await crypto.subtle.importKey('raw', prfResult, 'AES-GCM', false, ['encrypt', 'decrypt']);
+    const iv = randomBytes(12);
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, payload);
+    const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+    const verified = new TextDecoder().decode(plaintext) === new TextDecoder().decode(payload);
+
+    return {
+        iv: toBase64Url(iv),
+        ciphertext: toBase64Url(ciphertext),
+        verified
+    };
+}
+
+async function verifyPayloadEnvelope(metadata, prfResult) {
+    if (typeof metadata.iv !== 'string' || typeof metadata.ciphertext !== 'string') {
+        return false;
+    }
+
+    try {
+        const key = await crypto.subtle.importKey('raw', prfResult, 'AES-GCM', false, ['decrypt']);
+        const plaintext = await crypto.subtle.decrypt(
+            { name: 'AES-GCM', iv: fromBase64Url(metadata.iv) },
+            key,
+            fromBase64Url(metadata.ciphertext));
+        return new TextDecoder().decode(plaintext) === new TextDecoder().decode(payload);
+    } catch {
+        return false;
+    }
+}
+
+async function getCredential(metadata) {
+    return await navigator.credentials.get({
+        publicKey: {
+            challenge: randomBytes(32),
+            allowCredentials: [{
+                id: fromBase64Url(metadata.credentialId),
+                type: 'public-key',
+                transports: Array.isArray(metadata.transports) ? metadata.transports : undefined
+            }],
+            userVerification: 'required',
+            timeout: 60000,
+            extensions: {
+                prf: {
+                    eval: { first: fromBase64Url(metadata.prfSalt) }
+                }
+            }
+        }
+    });
+}
+
+function failureOutcome(error) {
+    return error?.name === 'NotAllowedError' ? outcomes.cancelled : outcomes.failed;
+}
+
+export async function getProbeStatus() {
+    const result = emptyResult(isWebAuthnAvailable() ? outcomes.ready : outcomes.unsupported);
+    try {
+        result.platformAuthenticatorAvailable = await platformAuthenticatorAvailable();
+    } catch {
+        result.platformAuthenticatorAvailable = null;
+    }
+
+    return result;
+}
+
+export async function provisionTestCredential() {
+    const result = emptyResult();
+    if (!result.webAuthnAvailable) {
+        result.outcome = outcomes.unsupported;
+        return result;
+    }
+
+    try {
+        result.platformAuthenticatorAvailable = await platformAuthenticatorAvailable();
+        if (result.platformAuthenticatorAvailable === false) {
+            result.outcome = outcomes.platformUnavailable;
+            return result;
+        }
+
+        const prfSalt = randomBytes(32);
+        const credential = await navigator.credentials.create({
+            publicKey: {
+                challenge: randomBytes(32),
+                rp: { name: 'Catch But Don’t Forget' },
+                user: {
+                    id: randomBytes(32),
+                    name: 'webauthn-capability-probe',
+                    displayName: 'WebAuthn capability probe'
+                },
+                pubKeyCredParams: [
+                    { type: 'public-key', alg: -7 },
+                    { type: 'public-key', alg: -257 }
+                ],
+                authenticatorSelection: {
+                    authenticatorAttachment: 'platform',
+                    residentKey: 'preferred',
+                    userVerification: 'required'
+                },
+                timeout: 60000,
+                attestation: 'none',
+                extensions: {
+                    prf: { eval: { first: prfSalt } }
+                }
+            }
+        });
+
+        if (credential === null) {
+            result.outcome = outcomes.failed;
+            return result;
+        }
+
+        result.credentialCreated = true;
+        const createPrf = getPrfDetails(credential);
+        result.createPrfEnabled = createPrf.enabled;
+        result.createPrfResultReturned = createPrf.result !== null;
+
+        const metadata = {
+            version: 1,
+            credentialId: toBase64Url(credential.rawId),
+            prfSalt: toBase64Url(prfSalt),
+            transports: credential.response.getTransports?.() ?? []
+        };
+        writeMetadata(metadata);
+        result.hasProbeMetadata = true;
+
+        result.outcome = outcomes.provisioned;
+        return result;
+    } catch (error) {
+        result.hasProbeMetadata = hasProbeMetadata();
+        result.outcome = failureOutcome(error);
+        return result;
+    }
+}
+
+export async function verifyOnlineCredential() {
+    const result = emptyResult();
+    if (!result.webAuthnAvailable) {
+        result.outcome = outcomes.unsupported;
+        return result;
+    }
+
+    const metadata = readMetadata();
+    if (metadata === null) {
+        result.outcome = outcomes.missingMetadata;
+        return result;
+    }
+
+    try {
+        result.platformAuthenticatorAvailable = await platformAuthenticatorAvailable();
+        const assertion = await getCredential(metadata);
+        if (assertion === null) {
+            result.outcome = outcomes.failed;
+            return result;
+        }
+
+        result.getSucceeded = true;
+        result.userVerified = userVerified(assertion);
+        const getPrf = getPrfDetails(assertion);
+        result.getPrfExtensionReported = getPrf.reported;
+        result.getPrfResultReturned = getPrf.result !== null;
+
+        if (getPrf.result !== null) {
+            const envelope = await createPayloadEnvelope(getPrf.result);
+            metadata.iv = envelope.iv;
+            metadata.ciphertext = envelope.ciphertext;
+            writeMetadata(metadata);
+            result.testPayloadVerified = envelope.verified;
+        }
+
+        result.outcome = outcomes.verifiedOnline;
+        return result;
+    } catch (error) {
+        result.outcome = failureOutcome(error);
+        return result;
+    }
+}
+
+export async function testOfflineUnlock() {
+    const result = emptyResult();
+    if (!result.webAuthnAvailable) {
+        result.outcome = outcomes.unsupported;
+        return result;
+    }
+
+    const metadata = readMetadata();
+    if (metadata === null) {
+        result.outcome = outcomes.missingMetadata;
+        return result;
+    }
+
+    try {
+        result.platformAuthenticatorAvailable = await platformAuthenticatorAvailable();
+        const assertion = await getCredential(metadata);
+        if (assertion === null) {
+            result.outcome = outcomes.failed;
+            return result;
+        }
+
+        result.getSucceeded = true;
+        result.userVerified = userVerified(assertion);
+        const getPrf = getPrfDetails(assertion);
+        result.getPrfExtensionReported = getPrf.reported;
+        result.getPrfResultReturned = getPrf.result !== null;
+        result.testPayloadVerified = getPrf.result !== null
+            && await verifyPayloadEnvelope(metadata, getPrf.result);
+        result.outcome = outcomes.retrieved;
+        return result;
+    } catch (error) {
+        result.outcome = failureOutcome(error);
+        return result;
+    }
+}
+
+export function removeProbeMetadata() {
+    localStorage.removeItem(storageKey);
+}

--- a/src/FishingLogBook.Web/wwwroot/js/browser/webauthn-capability-probe.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/webauthn-capability-probe.test.js
@@ -1,0 +1,238 @@
+import { webcrypto } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    getProbeStatus,
+    provisionTestCredential,
+    removeProbeMetadata,
+    testOfflineUnlock,
+    verifyOnlineCredential
+} from './webauthn-capability-probe.js';
+
+function prfResult(value = 7) {
+    return new Uint8Array(32).fill(value).buffer;
+}
+
+function authenticatorData(verified = true) {
+    const value = new Uint8Array(33);
+    value[32] = verified ? 0x05 : 0x01;
+    return value.buffer;
+}
+
+function createdCredential({ enabled = true, result = null } = {}) {
+    return {
+        rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+        response: { getTransports: () => ['internal'] },
+        getClientExtensionResults: () => ({
+            prf: {
+                enabled,
+                ...(result === null ? {} : { results: { first: result } })
+            }
+        })
+    };
+}
+
+function assertion({ verified = true, result = prfResult() } = {}) {
+    return {
+        response: { authenticatorData: authenticatorData(verified) },
+        getClientExtensionResults: () => ({
+            prf: result === null ? {} : { results: { first: result } }
+        })
+    };
+}
+
+function configureWebAuthn({ platform = true, create, get } = {}) {
+    class TestPublicKeyCredential {
+        static isUserVerifyingPlatformAuthenticatorAvailable = vi.fn(async () => platform);
+    }
+
+    vi.stubGlobal('PublicKeyCredential', TestPublicKeyCredential);
+    Object.defineProperty(navigator, 'credentials', {
+        configurable: true,
+        value: {
+            create: create ?? vi.fn(async () => createdCredential()),
+            get: get ?? vi.fn(async () => assertion())
+        }
+    });
+}
+
+function setOnline(value) {
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value });
+}
+
+describe('WebAuthn capability probe', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.stubGlobal('crypto', webcrypto);
+        setOnline(true);
+        configureWebAuthn();
+    });
+
+    it('reports an unsupported browser without invoking a credential ceremony', async () => {
+        vi.stubGlobal('PublicKeyCredential', undefined);
+
+        const result = await getProbeStatus();
+
+        expect(result.webAuthnAvailable).toBe(false);
+        expect(result.outcome).toBe('unsupported');
+        expect(result.platformAuthenticatorAvailable).toBeNull();
+    });
+
+    it('stops before CREATE when no platform authenticator is available', async () => {
+        const create = vi.fn();
+        configureWebAuthn({ platform: false, create });
+
+        const result = await provisionTestCredential();
+
+        expect(result.outcome).toBe('platform-unavailable');
+        expect(result.platformAuthenticatorAvailable).toBe(false);
+        expect(create).not.toHaveBeenCalled();
+    });
+
+    it('records CREATE capability without automatically invoking GET', async () => {
+        const create = vi.fn(async () => createdCredential({ enabled: true, result: null }));
+        const get = vi.fn(async () => assertion());
+        configureWebAuthn({ create, get });
+
+        const result = await provisionTestCredential();
+
+        expect(result.credentialCreated).toBe(true);
+        expect(result.createPrfEnabled).toBe(true);
+        expect(result.createPrfResultReturned).toBe(false);
+        expect(result.getSucceeded).toBe(false);
+        expect(create).toHaveBeenCalledTimes(1);
+        expect(get).not.toHaveBeenCalled();
+        expect(create.mock.calls[0][0].publicKey.authenticatorSelection.userVerification).toBe('required');
+    });
+
+    it('reports CREATE PRF result bytes without returning or storing them', async () => {
+        const secret = prfResult(99);
+        const consoleSpies = [
+            vi.spyOn(console, 'log'),
+            vi.spyOn(console, 'info'),
+            vi.spyOn(console, 'warn'),
+            vi.spyOn(console, 'error')
+        ];
+        configureWebAuthn({
+            create: vi.fn(async () => createdCredential({ result: secret })),
+            get: vi.fn(async () => assertion({ result: secret }))
+        });
+
+        const result = await provisionTestCredential();
+        const verified = await verifyOnlineCredential();
+        const stored = JSON.parse(localStorage.getItem(localStorage.key(0)));
+
+        expect(result.createPrfResultReturned).toBe(true);
+        expect(JSON.stringify(result)).not.toContain('99');
+        expect(JSON.stringify(verified)).not.toContain('99');
+        expect(Object.keys(stored).sort()).toEqual([
+            'ciphertext', 'credentialId', 'iv', 'prfSalt', 'transports', 'version'
+        ]);
+        expect(stored).not.toHaveProperty('prfResult');
+        for (const spy of consoleSpies) {
+            expect(spy).not.toHaveBeenCalled();
+        }
+    });
+
+    it('verifies online GET and encrypts the harmless payload after a separate explicit call', async () => {
+        const get = vi.fn(async () => assertion());
+        configureWebAuthn({ get });
+        await provisionTestCredential();
+
+        const result = await verifyOnlineCredential();
+
+        expect(result.getSucceeded).toBe(true);
+        expect(result.userVerified).toBe(true);
+        expect(result.getPrfExtensionReported).toBe(true);
+        expect(result.getPrfResultReturned).toBe(true);
+        expect(result.testPayloadVerified).toBe(true);
+        expect(result.outcome).toBe('verified-online');
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(get.mock.calls[0][0].publicKey.userVerification).toBe('required');
+    });
+
+    it('preserves metadata but reports missing PRF when online GET has no result', async () => {
+        configureWebAuthn({ get: vi.fn(async () => assertion({ result: null })) });
+        await provisionTestCredential();
+
+        const result = await verifyOnlineCredential();
+
+        expect(result.outcome).toBe('verified-online');
+        expect(result.hasProbeMetadata).toBe(true);
+        expect(result.getPrfResultReturned).toBe(false);
+        expect(result.testPayloadVerified).toBe(false);
+        expect(localStorage.length).toBe(1);
+    });
+
+    it('treats user cancellation as a normal allow-listed result', async () => {
+        const cancelled = new DOMException('private browser message', 'NotAllowedError');
+        configureWebAuthn({ create: vi.fn(async () => { throw cancelled; }) });
+
+        const result = await provisionTestCredential();
+
+        expect(result.outcome).toBe('cancelled');
+        expect(JSON.stringify(result)).not.toContain('private browser message');
+    });
+
+    it('retrieves and decrypts the harmless payload while offline after provisioning', async () => {
+        const get = vi.fn(async () => assertion());
+        configureWebAuthn({ get });
+        await provisionTestCredential();
+        await verifyOnlineCredential();
+        setOnline(false);
+
+        const result = await testOfflineUnlock();
+
+        expect(result.isOnlineAtInvocation).toBe(false);
+        expect(result.getSucceeded).toBe(true);
+        expect(result.userVerified).toBe(true);
+        expect(result.getPrfResultReturned).toBe(true);
+        expect(result.testPayloadVerified).toBe(true);
+        expect(result.outcome).toBe('retrieved');
+        expect(get).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports missing metadata without invoking GET', async () => {
+        const get = vi.fn();
+        configureWebAuthn({ get });
+
+        const result = await testOfflineUnlock();
+
+        expect(result.outcome).toBe('missing-metadata');
+        expect(get).not.toHaveBeenCalled();
+    });
+
+    it('reports an offline retrieval failure without exposing the browser error', async () => {
+        await provisionTestCredential();
+        const get = vi.fn(async () => { throw new Error('sensitive authenticator detail'); });
+        configureWebAuthn({ get });
+        setOnline(false);
+
+        const result = await testOfflineUnlock();
+
+        expect(result.outcome).toBe('failed');
+        expect(result.getSucceeded).toBe(false);
+        expect(JSON.stringify(result)).not.toContain('sensitive authenticator detail');
+    });
+
+    it('reports a successful assertion without claiming user verification when UV is absent', async () => {
+        await provisionTestCredential();
+        configureWebAuthn({ get: vi.fn(async () => assertion({ verified: false })) });
+
+        const result = await verifyOnlineCredential();
+
+        expect(result.getSucceeded).toBe(true);
+        expect(result.userVerified).toBe(false);
+    });
+
+    it('removes only the probe metadata owned by the module', async () => {
+        localStorage.setItem('unrelated', 'keep');
+        await provisionTestCredential();
+
+        removeProbeMetadata();
+
+        expect(localStorage.getItem('unrelated')).toBe('keep');
+        expect((await getProbeStatus()).hasProbeMetadata).toBe(false);
+    });
+});

--- a/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/DiagnosticsInspectorTests/WhenTestingProbe.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/DiagnosticsInspectorTests/WhenTestingProbe.cs
@@ -34,6 +34,8 @@ public class WhenTestingProbe : BaseDiagnosticsInspectorTest
                 .Contain(DiagnosticsInspector.StageCountReturned);
             cut.Find("#retry-diagnostics-probe-button").TextContent.Should()
                 .Contain("Retry diagnostic probe");
+            cut.Find("#webauthn-capability-probe-link").GetAttribute("href").Should()
+                .Be("/diagnostics/webauthn-capability-probe");
         });
         await store.Received(1).InspectExistingAsync(Arg.Any<CancellationToken>());
         await store.DidNotReceive().EnqueueAsync(Arg.Any<DiagnosticEventModel>(), Arg.Any<CancellationToken>());

--- a/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/WebAuthnCapabilityProbeTests/BaseWebAuthnCapabilityProbeTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/WebAuthnCapabilityProbeTests/BaseWebAuthnCapabilityProbeTest.cs
@@ -1,0 +1,34 @@
+using Bunit;
+using FishingLogBook.Web.Features.Diagnostics.Models;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Diagnostics.Pages.WebAuthnCapabilityProbeTests;
+
+public class BaseWebAuthnCapabilityProbeTest
+{
+    protected static BunitContext CreateContext(
+        IWebAuthnCapabilityProbeService probe,
+        WebAuthnCapabilityProbeResultModel? status = null)
+    {
+        probe.GetStatusAsync(Arg.Any<CancellationToken>()).Returns(status ?? new WebAuthnCapabilityProbeResultModel
+        {
+            WebAuthnAvailable = true,
+            PlatformAuthenticatorAvailable = true,
+            HasProbeMetadata = true,
+            Outcome = "ready"
+        });
+
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(probe);
+        context.Services.AddSingleton(Substitute.For<ICultureService>());
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/WebAuthnCapabilityProbeTests/WhenTestingProbe.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/WebAuthnCapabilityProbeTests/WhenTestingProbe.cs
@@ -1,0 +1,148 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Diagnostics.Models;
+using FishingLogBook.Web.Features.Diagnostics.Pages.WebAuthnCapabilityProbe;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Diagnostics.Pages.WebAuthnCapabilityProbeTests;
+
+public class WhenTestingProbe : BaseWebAuthnCapabilityProbeTest
+{
+    [Fact]
+    public void ItShouldRemainAnAnonymousDiagnosticRoute()
+    {
+        // Arrange
+        var component = typeof(WebAuthnCapabilityProbe);
+
+        // Act
+        var authorisation = component.GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true);
+
+        // Assert
+        authorisation.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotRunAnyCredentialCeremonyUntilTheUserTapsAButton()
+    {
+        // Arrange
+        var probe = Substitute.For<IWebAuthnCapabilityProbeService>();
+        await using var context = CreateContext(probe);
+
+        // Act
+        context.Render<WebAuthnCapabilityProbe>();
+
+        // Assert
+        await probe.Received(1).GetStatusAsync(Arg.Any<CancellationToken>());
+        await probe.DidNotReceive().ProvisionAsync(Arg.Any<CancellationToken>());
+        await probe.DidNotReceive().VerifyOnlineAsync(Arg.Any<CancellationToken>());
+        await probe.DidNotReceive().TestOfflineUnlockAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRenderCreateAndOnlineGetResultsSeparately()
+    {
+        // Arrange
+        var probe = Substitute.For<IWebAuthnCapabilityProbeService>();
+        probe.ProvisionAsync(Arg.Any<CancellationToken>()).Returns(new WebAuthnCapabilityProbeResultModel
+        {
+            WebAuthnAvailable = true,
+            PlatformAuthenticatorAvailable = true,
+            HasProbeMetadata = true,
+            CredentialCreated = true,
+            CreatePrfEnabled = true,
+            CreatePrfResultReturned = false,
+            Outcome = "provisioned"
+        });
+        probe.VerifyOnlineAsync(Arg.Any<CancellationToken>()).Returns(new WebAuthnCapabilityProbeResultModel
+        {
+            HasProbeMetadata = true,
+            GetSucceeded = true,
+            UserVerified = true,
+            GetPrfExtensionReported = true,
+            GetPrfResultReturned = true,
+            TestPayloadVerified = true,
+            Outcome = "verified-online"
+        });
+        await using var context = CreateContext(probe);
+        var cut = context.Render<WebAuthnCapabilityProbe>();
+
+        // Act
+        await cut.Find("#provision-webauthn-probe-button").ClickAsync();
+
+        // Assert
+        var createResults = cut.Find("#webauthn-provision-results").TextContent;
+        createResults.Should().Contain("PRF enabled on CREATE");
+        createResults.Should().Contain("PRF result on CREATE");
+        await probe.Received(1).ProvisionAsync(Arg.Any<CancellationToken>());
+
+        // Act
+        await cut.Find("#verify-online-webauthn-probe-button").ClickAsync();
+
+        // Assert
+        var getResults = cut.Find("#webauthn-online-verification-results").TextContent;
+        getResults.Should().Contain("Immediate GET succeeded");
+        getResults.Should().Contain("PRF extension reported on GET");
+        getResults.Should().Contain("Harmless payload decrypted");
+        await probe.Received(1).VerifyOnlineAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldTreatCancellationAsAReportedNonFatalOutcome()
+    {
+        // Arrange
+        var probe = Substitute.For<IWebAuthnCapabilityProbeService>();
+        probe.TestOfflineUnlockAsync(Arg.Any<CancellationToken>()).Returns(new WebAuthnCapabilityProbeResultModel
+        {
+            HasProbeMetadata = true,
+            Outcome = "cancelled"
+        });
+        await using var context = CreateContext(probe);
+        var cut = context.Render<WebAuthnCapabilityProbe>();
+
+        // Act
+        await cut.Find("#test-offline-webauthn-button").ClickAsync();
+
+        // Assert
+        cut.Find("#webauthn-offline-results").TextContent
+            .Should().Contain("Device authentication was cancelled");
+    }
+
+    [Fact]
+    public async Task ItShouldLocaliseTheProbeAndManualCredentialCleanupGuidance()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(FishingLogBook.Web.Localization.CultureNames.French);
+        var probe = Substitute.For<IWebAuthnCapabilityProbeService>();
+        await using var context = CreateContext(probe);
+
+        // Act
+        var cut = context.Render<WebAuthnCapabilityProbe>();
+
+        // Assert
+        cut.Find("#webauthn-probe-title").TextContent
+            .Should().Contain("Test de capacité de déverrouillage hors ligne");
+        cut.Find("#webauthn-probe-cleanup-note").TextContent.Should().Contain("Google Password Manager");
+    }
+
+    [Fact]
+    public async Task ItShouldRemoveOnlyProbeMetadataAfterExplicitAction()
+    {
+        // Arrange
+        var probe = Substitute.For<IWebAuthnCapabilityProbeService>();
+        await using var context = CreateContext(probe);
+        probe.GetStatusAsync(Arg.Any<CancellationToken>()).Returns(
+            new WebAuthnCapabilityProbeResultModel { HasProbeMetadata = true, Outcome = "ready" },
+            new WebAuthnCapabilityProbeResultModel { HasProbeMetadata = false, Outcome = "ready" });
+        var cut = context.Render<WebAuthnCapabilityProbe>();
+
+        // Act
+        await cut.Find("#remove-webauthn-probe-metadata-button").ClickAsync();
+
+        // Assert
+        await probe.Received(1).RemoveMetadataAsync(Arg.Any<CancellationToken>());
+        await probe.Received(2).GetStatusAsync(Arg.Any<CancellationToken>());
+        cut.Find("#remove-webauthn-probe-metadata-button").HasAttribute("disabled").Should().BeTrue();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Services/WebAuthnCapabilityProbeServiceTests/WhenTestingInterop.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Services/WebAuthnCapabilityProbeServiceTests/WhenTestingInterop.cs
@@ -1,0 +1,46 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.Diagnostics.Models;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Tests.Features.Diagnostics.TestSupport;
+
+namespace FishingLogBook.Web.Tests.Features.Diagnostics.Services.WebAuthnCapabilityProbeServiceTests;
+
+public class WhenTestingInterop
+{
+    [Fact]
+    public async Task ItShouldMapEachOperationToTheIsolatedBrowserModule()
+    {
+        // Arrange
+        var js = new FakeWebAuthnCapabilityProbeJsRuntime
+        {
+            HasMetadata = true,
+            Status = new WebAuthnCapabilityProbeResultModel { Outcome = "ready" },
+            ProvisionResult = new WebAuthnCapabilityProbeResultModel { Outcome = "provisioned" },
+            OnlineVerificationResult = new WebAuthnCapabilityProbeResultModel { Outcome = "verified-online" },
+            OfflineResult = new WebAuthnCapabilityProbeResultModel { Outcome = "retrieved" }
+        };
+        var sut = new WebAuthnCapabilityProbeService(js);
+
+        // Act
+        var hasMetadata = await sut.HasMetadataAsync(CancellationToken.None);
+        var status = await sut.GetStatusAsync(CancellationToken.None);
+        var provisioned = await sut.ProvisionAsync(CancellationToken.None);
+        var verifiedOnline = await sut.VerifyOnlineAsync(CancellationToken.None);
+        var retrieved = await sut.TestOfflineUnlockAsync(CancellationToken.None);
+        await sut.RemoveMetadataAsync(CancellationToken.None);
+
+        // Assert
+        hasMetadata.Should().BeTrue();
+        status.Outcome.Should().Be("ready");
+        provisioned.Outcome.Should().Be("provisioned");
+        verifiedOnline.Outcome.Should().Be("verified-online");
+        retrieved.Outcome.Should().Be("retrieved");
+        js.Invocations.Should().Equal(
+            "import", "hasProbeMetadata",
+            "import", "getProbeStatus",
+            "import", "provisionTestCredential",
+            "import", "verifyOnlineCredential",
+            "import", "testOfflineUnlock",
+            "import", "removeProbeMetadata");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Diagnostics/TestSupport/FakeWebAuthnCapabilityProbeJsRuntime.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Diagnostics/TestSupport/FakeWebAuthnCapabilityProbeJsRuntime.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using FishingLogBook.Web.Features.Diagnostics.Models;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Tests.Features.Diagnostics.TestSupport;
+
+public sealed class FakeWebAuthnCapabilityProbeJsRuntime : IJSRuntime, IJSObjectReference
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    public WebAuthnCapabilityProbeResultModel Status { get; set; } = new();
+
+    public WebAuthnCapabilityProbeResultModel ProvisionResult { get; set; } = new();
+
+    public WebAuthnCapabilityProbeResultModel OfflineResult { get; set; } = new();
+
+    public WebAuthnCapabilityProbeResultModel OnlineVerificationResult { get; set; } = new();
+
+    public bool HasMetadata { get; set; }
+
+    public List<string> Invocations { get; } = [];
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+        return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(
+        string identifier,
+        CancellationToken cancellationToken,
+        object?[]? args)
+    {
+        Invocations.Add(identifier);
+        if (identifier == "import")
+        {
+            return new ValueTask<TValue>((TValue)(object)this);
+        }
+
+        object? result = identifier switch
+        {
+            "getProbeStatus" => Status,
+            "hasProbeMetadata" => HasMetadata,
+            "provisionTestCredential" => ProvisionResult,
+            "verifyOnlineCredential" => OnlineVerificationResult,
+            "testOfflineUnlock" => OfflineResult,
+            "removeProbeMetadata" => null,
+            _ => throw new InvalidOperationException(identifier)
+        };
+
+        if (result is null)
+        {
+            return new ValueTask<TValue>(default(TValue)!);
+        }
+
+        var json = JsonSerializer.Serialize(result, Options);
+        return new ValueTask<TValue>(JsonSerializer.Deserialize<TValue>(json, Options)!);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/BaseLandingTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/BaseLandingTest.cs
@@ -1,5 +1,6 @@
 using Bunit;
 using Bunit.TestDoubles;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Onboarding.Services;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
@@ -9,13 +10,17 @@ namespace FishingLogBook.Web.Tests.Features.Onboarding.Pages.LandingTests;
 
 public class BaseLandingTest
 {
-    protected static BunitContext CreateContext(IOnboardingService onboarding, bool isAuthenticated = true)
+    protected static BunitContext CreateContext(
+        IOnboardingService onboarding,
+        bool isAuthenticated = true,
+        IWebAuthnCapabilityProbeService? probe = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
         context.Services.AddSingleton(onboarding);
+        context.Services.AddSingleton(probe ?? Probe(hasMetadata: false));
         var authorization = context.AddAuthorization();
         if (isAuthenticated)
         {
@@ -27,6 +32,13 @@ public class BaseLandingTest
         }
 
         return context;
+    }
+
+    protected static IWebAuthnCapabilityProbeService Probe(bool hasMetadata)
+    {
+        var probe = Substitute.For<IWebAuthnCapabilityProbeService>();
+        probe.HasMetadataAsync(Arg.Any<CancellationToken>()).Returns(hasMetadata);
+        return probe;
     }
 
     protected static IOnboardingService Onboarding(bool completed)

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -62,6 +62,43 @@ public class WhenTestingRouting : BaseLandingTest
     }
 
     [Fact]
+    public void ItShouldNotShowTheProbeActionWithoutProvisionedMetadata()
+    {
+        // Arrange
+        using var context = CreateContext(Onboarding(false), isAuthenticated: false);
+
+        // Act
+        var cut = context.Render<LandingPage>();
+
+        // Assert
+        cut.FindAll("#landing-webauthn-probe-action").Should().BeEmpty();
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().NotContain("webauthn-capability-probe");
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheProvisionedProbeWithoutNavigatingUntilTapped()
+    {
+        // Arrange
+        var probe = Probe(hasMetadata: true);
+        await using var context = CreateContext(Onboarding(false), isAuthenticated: false, probe);
+
+        // Act
+        var cut = context.Render<LandingPage>();
+
+        // Assert
+        cut.Find("#landing-webauthn-probe-action").TextContent.Should().Contain("Test offline device unlock");
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().NotContain("webauthn-capability-probe");
+        await probe.Received(1).HasMetadataAsync(Arg.Any<CancellationToken>());
+
+        // Act
+        await cut.Find("#landing-webauthn-probe-action").ClickAsync();
+
+        // Assert
+        context.Services.GetRequiredService<NavigationManager>().Uri
+            .Should().EndWith("/diagnostics/webauthn-capability-probe");
+    }
+
+    [Fact]
     public async Task ItShouldRouteAnIncompleteUserToOnboarding()
     {
         // Arrange


### PR DESCRIPTION
## Why

Issue #132 needs real-device evidence before choosing an offline-authentication design. The current Blazor OIDC user store uses session storage, so a fully terminated PWA does not retain its signed-in state. This PR adds a deliberately disposable probe to measure whether platform WebAuthn plus PRF can support a future local offline-unlock entitlement.

## What changed

- Adds an anonymous, isolated WebAuthn/PRF diagnostics page reachable from Diagnostics.
- Provisioning uses an explicit user action and a platform authenticator with user verification required.
- Keeps CREATE and GET ceremonies separate: provisioning records CREATE capability, while a second explicit **Verify online credential** action performs a fresh GET and tests a harmless AES-GCM round trip using PRF-derived key material.
- Adds a separate explicit **Test offline unlock** GET action for installed-PWA/offline testing.
- Stores only probe metadata, credential ID, salt, and encrypted harmless test payload; it never stores PRF output, a derived key, assertion data, tokens, user data, catches, or photographs.
- Shows a Landing-page action only when probe metadata already exists. It never redirects automatically and never invokes a credential ceremony from Landing.
- Adds EN/FR copy, component/service tests, and deterministic JavaScript capability tests.

## Manual device procedure

For each device, install/open the PWA, open the probe, provision while online, verify online, fully terminate the PWA, disable connectivity, relaunch, and use **Test offline unlock** explicitly:

- iPhone Safari-installed PWA: record platform availability, CREATE PRF reporting, GET PRF reporting, user verification, encrypted-payload recovery, and relaunch route.
- iPad Safari-installed PWA: same evidence, including whether relaunch starts at Landing or a protected route.
- Android Chrome-installed PWA: same evidence after force-stop/termination.
- Samsung Internet-installed PWA: same evidence where installation is available.
- Desktop Chrome/Edge installed PWA: secondary comparison only.

A protected deep link may still enter the existing login redirect path; opening at `/` should show Landing. The probe does not change either behavior.

## Removal / limitations

This is evidence-gathering code, not offline authentication or authorization. It does not alter OIDC, `RemoteAuthenticationService`, service workers, offline data ownership, catch save/sync, or server authorization. Probe cleanup removes only CBDF metadata; the platform credential may need manual removal in device/browser passkey settings. The probe should be removed once #132 records a product decision.

Physical-device outcomes are intentionally not claimed by this PR.

## Validation

- `npm test`: 222 passed
- `dotnet build FishingLogBook.sln --no-restore`: succeeded, 0 warnings/errors
- `dotnet test FishingLogBook.sln --no-build --no-restore`: all projects green (1,265 tests)
- `npm run test:browser`: 27 passed, 1 existing WebKit offline-service-worker test skipped
- `git diff --check`: passed
- Mandatory repository self-review completed; findings fixed by separating CREATE/GET user gestures and limiting Landing to a metadata-marker check.

References #132