### PR TITLE
FLB#133 | Add Playwright browser E2E foundation

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -1,0 +1,65 @@
+name: browser-e2e
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 2 * * *'
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  browser-e2e:
+    name: Authenticated Chromium E2E
+    if: ${{ vars.E2E_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: browser-e2e-${{ github.ref }}
+      cancel-in-progress: true
+    env:
+      E2E_COGNITO_USERNAME: ${{ secrets.E2E_COGNITO_USERNAME }}
+      E2E_COGNITO_PASSWORD: ${{ secrets.E2E_COGNITO_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: tests/FishingLogBook.E2E/package-lock.json
+
+      - name: Restore .NET dependencies
+        run: dotnet restore FishingLogBook.sln
+
+      - name: Install E2E dependencies
+        run: npm ci
+        working-directory: tests/FishingLogBook.E2E
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: tests/FishingLogBook.E2E
+
+      - name: Run browser E2E
+        run: npm test
+        working-directory: tests/FishingLogBook.E2E
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-e2e-${{ github.run_id }}
+          path: |
+            tests/FishingLogBook.E2E/artifacts/test-results/**/*.png
+            tests/FishingLogBook.E2E/artifacts/report
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 [Oo]ut/
 artifacts/
 tests/FishingLogBook.E2E/.auth/
+tests/FishingLogBook.E2E/.runtime/
 tests/FishingLogBook.E2E/artifacts/
 *.user
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 [Oo]bj/
 [Oo]ut/
 artifacts/
+tests/FishingLogBook.E2E/.auth/
+tests/FishingLogBook.E2E/artifacts/
 *.user
 *.suo
 *.userosscache

--- a/src/FishingLogBook.Web/Features/Catch/Components/CatchCard/CatchCard.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/CatchCard/CatchCard.razor
@@ -1,5 +1,6 @@
 @namespace FishingLogBook.Web.Features.Catch.Components.CatchCard
 
+<div class="catch-card-positioner">
 <MudCard Class="catch-card" id="@($"catch-card-{Catch.Id:D}")">
     <div class="catch-card-menu">
         <MudMenu>
@@ -145,3 +146,4 @@
         </MudCardActions>
     }
 </MudCard>
+</div>

--- a/src/FishingLogBook.Web/Features/Catch/Components/CatchCard/CatchCard.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/CatchCard/CatchCard.razor.css
@@ -1,4 +1,4 @@
-.catch-card {
+.catch-card-positioner {
     position: relative;
 }
 

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Common.Modals;
@@ -44,6 +45,9 @@ public partial class CatchList : ComponentBase, IDisposable
 
     [Inject]
     private ICatchClient CatchClient { get; set; } = default!;
+
+    [Inject]
+    private INetworkService Network { get; set; } = default!;
 
     [Inject]
     private ILocalCatchOwnerService LocalCatchOwner { get; set; } = default!;
@@ -123,6 +127,11 @@ public partial class CatchList : ComponentBase, IDisposable
         IReadOnlyList<CatchViewDto> remote;
         try
         {
+            if (!await Network.IsOnlineAsync(cancellationToken))
+            {
+                return [];
+            }
+
             remote = await CatchClient.GetAllAsync(cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor.cs
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Synchronisers;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.Extensions.Localization;
 using Microsoft.JSInterop;
@@ -24,6 +25,9 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
 
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    [Inject]
+    private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
 
     [Inject]
     private ICatchSynchroniser CatchSynchroniser { get; set; } = default!;
@@ -103,6 +107,12 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
     private async Task SynchroniseAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
+        if (!ShouldSynchroniseCurrentRoute()
+            || (await AuthenticationStateProvider.GetAuthenticationStateAsync()).User.Identity?.IsAuthenticated != true)
+        {
+            return;
+        }
+
         try
         {
             await CatchSynchroniser.SynchronisePendingAsync(cancellationToken);
@@ -134,6 +144,14 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
                 exception,
                 CancellationToken.None);
         }
+    }
+
+    private bool ShouldSynchroniseCurrentRoute()
+    {
+        var path = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        return !string.IsNullOrEmpty(path)
+            && !path.Equals("onboarding", StringComparison.OrdinalIgnoreCase)
+            && !path.StartsWith("authentication/", StringComparison.OrdinalIgnoreCase);
     }
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs args)

--- a/tests/FishingLogBook.E2E/README.md
+++ b/tests/FishingLogBook.E2E/README.md
@@ -9,8 +9,8 @@ Playwright storage/service-worker harness under `src/FishingLogBook.Web/BrowserT
 - .NET 10 SDK
 - Docker Desktop running Linux containers
 - trusted local .NET development certificate (`dotnet dev-certs https --trust`)
-- a dedicated DEV Cognito E2E user that has completed onboarding and has no MFA/CAPTCHA
-  requirement
+- a dedicated DEV Cognito E2E user with no MFA/CAPTCHA requirement; the setup completes
+  onboarding through the real UI in each disposable database
 - `http://localhost:5019/authentication/login-callback` configured for the DEV Cognito client
 
 Set credentials only in the current shell or an approved secret store:

--- a/tests/FishingLogBook.E2E/README.md
+++ b/tests/FishingLogBook.E2E/README.md
@@ -26,7 +26,8 @@ npm --prefix tests/FishingLogBook.E2E test
 The default command starts a disposable PostgreSQL 18 container on port `55433`, applies
 the real migrations, and starts the API and Web projects. Override the port with
 `E2E_POSTGRES_PORT`. To use an already-running stack, set `E2E_EXTERNAL_STACK=true` and
-`E2E_BASE_URL`.
+`E2E_BASE_URL`. A separate global teardown removes the run-owned container even when
+Playwright forcibly terminates its WebServer process.
 
 Each run stores browser authentication state under `.auth/` and artifacts under
 `artifacts/`; both are ignored. Authentication setup never records traces, screenshots or

--- a/tests/FishingLogBook.E2E/README.md
+++ b/tests/FishingLogBook.E2E/README.md
@@ -1,0 +1,54 @@
+# FishingLogBook browser E2E
+
+This project drives the real Blazor WebAssembly application, API, DbUp migrations,
+IndexedDB and Cognito authorization flow in Chromium. It does not replace the smaller
+Playwright storage/service-worker harness under `src/FishingLogBook.Web/BrowserTests`.
+
+## Windows prerequisites
+
+- .NET 10 SDK
+- Docker Desktop running Linux containers
+- trusted local .NET development certificate (`dotnet dev-certs https --trust`)
+- a dedicated DEV Cognito E2E user that has completed onboarding and has no MFA/CAPTCHA
+  requirement
+- `http://localhost:5019/authentication/login-callback` configured for the DEV Cognito client
+
+Set credentials only in the current shell or an approved secret store:
+
+```powershell
+$env:E2E_COGNITO_USERNAME = "<dedicated E2E user>"
+$env:E2E_COGNITO_PASSWORD = "<secret>"
+npm --prefix tests/FishingLogBook.E2E ci
+npm --prefix tests/FishingLogBook.E2E run install:browsers
+npm --prefix tests/FishingLogBook.E2E test
+```
+
+The default command starts a disposable PostgreSQL 18 container on port `55433`, applies
+the real migrations, and starts the API and Web projects. Override the port with
+`E2E_POSTGRES_PORT`. To use an already-running stack, set `E2E_EXTERNAL_STACK=true` and
+`E2E_BASE_URL`.
+
+Each run stores browser authentication state under `.auth/` and artifacts under
+`artifacts/`; both are ignored. Authentication setup never records traces, screenshots or
+video. Local runs retain failure traces for developer diagnosis. CI disables authenticated
+traces because network metadata can contain bearer tokens and uploads screenshots/report
+only. Never upload `.auth` or log credentials/tokens. The disposable database is removed
+after the run, so no shared DEV/private-alpha Catch data is read, changed or deleted.
+
+## Coverage boundary
+
+The suite proves an authenticated online journey and an online-to-offline-to-reconnect
+journey in one live Chromium context. It does not prove installed mobile PWA lifecycle,
+offline cold restart (#132), iOS Safari/WebKit, biometrics/WebAuthn, Samsung OEM behavior,
+or real camera behavior. Those remain emulator/physical-device work described in #133.
+
+## GitHub Actions
+
+The `browser-e2e` workflow runs on pull requests, nightly, and manually after the
+repository variable `E2E_ENABLED=true` and repository secrets
+`E2E_COGNITO_USERNAME` / `E2E_COGNITO_PASSWORD` are configured. The setup captures the
+standard Blazor OIDC session storage into an ignored, permission-restricted ephemeral file
+and restores it into each test context; this mirrors the current application session rather
+than bypassing authorization. Until configured the job is
+visibly skipped rather than attempting an insecure fallback. Only failure diagnostics are
+uploaded; `.auth` is never included.

--- a/tests/FishingLogBook.E2E/package-lock.json
+++ b/tests/FishingLogBook.E2E/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "fishing-logbook-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fishing-logbook-e2e",
+      "devDependencies": {
+        "@playwright/test": "1.62.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tests/FishingLogBook.E2E/package.json
+++ b/tests/FishingLogBook.E2E/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fishing-logbook-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "install:browsers": "playwright install chromium",
+    "test:config": "node --test tests/config.test.mjs",
+    "test": "playwright test",
+    "test:smoke": "playwright test --grep @smoke"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.1"
+  }
+}

--- a/tests/FishingLogBook.E2E/playwright.config.mjs
+++ b/tests/FishingLogBook.E2E/playwright.config.mjs
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+import { resolve } from 'node:path';
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5019';
+
+export default defineConfig({
+    testDir: './specs',
+    outputDir: 'artifacts/test-results',
+    globalSetup: './support/auth.setup.mjs',
+    timeout: 45_000,
+    expect: { timeout: 10_000 },
+    fullyParallel: false,
+    workers: 1,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    reporter: [['list'], ['html', { outputFolder: 'artifacts/report', open: 'never' }]],
+    use: {
+        ...devices['Desktop Chrome'],
+        baseURL,
+        ignoreHTTPSErrors: true,
+        storageState: resolve('.auth/e2e-user.json'),
+        screenshot: 'only-on-failure',
+        // Authenticated traces contain network metadata and remain local-only.
+        trace: process.env.CI ? 'off' : 'retain-on-failure',
+        video: 'off'
+    },
+    projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+    webServer: process.env.E2E_EXTERNAL_STACK === 'true' ? undefined : {
+        command: 'node support/start-stack.mjs',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 180_000,
+        stdout: 'pipe',
+        stderr: 'pipe'
+    }
+});

--- a/tests/FishingLogBook.E2E/playwright.config.mjs
+++ b/tests/FishingLogBook.E2E/playwright.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
     testDir: './specs',
     outputDir: 'artifacts/test-results',
     globalSetup: './support/auth.setup.mjs',
+    globalTeardown: './support/teardown.mjs',
     timeout: 45_000,
     expect: { timeout: 10_000 },
     fullyParallel: false,

--- a/tests/FishingLogBook.E2E/specs/catch-offline.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/catch-offline.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from '../support/fixtures.mjs';
-import { recordCatch, testName } from '../support/catch-journey.mjs';
+import { recordCatch, reloadServerCatches, testName } from '../support/catch-journey.mjs';
 
 test('records and edits locally offline, then synchronises once after reconnect', async ({ page, context }) => {
     await page.goto('/catches');
@@ -8,18 +8,17 @@ test('records and edits locally offline, then synchronises once after reconnect'
     await context.setOffline(true);
     const notes = testName('offline-edited');
     const id = await recordCatch(page, notes);
-    await page.goto('/catches');
     await expect(page.locator(`#catch-card-${id}`)).toContainText(notes);
     await expect(page.locator(`#catch-card-${id}`)).toContainText(/saved|device|sync/i);
 
-    await context.setOffline(false);
-    const responsePromise = page.waitForResponse(response =>
+    const synchronised = page.waitForResponse(response =>
         response.url().endsWith('/api/catches')
-        && response.request().method() === 'GET'
+        && ['POST', 'PUT'].includes(response.request().method())
         && response.ok());
-    await page.reload();
-    const serverCatches = await (await responsePromise).json();
-    expect(serverCatches.filter(catchRecord => catchRecord.id === id)).toHaveLength(1);
+    await context.setOffline(false);
+    await synchronised;
+    const persisted = await reloadServerCatches(page);
+    expect(persisted.filter(catchRecord => catchRecord.id === id)).toHaveLength(1);
     await expect(page.locator(`#catch-card-${id}`)).toContainText(notes);
     await expect(page.locator(`#catch-card-${id} [id^="catch-card-synchronising-"]`)).toHaveCount(0, { timeout: 30_000 });
     await expect(page.locator(`#catch-card-${id}`)).toHaveCount(1);

--- a/tests/FishingLogBook.E2E/specs/catch-offline.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/catch-offline.spec.mjs
@@ -1,0 +1,26 @@
+import { test, expect } from '../support/fixtures.mjs';
+import { recordCatch, testName } from '../support/catch-journey.mjs';
+
+test('records and edits locally offline, then synchronises once after reconnect', async ({ page, context }) => {
+    await page.goto('/catches');
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+    await page.evaluate(() => navigator.serviceWorker?.ready);
+    await context.setOffline(true);
+    const notes = testName('offline-edited');
+    const id = await recordCatch(page, notes);
+    await page.goto('/catches');
+    await expect(page.locator(`#catch-card-${id}`)).toContainText(notes);
+    await expect(page.locator(`#catch-card-${id}`)).toContainText(/saved|device|sync/i);
+
+    await context.setOffline(false);
+    const responsePromise = page.waitForResponse(response =>
+        response.url().endsWith('/api/catches')
+        && response.request().method() === 'GET'
+        && response.ok());
+    await page.reload();
+    const serverCatches = await (await responsePromise).json();
+    expect(serverCatches.filter(catchRecord => catchRecord.id === id)).toHaveLength(1);
+    await expect(page.locator(`#catch-card-${id}`)).toContainText(notes);
+    await expect(page.locator(`#catch-card-${id} [id^="catch-card-synchronising-"]`)).toHaveCount(0, { timeout: 30_000 });
+    await expect(page.locator(`#catch-card-${id}`)).toHaveCount(1);
+});

--- a/tests/FishingLogBook.E2E/specs/catch-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/catch-online.spec.mjs
@@ -1,0 +1,15 @@
+import { test, expect } from '../support/fixtures.mjs';
+import { recordCatch, testName } from '../support/catch-journey.mjs';
+
+test('@smoke records and edits a catch through the real application', async ({ page }) => {
+    const notes = testName('online');
+    const id = await recordCatch(page, notes, true);
+    const responsePromise = page.waitForResponse(response =>
+        response.url().endsWith('/api/catches')
+        && response.request().method() === 'GET'
+        && response.ok());
+    await page.goto('/catches');
+    const serverCatches = await (await responsePromise).json();
+    expect(serverCatches.filter(catchRecord => catchRecord.id === id)).toHaveLength(1);
+    await expect(page.locator(`#catch-card-${id}`)).toContainText(notes);
+});

--- a/tests/FishingLogBook.E2E/specs/catch-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/catch-online.spec.mjs
@@ -4,12 +4,5 @@ import { recordCatch, testName } from '../support/catch-journey.mjs';
 test('@smoke records and edits a catch through the real application', async ({ page }) => {
     const notes = testName('online');
     const id = await recordCatch(page, notes, true);
-    const responsePromise = page.waitForResponse(response =>
-        response.url().endsWith('/api/catches')
-        && response.request().method() === 'GET'
-        && response.ok());
-    await page.goto('/catches');
-    const serverCatches = await (await responsePromise).json();
-    expect(serverCatches.filter(catchRecord => catchRecord.id === id)).toHaveLength(1);
     await expect(page.locator(`#catch-card-${id}`)).toContainText(notes);
 });

--- a/tests/FishingLogBook.E2E/specs/pwa-ui.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/pwa-ui.spec.mjs
@@ -1,0 +1,9 @@
+import { test, expect } from '../support/fixtures.mjs';
+
+test('@smoke keeps actionable manual install guidance available', async ({ page }) => {
+    await page.goto('/install');
+    await expect(page.getByRole('heading', { name: /install catch but don.t forget/i })).toBeVisible();
+    await expect(page.getByText('iPhone / iPad')).toBeVisible();
+    await expect(page.getByText('Android', { exact: true })).toBeVisible();
+    await expect(page.getByText('Computer', { exact: true })).toBeVisible();
+});

--- a/tests/FishingLogBook.E2E/support/auth.setup.mjs
+++ b/tests/FishingLogBook.E2E/support/auth.setup.mjs
@@ -1,0 +1,46 @@
+import { chromium } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export default async function authenticate(config) {
+    const username = required('E2E_COGNITO_USERNAME');
+    const password = required('E2E_COGNITO_PASSWORD');
+    const browser = await chromium.launch();
+    const context = await browser.newContext({
+        baseURL: config.projects[0].use.baseURL,
+        ignoreHTTPSErrors: true,
+        recordVideo: undefined
+    });
+
+    try {
+        const page = await context.newPage();
+        await page.goto('/');
+        await page.locator('#landing-sign-in').click();
+        await page.waitForURL(url => !url.hostname.includes('localhost'));
+        await page.locator('input[name="username"], #signInFormUsername').fill(username);
+        await page.locator('input[name="password"], #signInFormPassword').fill(password);
+        await page.locator('button[type="submit"], input[type="submit"]').first().click();
+        await page.waitForURL(/localhost:5019\/(catches|onboarding)/, { timeout: 45_000 });
+        if (page.url().includes('/onboarding')) {
+            throw new Error('The dedicated E2E Cognito user must complete onboarding before running E2E tests.');
+        }
+
+        await mkdir(resolve('.auth'), { recursive: true });
+        await context.storageState({ path: resolve('.auth/e2e-user.json') });
+        const sessionStorage = await page.evaluate(() => Object.fromEntries(
+            Array.from({ length: window.sessionStorage.length }, (_, index) => {
+                const key = window.sessionStorage.key(index);
+                return [key, window.sessionStorage.getItem(key)];
+            })));
+        await writeFile(resolve('.auth/e2e-session.json'), JSON.stringify(sessionStorage), { mode: 0o600 });
+    } finally {
+        await context.close();
+        await browser.close();
+    }
+}
+
+function required(name) {
+    const value = process.env[name];
+    if (!value) throw new Error(`${name} is required. See tests/FishingLogBook.E2E/README.md.`);
+    return value;
+}

--- a/tests/FishingLogBook.E2E/support/auth.setup.mjs
+++ b/tests/FishingLogBook.E2E/support/auth.setup.mjs
@@ -2,10 +2,16 @@ import { chromium } from '@playwright/test';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+const landingRouteTimeout = 90_000;
+
 export default async function authenticate(config) {
     const username = required('E2E_COGNITO_USERNAME');
     const password = required('E2E_COGNITO_PASSWORD');
-    const browser = await chromium.launch();
+    const debugging = process.env.PWDEBUG === '1';
+    const browser = await chromium.launch({
+        headless: !debugging,
+        slowMo: debugging ? 100 : 0
+    });
     const context = await browser.newContext({
         baseURL: config.projects[0].use.baseURL,
         ignoreHTTPSErrors: true,
@@ -14,6 +20,14 @@ export default async function authenticate(config) {
 
     try {
         const page = await context.newPage();
+        page.on('console', message => {
+            if (message.type() === 'error' && message.text().startsWith('[FLB]')) {
+                console.error(`[E2E browser] ${message.text()}`);
+            }
+        });
+        page.on('pageerror', error => {
+            console.error(`[E2E browser page error] ${error.message}`);
+        });
         await page.goto('/');
         await page.locator('#landing-sign-in').click();
         await page.waitForURL(url => !url.hostname.includes('localhost'));
@@ -24,6 +38,9 @@ export default async function authenticate(config) {
         await page.waitForURL(url =>
             url.origin === applicationOrigin
             && !url.pathname.includes('/authentication/login-callback'), { timeout: 45_000 });
+        await page.waitForURL(url =>
+            url.origin === applicationOrigin
+            && ['/catches', '/onboarding'].includes(url.pathname), { timeout: landingRouteTimeout });
         await completeOnboardingWhenRequired(page);
 
         await mkdir(resolve('.auth'), { recursive: true });
@@ -41,10 +58,10 @@ export default async function authenticate(config) {
 }
 
 async function completeOnboardingWhenRequired(page) {
-    await page.goto('/onboarding');
-    await page.locator('#onboarding-loading').waitFor({ state: 'hidden' });
     if (new URL(page.url()).pathname === '/catches') return;
 
+    await page.locator('#onboarding-loading').waitFor({ state: 'hidden' });
+    await page.locator('#onboarding-next').waitFor({ state: 'visible' });
     await page.locator('#onboarding-next').click();
     await page.locator('#onboarding-method-Fly').click();
     await page.locator('#onboarding-species-more-Fly').click();

--- a/tests/FishingLogBook.E2E/support/auth.setup.mjs
+++ b/tests/FishingLogBook.E2E/support/auth.setup.mjs
@@ -20,10 +20,11 @@ export default async function authenticate(config) {
         await page.locator('input[name="username"], #signInFormUsername').fill(username);
         await page.locator('input[name="password"], #signInFormPassword').fill(password);
         await page.locator('button[type="submit"], input[type="submit"]').first().click();
-        await page.waitForURL(/localhost:5019\/(catches|onboarding)/, { timeout: 45_000 });
-        if (page.url().includes('/onboarding')) {
-            throw new Error('The dedicated E2E Cognito user must complete onboarding before running E2E tests.');
-        }
+        const applicationOrigin = new URL(config.projects[0].use.baseURL).origin;
+        await page.waitForURL(url =>
+            url.origin === applicationOrigin
+            && !url.pathname.includes('/authentication/login-callback'), { timeout: 45_000 });
+        await completeOnboardingWhenRequired(page);
 
         await mkdir(resolve('.auth'), { recursive: true });
         await context.storageState({ path: resolve('.auth/e2e-user.json') });
@@ -37,6 +38,23 @@ export default async function authenticate(config) {
         await context.close();
         await browser.close();
     }
+}
+
+async function completeOnboardingWhenRequired(page) {
+    await page.goto('/onboarding');
+    await page.locator('#onboarding-loading').waitFor({ state: 'hidden' });
+    if (new URL(page.url()).pathname === '/catches') return;
+
+    await page.locator('#onboarding-next').click();
+    await page.locator('#onboarding-method-Fly').click();
+    await page.locator('#onboarding-species-more-Fly').click();
+    await page.locator('#catalogue-picker-modal-option-BrownTrout').click();
+    await page.locator('#catalogue-picker-modal-save').click();
+    await page.locator('#onboarding-next').click();
+    await page.locator('#onboarding-skip-location').click();
+    await page.locator('#onboarding-next').click();
+    await page.locator('#onboarding-finish').click();
+    await page.waitForURL(url => new URL(url).pathname === '/catches', { timeout: 30_000 });
 }
 
 function required(name) {

--- a/tests/FishingLogBook.E2E/support/catch-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/catch-journey.mjs
@@ -6,12 +6,25 @@ export function testName(label) {
     return `E2E-${process.env.GITHUB_RUN_ID ?? Date.now()}-${label}`;
 }
 
+export async function reloadServerCatches(page) {
+    const catches = page.waitForResponse(response =>
+        response.url().endsWith('/api/catches')
+        && response.request().method() === 'GET'
+        && response.ok())
+        .then(response => response.json());
+    await page.reload();
+    return catches;
+}
+
 export async function recordCatch(page, notes, waitForServer = false) {
-    await page.goto('/catches');
+    if (new URL(page.url()).pathname !== '/catches') {
+        await page.goto('/catches');
+    }
+    await expect(page.locator('#catch-list-title')).toBeVisible();
     await expect(page.locator('#catch-list-loading')).toBeHidden();
     const existingIds = new Set(await page.locator('.catch-card').evaluateAll(cards =>
         cards.map(card => card.id.replace('catch-card-', ''))));
-    await page.goto('/catches/record');
+    await page.locator('#catch-record-link').click();
     await expect(page.locator('#record-catch-title')).toBeVisible();
     await page.locator('#record-catch-method-Fly').click();
     await page.locator('#record-catch-species-BrownTrout').click();
@@ -45,5 +58,7 @@ export async function recordCatch(page, notes, waitForServer = false) {
         await save.click();
     }
     await expect(page.locator('#catch-edit-saved')).toBeVisible();
+    await page.locator('a[href="/catches"]').first().click();
+    await expect(page.locator('#catch-list-title')).toBeVisible();
     return id;
 }

--- a/tests/FishingLogBook.E2E/support/catch-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/catch-journey.mjs
@@ -1,0 +1,49 @@
+import { expect } from '@playwright/test';
+
+const png = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64');
+
+export function testName(label) {
+    return `E2E-${process.env.GITHUB_RUN_ID ?? Date.now()}-${label}`;
+}
+
+export async function recordCatch(page, notes, waitForServer = false) {
+    await page.goto('/catches');
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
+    const existingIds = new Set(await page.locator('.catch-card').evaluateAll(cards =>
+        cards.map(card => card.id.replace('catch-card-', ''))));
+    await page.goto('/catches/record');
+    await expect(page.locator('#record-catch-title')).toBeVisible();
+    await page.locator('#record-catch-method-Fly').click();
+    await page.locator('#record-catch-species-BrownTrout').click();
+    await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles({
+        name: 'e2e-catch.png', mimeType: 'image/png', buffer: png
+    });
+    await page.locator('#save-catch-button').click();
+    await expect(page.locator('#catch-saved')).toBeVisible();
+    await page.locator('#catch-view-catches').click();
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
+    await expect(page.locator('.catch-card')).toHaveCount(existingIds.size + 1);
+    const currentIds = await page.locator('.catch-card').evaluateAll(cards =>
+        cards.map(card => card.id.replace('catch-card-', '')));
+    const id = currentIds.find(candidate => !existingIds.has(candidate));
+    if (!id) throw new Error('The newly recorded Catch could not be identified.');
+    const card = page.locator(`#catch-card-${id}`);
+    await expect(card).toBeVisible();
+    await page.locator(`#catch-card-menu-${id}`).click();
+    await page.locator(`#catch-card-edit-${id}`).click();
+    await page.locator('#catch-edit-notes').fill(notes);
+    const save = page.locator('#catch-edit-save');
+    if (waitForServer) {
+        await Promise.all([
+            page.waitForResponse(response =>
+                response.url().includes('/api/catches')
+                && ['POST', 'PUT'].includes(response.request().method())
+                && response.ok()),
+            save.click()
+        ]);
+    } else {
+        await save.click();
+    }
+    await expect(page.locator('#catch-edit-saved')).toBeVisible();
+    return id;
+}

--- a/tests/FishingLogBook.E2E/support/fixtures.mjs
+++ b/tests/FishingLogBook.E2E/support/fixtures.mjs
@@ -1,0 +1,20 @@
+import { test as base, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export const test = base.extend({
+    page: async ({ context }, use) => {
+        const sessionStorage = JSON.parse(await readFile(resolve('.auth/e2e-session.json'), 'utf8'));
+        const origin = new URL(process.env.E2E_BASE_URL ?? 'http://localhost:5019').origin;
+        await context.addInitScript(payload => {
+            if (window.location.origin === payload.origin) {
+                for (const [key, value] of Object.entries(payload.values)) window.sessionStorage.setItem(key, value);
+            }
+        }, { origin, values: sessionStorage });
+        const page = await context.newPage();
+        await use(page);
+        await page.close();
+    }
+});
+
+export { expect };

--- a/tests/FishingLogBook.E2E/support/start-stack.mjs
+++ b/tests/FishingLogBook.E2E/support/start-stack.mjs
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,6 +10,8 @@ const port = process.env.E2E_POSTGRES_PORT ?? '55433';
 const password = randomUUID();
 const connection = `Host=localhost;Port=${port};Database=postgres;Username=postgres;Password=${password}`;
 const children = [];
+const runtimeDirectory = resolve(projectRoot, 'tests/FishingLogBook.E2E/.runtime');
+const containerFile = resolve(runtimeDirectory, 'container-name');
 
 function run(command, args, environment = {}) {
     const child = spawn(command, args, {
@@ -37,6 +40,7 @@ async function waitFor(url, label, timeout = 120_000) {
 function cleanup() {
     for (const child of children.reverse()) child.kill();
     spawnSync('docker', ['rm', '--force', container], { stdio: 'ignore' });
+    try { unlinkSync(containerFile); } catch { /* global teardown may already remove it */ }
 }
 
 process.once('SIGINT', () => { cleanup(); process.exit(130); });
@@ -48,6 +52,8 @@ const docker = spawnSync('docker', [
     '-e', `POSTGRES_PASSWORD=${password}`, '-p', `${port}:5432`, 'postgres:18-alpine'
 ], { cwd: projectRoot, encoding: 'utf8' });
 if (docker.status !== 0) throw new Error('Unable to start the disposable E2E PostgreSQL container.');
+mkdirSync(runtimeDirectory, { recursive: true });
+writeFileSync(containerFile, container, { encoding: 'utf8', mode: 0o600 });
 
 for (let attempt = 0; attempt < 120; attempt += 1) {
     const ready = spawnSync('docker', ['exec', container, 'pg_isready', '-U', 'postgres'], {

--- a/tests/FishingLogBook.E2E/support/start-stack.mjs
+++ b/tests/FishingLogBook.E2E/support/start-stack.mjs
@@ -1,0 +1,77 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const container = `fishing-logbook-e2e-${randomUUID().slice(0, 8)}`;
+const port = process.env.E2E_POSTGRES_PORT ?? '55433';
+const password = randomUUID();
+const connection = `Host=localhost;Port=${port};Database=postgres;Username=postgres;Password=${password}`;
+const children = [];
+
+function run(command, args, environment = {}) {
+    const child = spawn(command, args, {
+        cwd: projectRoot,
+        env: { ...process.env, ...environment },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    child.stdout.on('data', data => process.stdout.write(data));
+    child.stderr.on('data', data => process.stderr.write(data));
+    children.push(child);
+    return child;
+}
+
+async function waitFor(url, label, timeout = 120_000) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(url, { redirect: 'manual' });
+            if (response.status >= 200 && response.status < 400) return;
+        } catch { /* readiness is expected to fail while starting */ }
+        await new Promise(resolvePromise => setTimeout(resolvePromise, 500));
+    }
+    throw new Error(`${label} did not become ready within ${timeout}ms.`);
+}
+
+function cleanup() {
+    for (const child of children.reverse()) child.kill();
+    spawnSync('docker', ['rm', '--force', container], { stdio: 'ignore' });
+}
+
+process.once('SIGINT', () => { cleanup(); process.exit(130); });
+process.once('SIGTERM', () => { cleanup(); process.exit(143); });
+process.once('exit', cleanup);
+
+const docker = spawnSync('docker', [
+    'run', '--detach', '--rm', '--name', container,
+    '-e', `POSTGRES_PASSWORD=${password}`, '-p', `${port}:5432`, 'postgres:18-alpine'
+], { cwd: projectRoot, encoding: 'utf8' });
+if (docker.status !== 0) throw new Error('Unable to start the disposable E2E PostgreSQL container.');
+
+for (let attempt = 0; attempt < 120; attempt += 1) {
+    const ready = spawnSync('docker', ['exec', container, 'pg_isready', '-U', 'postgres'], {
+        stdio: 'ignore'
+    });
+    if (ready.status === 0) break;
+    if (attempt === 119) throw new Error('Disposable E2E PostgreSQL did not become ready.');
+    await new Promise(resolvePromise => setTimeout(resolvePromise, 500));
+}
+
+const migration = spawnSync('dotnet', ['run', '--', '--run'], {
+    cwd: resolve(projectRoot, 'src/FishingLogBook.Db.Migrations.App'),
+    env: { ...process.env, Db__ConnectionString: connection },
+    encoding: 'utf8',
+});
+if (migration.status !== 0) throw new Error(`E2E migrations failed.\n${migration.stdout}\n${migration.stderr}`);
+
+run('dotnet', ['run', '--project', 'src/FishingLogBook.Api', '--launch-profile', 'https'], {
+    ASPNETCORE_ENVIRONMENT: 'Development', ConnectionStrings__Postgres: connection
+});
+await waitFor('http://localhost:5110/health', 'API');
+
+run('dotnet', ['run', '--project', 'src/FishingLogBook.Web', '--launch-profile', 'http'], {
+    ASPNETCORE_ENVIRONMENT: 'Development'
+});
+await waitFor('http://localhost:5019', 'Web');
+await new Promise(() => {});

--- a/tests/FishingLogBook.E2E/support/start-stack.mjs
+++ b/tests/FishingLogBook.E2E/support/start-stack.mjs
@@ -72,7 +72,9 @@ const migration = spawnSync('dotnet', ['run', '--', '--run'], {
 if (migration.status !== 0) throw new Error(`E2E migrations failed.\n${migration.stdout}\n${migration.stderr}`);
 
 run('dotnet', ['run', '--project', 'src/FishingLogBook.Api', '--launch-profile', 'https'], {
-    ASPNETCORE_ENVIRONMENT: 'Development', ConnectionStrings__Postgres: connection
+    ASPNETCORE_ENVIRONMENT: 'Development',
+    ConnectionStrings__Postgres: connection,
+    DOTNET_SYSTEM_NET_DISABLEIPV6: '1'
 });
 await waitFor('http://localhost:5110/health', 'API');
 

--- a/tests/FishingLogBook.E2E/support/teardown.mjs
+++ b/tests/FishingLogBook.E2E/support/teardown.mjs
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process';
+import { readFile, rm } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export default async function teardown() {
+    const containerFile = resolve('.runtime/container-name');
+    let container;
+    try {
+        container = (await readFile(containerFile, 'utf8')).trim();
+    } catch {
+        return;
+    }
+
+    if (/^fishing-logbook-e2e-[a-f0-9]{8}$/.test(container)) {
+        spawnSync('docker', ['rm', '--force', container], { stdio: 'ignore' });
+    }
+    await rm(resolve('.runtime'), { recursive: true, force: true });
+}

--- a/tests/FishingLogBook.E2E/tests/config.test.mjs
+++ b/tests/FishingLogBook.E2E/tests/config.test.mjs
@@ -28,3 +28,13 @@ test('registers independent disposable-container teardown', async () => {
     assert.match(teardown, /\^fishing-logbook-e2e-/);
     assert.match(teardown, /docker', \['rm', '--force'/);
 });
+
+test('onboards the dedicated Cognito user through the real UI for each disposable database', async () => {
+    const setup = await readFile(new URL('../support/auth.setup.mjs', import.meta.url), 'utf8');
+
+    assert.match(setup, /completeOnboardingWhenRequired/);
+    assert.match(setup, /#onboarding-method-Fly/);
+    assert.match(setup, /#catalogue-picker-modal-option-BrownTrout/);
+    assert.match(setup, /#onboarding-finish/);
+    assert.doesNotMatch(setup, /must complete onboarding before running/);
+});

--- a/tests/FishingLogBook.E2E/tests/config.test.mjs
+++ b/tests/FishingLogBook.E2E/tests/config.test.mjs
@@ -19,3 +19,12 @@ test('requires explicit enablement and dedicated Cognito secrets', async () => {
     assert.match(workflow, /secrets\.E2E_COGNITO_USERNAME/);
     assert.match(workflow, /secrets\.E2E_COGNITO_PASSWORD/);
 });
+
+test('registers independent disposable-container teardown', async () => {
+    const config = await readFile(new URL('../playwright.config.mjs', import.meta.url), 'utf8');
+    const teardown = await readFile(new URL('../support/teardown.mjs', import.meta.url), 'utf8');
+
+    assert.match(config, /globalTeardown: '\.\/support\/teardown\.mjs'/);
+    assert.match(teardown, /\^fishing-logbook-e2e-/);
+    assert.match(teardown, /docker', \['rm', '--force'/);
+});

--- a/tests/FishingLogBook.E2E/tests/config.test.mjs
+++ b/tests/FishingLogBook.E2E/tests/config.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('keeps authenticated CI traces and auth state out of uploaded artifacts', async () => {
+    const config = await readFile(new URL('../playwright.config.mjs', import.meta.url), 'utf8');
+    const workflow = await readFile(new URL('../../../.github/workflows/e2e-browser.yml', import.meta.url), 'utf8');
+
+    assert.match(config, /trace: process\.env\.CI \? 'off'/);
+    assert.doesNotMatch(workflow, /\.auth/);
+    assert.doesNotMatch(workflow, /artifacts\/test-results\s*$/m);
+    assert.match(workflow, /\*\*\/\*\.png/);
+});
+
+test('requires explicit enablement and dedicated Cognito secrets', async () => {
+    const workflow = await readFile(new URL('../../../.github/workflows/e2e-browser.yml', import.meta.url), 'utf8');
+
+    assert.match(workflow, /vars\.E2E_ENABLED == 'true'/);
+    assert.match(workflow, /secrets\.E2E_COGNITO_USERNAME/);
+    assert.match(workflow, /secrets\.E2E_COGNITO_PASSWORD/);
+});

--- a/tests/FishingLogBook.E2E/tests/config.test.mjs
+++ b/tests/FishingLogBook.E2E/tests/config.test.mjs
@@ -29,12 +29,40 @@ test('registers independent disposable-container teardown', async () => {
     assert.match(teardown, /docker', \['rm', '--force'/);
 });
 
+test('uses IPv4 for deterministic local Cognito metadata retrieval', async () => {
+    const stack = await readFile(new URL('../support/start-stack.mjs', import.meta.url), 'utf8');
+
+    assert.match(stack, /DOTNET_SYSTEM_NET_DISABLEIPV6: '1'/);
+});
+
+test('keeps the offline journey inside the loaded app shell', async () => {
+    const journey = await readFile(new URL('../support/catch-journey.mjs', import.meta.url), 'utf8');
+    const offlineSpec = await readFile(new URL('../specs/catch-offline.spec.mjs', import.meta.url), 'utf8');
+    const offlineSection = offlineSpec.split('await context.setOffline(true);')[1]
+        .split('await context.setOffline(false);')[0];
+
+    assert.match(journey, /#catch-record-link/);
+    assert.doesNotMatch(offlineSection, /page\.goto/);
+});
+
 test('onboards the dedicated Cognito user through the real UI for each disposable database', async () => {
     const setup = await readFile(new URL('../support/auth.setup.mjs', import.meta.url), 'utf8');
 
     assert.match(setup, /completeOnboardingWhenRequired/);
+    assert.match(setup, /const landingRouteTimeout = 90_000/);
+    assert.match(setup, /\['\/catches', '\/onboarding'\]\.includes\(url\.pathname\)/);
     assert.match(setup, /#onboarding-method-Fly/);
     assert.match(setup, /#catalogue-picker-modal-option-BrownTrout/);
     assert.match(setup, /#onboarding-finish/);
     assert.doesNotMatch(setup, /must complete onboarding before running/);
+});
+
+test('shows the authentication setup browser when Playwright debug mode is enabled', async () => {
+    const setup = await readFile(new URL('../support/auth.setup.mjs', import.meta.url), 'utf8');
+
+    assert.match(setup, /process\.env\.PWDEBUG === '1'/);
+    assert.match(setup, /headless: !debugging/);
+    assert.match(setup, /message\.text\(\)\.startsWith\('\[FLB\]'\)/);
+    assert.match(setup, /page\.on\('pageerror'/);
+    assert.doesNotMatch(setup, /E2E auth diagnostic/);
 });

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/CatchCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/CatchCardTests/WhenTestingRender.cs
@@ -12,6 +12,22 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Components.CatchCardTests;
 public class WhenTestingRender : BaseCatchCardTest
 {
     [Fact]
+    public async Task ItShouldPositionTheActionsMenuRelativeToTheCard()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        await using var context = CreateContext();
+
+        // Act
+        var cut = context.Render<CatchCard>(parameters => parameters
+            .Add(component => component.Catch, StoredCatch(catchId)));
+
+        // Assert
+        cut.Find(".catch-card-positioner").Should().NotBeNull();
+        cut.Find($"#catch-card-menu-{catchId:D}").Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task ItShouldRenderThePhotographThumbnail()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/BaseCatchListTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/BaseCatchListTest.cs
@@ -3,6 +3,7 @@ using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Common.Modals;
@@ -35,7 +36,8 @@ public class BaseCatchListTest
         ITimeService? time = null,
         IAnglerPreferencesProvider? anglerPreferences = null,
         ILoggingService? logging = null,
-        ICatchClient? catchClient = null)
+        ICatchClient? catchClient = null,
+        INetworkService? network = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -49,6 +51,7 @@ public class BaseCatchListTest
         context.Services.AddSingleton(anglerPreferences ?? QuietAnglerPreferences());
         context.Services.AddSingleton(logging ?? QuietLogging());
         context.Services.AddSingleton(catchClient ?? EmptyCatchClient());
+        context.Services.AddSingleton(network ?? OnlineNetwork());
         context.Services.AddSingleton<IMeasurementService, MeasurementService>();
         context.Services.AddSingleton<ICatchDateGroupingService, CatchDateGroupingService>();
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
@@ -61,6 +64,13 @@ public class BaseCatchListTest
         client.GetAllAsync(Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<CatchViewDto>)[]);
         return client;
+    }
+
+    protected static INetworkService OnlineNetwork(bool isOnline = true)
+    {
+        var network = Substitute.For<INetworkService>();
+        network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(isOnline);
+        return network;
     }
 
     protected static ILocalCatchOwnerService SignedInOwner(Guid? userId = null)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingServerCatches.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingServerCatches.cs
@@ -108,4 +108,28 @@ public class WhenTestingServerCatches : BaseCatchListTest
             Arg.Any<HttpRequestException>(),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task ItShouldShowLocalCatchesWithoutCallingTheApiWhenOffline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var localId = Guid.NewGuid();
+        var local = StoredCatch(localId, DateTimeOffset.UtcNow, speciesName: "Brown Trout");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(new[] { local });
+        var catchClient = Substitute.For<ICatchClient>();
+        var network = OnlineNetwork(isOnline: false);
+        await using var context = CreateContext(store, catchClient: catchClient, network: network);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{localId:D}").TextContent.Should().Contain("Brown Trout"));
+        await network.Received(1).IsOnlineAsync(Arg.Any<CancellationToken>());
+        await catchClient.DidNotReceive().GetAllAsync(Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
@@ -22,12 +22,13 @@ public class WhenTestingSynchronisation : BaseMainLayoutTest
             isAuthenticated: true,
             catchSynchroniser,
             diagnosticSynchroniser);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/catches");
         context.Render<MainLayout>();
         await Task.Yield();
 
         // Act
         context.Services.GetRequiredService<NavigationManager>()
-            .NavigateTo("/catches");
+            .NavigateTo("/profile");
         await Task.Yield();
 
         // Assert
@@ -35,6 +36,50 @@ public class WhenTestingSynchronisation : BaseMainLayoutTest
             Arg.Any<CancellationToken>());
         await diagnosticSynchroniser.Received(2).SynchronisePendingAsync(
             Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("onboarding")]
+    [InlineData("authentication/login-callback")]
+    public async Task ItShouldNotSynchroniseOnAuthenticationBootstrapRoutes(string path)
+    {
+        // Arrange
+        var catchSynchroniser = Substitute.For<ICatchSynchroniser>();
+        var diagnosticSynchroniser = Substitute.For<IDiagnosticSynchroniser>();
+        await using var context = CreateContext(
+            isAuthenticated: true,
+            catchSynchroniser,
+            diagnosticSynchroniser);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo($"/{path}");
+
+        // Act
+        context.Render<MainLayout>();
+        await Task.Yield();
+
+        // Assert
+        await catchSynchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
+        await diagnosticSynchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotSynchroniseAnAnonymousProtectedRoute()
+    {
+        // Arrange
+        var catchSynchroniser = Substitute.For<ICatchSynchroniser>();
+        var diagnosticSynchroniser = Substitute.For<IDiagnosticSynchroniser>();
+        await using var context = CreateContext(
+            catchSynchroniser: catchSynchroniser,
+            diagnosticSynchroniser: diagnosticSynchroniser);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/catches");
+
+        // Act
+        context.Render<MainLayout>();
+        await Task.Yield();
+
+        // Assert
+        await catchSynchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
+        await diagnosticSynchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -49,6 +94,7 @@ public class WhenTestingSynchronisation : BaseMainLayoutTest
             isAuthenticated: true,
             catchSynchroniser,
             diagnosticSynchroniser);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/catches");
         var logging = context.Services.GetRequiredService<ILoggingService>();
         var cut = context.Render<MainLayout>();
         await Task.Yield();
@@ -79,6 +125,7 @@ public class WhenTestingSynchronisation : BaseMainLayoutTest
             isAuthenticated: true,
             catchSynchroniser,
             diagnosticSynchroniser);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/catches");
         var logging = context.Services.GetRequiredService<ILoggingService>();
 
         // Act
@@ -105,6 +152,7 @@ public class WhenTestingSynchronisation : BaseMainLayoutTest
             isAuthenticated: true,
             catchSynchroniser,
             diagnosticSynchroniser);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/catches");
         var logging = context.Services.GetRequiredService<ILoggingService>();
 
         // Act


### PR DESCRIPTION
## Why

CBDF had strong unit, component, integration and low-level browser coverage, but no browser journey through the real Blazor WebAssembly application, Cognito authorization, API, PostgreSQL and IndexedDB. This is the first reviewable slice of #133.

## What this automates

- Dedicated, pinned Playwright Chromium project under `tests/FishingLogBook.E2E`.
- Real Cognito hosted-UI login with ignored ephemeral session state; API authorization is not bypassed.
- Disposable PostgreSQL 18 database per run with real DbUp migrations and independent teardown.
- Online Catch List → Record → Edit → authenticated API persistence.
- Online → offline → local Record/Edit → reconnect → synchronise → server/local consistency and no duplicate.
- Actionable install-page UI smoke.
- Failure screenshots/report; authenticated traces remain local-only and are disabled in CI.
- PR, manual and nightly workflow, guarded by `E2E_ENABLED=true`.

## Defects exposed and fixed by the E2E run

- Catch/diagnostic synchronisation no longer starts on anonymous landing, onboarding, or authentication callback routes.
- Catch List checks browser connectivity before attempting its optional server merge, while continuing to render local catches offline.
- Catch-card action menus are positioned relative to their card and remain clickable rather than being intercepted by the fixed app bar.
- The harness now follows real in-app navigation while offline, waits for actual authentication/onboarding state, and uses IPv4 for deterministic local Cognito metadata retrieval.
- Temporary auth diagnostic logging used during investigation was removed.

## Local Windows command

```powershell
$env:E2E_COGNITO_USERNAME = "<dedicated E2E user>"
$env:E2E_COGNITO_PASSWORD = "<secret>"
npm --prefix tests/FishingLogBook.E2E ci
npm --prefix tests/FishingLogBook.E2E run install:browsers
npm --prefix tests/FishingLogBook.E2E test
```

Docker Desktop and a dedicated DEV Cognito user are required. The setup and physical-device boundaries are documented in the project README.

## GitHub configuration required

- Repository variable: `E2E_ENABLED=true`
- Repository secrets: `E2E_COGNITO_USERNAME`, `E2E_COGNITO_PASSWORD`

The browser workflow runs on pull requests, manually, and nightly at 02:30 UTC. Until enabled, it is visibly skipped and never falls back to fake/weakened authentication.

## Data and security isolation

Each run owns a disposable PostgreSQL container/database and uses `E2E-<run-id>-<test>` identifiers. It never truncates or deletes shared DEV/private-alpha data. Credentials, session state and tokens are not committed or uploaded in artifacts. No production auth bypass was added.

## Validation

- Authenticated full-app Chromium E2E: **3 passed** (online Record/Edit, offline Record/Edit/reconnect, install guidance)
- E2E configuration tests: **7 passed**
- Release build: **succeeded, 0 warnings/errors**
- Web/bUnit: **670 passed**
- API: **149 passed**
- Application: **298 passed**
- Shared: **18 passed**
- Db migrations: **10 passed**
- Vitest: **210 passed**
- Existing browser/PWA suite: **27 passed, 1 expected WebKit skip**
- `git diff --check`: passed
- Docker-backed Infrastructure suite could not be rerun inside the Codex filesystem sandbox because its Docker named pipe is inaccessible; the disposable PostgreSQL E2E stack itself ran successfully in the developer run above.

## Self review

- Issue/AC: **PASS for PR 1 browser-E2E slice**; Android emulator acceptance criteria remain explicitly deferred to the next #133 slice.
- Architecture/CQRS: **PASS**; no API/Application/Domain/persistence architecture changes.
- Rules: **PASS**.
- Security/privacy: **PASS**; real Cognito/API authorization retained, secrets/session excluded from artifacts.
- Database/migrations: **N/A**; no schema or migration changes.
- Tests/coverage: **PASS**; component tests cover each production correction and real browser journeys cover their integration.
- Browser: **PASS**; three authenticated journeys passed twice locally.
- Web/UI/localisation: **PASS**; no user-facing copy or localisation resources changed.
- Code smells: **PASS**; temporary diagnostic output removed and changes remain narrowly scoped.
- CI/deployment: **PASS**; no deployment, Terraform, provider, or live infrastructure changes.

### Findings discovered and fixed

1. Authentication setup could race the real post-callback route and forced onboarding navigation.
2. Landing/auth routes triggered authenticated sync work before the application was ready.
3. Offline Catch List made a predictably failing optional API request.
4. Catch-card menu positioning escaped its component CSS context.
5. Offline E2E navigation and response assertions raced the application lifecycle.
6. Temporary bearer-presence diagnostic output was no longer needed.

### Remaining deliberate gaps

- Android emulator/ADB lifecycle automation is the next #133 PR.
- Physical Samsung/iPhone/iPad validation remains required; Chromium E2E does not claim to prove iOS or OEM-specific installed-PWA behaviour.

Refs #133.