### PR TITLE
FLB#132 | Stabilise pending authentication redirect test

### DIFF
--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Web.Features.Diagnostics.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using LandingPage = FishingLogBook.Web.Features.Onboarding.Pages.Landing.Landing;
@@ -129,14 +130,34 @@ public class WhenTestingRouting : BaseLandingTest
         await using var context = CreateContext(
             onboarding,
             authenticationStateProvider: Authentication(authentication.Task));
-        var cut = context.Render<LandingPage>();
+        context.Render<LandingPage>();
+        var navigation = context.Services.GetRequiredService<NavigationManager>();
+        var navigated = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+        {
+            if (args.Location.EndsWith("/catches", StringComparison.Ordinal))
+            {
+                navigated.TrySetResult();
+            }
+        }
+
+        navigation.LocationChanged += OnLocationChanged;
 
         // Act
-        authentication.SetResult(Authenticated());
+        try
+        {
+            authentication.SetResult(Authenticated());
+            await navigated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            navigation.LocationChanged -= OnLocationChanged;
+        }
 
         // Assert
-        cut.WaitForAssertion(() =>
-            context.Services.GetRequiredService<NavigationManager>().Uri.Should().EndWith("/catches"));
+        navigation.Uri.Should().EndWith("/catches");
         await onboarding.Received(1).IsCompletedAsync(Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## Summary

- makes the pending-authentication Landing redirect test await the actual `NavigationManager.LocationChanged` event
- removes its dependency on a component re-render that navigation does not guarantee
- does not change production code or deployment behaviour

## Diagnosis

The post-merge deployment workflows both succeeded. The separate `build-test` workflow failed because `ItShouldRedirectAfterPendingAuthenticationResolvesForACompletedUser` used bUnit `WaitForAssertion`, which reruns assertions after renders. The background authentication continuation navigates without requiring the Landing component to render again, so the test could time out despite correct navigation.

## Validation

- focused test passed 10 consecutive runs
- complete Web test suite: 679 passed
- test project Release build: 0 warnings / 0 errors
- `git diff --check`: passed

Follow-up to #132 and PR #137.