### PR TITLE
FLB#132 | Diagnose offline PRF payload decryption

### DIFF
--- a/src/FishingLogBook.Web/Features/Diagnostics/Models/WebAuthnCapabilityProbeResultModel.cs
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Models/WebAuthnCapabilityProbeResultModel.cs
@@ -10,6 +10,8 @@ public sealed record WebAuthnCapabilityProbeResultModel
 
     public bool HasProbeMetadata { get; init; }
 
+    public bool PayloadEnvelopeAvailable { get; init; }
+
     public bool CredentialCreated { get; init; }
 
     public bool? CreatePrfEnabled { get; init; }
@@ -24,7 +26,15 @@ public sealed record WebAuthnCapabilityProbeResultModel
 
     public bool GetPrfResultReturned { get; init; }
 
+    public int? PrfResultLength { get; init; }
+
+    public string PrfResultBranch { get; init; } = "missing";
+
+    public bool? PrfFingerprintMatches { get; init; }
+
     public bool TestPayloadVerified { get; init; }
+
+    public string PayloadVerificationOutcome { get; init; } = "not-attempted";
 
     public string Outcome { get; init; } = "unknown";
 }

--- a/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor
@@ -48,7 +48,11 @@
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_UserVerified"]" Value="@BooleanLabel(_onlineVerificationResult.UserVerified)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_GetPrfReported"]" Value="@BooleanLabel(_onlineVerificationResult.GetPrfExtensionReported)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_GetPrfResult"]" Value="@BooleanLabel(_onlineVerificationResult.GetPrfResultReturned)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PrfResultBranch"]" Value="@PrfResultBranchLabel(_onlineVerificationResult.PrfResultBranch)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PrfResultLength"]" Value="@LengthLabel(_onlineVerificationResult.PrfResultLength)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PayloadEnvelopeAvailable"]" Value="@BooleanLabel(_onlineVerificationResult.PayloadEnvelopeAvailable)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_PayloadVerified"]" Value="@BooleanLabel(_onlineVerificationResult.TestPayloadVerified)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PayloadVerificationOutcome"]" Value="@PayloadVerificationOutcomeLabel(_onlineVerificationResult.PayloadVerificationOutcome)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_Outcome"]" Value="@OutcomeLabel(_onlineVerificationResult.Outcome)" />
                     </div>
                 }
@@ -62,7 +66,7 @@
                 <MudButton Variant="Variant.Filled"
                            Color="Color.Secondary"
                            StartIcon="@Icons.Material.Filled.LockOpen"
-                           Disabled="@(_isBusy || _status?.HasProbeMetadata != true)"
+                           Disabled="@(_isBusy || _status?.PayloadEnvelopeAvailable != true)"
                            OnClick="TestOfflineUnlockAsync"
                            id="test-offline-webauthn-button">
                     @Loc["WebAuthnProbe_OfflineAction"]
@@ -70,12 +74,16 @@
                 @if (_offlineResult is not null)
                 {
                     <div id="webauthn-offline-results">
-                        <ProbeResultRow Label="@Loc["WebAuthnProbe_OfflineAtInvocation"]" Value="@BooleanLabel(!_offlineResult.IsOnlineAtInvocation)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_NetworkHint"]" Value="@NetworkHintLabel(_offlineResult.IsOnlineAtInvocation)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_GetSucceeded"]" Value="@BooleanLabel(_offlineResult.GetSucceeded)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_UserVerified"]" Value="@BooleanLabel(_offlineResult.UserVerified)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_GetPrfReported"]" Value="@BooleanLabel(_offlineResult.GetPrfExtensionReported)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_GetPrfResult"]" Value="@BooleanLabel(_offlineResult.GetPrfResultReturned)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PrfResultBranch"]" Value="@PrfResultBranchLabel(_offlineResult.PrfResultBranch)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PrfResultLength"]" Value="@LengthLabel(_offlineResult.PrfResultLength)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PrfFingerprintMatches"]" Value="@NullableBooleanLabel(_offlineResult.PrfFingerprintMatches)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_PayloadVerified"]" Value="@BooleanLabel(_offlineResult.TestPayloadVerified)" />
+                        <ProbeResultRow Label="@Loc["WebAuthnProbe_PayloadVerificationOutcome"]" Value="@PayloadVerificationOutcomeLabel(_offlineResult.PayloadVerificationOutcome)" />
                         <ProbeResultRow Label="@Loc["WebAuthnProbe_Outcome"]" Value="@OutcomeLabel(_offlineResult.Outcome)" />
                     </div>
                 }

