### PR TITLE
FLB#132 | Keep offline capability probe available without authentication

### DIFF
--- a/src/FishingLogBook.Web/App.razor
+++ b/src/FishingLogBook.Web/App.razor
@@ -5,7 +5,8 @@
     <CascadingAuthenticationState>
         <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(FishingLogBook.Web.Pages.NotFound.NotFound)">
             <Found Context="routeData">
-                @if (routeData.PageType == typeof(FishingLogBook.Web.Features.Onboarding.Pages.Landing.Landing))
+                @if (routeData.PageType == typeof(FishingLogBook.Web.Features.Onboarding.Pages.Landing.Landing)
+                    || routeData.PageType == typeof(FishingLogBook.Web.Features.Diagnostics.Pages.WebAuthnCapabilityProbe.WebAuthnCapabilityProbe))
                 {
                     <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
                 }

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -34,6 +34,35 @@ public class WhenTestingRouting : BaseLandingTest
     }
 
     [Fact]
+    public async Task ItShouldRenderTheOfflineProbeThroughTheRouterWhileAuthenticationIsPending()
+    {
+        // Arrange
+        var authentication = new TaskCompletionSource<AuthenticationState>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var probe = Probe(hasMetadata: true);
+        probe.GetStatusAsync(Arg.Any<CancellationToken>()).Returns(
+            new FishingLogBook.Web.Features.Diagnostics.Models.WebAuthnCapabilityProbeResultModel
+            {
+                HasProbeMetadata = true,
+                Outcome = "ready"
+            });
+        await using var context = CreateContext(
+            Onboarding(false),
+            probe: probe,
+            authenticationStateProvider: Authentication(authentication.Task));
+        AddApplicationShell(context);
+        context.Services.GetRequiredService<NavigationManager>()
+            .NavigateTo("/diagnostics/webauthn-capability-probe");
+
+        // Act
+        var cut = context.Render<App>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#test-offline-webauthn-button").Should().NotBeNull());
+        cut.Markup.Should().NotContain("Authorizing...");
+    }
+
+    [Fact]
     public void ItShouldKeepApplicationPagesProtected()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- routes the disposable WebAuthn capability probe without waiting for remote authentication state
- allows the Landing probe action to work after an offline iPhone PWA cold start
- keeps all existing `[Authorize]` application routes unchanged
- adds a router-level regression test with authentication deliberately left pending

## Validation

- focused Landing/probe tests: 20 passed
- complete Web suite: 680 passed
- Release solution build: 0 warnings / 0 errors
- `git diff --check`: passed

Follow-up to #132. This contains the physical-device finding discovered after PR #138 had already been merged.