### PR TITLE
FLB#141 | Add production offline access setup

### DIFF
--- a/src/FishingLogBook.Api/Endpoints/UserEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/UserEndpoints.cs
@@ -1,5 +1,8 @@
 using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.OfflineAccess.Commands;
+using FishingLogBook.Application.OfflineAccess.Queries;
 using FishingLogBook.Shared.Dtos;
+using MediatR;
 
 namespace FishingLogBook.Api.Endpoints;
 
@@ -15,6 +18,22 @@ public static class UserEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status503ServiceUnavailable);
 
+        endpoints.MapGet("/api/users/current/offline-access-preference", GetOfflineAccessPreferenceAsync)
+            .WithName("GetOfflineAccessPreference")
+            .WithTags("Users")
+            .RequireAuthorization()
+            .Produces<OfflineAccessPreferenceDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        endpoints.MapPut("/api/users/current/offline-access-preference", UpdateOfflineAccessPreferenceAsync)
+            .WithName("UpdateOfflineAccessPreference")
+            .WithTags("Users")
+            .RequireAuthorization()
+            .Produces<OfflineAccessPreferenceDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
         return endpoints;
     }
 
@@ -25,6 +44,48 @@ public static class UserEndpoints
             return Results.Unauthorized();
         }
 
-        return Results.Ok(new CurrentUserDto(currentUser.UserId, currentUser.Email));
+        return Results.Ok(new CurrentUserDto(
+            currentUser.UserId,
+            currentUser.Email,
+            currentUser.Provider,
+            currentUser.Subject));
+    }
+
+    private static async Task<IResult> GetOfflineAccessPreferenceAsync(
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new GetOfflineAccessPreferenceQuery { UserId = currentUser.UserId }, cancellationToken);
+        return response.IsFailure || response.Preference is null
+            ? Results.Problem(response.ErrorMessage, statusCode: StatusCodes.Status503ServiceUnavailable)
+            : Results.Ok(response.Preference);
+    }
+
+    private static async Task<IResult> UpdateOfflineAccessPreferenceAsync(
+        OfflineAccessPreferenceDto preference,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(new UpdateOfflineAccessPreferenceCommand
+        {
+            UserId = currentUser.UserId,
+            Enabled = preference.Enabled
+        }, cancellationToken);
+        return response.IsFailure || response.Preference is null
+            ? Results.Problem(response.ErrorMessage, statusCode: StatusCodes.Status503ServiceUnavailable)
+            : Results.Ok(response.Preference);
     }
 }

--- a/src/FishingLogBook.Api/Middleware/CurrentUserMiddleware.cs
+++ b/src/FishingLogBook.Api/Middleware/CurrentUserMiddleware.cs
@@ -47,7 +47,7 @@ public sealed class CurrentUserMiddleware
                     Email = authenticatedEmail
                 },
                 context.RequestAborted);
-            if (!TryAssignCurrentUser(context, currentUser, response, authenticatedEmail))
+            if (!TryAssignCurrentUser(context, currentUser, response, authenticatedEmail, subject))
             {
                 return;
             }
@@ -71,7 +71,8 @@ public sealed class CurrentUserMiddleware
         HttpContext context,
         ICurrentUser currentUser,
         ResolveCurrentUserResponse response,
-        string email)
+        string email,
+        string subject)
     {
         if (response.IsFailure)
         {
@@ -81,7 +82,7 @@ public sealed class CurrentUserMiddleware
             return false;
         }
 
-        currentUser.Assign(response.UserId, email);
+        currentUser.Assign(response.UserId, email, IdentityProviderConstants.Cognito, subject);
         return true;
     }
 