--- a/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor.cs
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Pages/WebAuthnCapabilityProbe/WebAuthnCapabilityProbe.razor.cs
@@ -58,6 +58,7 @@ public partial class WebAuthnCapabilityProbe : ComponentBase
         try
         {
             _onlineVerificationResult = await Probe.VerifyOnlineAsync(CancellationToken.None);
+            _status = _onlineVerificationResult;
         }
         finally
         {
@@ -95,5 +96,27 @@ public partial class WebAuthnCapabilityProbe : ComponentBase
     private string OutcomeLabel(string outcome)
     {
         return Loc[$"WebAuthnProbe_Outcome_{outcome}"];
+    }
+
+    private string PrfResultBranchLabel(string branch)
+    {
+        return Loc[$"WebAuthnProbe_PrfResultBranch_{branch}"];
+    }
+
+    private string PayloadVerificationOutcomeLabel(string outcome)
+    {
+        return Loc[$"WebAuthnProbe_PayloadVerificationOutcome_{outcome}"];
+    }
+
+    private string LengthLabel(int? length)
+    {
+        return length.HasValue ? Loc["WebAuthnProbe_Bytes", length.Value] : Loc["WebAuthnProbe_NotReported"];
+    }
+
+    private string NetworkHintLabel(bool browserReportsOnline)
+    {
+        return browserReportsOnline
+            ? Loc["WebAuthnProbe_NetworkHintOnline"]
+            : Loc["WebAuthnProbe_NetworkHintOffline"];
     }
 }

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -756,7 +756,25 @@
   <data name="WebAuthnProbe_GetPrfReported" xml:space="preserve"><value>Extension PRF indiquée lors de GET</value></data>
   <data name="WebAuthnProbe_GetPrfResult" xml:space="preserve"><value>Résultat PRF lors de GET</value></data>
   <data name="WebAuthnProbe_PayloadVerified" xml:space="preserve"><value>Contenu inoffensif déchiffré</value></data>
-  <data name="WebAuthnProbe_OfflineAtInvocation" xml:space="preserve"><value>Hors ligne lors du lancement</value></data>
+  <data name="WebAuthnProbe_NetworkHint" xml:space="preserve"><value>Indication réseau du navigateur</value></data>
+  <data name="WebAuthnProbe_NetworkHintOnline" xml:space="preserve"><value>En ligne (signalé par le navigateur, non fiable)</value></data>
+  <data name="WebAuthnProbe_NetworkHintOffline" xml:space="preserve"><value>Hors ligne (signalé par le navigateur)</value></data>
+  <data name="WebAuthnProbe_PayloadEnvelopeAvailable" xml:space="preserve"><value>Contenu chiffré prêt</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch" xml:space="preserve"><value>Représentation du résultat PRF</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_array-buffer" xml:space="preserve"><value>ArrayBuffer</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_typed-array" xml:space="preserve"><value>Vue de tableau typé</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_missing" xml:space="preserve"><value>Non renvoyé</value></data>
+  <data name="WebAuthnProbe_PrfResultLength" xml:space="preserve"><value>Longueur du résultat PRF</value></data>
+  <data name="WebAuthnProbe_Bytes" xml:space="preserve"><value>{0} octets</value></data>
+  <data name="WebAuthnProbe_PrfFingerprintMatches" xml:space="preserve"><value>Empreinte de comparaison PRF identique</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome" xml:space="preserve"><value>Détail de la vérification du contenu</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_not-attempted" xml:space="preserve"><value>Non tenté</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_missing-envelope" xml:space="preserve"><value>Exécutez d’abord la vérification en ligne</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_prf-mismatch" xml:space="preserve"><value>Le matériel PRF diffère de la vérification en ligne</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_invalid-envelope" xml:space="preserve"><value>Les métadonnées du contenu enregistré sont invalides</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_decrypt-failed" xml:space="preserve"><value>Le déchiffrement AES-GCM a échoué</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_plaintext-mismatch" xml:space="preserve"><value>Le contenu déchiffré ne correspond pas</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_verified" xml:space="preserve"><value>Contenu déchiffré et conforme</value></data>
   <data name="WebAuthnProbe_Outcome" xml:space="preserve"><value>Résultat</value></data>
   <data name="WebAuthnProbe_Yes" xml:space="preserve"><value>Oui</value></data>
   <data name="WebAuthnProbe_No" xml:space="preserve"><value>Non</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -756,7 +756,25 @@
   <data name="WebAuthnProbe_GetPrfReported" xml:space="preserve"><value>PRF extension reported on GET</value></data>
   <data name="WebAuthnProbe_GetPrfResult" xml:space="preserve"><value>PRF result on GET</value></data>
   <data name="WebAuthnProbe_PayloadVerified" xml:space="preserve"><value>Harmless payload decrypted</value></data>
-  <data name="WebAuthnProbe_OfflineAtInvocation" xml:space="preserve"><value>Offline at invocation</value></data>
+  <data name="WebAuthnProbe_NetworkHint" xml:space="preserve"><value>Browser network hint</value></data>
+  <data name="WebAuthnProbe_NetworkHintOnline" xml:space="preserve"><value>Online (browser-reported; not authoritative)</value></data>
+  <data name="WebAuthnProbe_NetworkHintOffline" xml:space="preserve"><value>Offline (browser-reported)</value></data>
+  <data name="WebAuthnProbe_PayloadEnvelopeAvailable" xml:space="preserve"><value>Encrypted payload ready</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch" xml:space="preserve"><value>PRF result representation</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_array-buffer" xml:space="preserve"><value>ArrayBuffer</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_typed-array" xml:space="preserve"><value>Typed array view</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_missing" xml:space="preserve"><value>Not returned</value></data>
+  <data name="WebAuthnProbe_PrfResultLength" xml:space="preserve"><value>PRF result length</value></data>
+  <data name="WebAuthnProbe_Bytes" xml:space="preserve"><value>{0} bytes</value></data>
+  <data name="WebAuthnProbe_PrfFingerprintMatches" xml:space="preserve"><value>PRF comparison fingerprint matches</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome" xml:space="preserve"><value>Payload verification detail</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_not-attempted" xml:space="preserve"><value>Not attempted</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_missing-envelope" xml:space="preserve"><value>Run online verification first</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_prf-mismatch" xml:space="preserve"><value>PRF material differed from online verification</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_invalid-envelope" xml:space="preserve"><value>Stored payload metadata is invalid</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_decrypt-failed" xml:space="preserve"><value>AES-GCM decryption failed</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_plaintext-mismatch" xml:space="preserve"><value>Decrypted payload did not match</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_verified" xml:space="preserve"><value>Payload decrypted and matched</value></data>
   <data name="WebAuthnProbe_Outcome" xml:space="preserve"><value>Outcome</value></data>
   <data name="WebAuthnProbe_Yes" xml:space="preserve"><value>Yes</value></data>
   <data name="WebAuthnProbe_No" xml:space="preserve"><value>No</value></data>

--- a/src/FishingLogBook.Web/wwwroot/js/browser/webauthn-capability-probe.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/webauthn-capability-probe.js
@@ -1,5 +1,6 @@
 const storageKey = 'fishingLogBook.webAuthnCapabilityProbe.v1';
 const payload = new TextEncoder().encode('cbdf-webauthn-capability-probe');