--- a/src/FishingLogBook.Application/Contracts/Repositories/IOfflineAccessPreferenceRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/Repositories/IOfflineAccessPreferenceRepository.cs
@@ -1,0 +1,14 @@
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Repositories;
+
+public interface IOfflineAccessPreferenceRepository
+{
+    Task<Result<OfflineAccessPreferenceDto>> GetAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task<Result<OfflineAccessPreferenceDto>> SetAsync(
+        Guid userId,
+        bool enabled,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Contracts/Services/ICurrentUser.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/ICurrentUser.cs
@@ -6,7 +6,11 @@ public interface ICurrentUser
 
     string Email { get; }
 
+    string Provider { get; }
+
+    string Subject { get; }
+
     bool IsResolved { get; }
 
-    void Assign(Guid userId, string email);
+    void Assign(Guid userId, string email, string provider, string subject);
 }

--- a/src/FishingLogBook.Application/Contracts/Services/IOfflineAccessPreferenceService.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/IOfflineAccessPreferenceService.cs
@@ -1,0 +1,14 @@
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Services;
+
+public interface IOfflineAccessPreferenceService
+{
+    Task<Result<OfflineAccessPreferenceDto>> GetAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task<Result<OfflineAccessPreferenceDto>> SetAsync(
+        Guid userId,
+        bool enabled,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/OfflineAccess/Commands/UpdateOfflineAccessPreferenceCommand.cs
+++ b/src/FishingLogBook.Application/OfflineAccess/Commands/UpdateOfflineAccessPreferenceCommand.cs
@@ -1,0 +1,38 @@
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using MediatR;
+
+namespace FishingLogBook.Application.OfflineAccess.Commands;
+
+public sealed class UpdateOfflineAccessPreferenceCommand : IRequest<UpdateOfflineAccessPreferenceResponse>
+{
+    public Guid UserId { get; init; }
+    public bool Enabled { get; init; }
+}
+
+public sealed class UpdateOfflineAccessPreferenceResponse : ValidatedResponse
+{
+    public OfflineAccessPreferenceDto? Preference { get; init; }
+}
+
+public sealed class UpdateOfflineAccessPreferenceHandler : IRequestHandler<UpdateOfflineAccessPreferenceCommand, UpdateOfflineAccessPreferenceResponse>
+{
+    private readonly IOfflineAccessPreferenceService _service;
+
+    public UpdateOfflineAccessPreferenceHandler(IOfflineAccessPreferenceService service) => _service = service;
+
+    public async Task<UpdateOfflineAccessPreferenceResponse> Handle(UpdateOfflineAccessPreferenceCommand command, CancellationToken cancellationToken)
+    {
+        var result = await _service.SetAsync(command.UserId, command.Enabled, cancellationToken);
+        return result.IsFailed
+            ? new UpdateOfflineAccessPreferenceResponse { ErrorMessage = result.Errors[0].Message }
+            : new UpdateOfflineAccessPreferenceResponse { Preference = result.Value };
+    }
+}
+
+public sealed class UpdateOfflineAccessPreferenceCommandValidator : AbstractValidator<UpdateOfflineAccessPreferenceCommand>
+{
+    public UpdateOfflineAccessPreferenceCommandValidator() => RuleFor(command => command.UserId).NotEmpty();
+}

--- a/src/FishingLogBook.Application/OfflineAccess/Queries/GetOfflineAccessPreferenceQuery.cs
+++ b/src/FishingLogBook.Application/OfflineAccess/Queries/GetOfflineAccessPreferenceQuery.cs
@@ -1,0 +1,37 @@
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using MediatR;
+
+namespace FishingLogBook.Application.OfflineAccess.Queries;
+
+public sealed class GetOfflineAccessPreferenceQuery : IRequest<GetOfflineAccessPreferenceResponse>
+{
+    public Guid UserId { get; init; }
+}
+
+public sealed class GetOfflineAccessPreferenceResponse : ValidatedResponse
+{
+    public OfflineAccessPreferenceDto? Preference { get; init; }
+}
+
+public sealed class GetOfflineAccessPreferenceHandler : IRequestHandler<GetOfflineAccessPreferenceQuery, GetOfflineAccessPreferenceResponse>
+{
+    private readonly IOfflineAccessPreferenceService _service;
+
+    public GetOfflineAccessPreferenceHandler(IOfflineAccessPreferenceService service) => _service = service;
+
+    public async Task<GetOfflineAccessPreferenceResponse> Handle(GetOfflineAccessPreferenceQuery query, CancellationToken cancellationToken)
+    {
+        var result = await _service.GetAsync(query.UserId, cancellationToken);
+        return result.IsFailed
+            ? new GetOfflineAccessPreferenceResponse { ErrorMessage = result.Errors[0].Message }
+            : new GetOfflineAccessPreferenceResponse { Preference = result.Value };
+    }
+}
+
+public sealed class GetOfflineAccessPreferenceQueryValidator : AbstractValidator<GetOfflineAccessPreferenceQuery>
+{
+    public GetOfflineAccessPreferenceQueryValidator() => RuleFor(query => query.UserId).NotEmpty();
+}

--- a/src/FishingLogBook.Application/OfflineAccess/Services/OfflineAccessPreferenceService.cs
+++ b/src/FishingLogBook.Application/OfflineAccess/Services/OfflineAccessPreferenceService.cs
@@ -1,0 +1,27 @@
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.OfflineAccess.Services;
+
+public sealed class OfflineAccessPreferenceService : IOfflineAccessPreferenceService
+{
+    private readonly IOfflineAccessPreferenceRepository _repository;
+
+    public OfflineAccessPreferenceService(IOfflineAccessPreferenceRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<Result<OfflineAccessPreferenceDto>> GetAsync(
+        Guid userId,
+        CancellationToken cancellationToken) =>
+        _repository.GetAsync(userId, cancellationToken);
+
+    public Task<Result<OfflineAccessPreferenceDto>> SetAsync(
+        Guid userId,
+        bool enabled,
+        CancellationToken cancellationToken) =>
+        _repository.SetAsync(userId, enabled, cancellationToken);
+}

--- a/src/FishingLogBook.Application/Users/CurrentUser.cs
+++ b/src/FishingLogBook.Application/Users/CurrentUser.cs
@@ -8,9 +8,13 @@ public sealed class CurrentUser : ICurrentUser
 
     public string Email { get; private set; } = string.Empty;
 
+    public string Provider { get; private set; } = string.Empty;
+
+    public string Subject { get; private set; } = string.Empty;
+
     public bool IsResolved { get; private set; }
 
-    public void Assign(Guid userId, string email)
+    public void Assign(Guid userId, string email, string provider, string subject)
     {
         if (userId == Guid.Empty)
         {
@@ -22,8 +26,15 @@ public sealed class CurrentUser : ICurrentUser
             throw new InvalidOperationException("Authenticated email is missing.");
         }
 
+        if (string.IsNullOrWhiteSpace(provider) || string.IsNullOrWhiteSpace(subject))
+        {
+            throw new InvalidOperationException("Authenticated identity is missing.");
+        }
+
         UserId = userId;
         Email = email;
+        Provider = provider;
+        Subject = subject;
         IsResolved = true;
     }
 }

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608231300_141_AddOfflineAccessPreference.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608231300_141_AddOfflineAccessPreference.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "User"
+ADD COLUMN "OfflineAccessEnabled" boolean NOT NULL DEFAULT false,
+ADD COLUMN "OfflineAccessEnabledAt" timestamp with time zone NULL;

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using FishingLogBook.Application.Contracts.Repositories;
 using FishingLogBook.Application.Contracts.Services;
 using FishingLogBook.Application.Diagnostics;
 using FishingLogBook.Application.FishingPreferences.Services;
+using FishingLogBook.Application.OfflineAccess.Services;
 using FishingLogBook.Application.Profiles.Services;
 using FishingLogBook.Application.SystemStatus;
 using FishingLogBook.Application.Users;
@@ -55,6 +56,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICatchLocationPrivacyService, CatchLocationPrivacyService>();
         services.AddScoped<IPlatformCapabilityService, PlatformCapabilityService>();
         services.AddScoped<IFishingPreferenceService, FishingPreferenceService>();
+        services.AddScoped<IOfflineAccessPreferenceService, OfflineAccessPreferenceService>();
 
         return services;
     }
@@ -82,6 +84,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserPlatformCapabilityRepository, UserPlatformCapabilityRepository>();
         services.AddScoped<IFishingCatalogueRepository, FishingCatalogueRepository>();
         services.AddScoped<IFishingPreferenceRepository, FishingPreferenceRepository>();
+        services.AddScoped<IOfflineAccessPreferenceRepository, OfflineAccessPreferenceRepository>();
         services.Configure<ObjectStorageConfig>(configuration.GetSection(ObjectStorageConfig.SectionName));
         services.Configure<DiagnosticsConfig>(configuration.GetSection(DiagnosticsConfig.SectionName));
         services.AddSingleton<IObjectStorage, S3CompatibleObjectStorage>();

--- a/src/FishingLogBook.Domain/Users/User.cs
+++ b/src/FishingLogBook.Domain/Users/User.cs
@@ -6,5 +6,9 @@ public sealed class User
 
     public string Email { get; init; } = string.Empty;
 
+    public bool OfflineAccessEnabled { get; init; }
+
+    public DateTimeOffset? OfflineAccessEnabledAt { get; init; }
+
     public DateTimeOffset CreatedOn { get; init; }
 }

--- a/src/FishingLogBook.Infrastructure/Persistence/Repositories/OfflineAccessPreferenceRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/Repositories/OfflineAccessPreferenceRepository.cs
@@ -55,7 +55,10 @@ public sealed class OfflineAccessPreferenceRepository : IOfflineAccessPreference
             const string sql = """
                 UPDATE "User"
                 SET "OfflineAccessEnabled" = @Enabled,
-                    "OfflineAccessEnabledAt" = CASE WHEN @Enabled THEN CURRENT_TIMESTAMP ELSE NULL END
+                    "OfflineAccessEnabledAt" = CASE
+                        WHEN @Enabled THEN CURRENT_TIMESTAMP
+                        ELSE "OfflineAccessEnabledAt"
+                    END
                 WHERE "Id" = @UserId
                 RETURNING "OfflineAccessEnabled" AS "Enabled",
                           "OfflineAccessEnabledAt" AS "EnabledAt";

--- a/src/FishingLogBook.Infrastructure/Persistence/Repositories/OfflineAccessPreferenceRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/Repositories/OfflineAccessPreferenceRepository.cs
@@ -1,0 +1,78 @@
+using Dapper;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using Microsoft.Extensions.Logging;
+
+namespace FishingLogBook.Infrastructure.Persistence.Repositories;
+
+public sealed class OfflineAccessPreferenceRepository : IOfflineAccessPreferenceRepository
+{
+    private const string FailureMessage = "Failed to update offline access preference.";
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly ILogger<OfflineAccessPreferenceRepository> _logger;
+
+    public OfflineAccessPreferenceRepository(IDbConnectionFactory connectionFactory, ILogger<OfflineAccessPreferenceRepository> logger)
+    {
+        _connectionFactory = connectionFactory;
+        _logger = logger;
+    }
+
+    public async Task<Result<OfflineAccessPreferenceDto>> GetAsync(
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                SELECT "OfflineAccessEnabled" AS "Enabled",
+                       "OfflineAccessEnabledAt" AS "EnabledAt"
+                FROM "User"
+                WHERE "Id" = @UserId;
+                """;
+            var value = await connection.QuerySingleOrDefaultAsync<OfflineAccessPreferenceDto>(
+                new CommandDefinition(sql, new { UserId = userId }, cancellationToken: cancellationToken));
+            return value is not null
+                ? Result.Ok(value)
+                : Result.Fail<OfflineAccessPreferenceDto>(FailureMessage);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to get offline access preference for user {UserId}.", userId);
+            return Result.Fail<OfflineAccessPreferenceDto>(FailureMessage);
+        }
+    }
+
+    public async Task<Result<OfflineAccessPreferenceDto>> SetAsync(
+        Guid userId,
+        bool enabled,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                UPDATE "User"
+                SET "OfflineAccessEnabled" = @Enabled,
+                    "OfflineAccessEnabledAt" = CASE WHEN @Enabled THEN CURRENT_TIMESTAMP ELSE NULL END
+                WHERE "Id" = @UserId
+                RETURNING "OfflineAccessEnabled" AS "Enabled",
+                          "OfflineAccessEnabledAt" AS "EnabledAt";
+                """;
+            var value = await connection.QuerySingleOrDefaultAsync<OfflineAccessPreferenceDto>(
+                new CommandDefinition(
+                    sql,
+                    new { UserId = userId, Enabled = enabled },
+                    cancellationToken: cancellationToken));
+            return value is not null
+                ? Result.Ok(value)
+                : Result.Fail<OfflineAccessPreferenceDto>(FailureMessage);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to set offline access preference for user {UserId}.", userId);
+            return Result.Fail<OfflineAccessPreferenceDto>(FailureMessage);
+        }
+    }
+}

--- a/src/FishingLogBook.Shared/Dtos/CurrentUserDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/CurrentUserDto.cs
@@ -1,3 +1,3 @@
 namespace FishingLogBook.Shared.Dtos;
 
-public sealed record CurrentUserDto(Guid UserId, string Email);
+public sealed record CurrentUserDto(Guid UserId, string Email, string Provider, string Subject);

--- a/src/FishingLogBook.Shared/Dtos/OfflineAccessPreferenceDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/OfflineAccessPreferenceDto.cs
@@ -1,0 +1,18 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record OfflineAccessPreferenceDto
+{
+    public OfflineAccessPreferenceDto()
+    {
+    }
+
+    public OfflineAccessPreferenceDto(bool enabled, DateTimeOffset? enabledAt = null)
+    {
+        Enabled = enabled;
+        EnabledAt = enabledAt;
+    }
+
+    public bool Enabled { get; init; }
+
+    public DateTimeOffset? EnabledAt { get; init; }
+}

--- a/src/FishingLogBook.Web/Features/Authentication/Components/UserMenu/UserMenu.razor.cs
+++ b/src/FishingLogBook.Web/Features/Authentication/Components/UserMenu/UserMenu.razor.cs
@@ -1,6 +1,6 @@
 using System.Security.Claims;
-using FishingLogBook.Web.Features.Authentication.Services;
 using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Authentication.Services;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Providers;
 using FishingLogBook.Web.Localization;

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Clients/IOfflineAccessPreferenceClient.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Clients/IOfflineAccessPreferenceClient.cs
@@ -1,0 +1,9 @@
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Features.OfflineAccess.Clients;
+
+public interface IOfflineAccessPreferenceClient
+{
+    Task<OfflineAccessPreferenceDto> GetAsync(CancellationToken cancellationToken);
+    Task<OfflineAccessPreferenceDto> SetAsync(bool enabled, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Clients/OfflineAccessPreferenceClient.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Clients/OfflineAccessPreferenceClient.cs
@@ -1,0 +1,26 @@
+using System.Net.Http.Json;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Configuration;
+
+namespace FishingLogBook.Web.Features.OfflineAccess.Clients;
+
+public sealed class OfflineAccessPreferenceClient : IOfflineAccessPreferenceClient
+{
+    private const string Path = "api/users/current/offline-access-preference";
+    private readonly HttpClient _client;
+
+    public OfflineAccessPreferenceClient(IHttpClientFactory factory) =>
+        _client = factory.CreateClient(HttpClientNames.AuthorizedApi);
+
+    public async Task<OfflineAccessPreferenceDto> GetAsync(CancellationToken cancellationToken) =>
+        await _client.GetFromJsonAsync<OfflineAccessPreferenceDto>(Path, cancellationToken)
+        ?? throw new HttpRequestException("Offline access preference was missing.");
+
+    public async Task<OfflineAccessPreferenceDto> SetAsync(bool enabled, CancellationToken cancellationToken)
+    {
+        var response = await _client.PutAsJsonAsync(Path, new OfflineAccessPreferenceDto(enabled), cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<OfflineAccessPreferenceDto>(cancellationToken)
+            ?? throw new HttpRequestException("Offline access preference was missing.");
+    }
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
@@ -1,0 +1,107 @@
+@using FishingLogBook.Web.Features.OfflineAccess.Services
+@using FishingLogBook.Web.Browser.Install
+@using FishingLogBook.Web.Localization
+@using Microsoft.Extensions.Localization
+@using Microsoft.Extensions.DependencyInjection
+@inject IServiceProvider Services
+@inject IStringLocalizer<UiStrings> Loc
+
+<MudPaper Class="pa-4" Elevation="1" id="offline-access-setup">
+    <MudStack Spacing="2">
+        <MudText Typo="Typo.h5">@Loc["OfflineAccess_Title"]</MudText>
+        <MudText>@Loc["OfflineAccess_Description"]</MudText>
+        @if (_loading)
+        {
+            <MudProgressCircular Indeterminate="true" Size="Size.Small" id="offline-access-loading" />
+        }
+        else
+        {
+            <MudAlert Severity="@StatusSeverity" id="offline-access-status">@StatusText</MudAlert>
+            @if (_status?.IsReady == true)
+            {
+                <MudButton Variant="Variant.Outlined" OnClick="RemoveAsync" Disabled="_busy" id="offline-access-remove-device">
+                    @Loc["OfflineAccess_RemoveDevice"]
+                </MudButton>
+                <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="TurnOffAsync" Disabled="_busy" id="offline-access-turn-off">
+                    @Loc["OfflineAccess_TurnOffAccount"]
+                </MudButton>
+            }
+            else
+            {
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Fingerprint"
+                           OnClick="SetupAsync" Disabled="@(_busy || _installRequired)" id="offline-access-enable">
+                    @Loc["OfflineAccess_Setup"]
+                </MudButton>
+            }
+        }
+    </MudStack>
+</MudPaper>
+
+@code {
+    [Parameter] public EventCallback<bool> ReadyChanged { get; set; }
+
+    private FishingLogBook.Web.Features.OfflineAccess.Models.OfflineAccessStatusModel? _status;
+    private bool _loading = true;
+    private bool _busy;
+    private bool _installRequired;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var installService = Services.GetService<IInstallService>();
+            if (installService is not null)
+            {
+                var install = await installService.GetStateAsync(CancellationToken.None);
+                _installRequired = install.IsIos && !install.IsInstalled;
+            }
+
+            _status = _installRequired
+                ? new(false, "install-required")
+                : await Service.GetStatusAsync(CancellationToken.None);
+        }
+        catch { _status = new(false, "failed"); }
+        finally
+        {
+            _loading = false;
+            await ReadyChanged.InvokeAsync(_status?.IsReady == true);
+        }
+    }
+
+    private string StatusText => _status?.DeviceState switch
+    {
+        "ready" => Loc["OfflineAccess_Ready"],
+        "unsupported" => Loc["OfflineAccess_Unsupported"],
+        "install-required" => Loc["OfflineAccess_InstallRequired"],
+        "repair" => Loc["OfflineAccess_Repair"],
+        "cancelled" => Loc["OfflineAccess_Cancelled"],
+        "failed" => Loc["OfflineAccess_Failed"],
+        _ when _status?.AccountEnabled == true => Loc["OfflineAccess_EnabledOtherDevice"],
+        _ => Loc["OfflineAccess_NotConfigured"]
+    };
+
+    private Severity StatusSeverity => _status?.DeviceState switch
+    {
+        "ready" => Severity.Success,
+        "unsupported" or "install-required" or "repair" or "failed" => Severity.Warning,
+        _ => Severity.Info
+    };
+
+    private IOfflineAccessService Service => Services.GetRequiredService<IOfflineAccessService>();
+
+    private async Task SetupAsync() => await RunAsync(() => Service.SetupAsync(CancellationToken.None));
+    private async Task RemoveAsync() => await RunAsync(() => Service.RemoveFromDeviceAsync(CancellationToken.None));
+    private async Task TurnOffAsync() => await RunAsync(() => Service.TurnOffAccountAsync(CancellationToken.None));
+
+    private async Task RunAsync(Func<Task<FishingLogBook.Web.Features.OfflineAccess.Models.OfflineAccessStatusModel>> action)
+    {
+        _busy = true;
+        try
+        {
+            _status = await action();
+            await ReadyChanged.InvokeAsync(_status.IsReady);
+        }
+        catch { _status = new(_status?.AccountEnabled == true, "failed"); }
+        finally { _busy = false; }
+    }
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Models/OfflineAccessStatusModel.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Models/OfflineAccessStatusModel.cs
@@ -1,0 +1,10 @@
+namespace FishingLogBook.Web.Features.OfflineAccess.Models;
+
+public sealed record OfflineAccessStatusModel(bool AccountEnabled, string DeviceState)
+{
+    public bool IsReady => DeviceState == "ready";
+}
+
+public sealed record OfflineAccessDeviceResultModel(string State);
+
+public sealed record OfflineAccessIdentityModel(Guid UserId, string Provider, string Subject);

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/IOfflineAccessDeviceService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/IOfflineAccessDeviceService.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+
+namespace FishingLogBook.Web.Features.OfflineAccess.Services;
+
+public interface IOfflineAccessDeviceService
+{
+    Task<OfflineAccessDeviceResultModel> GetStatusAsync(OfflineAccessIdentityModel identity, CancellationToken cancellationToken);
+    Task<OfflineAccessDeviceResultModel> SetupAsync(OfflineAccessIdentityModel identity, CancellationToken cancellationToken);
+    Task RemoveAsync(OfflineAccessIdentityModel identity, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/IOfflineAccessService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/IOfflineAccessService.cs
@@ -1,0 +1,11 @@
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+
+namespace FishingLogBook.Web.Features.OfflineAccess.Services;
+
+public interface IOfflineAccessService
+{
+    Task<OfflineAccessStatusModel> GetStatusAsync(CancellationToken cancellationToken);
+    Task<OfflineAccessStatusModel> SetupAsync(CancellationToken cancellationToken);
+    Task<OfflineAccessStatusModel> RemoveFromDeviceAsync(CancellationToken cancellationToken);
+    Task<OfflineAccessStatusModel> TurnOffAccountAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessDeviceService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessDeviceService.cs
@@ -1,0 +1,33 @@
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Features.OfflineAccess.Services;
+
+public sealed class OfflineAccessDeviceService : IOfflineAccessDeviceService
+{
+    private const string ModulePath = "./js/browser/offline-access.js";
+    private readonly IJSRuntime _jsRuntime;
+
+    public OfflineAccessDeviceService(IJSRuntime jsRuntime) => _jsRuntime = jsRuntime;
+
+    public async Task<OfflineAccessDeviceResultModel> GetStatusAsync(OfflineAccessIdentityModel identity, CancellationToken cancellationToken)
+    {
+        var module = await ImportAsync(cancellationToken);
+        return await module.InvokeAsync<OfflineAccessDeviceResultModel>("getDeviceStatus", cancellationToken, identity);
+    }
+
+    public async Task<OfflineAccessDeviceResultModel> SetupAsync(OfflineAccessIdentityModel identity, CancellationToken cancellationToken)
+    {
+        var module = await ImportAsync(cancellationToken);
+        return await module.InvokeAsync<OfflineAccessDeviceResultModel>("setupDevice", cancellationToken, identity);
+    }
+
+    public async Task RemoveAsync(OfflineAccessIdentityModel identity, CancellationToken cancellationToken)
+    {
+        var module = await ImportAsync(cancellationToken);
+        await module.InvokeVoidAsync("removeDevice", cancellationToken, identity);
+    }
+
+    private ValueTask<IJSObjectReference> ImportAsync(CancellationToken cancellationToken) =>
+        _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessService.cs
@@ -1,0 +1,63 @@
+using FishingLogBook.Web.Features.OfflineAccess.Clients;
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+using FishingLogBook.Web.Features.Users.Clients;
+
+namespace FishingLogBook.Web.Features.OfflineAccess.Services;
+
+public sealed class OfflineAccessService : IOfflineAccessService
+{
+    private readonly ICurrentUserClient _currentUserClient;
+    private readonly IOfflineAccessPreferenceClient _preferenceClient;
+    private readonly IOfflineAccessDeviceService _deviceService;
+
+    public OfflineAccessService(ICurrentUserClient currentUserClient, IOfflineAccessPreferenceClient preferenceClient, IOfflineAccessDeviceService deviceService)
+    {
+        _currentUserClient = currentUserClient;
+        _preferenceClient = preferenceClient;
+        _deviceService = deviceService;
+    }
+
+    public async Task<OfflineAccessStatusModel> GetStatusAsync(CancellationToken cancellationToken)
+    {
+        var preference = await _preferenceClient.GetAsync(cancellationToken);
+        var identity = await IdentityAsync(cancellationToken);
+        var device = await _deviceService.GetStatusAsync(identity, cancellationToken);
+        if (!preference.Enabled && device.State == "ready")
+        {
+            await _deviceService.RemoveAsync(identity, cancellationToken);
+            return new OfflineAccessStatusModel(false, "not-configured");
+        }
+
+        return new OfflineAccessStatusModel(preference.Enabled, device.State);
+    }
+
+    public async Task<OfflineAccessStatusModel> SetupAsync(CancellationToken cancellationToken)
+    {
+        var identity = await IdentityAsync(cancellationToken);
+        var device = await _deviceService.SetupAsync(identity, cancellationToken);
+        if (device.State == "ready") await _preferenceClient.SetAsync(true, cancellationToken);
+        return new OfflineAccessStatusModel(device.State == "ready", device.State);
+    }
+
+    public async Task<OfflineAccessStatusModel> RemoveFromDeviceAsync(CancellationToken cancellationToken)
+    {
+        var identity = await IdentityAsync(cancellationToken);
+        await _deviceService.RemoveAsync(identity, cancellationToken);
+        var preference = await _preferenceClient.GetAsync(cancellationToken);
+        return new OfflineAccessStatusModel(preference.Enabled, "not-configured");
+    }
+
+    public async Task<OfflineAccessStatusModel> TurnOffAccountAsync(CancellationToken cancellationToken)
+    {
+        var identity = await IdentityAsync(cancellationToken);
+        await _deviceService.RemoveAsync(identity, cancellationToken);
+        await _preferenceClient.SetAsync(false, cancellationToken);
+        return new OfflineAccessStatusModel(false, "not-configured");
+    }
+
+    private async Task<OfflineAccessIdentityModel> IdentityAsync(CancellationToken cancellationToken)
+    {
+        var current = await _currentUserClient.GetCurrentAsync(cancellationToken);
+        return new OfflineAccessIdentityModel(current.UserId, current.Provider, current.Subject);
+    }
+}

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using FishingLogBook.Shared.Enums
 @using FishingLogBook.Web.Browser.Install
+@using FishingLogBook.Web.Features.OfflineAccess.Components
 @attribute [Authorize]
 
 <PageTitle>@Loc["Onboarding_PageTitle"]</PageTitle>
@@ -132,6 +133,14 @@
                                 <InstallGuidance ShowInstallLaterMessage="true" />
                             </div>
                         </MudStep>
+                        <MudStep Title="@Loc["Onboarding_OfflineAccessStep"]">
+                            <div class="py-4">
+                                <OfflineAccessSetup ReadyChanged="OnOfflineAccessReadyChanged" />
+                                <MudText Typo="Typo.caption" Class="mt-3 mud-text-secondary" id="onboarding-offline-optional">
+                                    @Loc["Onboarding_OfflineAccessOptional"]
+                                </MudText>
+                            </div>
+                        </MudStep>
                     </ChildContent>
                     <ActionContent></ActionContent>
                 </MudStepper>
@@ -151,13 +160,15 @@
                     {
                         <MudButton Variant="Variant.Text" OnClick="Previous" id="onboarding-previous">@Loc["Action_Back"]</MudButton>
                     }
-                    @if (_activeStep < 3)
+                    @if (_activeStep < 4)
                     {
                         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="NextAsync" Disabled="@(_isSaving || (_activeStep == 2 && !_locationHandled))" id="onboarding-next">@Loc["Action_Next"]</MudButton>
                     }
                     else
                     {
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="FinishAsync" Disabled="_isSaving" id="onboarding-finish">@Loc["Onboarding_Finish"]</MudButton>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="FinishAsync" Disabled="_isSaving" id="onboarding-finish">
+                            @Loc[_offlineAccessReady ? "Onboarding_Finish" : "Action_NotNow"]
+                        </MudButton>
                     }
                 </MudStack>
             </MudStack>

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
@@ -20,6 +20,7 @@ public partial class Onboarding : ComponentBase, IDisposable
     private bool _isSaving;
     private bool _saveFailed;
     private bool _locationHandled;
+    private bool _offlineAccessReady;
     private string? _preferenceValidationMessage;
     private WeightUnitEnum _weightUnit = WeightUnitEnum.Kg;
     private LengthUnitEnum _lengthUnit = LengthUnitEnum.Cm;
@@ -340,6 +341,8 @@ public partial class Onboarding : ComponentBase, IDisposable
             _isSaving = false;
         }
     }
+
+    private void OnOfflineAccessReadyChanged(bool ready) => _offlineAccessReady = ready;
 
     public void Dispose()
     {

--- a/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor
+++ b/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using FishingLogBook.Shared.Dtos
 @using FishingLogBook.Shared.Enums
+@using FishingLogBook.Web.Features.OfflineAccess.Components
 @attribute [Authorize]
 
 <PageTitle>@Loc["Profile_PageTitle"]</PageTitle>
@@ -213,4 +214,5 @@
             </MudPaper>
         }
     </MudStack>
+    <OfflineAccessSetup />
 </MudContainer>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -789,4 +789,19 @@
   <data name="WebAuthnProbe_Outcome_missing-metadata" xml:space="preserve"><value>Aucune métadonnée de test n’est enregistrée</value></data>
   <data name="WebAuthnProbe_Outcome_cancelled" xml:space="preserve"><value>L’authentification de l’appareil a été annulée</value></data>
   <data name="WebAuthnProbe_Outcome_failed" xml:space="preserve"><value>Le test de capacité a échoué</value></data>
+  <data name="OfflineAccess_Title" xml:space="preserve"><value>Accès hors ligne</value></data>
+  <data name="OfflineAccess_Description" xml:space="preserve"><value>Configurez cet appareil pour ouvrir en toute sécurité vos propres données de pêche enregistrées sans connexion. Votre appareil vous demandera de confirmer votre identité.</value></data>
+  <data name="OfflineAccess_Setup" xml:space="preserve"><value>Configurer l’accès hors ligne</value></data>
+  <data name="OfflineAccess_Ready" xml:space="preserve"><value>L’accès hors ligne est prêt sur cet appareil.</value></data>
+  <data name="OfflineAccess_NotConfigured" xml:space="preserve"><value>L’accès hors ligne n’est pas configuré sur cet appareil.</value></data>
+  <data name="OfflineAccess_EnabledOtherDevice" xml:space="preserve"><value>L’accès hors ligne est activé pour votre compte. Configurez cet appareil pour l’utiliser ici.</value></data>
+  <data name="OfflineAccess_Unsupported" xml:space="preserve"><value>Cet appareil ou navigateur ne permet pas de configurer un accès hors ligne sécurisé.</value></data>
+  <data name="OfflineAccess_InstallRequired" xml:space="preserve"><value>Sur iPhone ou iPad, installez d’abord Catch But Don’t Forget et ouvrez l’app depuis votre écran d’accueil. Vous pourrez ensuite configurer l’accès hors ligne ici.</value></data>
+  <data name="OfflineAccess_Repair" xml:space="preserve"><value>L’accès hors ligne doit être reconfiguré sur cet appareil.</value></data>
+  <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>La vérification de l’appareil a été annulée. Vous pouvez réessayer ou continuer sans accès hors ligne.</value></data>
+  <data name="OfflineAccess_Failed" xml:space="preserve"><value>Impossible de configurer l’accès hors ligne. Veuillez réessayer.</value></data>
+  <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Supprimer de cet appareil</value></data>
+  <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Désactiver pour mon compte</value></data>
+  <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Accès hors ligne</value></data>
+  <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>L’accès hors ligne est facultatif. Choisissez Ouvrir mon carnet pour continuer sans le configurer.</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -789,4 +789,19 @@
   <data name="WebAuthnProbe_Outcome_missing-metadata" xml:space="preserve"><value>No probe metadata is stored</value></data>
   <data name="WebAuthnProbe_Outcome_cancelled" xml:space="preserve"><value>Device authentication was cancelled</value></data>
   <data name="WebAuthnProbe_Outcome_failed" xml:space="preserve"><value>The capability check failed</value></data>
+  <data name="OfflineAccess_Title" xml:space="preserve"><value>Offline access</value></data>
+  <data name="OfflineAccess_Description" xml:space="preserve"><value>Set up this device so you can securely open your own saved fishing data without a connection. Your device will ask you to verify it is you.</value></data>
+  <data name="OfflineAccess_Setup" xml:space="preserve"><value>Set up offline access</value></data>
+  <data name="OfflineAccess_Ready" xml:space="preserve"><value>Offline access is ready on this device.</value></data>
+  <data name="OfflineAccess_NotConfigured" xml:space="preserve"><value>Offline access is not set up on this device.</value></data>
+  <data name="OfflineAccess_EnabledOtherDevice" xml:space="preserve"><value>Offline access is enabled for your account. Set up this device to use it here.</value></data>
+  <data name="OfflineAccess_Unsupported" xml:space="preserve"><value>This device or browser cannot set up secure offline access.</value></data>
+  <data name="OfflineAccess_InstallRequired" xml:space="preserve"><value>On iPhone or iPad, first install Catch But Don’t Forget and open it from your Home Screen. You can then set up offline access here.</value></data>
+  <data name="OfflineAccess_Repair" xml:space="preserve"><value>Offline access needs to be set up again on this device.</value></data>
+  <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>Device verification was cancelled. You can try again or continue without offline access.</value></data>
+  <data name="OfflineAccess_Failed" xml:space="preserve"><value>Offline access could not be set up. Please try again.</value></data>
+  <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Remove from this device</value></data>
+  <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Turn off for my account</value></data>
+  <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Offline Access</value></data>
+  <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>Offline access is optional. Choose Open my Logbook to continue without setting it up.</value></data>
 </root>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
 using FishingLogBook.Web.Features.Diagnostics.Storage.Stores;
 using FishingLogBook.Web.Features.Diagnostics.Synchronisers;
+using FishingLogBook.Web.Features.OfflineAccess.Clients;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Features.Onboarding.Services;
 using FishingLogBook.Web.Features.Profile.Clients;
 using FishingLogBook.Web.Features.Profile.Offline;
@@ -70,6 +72,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IInstallService, InstallService>();
         services.AddScoped<IAppUpdateService, AppUpdateService>();
         services.AddScoped<IOnboardingService, OnboardingService>();
+        services.AddScoped<IOfflineAccessPreferenceClient, OfflineAccessPreferenceClient>();
+        services.AddScoped<IOfflineAccessDeviceService, OfflineAccessDeviceService>();
+        services.AddScoped<IOfflineAccessService, OfflineAccessService>();
         services.AddScoped<ITimeService, TimeService>();
         services.AddScoped<ICatchStore, IndexedDbCatchStore>();
         services.AddScoped<ICatchSynchroniser, CatchSynchroniser>();

--- a/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.js
@@ -1,0 +1,181 @@
+const databaseName = 'FishingLogBookOfflineAccess';
+const databaseVersion = 1;
+const storeName = 'deviceEntitlements';
+const envelopeVersion = 1;
+const purpose = 'cbdf-offline-access';
+
+export async function getDeviceStatus(identity) {
+    if (!isSupported()) return { state: 'unsupported' };
+    const ownerKey = await createOwnerKey(identity.provider, identity.subject);
+    const record = await getRecord(ownerKey);
+    return { state: record?.state === 'ready' ? 'ready' : record ? 'repair' : 'not-configured' };
+}
+
+export async function setupDevice(identity) {
+    if (!isSupported()) return { state: 'unsupported' };
+    const ownerKey = await createOwnerKey(identity.provider, identity.subject);
+    try {
+        const salt = randomBytes(32);
+        const credential = await navigator.credentials.create({ publicKey: createOptions(salt) });
+        if (!credential) return { state: 'failed' };
+        const createPrf = getPrfResult(credential);
+        if (!createPrf) return { state: 'unsupported' };
+
+        const record = await encryptCandidate(identity, ownerKey, credential, salt, createPrf);
+        await putRecord(record);
+
+        const assertion = await getCredential(record);
+        if (!assertion || !userVerified(assertion)) return { state: 'repair' };
+        const getPrf = getPrfResult(assertion);
+        if (!getPrf) return { state: 'repair' };
+        const recovered = await decryptEntitlement(record, getPrf);
+        if (!sameIdentity(identity, recovered)) return { state: 'repair' };
+
+        record.state = 'ready';
+        record.verifiedOn = new Date().toISOString();
+        await putRecord(record);
+        return { state: 'ready' };
+    } catch (error) {
+        return { state: error?.name === 'NotAllowedError' ? 'cancelled' : 'failed' };
+    }
+}
+
+export async function removeDevice(identity) {
+    const ownerKey = await createOwnerKey(identity.provider, identity.subject);
+    await deleteRecord(ownerKey);
+}
+
+function isSupported() {
+    return typeof PublicKeyCredential !== 'undefined'
+        && typeof navigator.credentials?.create === 'function'
+        && typeof navigator.credentials?.get === 'function'
+        && typeof crypto?.subtle !== 'undefined';
+}
+
+function createOptions(salt) {
+    return {
+        challenge: randomBytes(32),
+        rp: { name: 'Catch But Don’t Forget' },
+        user: { id: randomBytes(32), name: 'offline-access', displayName: 'Offline access' },
+        pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
+        authenticatorSelection: {
+            authenticatorAttachment: 'platform',
+            residentKey: 'preferred',
+            userVerification: 'required'
+        },
+        timeout: 60000,
+        attestation: 'none',
+        extensions: { prf: { eval: { first: salt } } }
+    };
+}
+
+async function getCredential(record) {
+    return await navigator.credentials.get({ publicKey: {
+        challenge: randomBytes(32),
+        allowCredentials: [{
+            id: fromBase64Url(record.credentialId),
+            type: 'public-key',
+            transports: record.transports
+        }],
+        userVerification: 'required',
+        timeout: 60000,
+        extensions: { prf: { eval: { first: fromBase64Url(record.prfSalt) } } }
+    }});
+}
+
+async function encryptCandidate(identity, ownerKey, credential, salt, prf) {
+    const iv = randomBytes(12);
+    const aad = new TextEncoder().encode(`${purpose}:${envelopeVersion}:${ownerKey}:${toBase64Url(credential.rawId)}`);
+    const key = await crypto.subtle.importKey('raw', prf, 'AES-GCM', false, ['encrypt']);
+    const plaintext = new TextEncoder().encode(JSON.stringify({
+        version: envelopeVersion,
+        purpose,
+        provider: identity.provider,
+        subject: identity.subject,
+        userId: identity.userId,
+        configuredOn: new Date().toISOString()
+    }));
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv, additionalData: aad }, key, plaintext);
+    return {
+        ownerKey,
+        version: envelopeVersion,
+        state: 'candidate',
+        credentialId: toBase64Url(credential.rawId),
+        prfSalt: toBase64Url(salt),
+        transports: credential.response.getTransports?.() ?? [],
+        iv: toBase64Url(iv),
+        ciphertext: toBase64Url(ciphertext)
+    };
+}
+
+async function decryptEntitlement(record, prf) {
+    const aad = new TextEncoder().encode(`${purpose}:${record.version}:${record.ownerKey}:${record.credentialId}`);
+    const key = await crypto.subtle.importKey('raw', prf, 'AES-GCM', false, ['decrypt']);
+    const plaintext = await crypto.subtle.decrypt({
+        name: 'AES-GCM', iv: fromBase64Url(record.iv), additionalData: aad
+    }, key, fromBase64Url(record.ciphertext));
+    return JSON.parse(new TextDecoder().decode(plaintext));
+}
+
+function sameIdentity(expected, actual) {
+    return actual?.version === envelopeVersion && actual?.purpose === purpose
+        && actual.provider === expected.provider && actual.subject === expected.subject
+        && actual.userId === expected.userId;
+}
+
+function getPrfResult(credential) {
+    const first = credential.getClientExtensionResults?.().prf?.results?.first;
+    if (first instanceof ArrayBuffer) return new Uint8Array(first);
+    return ArrayBuffer.isView(first)
+        ? new Uint8Array(first.buffer, first.byteOffset, first.byteLength)
+        : null;
+}
+
+function userVerified(assertion) {
+    const data = new Uint8Array(assertion.response.authenticatorData);
+    return data.length > 32 && (data[32] & 0x04) !== 0;
+}
+
+async function createOwnerKey(provider, subject) {
+    const value = new TextEncoder().encode(`${provider}\n${subject}`);
+    return toBase64Url(await crypto.subtle.digest('SHA-256', value));
+}
+
+function randomBytes(length) { return crypto.getRandomValues(new Uint8Array(length)); }
+function toBase64Url(value) {
+    let binary = '';
+    for (const byte of new Uint8Array(value)) binary += String.fromCharCode(byte);
+    return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+function fromBase64Url(value) {
+    const padded = value.replaceAll('-', '+').replaceAll('_', '/').padEnd(Math.ceil(value.length / 4) * 4, '=');
+    return Uint8Array.from(atob(padded), character => character.charCodeAt(0));
+}
+
+async function openDatabase() {
+    return await new Promise((resolve, reject) => {
+        const request = indexedDB.open(databaseName, databaseVersion);
+        request.onupgradeneeded = () => {
+            if (!request.result.objectStoreNames.contains(storeName))
+                request.result.createObjectStore(storeName, { keyPath: 'ownerKey' });
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+async function transact(mode, action) {
+    const database = await openDatabase();
+    try {
+        return await new Promise((resolve, reject) => {
+            const transaction = database.transaction(storeName, mode);
+            const request = action(transaction.objectStore(storeName));
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    } finally { database.close(); }
+}
+
+function getRecord(ownerKey) { return transact('readonly', store => store.get(ownerKey)); }
+function putRecord(record) { return transact('readwrite', store => store.put(record)); }
+function deleteRecord(ownerKey) { return transact('readwrite', store => store.delete(ownerKey)); }

--- a/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.test.js
@@ -1,0 +1,98 @@
+import { webcrypto } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDeviceStatus, removeDevice, setupDevice } from './offline-access.js';
+
+const identity = {
+    userId: '11111111-1111-1111-1111-111111111111',
+    provider: 'Cognito',
+    subject: 'stable-cognito-subject'
+};
+
+function credential(prf) {
+    return {
+        rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+        response: { getTransports: () => ['internal'] },
+        getClientExtensionResults: () => ({ prf: { results: { first: prf } } })
+    };
+}
+
+function assertion(prf) {
+    const authenticatorData = new Uint8Array(33);
+    authenticatorData[32] = 0x05;
+    return {
+        response: { authenticatorData: authenticatorData.buffer },
+        getClientExtensionResults: () => ({ prf: { results: { first: prf } } })
+    };
+}
+
+describe('production offline access entitlement', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.stubGlobal('crypto', webcrypto);
+        vi.stubGlobal('PublicKeyCredential', class {});
+    });
+
+    it('becomes ready only after a separate GET recovers and verifies the encrypted identity', async () => {
+        const prf = new Uint8Array(32).fill(9).buffer;
+        Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
+            create: vi.fn(async () => credential(prf)),
+            get: vi.fn(async () => assertion(prf))
+        }});
+
+        const result = await setupDevice(identity);
+
+        expect(result.state).toBe('ready');
+        expect(navigator.credentials.create).toHaveBeenCalledOnce();
+        expect(navigator.credentials.get).toHaveBeenCalledOnce();
+        expect((await getDeviceStatus(identity)).state).toBe('ready');
+        const persisted = await readPersistedRecords();
+        expect(JSON.stringify(persisted)).not.toContain(identity.subject);
+        expect(JSON.stringify(persisted)).not.toContain(identity.userId);
+    });
+
+    it('fails closed when GET returns different PRF material', async () => {
+        Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
+            create: vi.fn(async () => credential(new Uint8Array(32).fill(1).buffer)),
+            get: vi.fn(async () => assertion(new Uint8Array(32).fill(2).buffer))
+        }});
+
+        const result = await setupDevice(identity);
+
+        expect(result.state).toBe('failed');
+        expect((await getDeviceStatus(identity)).state).toBe('repair');
+    });
+
+    it('removes only the matching owner record', async () => {
+        const prf = new Uint8Array(32).fill(7).buffer;
+        Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
+            create: vi.fn(async () => credential(prf)),
+            get: vi.fn(async () => assertion(prf))
+        }});
+        const other = { ...identity, userId: '22222222-2222-2222-2222-222222222222', subject: 'other-subject' };
+        await setupDevice(identity);
+        await setupDevice(other);
+
+        await removeDevice(identity);
+
+        expect((await getDeviceStatus(identity)).state).toBe('not-configured');
+        expect((await getDeviceStatus(other)).state).toBe('ready');
+    });
+});
+
+async function readPersistedRecords() {
+    const database = await new Promise((resolve, reject) => {
+        const request = indexedDB.open('FishingLogBookOfflineAccess', 1);
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+    try {
+        return await new Promise((resolve, reject) => {
+            const request = database.transaction('deviceEntitlements').objectStore('deviceEntitlements').getAll();
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    } finally {
+        database.close();
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -32,6 +32,9 @@ public class SystemApiFactory : WebApplicationFactory<Program>
 
     public IUserIdentityRepository UserIdentityRepository { get; } = Substitute.For<IUserIdentityRepository>();
 
+    public IOfflineAccessPreferenceRepository OfflineAccessPreferenceRepository { get; } =
+        Substitute.For<IOfflineAccessPreferenceRepository>();
+
     public IProfileRepository ProfileRepository { get; } = Substitute.For<IProfileRepository>();
 
     public ICatchRepository CatchRepository { get; } = Substitute.For<ICatchRepository>();
@@ -66,6 +69,14 @@ public class SystemApiFactory : WebApplicationFactory<Program>
         UserIdentityRepository
             .UpdateEmailAsync(Arg.Any<User>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok());
+        OfflineAccessPreferenceRepository
+            .GetAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(new FishingLogBook.Shared.Dtos.OfflineAccessPreferenceDto(false)));
+        OfflineAccessPreferenceRepository
+            .SetAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(new FishingLogBook.Shared.Dtos.OfflineAccessPreferenceDto(
+                call.ArgAt<bool>(1),
+                call.ArgAt<bool>(1) ? DateTimeOffset.Parse("2026-08-23T12:00:00Z") : null)));
         ProfileRepository
             .UserExistsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok(true));
@@ -195,6 +206,8 @@ public class SystemApiFactory : WebApplicationFactory<Program>
             services.AddSingleton(_ => ObjectStorage);
             services.RemoveAll<IUserIdentityRepository>();
             services.AddSingleton(UserIdentityRepository);
+            services.RemoveAll<IOfflineAccessPreferenceRepository>();
+            services.AddSingleton(OfflineAccessPreferenceRepository);
             services.RemoveAll<IProfileRepository>();
             services.AddSingleton(ProfileRepository);
             services.RemoveAll<ICatchRepository>();

--- a/tests/FishingLogBook.Api.Tests/UserEndpointsTests/WhenTestingGetCurrent.cs
+++ b/tests/FishingLogBook.Api.Tests/UserEndpointsTests/WhenTestingGetCurrent.cs
@@ -166,6 +166,8 @@ public class WhenTestingGetCurrent : IClassFixture<SystemApiFactory>
         body.Should().NotBeNull();
         body!.UserId.Should().NotBe(Guid.Empty);
         body.Email.Should().Be(TestJwt.Email);
+        body.Provider.Should().Be(IdentityProviderConstants.Cognito);
+        body.Subject.Should().Be(TestJwt.Subject);
         await _factory.UserIdentityRepository.Received(1).FindUserIdAsync(
             Arg.Is<FindUserIdentityArgs>(args =>
                 args.Provider == IdentityProviderConstants.Cognito
@@ -392,6 +394,42 @@ public class WhenTestingGetCurrent : IClassFixture<SystemApiFactory>
             Arg.Any<CancellationToken>());
         await _factory.UserIdentityRepository.DidNotReceive().UpdateEmailAsync(
             Arg.Any<User>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheCurrentUsersOfflineAccessPreference()
+    {
+        _factory.OfflineAccessPreferenceRepository.ClearReceivedCalls();
+        var client = _factory.CreateAuthenticatedClient();
+
+        var response = await client.GetAsync("/api/users/current/offline-access-preference");
+        var body = await response.Content.ReadFromJsonAsync<OfflineAccessPreferenceDto>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Be(new OfflineAccessPreferenceDto(false));
+        await _factory.OfflineAccessPreferenceRepository.Received(1).GetAsync(
+            Arg.Is<Guid>(value => value != Guid.Empty),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldEnableOfflineAccessUsingServerControlledIdentityAndTimestamp()
+    {
+        _factory.OfflineAccessPreferenceRepository.ClearReceivedCalls();
+        var client = _factory.CreateAuthenticatedClient();
+
+        var response = await client.PutAsJsonAsync(
+            "/api/users/current/offline-access-preference",
+            new OfflineAccessPreferenceDto(true, DateTimeOffset.MinValue));
+        var body = await response.Content.ReadFromJsonAsync<OfflineAccessPreferenceDto>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body!.Enabled.Should().BeTrue();
+        body.EnabledAt.Should().Be(DateTimeOffset.Parse("2026-08-23T12:00:00Z"));
+        await _factory.OfflineAccessPreferenceRepository.Received(1).SetAsync(
+            Arg.Is<Guid>(value => value != Guid.Empty),
+            true,
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Application.Tests/Users/CurrentUserTests/WhenTestingAssign.cs
+++ b/tests/FishingLogBook.Application.Tests/Users/CurrentUserTests/WhenTestingAssign.cs
@@ -9,7 +9,7 @@ public class WhenTestingAssign : BaseCurrentUserTest
     public void ItShouldRejectAnEmptyUserId()
     {
         // Arrange
-        var act = () => Sut.Assign(Guid.Empty, "eamonn@example.test");
+        var act = () => Sut.Assign(Guid.Empty, "eamonn@example.test", "Cognito", "subject");
 
         // Act
         // Assert
@@ -25,7 +25,7 @@ public class WhenTestingAssign : BaseCurrentUserTest
     {
         // Arrange
         var userId = Guid.NewGuid();
-        var act = () => Sut.Assign(userId, "  ");
+        var act = () => Sut.Assign(userId, "  ", "Cognito", "subject");
 
         // Act
         // Assert
@@ -44,13 +44,27 @@ public class WhenTestingAssign : BaseCurrentUserTest
         const string email = "eamonn@example.test";
 
         // Act
-        Sut.Assign(userId, email);
+        Sut.Assign(userId, email, "Cognito", "subject");
 
         // Assert
         Sut.IsResolved.Should().BeTrue();
         Sut.UserId.Should().Be(userId);
         Sut.UserId.Should().NotBe(Guid.Empty);
         Sut.Email.Should().Be(email);
+        Sut.Provider.Should().Be("Cognito");
+        Sut.Subject.Should().Be("subject");
         typeof(ICurrentUser).GetProperty(nameof(ICurrentUser.Email)).Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("", "subject")]
+    [InlineData("Cognito", "")]
+    public void ItShouldRejectMissingTrustedIdentity(string provider, string subject)
+    {
+        var act = () => Sut.Assign(Guid.NewGuid(), "eamonn@example.test", provider, subject);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Authenticated identity is missing.");
+        Sut.IsResolved.Should().BeFalse();
     }
 }

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Migrations/SchemaTests/WhenTestingSchema.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Migrations/SchemaTests/WhenTestingSchema.cs
@@ -110,4 +110,24 @@ public class WhenTestingSchema
         // Assert
         nullable.Should().Be("YES");
     }
+
+    [Fact]
+    public async Task ItShouldExposeOfflineAccessPreferenceAndServerTimestamp()
+    {
+        var connectionFactory = new NpgsqlConnectionFactory(_fixture.ConnectionString);
+        await using var connection = await connectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+
+        var columns = await connection.QueryAsync<(string Name, string Nullable)>(
+            """
+            SELECT "column_name" AS "Name", "is_nullable" AS "Nullable"
+            FROM information_schema.columns
+            WHERE "table_schema" = 'public' AND "table_name" = 'User'
+              AND "column_name" IN ('OfflineAccessEnabled', 'OfflineAccessEnabledAt');
+            """);
+
+        columns.Should().Contain(column =>
+            column.Name == "OfflineAccessEnabled" && column.Nullable == "NO");
+        columns.Should().Contain(column =>
+            column.Name == "OfflineAccessEnabledAt" && column.Nullable == "YES");
+    }
 }

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/OfflineAccessPreferenceRepositoryTests/WhenTestingPreference.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/OfflineAccessPreferenceRepositoryTests/WhenTestingPreference.cs
@@ -15,7 +15,7 @@ public class WhenTestingPreference
         _connectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
 
     [Fact]
-    public async Task ItShouldDefaultDisabledAndUseAServerTimestampOnlyWhileEnabled()
+    public async Task ItShouldDefaultDisabledAndPreserveTheMostRecentServerEnablementTimestamp()
     {
         var user = new UserBuilder().Build();
         var identity = new UserIdentityBuilder().ForUser(user).Build();
@@ -30,12 +30,16 @@ public class WhenTestingPreference
         var initial = await sut.GetAsync(user.Id, CancellationToken.None);
         var enabled = await sut.SetAsync(user.Id, true, CancellationToken.None);
         var disabled = await sut.SetAsync(user.Id, false, CancellationToken.None);
+        await Task.Delay(10);
+        var reenabled = await sut.SetAsync(user.Id, true, CancellationToken.None);
 
         initial.Value.Enabled.Should().BeFalse();
         initial.Value.EnabledAt.Should().BeNull();
         enabled.Value.Enabled.Should().BeTrue();
         enabled.Value.EnabledAt.Should().NotBeNull();
         disabled.Value.Enabled.Should().BeFalse();
-        disabled.Value.EnabledAt.Should().BeNull();
+        disabled.Value.EnabledAt.Should().Be(enabled.Value.EnabledAt);
+        reenabled.Value.Enabled.Should().BeTrue();
+        reenabled.Value.EnabledAt.Should().BeAfter(enabled.Value.EnabledAt!.Value);
     }
 }

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/OfflineAccessPreferenceRepositoryTests/WhenTestingPreference.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/OfflineAccessPreferenceRepositoryTests/WhenTestingPreference.cs
@@ -1,0 +1,41 @@
+using AwesomeAssertions;
+using FishingLogBook.Infrastructure.Persistence;
+using FishingLogBook.Infrastructure.Persistence.Repositories;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+using FishingLogBook.Tests.Common.Builders;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Repositories.OfflineAccessPreferenceRepositoryTests;
+
+[Collection(PostgresCollection.Name)]
+public class WhenTestingPreference
+{
+    private readonly NpgsqlConnectionFactory _connectionFactory;
+
+    public WhenTestingPreference(PostgresFixture fixture) =>
+        _connectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
+
+    [Fact]
+    public async Task ItShouldDefaultDisabledAndUseAServerTimestampOnlyWhileEnabled()
+    {
+        var user = new UserBuilder().Build();
+        var identity = new UserIdentityBuilder().ForUser(user).Build();
+        var identityRepository = new UserIdentityRepository(
+            _connectionFactory,
+            new RecordingLogger<UserIdentityRepository>());
+        await identityRepository.CreateAsync(user, identity, CancellationToken.None);
+        var sut = new OfflineAccessPreferenceRepository(
+            _connectionFactory,
+            new RecordingLogger<OfflineAccessPreferenceRepository>());
+
+        var initial = await sut.GetAsync(user.Id, CancellationToken.None);
+        var enabled = await sut.SetAsync(user.Id, true, CancellationToken.None);
+        var disabled = await sut.SetAsync(user.Id, false, CancellationToken.None);
+
+        initial.Value.Enabled.Should().BeFalse();
+        initial.Value.EnabledAt.Should().BeNull();
+        enabled.Value.Enabled.Should().BeTrue();
+        enabled.Value.EnabledAt.Should().NotBeNull();
+        disabled.Value.Enabled.Should().BeFalse();
+        disabled.Value.EnabledAt.Should().BeNull();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/UserMenuTests/BaseUserMenuTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/UserMenuTests/BaseUserMenuTest.cs
@@ -1,7 +1,7 @@
 using Bunit;
 using Bunit.TestDoubles;
-using FishingLogBook.Web.Features.Authentication.Components.UserMenu;
 using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Authentication.Components.UserMenu;
 using FishingLogBook.Web.Features.Authentication.Services;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Providers;

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/LocalCatchOwnerServiceTests/BaseLocalCatchOwnerServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/LocalCatchOwnerServiceTests/BaseLocalCatchOwnerServiceTest.cs
@@ -27,7 +27,7 @@ public class BaseLocalCatchOwnerServiceTest
     {
         var client = Substitute.For<ICurrentUserClient>();
         client.GetCurrentAsync(Arg.Any<CancellationToken>())
-            .Returns(new CurrentUserDto(userId, email));
+            .Returns(new CurrentUserDto(userId, email, "Cognito", OwnerSubject));
         return client;
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/LocalCatchOwnerServiceTests/WhenTestingGetUserId.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/LocalCatchOwnerServiceTests/WhenTestingGetUserId.cs
@@ -32,7 +32,7 @@ public class WhenTestingGetUserId : BaseLocalCatchOwnerServiceTest
         // Arrange
         var currentUser = Substitute.For<ICurrentUserClient>();
         currentUser.GetCurrentAsync(Arg.Any<CancellationToken>())
-            .Returns(new CurrentUserDto(Guid.Empty, "owner@example.test"));
+            .Returns(new CurrentUserDto(Guid.Empty, "owner@example.test", "Cognito", OwnerSubject));
         var jsRuntime = new MemoryJsRuntime();
         var sut = CreateSut(Authenticated(OwnerSubject), currentUser, jsRuntime);
 

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
@@ -1,0 +1,63 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.OfflineAccess.Components;
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.OfflineAccess.Components.OfflineAccessSetupTests;
+
+public class WhenTestingActions
+{
+    [Fact]
+    public async Task ItShouldSetupOnlyAfterTheUserExplicitlyChoosesIt()
+    {
+        var service = Substitute.For<IOfflineAccessService>();
+        service.GetStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessStatusModel(false, "not-configured"));
+        service.SetupAsync(Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessStatusModel(true, "ready"));
+        await using var context = CreateContext(service);
+        var cut = context.Render<OfflineAccessSetup>();
+        cut.WaitForAssertion(() => cut.Find("#offline-access-enable"));
+        await service.DidNotReceive().SetupAsync(Arg.Any<CancellationToken>());
+
+        await cut.Find("#offline-access-enable").ClickAsync();
+
+        cut.WaitForAssertion(() => cut.Find("#offline-access-status").TextContent
+            .Should().Contain("ready"));
+        await service.Received(1).SetupAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldExposeBothExplicitRemovalActionsWhenReady()
+    {
+        var service = Substitute.For<IOfflineAccessService>();
+        service.GetStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessStatusModel(true, "ready"));
+        await using var context = CreateContext(service);
+
+        var cut = context.Render<OfflineAccessSetup>();
+
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#offline-access-remove-device").Should().NotBeNull();
+            cut.Find("#offline-access-turn-off").Should().NotBeNull();
+        });
+    }
+
+    private static BunitContext CreateContext(IOfflineAccessService service)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(service);
+        context.Services.AddSingleton(Substitute.For<ICultureService>());
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessServiceTests/WhenTestingLifecycle.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessServiceTests/WhenTestingLifecycle.cs
@@ -1,0 +1,77 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.OfflineAccess.Clients;
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Features.Users.Clients;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.OfflineAccess.Services.OfflineAccessServiceTests;
+
+public class WhenTestingLifecycle
+{
+    private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public async Task ItShouldEnableTheAccountOnlyAfterTheDeviceRoundTripIsReady()
+    {
+        var fixture = CreateFixture("ready");
+
+        var status = await fixture.Sut.SetupAsync(CancellationToken.None);
+
+        status.Should().Be(new OfflineAccessStatusModel(true, "ready"));
+        await fixture.Preference.Received(1).SetAsync(true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotEnableTheAccountWhenDeviceVerificationIsCancelled()
+    {
+        var fixture = CreateFixture("cancelled");
+
+        var status = await fixture.Sut.SetupAsync(CancellationToken.None);
+
+        status.Should().Be(new OfflineAccessStatusModel(false, "cancelled"));
+        await fixture.Preference.DidNotReceive().SetAsync(true, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRemoveAStaleLocalEntitlementWhenTheAccountWasTurnedOffElsewhere()
+    {
+        var fixture = CreateFixture("ready");
+        fixture.Preference.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessPreferenceDto(false));
+
+        var status = await fixture.Sut.GetStatusAsync(CancellationToken.None);
+
+        status.Should().Be(new OfflineAccessStatusModel(false, "not-configured"));
+        await fixture.Device.Received(1).RemoveAsync(
+            Arg.Is<OfflineAccessIdentityModel>(identity =>
+                identity.UserId == UserId
+                && identity.Provider == "Cognito"
+                && identity.Subject == "trusted-subject"),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static Fixture CreateFixture(string deviceState)
+    {
+        var currentUser = Substitute.For<ICurrentUserClient>();
+        currentUser.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .Returns(new CurrentUserDto(UserId, "owner@example.test", "Cognito", "trusted-subject"));
+        var preference = Substitute.For<IOfflineAccessPreferenceClient>();
+        preference.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessPreferenceDto(true, DateTimeOffset.UtcNow));
+        preference.SetAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(call => new OfflineAccessPreferenceDto(call.ArgAt<bool>(0), DateTimeOffset.UtcNow));
+        var device = Substitute.For<IOfflineAccessDeviceService>();
+        device.SetupAsync(Arg.Any<OfflineAccessIdentityModel>(), Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessDeviceResultModel(deviceState));
+        device.GetStatusAsync(Arg.Any<OfflineAccessIdentityModel>(), Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessDeviceResultModel(deviceState));
+        return new Fixture(new OfflineAccessService(currentUser, preference, device), preference, device);
+    }
+
+    private sealed record Fixture(
+        OfflineAccessService Sut,
+        IOfflineAccessPreferenceClient Preference,
+        IOfflineAccessDeviceService Device);
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
@@ -263,6 +263,8 @@ public class WhenTestingPreferences
         await cut.Find("#onboarding-skip-location").ClickAsync();
         await cut.Find("#onboarding-next").ClickAsync();
         cut.WaitForAssertion(() => cut.Find("#install-guidance-later").Should().NotBeNull());
+        await cut.Find("#onboarding-next").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#onboarding-offline-optional").Should().NotBeNull());
         await cut.Find("#onboarding-finish").ClickAsync();
 
         await fixture.Onboarding.Received(1).CompleteAsync(Arg.Any<CancellationToken>());

--- a/tests/FishingLogBook.Web.Tests/Features/Users/Clients/CurrentUserClientTests/WhenTestingGetCurrent.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Users/Clients/CurrentUserClientTests/WhenTestingGetCurrent.cs
@@ -47,7 +47,9 @@ public class WhenTestingGetCurrent : BaseCurrentUserClientTest
         // Arrange
         var expected = new CurrentUserDto(
             Guid.Parse("11111111-1111-1111-1111-111111111111"),
-            "owner@example.test");
+            "owner@example.test",
+            "Cognito",
+            "owner-subject");
         var json = JsonSerializer.Serialize(expected, new JsonSerializerOptions(JsonSerializerDefaults.Web));
         var apiHandler = new RecordingHandler(HttpStatusCode.OK, json);
         var client = CreateClient(apiHandler);


### PR DESCRIPTION
## Summary

Implements the production opt-in setup and per-device encrypted entitlement foundation for #141.

- adds private `OfflineAccessEnabled` and `OfflineAccessEnabledAt` user preferences behind dedicated current-user endpoints
- derives the trusted Cognito provider, subject and internal CBDF UserId exclusively from the authenticated server request
- provisions a versioned owner-scoped entitlement in the dedicated `FishingLogBookOfflineAccess` IndexedDB database
- uses the physically proven WebAuthn PRF direct-key path with AES-GCM and AAD binding
- verifies setup through a separate GET/decrypt/trusted-identity comparison before marking the device ready
- adds the optional final onboarding step and Profile management controls
- preserves the configured device entitlement during ordinary Cognito sign-out
- provides explicit **Remove from this device** and **Turn off for my account** actions
- keeps the #140 capability probe in place pending physical validation

## Security and data handling

- no Cognito tokens are stored in the entitlement
- no raw PRF output or CryptoKey is persisted
- plaintext subject/UserId remains inside the encrypted envelope
- the stored owner lookup key is a non-secret hash
- the client cannot nominate the identity being entitled
- disabling/removing offline access does not delete catches, photographs or pending sync work
- `OfflineAccessEnabledAt` means “most recently enabled at”: it is null before first enablement, replaced with the current server UTC timestamp whenever access is enabled, and preserved when access is disabled
- the client never supplies the enablement timestamp

## Validation

- focused PostgreSQL preference test: passed
- Release build: passed with 0 warnings and 0 errors
- .NET tests: 1,290 passed
- JS/Vitest tests: 229 passed
- browser tests: 27 passed, 1 existing WebKit service-worker test skipped
- formatting verification: passed
- mandatory repository self-review: completed

## Self Review

- Issue/AC: PASS — corrected enablement timestamp semantics are implemented and tested
- Architecture/CQRS: PASS — the dedicated preference endpoint and repository responsibility are unchanged
- Rules: PASS
- Security/privacy: PASS — timestamp remains server-generated and no identity or entitlement boundary changed
- Database/migrations: PASS — no schema or migration change; existing nullable column is retained
- Tests/coverage: PASS — initial, enable, disable-preserve and later re-enable behaviour are covered against PostgreSQL
- Browser: PASS — existing browser suite remains green; physical entitlement validation remains deliberately outstanding
- Web/UI/localisation: N/A — no UI copy or localisation changed
- Code smells: PASS
- CI/deployment: PASS — no infrastructure or deployment change

Findings discovered during self-review:
1. The focused test initially proved preservation on disable but not replacement on a later re-enable.

Fixes made:
1. Added a later re-enable assertion proving a newer server timestamp replaces the preserved value.

Remaining deliberate gaps:
- Physical Samsung/iPhone production validation remains outstanding.
- The #140 capability probe remains until that validation succeeds.

## Physical validation gate

This PR is intentionally a draft. Production offline entitlement setup still requires real-device validation on Samsung/Android and an installed iPhone Home Screen PWA.

The disposable #140 capability probe has **not** been removed. It will remain until the production replacement passes the required physical validation.

## Out of scope

This does not add an offline authentication principal, offline catch routes, token persistence, Cognito changes, service-worker redesign, catch sync redesign, audit/history tables, or a disabled timestamp.

References #141.