+const fingerprintLength = 12;
 
 const outcomes = Object.freeze({
     unknown: 'unknown',
@@ -20,6 +21,7 @@ function emptyResult(outcome = outcomes.unknown) {
         platformAuthenticatorAvailable: null,
         isOnlineAtInvocation: navigator.onLine,
         hasProbeMetadata: hasProbeMetadata(),
+        payloadEnvelopeAvailable: hasPayloadEnvelope(),
         credentialCreated: false,
         createPrfEnabled: null,
         createPrfResultReturned: false,
@@ -27,7 +29,11 @@ function emptyResult(outcome = outcomes.unknown) {
         userVerified: false,
         getPrfExtensionReported: false,
         getPrfResultReturned: false,
+        prfResultLength: null,
+        prfResultBranch: 'missing',
+        prfFingerprintMatches: null,
         testPayloadVerified: false,
+        payloadVerificationOutcome: 'not-attempted',
         outcome
     };
 }
@@ -74,14 +80,20 @@ function fromBase64Url(value) {
 function getPrfDetails(credential) {
     const prf = credential.getClientExtensionResults?.().prf;
     const first = prf?.results?.first;
+    const result = first instanceof ArrayBuffer
+        ? new Uint8Array(first)
+        : ArrayBuffer.isView(first)
+            ? new Uint8Array(first.buffer, first.byteOffset, first.byteLength)
+            : null;
     return {
         reported: prf !== undefined,
         enabled: typeof prf?.enabled === 'boolean' ? prf.enabled : null,
-        result: first instanceof ArrayBuffer
-            ? new Uint8Array(first)
+        result,
+        branch: first instanceof ArrayBuffer
+            ? 'array-buffer'
             : ArrayBuffer.isView(first)
-                ? new Uint8Array(first.buffer, first.byteOffset, first.byteLength)
-                : null
+                ? 'typed-array'
+                : 'missing'
     };
 }
 
@@ -114,6 +126,18 @@ function writeMetadata(metadata) {
     localStorage.setItem(storageKey, JSON.stringify(metadata));
 }
 
+function hasPayloadEnvelope(metadata = readMetadata()) {
+    return metadata !== null
+        && typeof metadata.iv === 'string'
+        && typeof metadata.ciphertext === 'string'
+        && typeof metadata.prfFingerprint === 'string';
+}
+
+async function fingerprint(value) {
+    const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', value));
+    return toBase64Url(digest.slice(0, fingerprintLength));
+}
+
 async function createPayloadEnvelope(prfResult) {
     const key = await crypto.subtle.importKey('raw', prfResult, 'AES-GCM', false, ['encrypt', 'decrypt']);
     const iv = randomBytes(12);
@@ -124,24 +148,52 @@ async function createPayloadEnvelope(prfResult) {
     return {
         iv: toBase64Url(iv),
         ciphertext: toBase64Url(ciphertext),
+        prfFingerprint: await fingerprint(prfResult),
         verified
     };
 }
 
 async function verifyPayloadEnvelope(metadata, prfResult) {
-    if (typeof metadata.iv !== 'string' || typeof metadata.ciphertext !== 'string') {
-        return false;
+    if (!hasPayloadEnvelope(metadata)) {
+        return { verified: false, fingerprintMatches: null, outcome: 'missing-envelope' };
+    }
+
+    let fingerprintMatches = null;
+    try {
+        fingerprintMatches = await fingerprint(prfResult) === metadata.prfFingerprint;
+        if (!fingerprintMatches) {
+            return { verified: false, fingerprintMatches: false, outcome: 'prf-mismatch' };
+        }
+    } catch {
+        return { verified: false, fingerprintMatches, outcome: 'decrypt-failed' };
+    }
+
+    let iv;
+    let ciphertext;
+    try {
+        iv = fromBase64Url(metadata.iv);
+        ciphertext = fromBase64Url(metadata.ciphertext);
+        if (iv.byteLength !== 12 || ciphertext.byteLength <= 16) {
+            return { verified: false, fingerprintMatches: true, outcome: 'invalid-envelope' };
+        }
+    } catch {
+        return { verified: false, fingerprintMatches: true, outcome: 'invalid-envelope' };
     }
 
     try {
         const key = await crypto.subtle.importKey('raw', prfResult, 'AES-GCM', false, ['decrypt']);
         const plaintext = await crypto.subtle.decrypt(
-            { name: 'AES-GCM', iv: fromBase64Url(metadata.iv) },
+            { name: 'AES-GCM', iv },
             key,
-            fromBase64Url(metadata.ciphertext));
-        return new TextDecoder().decode(plaintext) === new TextDecoder().decode(payload);
+            ciphertext);
+        const verified = new TextDecoder().decode(plaintext) === new TextDecoder().decode(payload);
+        return {
+            verified,
+            fingerprintMatches: true,
+            outcome: verified ? 'verified' : 'plaintext-mismatch'
+        };
     } catch {
-        return false;
+        return { verified: false, fingerprintMatches: true, outcome: 'decrypt-failed' };
     }
 }
 
@@ -275,13 +327,19 @@ export async function verifyOnlineCredential() {
         const getPrf = getPrfDetails(assertion);
         result.getPrfExtensionReported = getPrf.reported;
         result.getPrfResultReturned = getPrf.result !== null;
+        result.prfResultLength = getPrf.result?.byteLength ?? null;
+        result.prfResultBranch = getPrf.branch;
 
         if (getPrf.result !== null) {
             const envelope = await createPayloadEnvelope(getPrf.result);
             metadata.iv = envelope.iv;
             metadata.ciphertext = envelope.ciphertext;
+            metadata.prfFingerprint = envelope.prfFingerprint;
             writeMetadata(metadata);
+            result.payloadEnvelopeAvailable = true;
+            result.prfFingerprintMatches = true;
             result.testPayloadVerified = envelope.verified;
+            result.payloadVerificationOutcome = envelope.verified ? 'verified' : 'plaintext-mismatch';
         }
 
         result.outcome = outcomes.verifiedOnline;
@@ -318,8 +376,15 @@ export async function testOfflineUnlock() {
         const getPrf = getPrfDetails(assertion);
         result.getPrfExtensionReported = getPrf.reported;
         result.getPrfResultReturned = getPrf.result !== null;
-        result.testPayloadVerified = getPrf.result !== null
-            && await verifyPayloadEnvelope(metadata, getPrf.result);
+        result.prfResultLength = getPrf.result?.byteLength ?? null;
+        result.prfResultBranch = getPrf.branch;
+        result.payloadEnvelopeAvailable = hasPayloadEnvelope(metadata);
+        if (getPrf.result !== null) {
+            const verification = await verifyPayloadEnvelope(metadata, getPrf.result);
+            result.testPayloadVerified = verification.verified;
+            result.prfFingerprintMatches = verification.fingerprintMatches;
+            result.payloadVerificationOutcome = verification.outcome;
+        }
         result.outcome = outcomes.retrieved;
         return result;
     } catch (error) {

--- a/src/FishingLogBook.Web/wwwroot/js/browser/webauthn-capability-probe.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/webauthn-capability-probe.test.js
@@ -127,7 +127,7 @@ describe('WebAuthn capability probe', () => {
         expect(JSON.stringify(result)).not.toContain('99');
         expect(JSON.stringify(verified)).not.toContain('99');
         expect(Object.keys(stored).sort()).toEqual([
-            'ciphertext', 'credentialId', 'iv', 'prfSalt', 'transports', 'version'
+            'ciphertext', 'credentialId', 'iv', 'prfFingerprint', 'prfSalt', 'transports', 'version'
         ]);
         expect(stored).not.toHaveProperty('prfResult');
         for (const spy of consoleSpies) {
@@ -146,7 +146,12 @@ describe('WebAuthn capability probe', () => {
         expect(result.userVerified).toBe(true);
         expect(result.getPrfExtensionReported).toBe(true);
         expect(result.getPrfResultReturned).toBe(true);
+        expect(result.prfResultLength).toBe(32);
+        expect(result.prfResultBranch).toBe('array-buffer');
+        expect(result.prfFingerprintMatches).toBe(true);
+        expect(result.payloadEnvelopeAvailable).toBe(true);
         expect(result.testPayloadVerified).toBe(true);
+        expect(result.payloadVerificationOutcome).toBe('verified');
         expect(result.outcome).toBe('verified-online');
         expect(get).toHaveBeenCalledTimes(1);
         expect(get.mock.calls[0][0].publicKey.userVerification).toBe('required');
@@ -188,9 +193,68 @@ describe('WebAuthn capability probe', () => {
         expect(result.getSucceeded).toBe(true);
         expect(result.userVerified).toBe(true);
         expect(result.getPrfResultReturned).toBe(true);
+        expect(result.prfFingerprintMatches).toBe(true);
         expect(result.testPayloadVerified).toBe(true);
+        expect(result.payloadVerificationOutcome).toBe('verified');
         expect(result.outcome).toBe('retrieved');
         expect(get).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not claim payload readiness until online verification creates the envelope', async () => {
+        await provisionTestCredential();
+
+        expect((await getProbeStatus()).payloadEnvelopeAvailable).toBe(false);
+
+        const prematureResult = await testOfflineUnlock();
+        expect(prematureResult.testPayloadVerified).toBe(false);
+        expect(prematureResult.payloadVerificationOutcome).toBe('missing-envelope');
+
+        await verifyOnlineCredential();
+
+        expect((await getProbeStatus()).payloadEnvelopeAvailable).toBe(true);
+    });
+
+    it('distinguishes different offline PRF material without exposing it', async () => {
+        const get = vi.fn()
+            .mockResolvedValueOnce(assertion({ result: prfResult(7) }))
+            .mockResolvedValueOnce(assertion({ result: prfResult(8) }));
+        configureWebAuthn({ get });
+        await provisionTestCredential();
+        await verifyOnlineCredential();
+
+        const result = await testOfflineUnlock();
+
+        expect(result.getPrfResultReturned).toBe(true);
+        expect(result.prfFingerprintMatches).toBe(false);
+        expect(result.testPayloadVerified).toBe(false);
+        expect(result.payloadVerificationOutcome).toBe('prf-mismatch');
+        expect(JSON.stringify(result)).not.toContain(new Uint8Array(prfResult(8)).toString());
+    });
+
+    it('distinguishes invalid persisted envelope encoding from a PRF mismatch', async () => {
+        await provisionTestCredential();
+        await verifyOnlineCredential();
+        const key = localStorage.key(0);
+        const metadata = JSON.parse(localStorage.getItem(key));
+        metadata.iv = '';
+        localStorage.setItem(key, JSON.stringify(metadata));
+
+        const result = await testOfflineUnlock();
+
+        expect(result.prfFingerprintMatches).toBe(true);
+        expect(result.testPayloadVerified).toBe(false);
+        expect(result.payloadVerificationOutcome).toBe('invalid-envelope');
+    });
+
+    it('records a typed-array PRF result representation', async () => {
+        configureWebAuthn({ get: vi.fn(async () => assertion({ result: new Uint8Array(32).fill(7) })) });
+        await provisionTestCredential();
+
+        const result = await verifyOnlineCredential();
+
+        expect(result.prfResultBranch).toBe('typed-array');
+        expect(result.prfResultLength).toBe(32);
+        expect(result.testPayloadVerified).toBe(true);
     });
 
     it('reports missing metadata without invoking GET', async () => {

--- a/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/WebAuthnCapabilityProbeTests/BaseWebAuthnCapabilityProbeTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/WebAuthnCapabilityProbeTests/BaseWebAuthnCapabilityProbeTest.cs
@@ -19,6 +19,7 @@ public class BaseWebAuthnCapabilityProbeTest
             WebAuthnAvailable = true,
             PlatformAuthenticatorAvailable = true,
             HasProbeMetadata = true,
+            PayloadEnvelopeAvailable = true,
             Outcome = "ready"
         });
 

--- a/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/WebAuthnCapabilityProbeTests/WhenTestingProbe.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Pages/WebAuthnCapabilityProbeTests/WhenTestingProbe.cs
@@ -62,7 +62,12 @@ public class WhenTestingProbe : BaseWebAuthnCapabilityProbeTest
             UserVerified = true,
             GetPrfExtensionReported = true,
             GetPrfResultReturned = true,
+            PrfResultLength = 32,
+            PrfResultBranch = "array-buffer",
+            PrfFingerprintMatches = true,
+            PayloadEnvelopeAvailable = true,
             TestPayloadVerified = true,
+            PayloadVerificationOutcome = "verified",
             Outcome = "verified-online"
         });
         await using var context = CreateContext(probe);
@@ -84,8 +89,30 @@ public class WhenTestingProbe : BaseWebAuthnCapabilityProbeTest
         var getResults = cut.Find("#webauthn-online-verification-results").TextContent;
         getResults.Should().Contain("Immediate GET succeeded");
         getResults.Should().Contain("PRF extension reported on GET");
+        getResults.Should().Contain("32 bytes");
+        getResults.Should().Contain("ArrayBuffer");
         getResults.Should().Contain("Harmless payload decrypted");
         await probe.Received(1).VerifyOnlineAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRequireOnlineVerificationBeforeOfferingOfflineDecryption()
+    {
+        // Arrange
+        var probe = Substitute.For<IWebAuthnCapabilityProbeService>();
+        await using var context = CreateContext(probe, new WebAuthnCapabilityProbeResultModel
+        {
+            HasProbeMetadata = true,
+            PayloadEnvelopeAvailable = false,
+            Outcome = "ready"
+        });
+
+        // Act
+        var cut = context.Render<WebAuthnCapabilityProbe>();
+
+        // Assert
+        cut.Find("#test-offline-webauthn-button").HasAttribute("disabled").Should().BeTrue();
+        cut.Find("#verify-online-webauthn-probe-button").HasAttribute("disabled").Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- fixes the capability probe allowing offline unlock before its harmless AES-GCM payload envelope had been created
- adds safe diagnostics to distinguish missing envelope, PRF mismatch, invalid encoding, decrypt failure and plaintext mismatch
- handles both ArrayBuffer and typed-array PRF result representations
- labels `navigator.onLine` as a non-authoritative browser network hint
- keeps all changes confined to the disposable WebAuthn capability probe

No production offline authentication, Cognito, token storage, service-worker, catch storage or sync behaviour is changed. The known-working capability probe is deliberately retained until #141 proves and replaces it with the production implementation.

## Diagnosis

Provisioning persisted the credential ID and PRF salt, but the encrypted harmless-payload envelope was created only by the separate online verification action. The previous UI enabled offline testing after provisioning alone, so a successful offline GET with a PRF result could still report “Harmless payload decrypted: No” simply because there was no envelope to decrypt.

The earlier failure was therefore a probe sequencing bug, **not** evidence that iPhone WebAuthn PRF could not recover stable cryptographic material.

## Physical-device validation — passed

### iPhone installed Home Screen PWA

Validated with Wi-Fi and cellular explicitly disabled after online provisioning and verification:

online provision → online verification/envelope creation → kill PWA → reopen genuinely offline → explicit unlock → device verification → WebAuthn GET → PRF result → AES-GCM decrypt → plaintext match.

Observed:
- GET succeeded: Yes
- user verification: Yes
- PRF extension/result: Yes
- representation: ArrayBuffer
- length: 32 bytes
- PRF comparison fingerprint: matched
- harmless payload: decrypted and matched
- outcome: credential retrieval completed

Face ID, passkey/device credential, and mixed verification combinations succeeded.

### Android / Samsung

Offline credential retrieval and encrypted-payload recovery succeeded with multiple device-verification methods.

### Network hint

On iPhone, `navigator.onLine` reported online while both Wi-Fi and cellular were disabled. It is correctly retained only as a browser hint and must not become authoritative connectivity or authorization evidence in #141.

## Validation

- GitHub CI: all required checks passed
- JavaScript unit tests: 226 passed locally
- Web tests: 687 passed locally
- browser/PWA tests: 27 passed, 1 existing WebKit offline-shell skip
- Release build: 0 warnings / 0 errors
- formatting of PR #140 files and diff checks: clean
- local full-solution container tests could not access the Docker named pipe; the same complete .NET solution passed in GitHub CI

## Self review

- Issue/AC: PASS — capability question answered on real iPhone and Android devices
- Architecture/CQRS: PASS — disposable client-side probe only; no production authentication path
- Rules: PASS
- Security/privacy: PASS — no raw PRF material logged or persisted; safe comparison fingerprint only
- Database/migrations: N/A
- Tests/coverage: PASS
- Browser: PASS — automated browser suite plus genuine offline physical-device validation
- Web/UI/localisation: PASS — EN/FR diagnostic parity retained
- Code smells: PASS — diagnostics are narrowly scoped and distinguish actionable outcomes
- CI/deployment: PASS — no infrastructure or production-authentication changes

Findings discovered during self-review:
1. No BLOCKER or SHOULD FIX findings.
2. Local Docker/Testcontainers access was unavailable; GitHub CI confirms the complete .NET suite passes.

Fixes made:
1. No code changes required during close-out.
2. Updated this PR and #132 with the completed physical-device evidence and corrected diagnosis.

Remaining deliberate gaps:
- Production offline entitlement, principal/routes, lifecycle and removal of the probe belong to #141.

Follow-up to #132 and merged PR #139.