### PR TITLE
FLB#141 | Fix Samsung offline entitlement verification

### DIFF
--- a/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
@@ -17,6 +17,12 @@
         else
         {
             <MudAlert Severity="@StatusSeverity" id="offline-access-status">@StatusText</MudAlert>
+            @if (_status?.Diagnostic is { State: not "ready", Stage: not null } diagnostic)
+            {
+                <MudText Typo="Typo.caption" id="offline-access-diagnostic">
+                    @Loc["OfflineAccess_Diagnostic", diagnostic.Stage, DiagnosticError(diagnostic)]
+                </MudText>
+            }
             @if (_status?.IsReady == true)
             {
                 <MudButton Variant="Variant.Outlined" OnClick="RemoveAsync" Disabled="_busy" id="offline-access-remove-device">
@@ -86,6 +92,9 @@
         "unsupported" or "install-required" or "repair" or "failed" => Severity.Warning,
         _ => Severity.Info
     };
+
+    private static string DiagnosticError(FishingLogBook.Web.Features.OfflineAccess.Models.OfflineAccessDeviceResultModel diagnostic) =>
+        string.Join(": ", new[] { diagnostic.ErrorName, diagnostic.ErrorMessage }.Where(value => !string.IsNullOrWhiteSpace(value)));
 
     private IOfflineAccessService Service => Services.GetRequiredService<IOfflineAccessService>();
 

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Models/OfflineAccessStatusModel.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Models/OfflineAccessStatusModel.cs
@@ -1,10 +1,18 @@
 namespace FishingLogBook.Web.Features.OfflineAccess.Models;
 
-public sealed record OfflineAccessStatusModel(bool AccountEnabled, string DeviceState)
+public sealed record OfflineAccessStatusModel(
+    bool AccountEnabled,
+    string DeviceState,
+    OfflineAccessDeviceResultModel? Diagnostic = null)
 {
     public bool IsReady => DeviceState == "ready";
 }
 
-public sealed record OfflineAccessDeviceResultModel(string State);
+public sealed record OfflineAccessDeviceResultModel(
+    string State,
+    string? Stage = null,
+    string? ErrorName = null,
+    string? ErrorMessage = null,
+    bool? CreatePrfMatchesGet = null);
 
 public sealed record OfflineAccessIdentityModel(Guid UserId, string Provider, string Subject);

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessService.cs
@@ -36,7 +36,7 @@ public sealed class OfflineAccessService : IOfflineAccessService
         var identity = await IdentityAsync(cancellationToken);
         var device = await _deviceService.SetupAsync(identity, cancellationToken);
         if (device.State == "ready") await _preferenceClient.SetAsync(true, cancellationToken);
-        return new OfflineAccessStatusModel(device.State == "ready", device.State);
+        return new OfflineAccessStatusModel(device.State == "ready", device.State, device);
     }
 
     public async Task<OfflineAccessStatusModel> RemoveFromDeviceAsync(CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -706,102 +706,180 @@
   <data name="Install_SamsungStep2" xml:space="preserve"><value>Choisissez Ajouter la page à.</value></data>
   <data name="Install_SamsungStep3" xml:space="preserve"><value>Choisissez Écran d’accueil, puis confirmez.</value></data>
   <data name="Install_ComputerHeading" xml:space="preserve"><value>Installer sur votre ordinateur</value></data>
-  <data name="Install_ComputerStep1" xml:space="preserve"><value>Dans Chrome ou Edge, recherchez l’icône d’installation à droite de la barre d’adresse et sélectionnez-la.</value></data>
-  <data name="Install_ComputerStep2" xml:space="preserve"><value>Aucune icône dans Chrome ? Ouvrez le menu du navigateur (⋮), puis choisissez Diffuser, enregistrer et partager, puis Installer la page en tant qu’application.</value></data>
-  <data name="Install_ComputerStep3" xml:space="preserve"><value>Dans Edge, ouvrez le menu du navigateur, puis choisissez Applications, puis Installer ce site en tant qu’application.</value></data>
-  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirmez l’installation, puis ouvrez l’application Catch But Don’t Forget depuis le menu Démarrer, le Dock ou votre liste d’applications.</value></data>
-  <data name="Install_Later" xml:space="preserve"><value>L’installation est facultative. Vous pouvez continuer et retrouver ces instructions plus tard depuis le menu de l’application.</value></data>
-  <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choisissez au moins une méthode de pêche.</value></data>
-  <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choisissez au moins une espèce pour {0}.</value></data>
-  <data name="Onboarding_ValidationSpeciesForMethods" xml:space="preserve"><value>Choisissez au moins une espèce pour chacune de ces méthodes de pêche : {0}.</value></data>
-  <data name="Build_About" xml:space="preserve"><value>À propos</value></data>
-  <data name="Build_App" xml:space="preserve"><value>Application</value></data>
+  <data name="Install_ComputerStep1" xml:space="preserve"><value>Dans Chrome ou Edge, recherchez l’icône d’installation à d}v띭ǲڮ݆͹޼/value></data>
+  <data name="Onboarding_LocationTitle" xml:space="preserve"><value>Remember where you caught it</value></data>
+  <data name="Onboarding_LocationBody" xml:space="preserve"><value>Allow location only when you want the app to capture a catch position. You can skip this step.</value></data>
+  <data name="Onboarding_LocationPrivacy" xml:space="preserve"><value>New catch locations are private by default. The browser asks for permission only after you choose Allow location.</value></data>
+  <data name="Onboarding_AllowLocation" xml:space="preserve"><value>Allow location</value></data>
+  <data name="Onboarding_LocationHandled" xml:space="preserve"><value>Your choice is saved. It will not block setup.</value></data>
+  <data name="Onboarding_InstallStep" xml:space="preserve"><value>Install</value></data>
+  <data name="Onboarding_InstallNav" xml:space="preserve"><value>Install app</value></data>
+  <data name="Onboarding_InstallTitle" xml:space="preserve"><value>Keep your Logbook close</value></data>
+  <data name="Onboarding_AlreadyInstalled" xml:space="preserve"><value>The app is already installed on this device.</value></data>
+  <data name="Onboarding_InstallPromptBody" xml:space="preserve"><value>Install the app for quick access and a more reliable experience by the water.</value></data>
+  <data name="Onboarding_InstallAction" xml:space="preserve"><value>Install app</value></data>
+  <data name="Onboarding_InstallIos" xml:space="preserve"><value>In Safari, tap Share, then Add to Home Screen.</value></data>
+  <data name="Onboarding_InstallAndroid" xml:space="preserve"><value>Open your browser menu and choose Install app or Add to Home screen.</value></data>
+  <data name="Onboarding_InstallUnavailable" xml:space="preserve"><value>You can continue now and install later from your browser menu.</value></data>
+  <data name="Onboarding_SaveFailed" xml:space="preserve"><value>We couldn’t save that yet. Check your connection and try again.</value></data>
+  <data name="Onboarding_Finish" xml:space="preserve"><value>Open my Logbook</value></data>
+  <data name="Action_NotNow" xml:space="preserve"><value>Not now</value></data>
+  <data name="Action_Back" xml:space="preserve"><value>Back</value></data>
+  <data name="Action_Next" xml:space="preserve"><value>Next</value></data>
+  <data name="Landing_PageTitle" xml:space="preserve"><value>Catch But Don’t Forget</value></data>
+  <data name="Landing_Tagline" xml:space="preserve"><value>Catch · Release · Remember</value></data>
+  <data name="Landing_Heading" xml:space="preserve"><value>Your private fishing logbook</value></data>
+  <data name="Landing_Introduction" xml:space="preserve"><value>Keep every catch, photograph and memory together—wherever you fish.</value></data>
+  <data name="Landing_BenefitRecord" xml:space="preserve"><value>Quickly record catches and photographs</value></data>
+  <data name="Landing_BenefitPrivate" xml:space="preserve"><value>Fishing spots stay private by default</value></data>
+  <data name="Landing_BenefitOffline" xml:space="preserve"><value>Designed for poor signal and offline use</value></data>
+  <data name="Modal_Save" xml:space="preserve"><value>Save</value></data>
+  <data name="Modal_Selected" xml:space="preserve"><value>Selected</value></data>
+  <data name="Modal_Available" xml:space="preserve"><value>Available</value></data>
+  <data name="Modal_NoneSelected" xml:space="preserve"><value>None selected</value></data>
+  <data name="Modal_ShowingLimited" xml:space="preserve"><value>Showing {0} of {1} {2}. Search to find more.</value></data>
+  <data name="Modal_Species" xml:space="preserve"><value>species</value></data>
+  <data name="Modal_FishingMethods" xml:space="preserve"><value>fishing methods</value></data>
+  <data name="Install_Title" xml:space="preserve"><value>Install Catch But Don’t Forget</value></data>
+  <data name="Install_Benefit" xml:space="preserve"><value>Install the app for quick access from your device and a more reliable experience when you are out fishing.</value></data>
+  <data name="Install_NativeAvailable" xml:space="preserve"><value>Your browser can install the app for you.</value></data>
+  <data name="Install_Action" xml:space="preserve"><value>Install app</value></data>
+  <data name="Install_Dismissed" xml:space="preserve"><value>The app was not installed. You can try again, or follow the steps for your device below.</value></data>
+  <data name="Install_ManualIntro" xml:space="preserve"><value>Choose your device below for step-by-step instructions.</value></data>
+  <data name="Install_InstalledTitle" xml:space="preserve"><value>App is installed</value></data>
+  <data name="Install_InstalledBody" xml:space="preserve"><value>You are using the installed app. Open the Catch But Don’t Forget app from your Home Screen whenever you go fishing.</value></data>
+  <data name="Install_InstalledDesktop" xml:space="preserve"><value>You are using the installed app. Open the Catch But Don’t Forget app from your Start menu, Dock or app list, and pin it where convenient.</value></data>
+  <data name="Install_InstalledOtherDevices" xml:space="preserve"><value>Installing on another phone, tablet or computer? The steps for every device are below.</value></data>
+  <data name="Install_IosPanel" xml:space="preserve"><value>iPhone / iPad</value></data>
+  <data name="Install_AndroidPanel" xml:space="preserve"><value>Android</value></data>
+  <data name="Install_ComputerPanel" xml:space="preserve"><value>Computer</value></data>
+  <data name="Install_IosHeading" xml:space="preserve"><value>Add the app to your Home Screen</value></data>
+  <data name="Install_IosUseSafari" xml:space="preserve"><value>You are not using Safari. Open Catch But Don’t Forget in Safari first, then follow the steps below.</value></data>
+  <data name="Install_IphoneHeading" xml:space="preserve"><value>iPhone</value></data>
+  <data name="Install_IphoneStep1" xml:space="preserve"><value>Open Catch But Don’t Forget in Safari.</value></data>
+  <data name="Install_IphoneStep2" xml:space="preserve"><value>Tap ⋯ More in the Safari toolbar.</value></data>
+  <data name="Install_IphoneStep3" xml:space="preserve"><value>Tap Share.</value></data>
+  <data name="Install_IphoneStep4" xml:space="preserve"><value>If a Share button is already visible in your Safari layout, you can tap it directly instead.</value></data>
+  <data name="Install_IphoneStep5" xml:space="preserve"><value>Choose Add to Home Screen.</value></data>
+  <data name="Install_IphoneStep6" xml:space="preserve"><value>If Safari shows Open as Web App, make sure it is enabled.</value></data>
+  <data name="Install_IphoneStep7" xml:space="preserve"><value>Tap Add.</value></data>
+  <data name="Install_IphoneStep8" xml:space="preserve"><value>Open the Catch But Don’t Forget app from the new Home Screen icon.</value></data>
+  <data name="Install_IpadHeading" xml:space="preserve"><value>iPad</value></data>
+  <data name="Install_IpadStep1" xml:space="preserve"><value>Open Catch But Don’t Forget in Safari.</value></data>
+  <data name="Install_IpadStep2" xml:space="preserve"><value>Tap Share in the top toolbar.</value></data>
+  <data name="Install_IpadStep3" xml:space="preserve"><value>Choose Add to Home Screen. If Safari shows it through More, open More first.</value></data>
+  <data name="Install_IpadStep4" xml:space="preserve"><value>If Safari shows Open as Web App, make sure it is enabled.</value></data>
+  <data name="Install_IpadStep5" xml:space="preserve"><value>Tap Add.</value></data>
+  <data name="Install_IpadStep6" xml:space="preserve"><value>Open the Catch But Don’t Forget app from your Home Screen.</value></data>
+  <data name="Install_IosFallbackHeading" xml:space="preserve"><value>No Add to Home Screen option?</value></data>
+  <data name="Install_IosFallbackBody" xml:space="preserve"><value>You have probably opened the page in another browser, or inside another app such as a messaging app. Choose Open in Safari if it is offered, or copy the web address, paste it into Safari, then follow the iPhone or iPad steps above.</value></data>
+  <data name="Install_AndroidHeading" xml:space="preserve"><value>Install with Chrome or another Chromium browser</value></data>
+  <data name="Install_AndroidStep1" xml:space="preserve"><value>Open the browser menu, the three dots (⋮) at the top of the screen.</value></data>
+  <data name="Install_AndroidStep2" xml:space="preserve"><value>Choose Install app, or Add to Home screen if that is the wording you see.</value></data>
+  <data name="Install_AndroidStep3" xml:space="preserve"><value>Confirm the installation when your browser asks.</value></data>
+  <data name="Install_AndroidStep4" xml:space="preserve"><value>Open the Catch But Don’t Forget app from its new Home Screen icon.</value></data>
+  <data name="Install_SamsungHeading" xml:space="preserve"><value>Samsung Internet</value></data>
+  <data name="Install_SamsungStep1" xml:space="preserve"><value>Open the browser menu at the bottom of the screen.</value></data>
+  <data name="Install_SamsungStep2" xml:space="preserve"><value>Choose Add page to.</value></data>
+  <data name="Install_SamsungStep3" xml:space="preserve"><value>Choose Home screen, then confirm.</value></data>
+  <data name="Install_ComputerHeading" xml:space="preserve"><value>Install on your computer</value></data>
+  <data name="Install_ComputerStep1" xml:space="preserve"><value>In Chrome or Edge, look for the install icon at the right-hand end of the address bar and select it.</value></data>
+  <data name="Install_ComputerStep2" xml:space="preserve"><value>No icon in Chrome? Open the browser menu (⋮), then choose Cast, save and share, then Install page as app.</value></data>
+  <data name="Install_ComputerStep3" xml:space="preserve"><value>In Edge, open the browser menu, then choose Apps, then Install this site as an app.</value></data>
+  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirm the installation, then open the Catch But Don’t Forget app from your Start menu, Dock or app list.</value></data>
+  <data name="Install_Later" xml:space="preserve"><value>Installation is optional. You can continue now and find this guidance again from the app menu.</value></data>
+  <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choose at least one fishing method.</value></data>
+  <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choose at least one species for {0}.</value></data>
+  <data name="Onboarding_ValidationSpeciesForMethods" xml:space="preserve"><value>Choose at least one species for each of these fishing methods: {0}.</value></data>
+  <data name="Build_About" xml:space="preserve"><value>About</value></data>
+  <data name="Build_App" xml:space="preserve"><value>App</value></data>
   <data name="Build_Api" xml:space="preserve"><value>API</value></data>
   <data name="Build_Version" xml:space="preserve"><value>Version</value></data>
   <data name="Build_Commit" xml:space="preserve"><value>Build</value></data>
-  <data name="Build_Environment" xml:space="preserve"><value>Environnement</value></data>
-  <data name="Build_Unavailable" xml:space="preserve"><value>Indisponible</value></data>
-  <data name="Update_BannerTitle" xml:space="preserve"><value>Nouvelle version disponible</value></data>
-  <data name="Update_BannerBody" xml:space="preserve"><value>Obtenez les derniers correctifs et nouveautés.</value></data>
-  <data name="Update_Action" xml:space="preserve"><value>Mettre à jour</value></data>
-  <data name="Update_ActivatingTitle" xml:space="preserve"><value>Mise à jour en cours</value></data>
-  <data name="Update_ActivatingBody" xml:space="preserve"><value>L’application va rouvrir sur la nouvelle version dans un instant.</value></data>
-  <data name="Update_FailedTitle" xml:space="preserve"><value>La mise à jour n’a pas pu être effectuée</value></data>
-  <data name="Update_FailedBody" xml:space="preserve"><value>Vous pouvez continuer à utiliser l’application normalement et réessayer.</value></data>
-  <data name="Update_StatusLabel" xml:space="preserve"><value>Mise à jour</value></data>
-  <data name="Update_StatusCurrent" xml:space="preserve"><value>À jour</value></data>
-  <data name="Update_StatusAvailable" xml:space="preserve"><value>Nouvelle version disponible</value></data>
-  <data name="WebAuthnProbe_PageTitle" xml:space="preserve"><value>Test de capacité WebAuthn</value></data>
-  <data name="WebAuthnProbe_Title" xml:space="preserve"><value>Test de capacité de déverrouillage hors ligne</value></data>
-  <data name="WebAuthnProbe_Scope" xml:space="preserve"><value>Ce diagnostic temporaire vérifie uniquement l’authentification de l’appareil. Il ne peut pas vous connecter, accéder aux données de pêche ni appeler l’API.</value></data>
-  <data name="WebAuthnProbe_ProvisionTitle" xml:space="preserve"><value>Configurer en ligne</value></data>
-  <data name="WebAuthnProbe_ProvisionBody" xml:space="preserve"><value>Effectuez ce test dans l’application installée lorsque vous êtes en ligne. Créez d’abord l’identifiant de test, puis appuyez sur Vérifier l’identifiant en ligne afin que chaque authentification de l’appareil ait sa propre action explicite.</value></data>
-  <data name="WebAuthnProbe_ProvisionAction" xml:space="preserve"><value>Configurer l’identifiant de test</value></data>
-  <data name="WebAuthnProbe_VerifyOnlineAction" xml:space="preserve"><value>Vérifier l’identifiant en ligne</value></data>
-  <data name="WebAuthnProbe_OfflineTitle" xml:space="preserve"><value>Tester après un démarrage à froid hors ligne</value></data>
-  <data name="WebAuthnProbe_OfflineBody" xml:space="preserve"><value>Fermez complètement l’application installée, activez le mode Avion, rouvrez-la depuis son icône, revenez ici depuis l’accueil, puis appuyez sur le bouton. L’authentification de l’appareil ne démarre jamais automatiquement.</value></data>
-  <data name="WebAuthnProbe_OfflineAction" xml:space="preserve"><value>Tester le déverrouillage hors ligne</value></data>
-  <data name="WebAuthnProbe_OpenAction" xml:space="preserve"><value>Ouvrir le test de déverrouillage de l’appareil</value></data>
-  <data name="WebAuthnProbe_CleanupNote" xml:space="preserve"><value>La suppression des métadonnées du test retire uniquement les valeurs de test inoffensives de l’application. La clé d’accès de test devra peut-être être supprimée manuellement dans Mots de passe Apple, Google Password Manager ou les réglages d’identifiants de votre appareil.</value></data>
-  <data name="WebAuthnProbe_RemoveMetadataAction" xml:space="preserve"><value>Supprimer les métadonnées du test</value></data>
-  <data name="WebAuthnProbe_LeaveAction" xml:space="preserve"><value>Quitter le test</value></data>
-  <data name="WebAuthnProbe_WebAuthnAvailable" xml:space="preserve"><value>API WebAuthn disponible</value></data>
-  <data name="WebAuthnProbe_PlatformAvailable" xml:space="preserve"><value>Authentificateur de plateforme disponible</value></data>
-  <data name="WebAuthnProbe_CreateSucceeded" xml:space="preserve"><value>CREATE réussi</value></data>
-  <data name="WebAuthnProbe_CreatePrfEnabled" xml:space="preserve"><value>PRF activée lors de CREATE</value></data>
-  <data name="WebAuthnProbe_CreatePrfResult" xml:space="preserve"><value>Résultat PRF lors de CREATE</value></data>
-  <data name="WebAuthnProbe_ImmediateGetSucceeded" xml:space="preserve"><value>GET immédiat réussi</value></data>
-  <data name="WebAuthnProbe_GetSucceeded" xml:space="preserve"><value>GET réussi</value></data>
-  <data name="WebAuthnProbe_UserVerified" xml:space="preserve"><value>Vérification de l’utilisateur confirmée</value></data>
-  <data name="WebAuthnProbe_GetPrfReported" xml:space="preserve"><value>Extension PRF indiquée lors de GET</value></data>
-  <data name="WebAuthnProbe_GetPrfResult" xml:space="preserve"><value>Résultat PRF lors de GET</value></data>
-  <data name="WebAuthnProbe_PayloadVerified" xml:space="preserve"><value>Contenu inoffensif déchiffré</value></data>
-  <data name="WebAuthnProbe_NetworkHint" xml:space="preserve"><value>Indication réseau du navigateur</value></data>
-  <data name="WebAuthnProbe_NetworkHintOnline" xml:space="preserve"><value>En ligne (signalé par le navigateur, non fiable)</value></data>
-  <data name="WebAuthnProbe_NetworkHintOffline" xml:space="preserve"><value>Hors ligne (signalé par le navigateur)</value></data>
-  <data name="WebAuthnProbe_PayloadEnvelopeAvailable" xml:space="preserve"><value>Contenu chiffré prêt</value></data>
-  <data name="WebAuthnProbe_PrfResultBranch" xml:space="preserve"><value>Représentation du résultat PRF</value></data>
+  <data name="Build_Environment" xml:space="preserve"><value>Environment</value></data>
+  <data name="Build_Unavailable" xml:space="preserve"><value>Unavailable</value></data>
+  <data name="Update_BannerTitle" xml:space="preserve"><value>New version available</value></data>
+  <data name="Update_BannerBody" xml:space="preserve"><value>Get the latest fixes and features.</value></data>
+  <data name="Update_Action" xml:space="preserve"><value>Update now</value></data>
+  <data name="Update_ActivatingTitle" xml:space="preserve"><value>Updating</value></data>
+  <data name="Update_ActivatingBody" xml:space="preserve"><value>The app will reopen on the new version in a moment.</value></data>
+  <data name="Update_FailedTitle" xml:space="preserve"><value>Update could not be completed</value></data>
+  <data name="Update_FailedBody" xml:space="preserve"><value>You can keep using the app as normal and try again.</value></data>
+  <data name="Update_StatusLabel" xml:space="preserve"><value>Update</value></data>
+  <data name="Update_StatusCurrent" xml:space="preserve"><value>Up to date</value></data>
+  <data name="Update_StatusAvailable" xml:space="preserve"><value>New version available</value></data>
+  <data name="WebAuthnProbe_PageTitle" xml:space="preserve"><value>WebAuthn capability probe</value></data>
+  <data name="WebAuthnProbe_Title" xml:space="preserve"><value>Offline device unlock capability probe</value></data>
+  <data name="WebAuthnProbe_Scope" xml:space="preserve"><value>This disposable diagnostic checks device authentication only. It cannot sign you in, access fishing data or call the API.</value></data>
+  <data name="WebAuthnProbe_ProvisionTitle" xml:space="preserve"><value>Provision while online</value></data>
+  <data name="WebAuthnProbe_ProvisionBody" xml:space="preserve"><value>Run this inside the installed app while online. First create the test credential, then tap Verify online credential so each device-authentication request has its own explicit action.</value></data>
+  <data name="WebAuthnProbe_ProvisionAction" xml:space="preserve"><value>Provision test credential</value></data>
+  <data name="WebAuthnProbe_VerifyOnlineAction" xml:space="preserve"><value>Verify online credential</value></data>
+  <data name="WebAuthnProbe_OfflineTitle" xml:space="preserve"><value>Test after a cold offline start</value></data>
+  <data name="WebAuthnProbe_OfflineBody" xml:space="preserve"><value>Kill the installed app, enable Airplane Mode, reopen it from the app icon, return here from Landing, then tap the button. Device authentication never starts automatically.</value></data>
+  <data name="WebAuthnProbe_OfflineAction" xml:space="preserve"><value>Test offline device unlock</value></data>
+  <data name="WebAuthnProbe_OpenAction" xml:space="preserve"><value>Open device unlock capability probe</value></data>
+  <data name="WebAuthnProbe_CleanupNote" xml:space="preserve"><value>Removing probe metadata removes only this app’s harmless test values. The test passkey may need to be removed manually from Apple Passwords, Google Password Manager or your device credential settings.</value></data>
+  <data name="WebAuthnProbe_RemoveMetadataAction" xml:space="preserve"><value>Remove probe metadata</value></data>
+  <data name="WebAuthnProbe_LeaveAction" xml:space="preserve"><value>Leave probe</value></data>
+  <data name="WebAuthnProbe_WebAuthnAvailable" xml:space="preserve"><value>WebAuthn API available</value></data>
+  <data name="WebAuthnProbe_PlatformAvailable" xml:space="preserve"><value>Platform authenticator available</value></data>
+  <data name="WebAuthnProbe_CreateSucceeded" xml:space="preserve"><value>CREATE succeeded</value></data>
+  <data name="WebAuthnProbe_CreatePrfEnabled" xml:space="preserve"><value>PRF enabled on CREATE</value></data>
+  <data name="WebAuthnProbe_CreatePrfResult" xml:space="preserve"><value>PRF result on CREATE</value></data>
+  <data name="WebAuthnProbe_ImmediateGetSucceeded" xml:space="preserve"><value>Immediate GET succeeded</value></data>
+  <data name="WebAuthnProbe_GetSucceeded" xml:space="preserve"><value>GET succeeded</value></data>
+  <data name="WebAuthnProbe_UserVerified" xml:space="preserve"><value>User verification true</value></data>
+  <data name="WebAuthnProbe_GetPrfReported" xml:space="preserve"><value>PRF extension reported on GET</value></data>
+  <data name="WebAuthnProbe_GetPrfResult" xml:space="preserve"><value>PRF result on GET</value></data>
+  <data name="WebAuthnProbe_PayloadVerified" xml:space="preserve"><value>Harmless payload decrypted</value></data>
+  <data name="WebAuthnProbe_NetworkHint" xml:space="preserve"><value>Browser network hint</value></data>
+  <data name="WebAuthnProbe_NetworkHintOnline" xml:space="preserve"><value>Online (browser-reported; not authoritative)</value></data>
+  <data name="WebAuthnProbe_NetworkHintOffline" xml:space="preserve"><value>Offline (browser-reported)</value></data>
+  <data name="WebAuthnProbe_PayloadEnvelopeAvailable" xml:space="preserve"><value>Encrypted payload ready</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch" xml:space="preserve"><value>PRF result representation</value></data>
   <data name="WebAuthnProbe_PrfResultBranch_array-buffer" xml:space="preserve"><value>ArrayBuffer</value></data>
-  <data name="WebAuthnProbe_PrfResultBranch_typed-array" xml:space="preserve"><value>Vue de tableau typé</value></data>
-  <data name="WebAuthnProbe_PrfResultBranch_missing" xml:space="preserve"><value>Non renvoyé</value></data>
-  <data name="WebAuthnProbe_PrfResultLength" xml:space="preserve"><value>Longueur du résultat PRF</value></data>
-  <data name="WebAuthnProbe_Bytes" xml:space="preserve"><value>{0} octets</value></data>
-  <data name="WebAuthnProbe_PrfFingerprintMatches" xml:space="preserve"><value>Empreinte de comparaison PRF identique</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome" xml:space="preserve"><value>Détail de la vérification du contenu</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_not-attempted" xml:space="preserve"><value>Non tenté</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_missing-envelope" xml:space="preserve"><value>Exécutez d’abord la vérification en ligne</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_prf-mismatch" xml:space="preserve"><value>Le matériel PRF diffère de la vérification en ligne</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_invalid-envelope" xml:space="preserve"><value>Les métadonnées du contenu enregistré sont invalides</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_decrypt-failed" xml:space="preserve"><value>Le déchiffrement AES-GCM a échoué</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_plaintext-mismatch" xml:space="preserve"><value>Le contenu déchiffré ne correspond pas</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_verified" xml:space="preserve"><value>Contenu déchiffré et conforme</value></data>
-  <data name="WebAuthnProbe_Outcome" xml:space="preserve"><value>Résultat</value></data>
-  <data name="WebAuthnProbe_Yes" xml:space="preserve"><value>Oui</value></data>
-  <data name="WebAuthnProbe_No" xml:space="preserve"><value>Non</value></data>
-  <data name="WebAuthnProbe_NotReported" xml:space="preserve"><value>Non indiqué</value></data>
-  <data name="WebAuthnProbe_Outcome_unknown" xml:space="preserve"><value>Non exécuté</value></data>
-  <data name="WebAuthnProbe_Outcome_ready" xml:space="preserve"><value>Prêt</value></data>
-  <data name="WebAuthnProbe_Outcome_unsupported" xml:space="preserve"><value>WebAuthn n’est pas pris en charge</value></data>
-  <data name="WebAuthnProbe_Outcome_platform-unavailable" xml:space="preserve"><value>Aucun authentificateur de plateforme n’est disponible</value></data>
-  <data name="WebAuthnProbe_Outcome_provisioned" xml:space="preserve"><value>Configuration terminée</value></data>
-  <data name="WebAuthnProbe_Outcome_verified-online" xml:space="preserve"><value>Vérification en ligne terminée</value></data>
-  <data name="WebAuthnProbe_Outcome_retrieved" xml:space="preserve"><value>Récupération de l’identifiant terminée</value></data>
-  <data name="WebAuthnProbe_Outcome_missing-metadata" xml:space="preserve"><value>Aucune métadonnée de test n’est enregistrée</value></data>
-  <data name="WebAuthnProbe_Outcome_cancelled" xml:space="preserve"><value>L’authentification de l’appareil a été annulée</value></data>
-  <data name="WebAuthnProbe_Outcome_failed" xml:space="preserve"><value>Le test de capacité a échoué</value></data>
-  <data name="OfflineAccess_Title" xml:space="preserve"><value>Accès hors ligne</value></data>
-  <data name="OfflineAccess_Description" xml:space="preserve"><value>Configurez cet appareil pour ouvrir en toute sécurité vos propres données de pêche enregistrées sans connexion. Votre appareil vous demandera de confirmer votre identité.</value></data>
-  <data name="OfflineAccess_Setup" xml:space="preserve"><value>Configurer l’accès hors ligne</value></data>
-  <data name="OfflineAccess_Ready" xml:space="preserve"><value>L’accès hors ligne est prêt sur cet appareil.</value></data>
-  <data name="OfflineAccess_NotConfigured" xml:space="preserve"><value>L’accès hors ligne n’est pas configuré sur cet appareil.</value></data>
-  <data name="OfflineAccess_EnabledOtherDevice" xml:space="preserve"><value>L’accès hors ligne est activé pour votre compte. Configurez cet appareil pour l’utiliser ici.</value></data>
-  <data name="OfflineAccess_Unsupported" xml:space="preserve"><value>Cet appareil ou navigateur ne permet pas de configurer un accès hors ligne sécurisé.</value></data>
-  <data name="OfflineAccess_InstallRequired" xml:space="preserve"><value>Sur iPhone ou iPad, installez d’abord Catch But Don’t Forget et ouvrez l’app depuis votre écran d’accueil. Vous pourrez ensuite configurer l’accès hors ligne ici.</value></data>
-  <data name="OfflineAccess_Repair" xml:space="preserve"><value>L’accès hors ligne doit être reconfiguré sur cet appareil.</value></data>
-  <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>La vérification de l’appareil a été annulée. Vous pouvez réessayer ou continuer sans accès hors ligne.</value></data>
-  <data name="OfflineAccess_Failed" xml:space="preserve"><value>Impossible de configurer l’accès hors ligne. Veuillez réessayer.</value></data>
-  <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Supprimer de cet appareil</value></data>
-  <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Désactiver pour mon compte</value></data>
-  <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Accès hors ligne</value></data>
-  <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>L’accès hors ligne est facultatif. Choisissez Ouvrir mon carnet pour continuer sans le configurer.</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_typed-array" xml:space="preserve"><value>Typed array view</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_missing" xml:space="preserve"><value>Not returned</value></data>
+  <data name="WebAuthnProbe_PrfResultLength" xml:space="preserve"><value>PRF result length</value></data>
+  <data name="WebAuthnProbe_Bytes" xml:space="preserve"><value>{0} bytes</value></data>
+  <data name="WebAuthnProbe_PrfFingerprintMatches" xml:space="preserve"><value>PRF comparison fingerprint matches</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome" xml:space="preserve"><value>Payload verification detail</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_not-attempted" xml:space="preserve"><value>Not attempted</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_missing-envelope" xml:space="preserve"><value>Run online verification first</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_prf-mismatch" xml:space="preserve"><value>PRF material differed from online verification</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_invalid-envelope" xml:space="preserve"><value>Stored payload metadata is invalid</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_decrypt-failed" xml:space="preserve"><value>AES-GCM decryption failed</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_plaintext-mismatch" xml:space="preserve"><value>Decrypted payload did not match</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_verified" xml:space="preserve"><value>Payload decrypted and matched</value></data>
+  <data name="WebAuthnProbe_Outcome" xml:space="preserve"><value>Outcome</value></data>
+  <data name="WebAuthnProbe_Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="WebAuthnProbe_No" xml:space="preserve"><value>No</value></data>
+  <data name="WebAuthnProbe_NotReported" xml:space="preserve"><value>Not reported</value></data>
+  <data name="WebAuthnProbe_Outcome_unknown" xml:space="preserve"><value>Not run</value></data>
+  <data name="WebAuthnProbe_Outcome_ready" xml:space="preserve"><value>Ready</value></data>
+  <data name="WebAuthnProbe_Outcome_unsupported" xml:space="preserve"><value>WebAuthn is not supported</value></data>
+  <data name="WebAuthnProbe_Outcome_platform-unavailable" xml:space="preserve"><value>No platform authenticator is available</value></data>
+  <data name="WebAuthnProbe_Outcome_provisioned" xml:space="preserve"><value>Provisioning completed</value></data>
+  <data name="WebAuthnProbe_Outcome_verified-online" xml:space="preserve"><value>Online verification completed</value></data>
+  <data name="WebAuthnProbe_Outcome_retrieved" xml:space="preserve"><value>Credential retrieval completed</value></data>
+  <data name="WebAuthnProbe_Outcome_missing-metadata" xml:space="preserve"><value>No probe metadata is stored</value></data>
+  <data name="WebAuthnProbe_Outcome_cancelled" xml:space="preserve"><value>Device authentication was cancelled</value></data>
+  <data name="WebAuthnProbe_Outcome_failed" xml:space="preserve"><value>The capability check failed</value></data>
+  <data name="OfflineAccess_Title" xml:space="preserve"><value>Offline access</value></data>
+  <data name="OfflineAccess_Description" xml:space="preserve"><value>Set up this device so you can securely open your own saved fishing data without a connection. Your device will ask you to verify it is you.</value></data>
+  <data name="OfflineAccess_Setup" xml:space="preserve"><value>Set up offline access</value></data>
+  <data name="OfflineAccess_Ready" xml:space="preserve"><value>Offline access is ready on this device.</value></data>
+  <data name="OfflineAccess_NotConfigured" xml:space="preserve"><value>Offline access is not set up on this device.</value></data>
+  <data name="OfflineAccess_EnabledOtherDevice" xml:space="preserve"><value>Offline access is enabled for your account. Set up this device to use it here.</value></data>
+  <data name="OfflineAccess_Unsupported" xml:space="preserve"><value>This device or browser cannot set up secure offline access.</value></data>
+  <data name="OfflineAccess_InstallRequired" xml:space="preserve"><value>On iPhone or iPad, first install Catch But Don’t Forget and open it from your Home Screen. You can then set up offline access here.</value></data>
+  <data name="OfflineAccess_Repair" xml:space="preserve"><value>Offline access needs to be set up again on this device.</value></data>
+  <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>Device verification was cancelled. You can try again or continue without offline access.</value></data>
+  <data name="OfflineAccess_Failed" xml:space="preserve"><value>Offline access could not be set up. Please try again.</value></data>
+  <data name="OfflineAccess_Diagnostic" xml:space="preserve"><value>Validation stage: {0}. Safe error: {1}</value></data>
+  <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Remove from this device</value></data>
+  <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Turn off for my account</value></data>
+  <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Offline Access</value></data>
+  <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>Offline access is optional. Choose Open my Logbook to continue without setting it up.</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -706,180 +706,103 @@
   <data name="Install_SamsungStep2" xml:space="preserve"><value>Choisissez Ajouter la page à.</value></data>
   <data name="Install_SamsungStep3" xml:space="preserve"><value>Choisissez Écran d’accueil, puis confirmez.</value></data>
   <data name="Install_ComputerHeading" xml:space="preserve"><value>Installer sur votre ordinateur</value></data>
-  <data name="Install_ComputerStep1" xml:space="preserve"><value>Dans Chrome ou Edge, recherchez l’icône d’installation à d}v띭ǲڮ݆͹޼/value></data>
-  <data name="Onboarding_LocationTitle" xml:space="preserve"><value>Remember where you caught it</value></data>
-  <data name="Onboarding_LocationBody" xml:space="preserve"><value>Allow location only when you want the app to capture a catch position. You can skip this step.</value></data>
-  <data name="Onboarding_LocationPrivacy" xml:space="preserve"><value>New catch locations are private by default. The browser asks for permission only after you choose Allow location.</value></data>
-  <data name="Onboarding_AllowLocation" xml:space="preserve"><value>Allow location</value></data>
-  <data name="Onboarding_LocationHandled" xml:space="preserve"><value>Your choice is saved. It will not block setup.</value></data>
-  <data name="Onboarding_InstallStep" xml:space="preserve"><value>Install</value></data>
-  <data name="Onboarding_InstallNav" xml:space="preserve"><value>Install app</value></data>
-  <data name="Onboarding_InstallTitle" xml:space="preserve"><value>Keep your Logbook close</value></data>
-  <data name="Onboarding_AlreadyInstalled" xml:space="preserve"><value>The app is already installed on this device.</value></data>
-  <data name="Onboarding_InstallPromptBody" xml:space="preserve"><value>Install the app for quick access and a more reliable experience by the water.</value></data>
-  <data name="Onboarding_InstallAction" xml:space="preserve"><value>Install app</value></data>
-  <data name="Onboarding_InstallIos" xml:space="preserve"><value>In Safari, tap Share, then Add to Home Screen.</value></data>
-  <data name="Onboarding_InstallAndroid" xml:space="preserve"><value>Open your browser menu and choose Install app or Add to Home screen.</value></data>
-  <data name="Onboarding_InstallUnavailable" xml:space="preserve"><value>You can continue now and install later from your browser menu.</value></data>
-  <data name="Onboarding_SaveFailed" xml:space="preserve"><value>We couldn’t save that yet. Check your connection and try again.</value></data>
-  <data name="Onboarding_Finish" xml:space="preserve"><value>Open my Logbook</value></data>
-  <data name="Action_NotNow" xml:space="preserve"><value>Not now</value></data>
-  <data name="Action_Back" xml:space="preserve"><value>Back</value></data>
-  <data name="Action_Next" xml:space="preserve"><value>Next</value></data>
-  <data name="Landing_PageTitle" xml:space="preserve"><value>Catch But Don’t Forget</value></data>
-  <data name="Landing_Tagline" xml:space="preserve"><value>Catch · Release · Remember</value></data>
-  <data name="Landing_Heading" xml:space="preserve"><value>Your private fishing logbook</value></data>
-  <data name="Landing_Introduction" xml:space="preserve"><value>Keep every catch, photograph and memory together—wherever you fish.</value></data>
-  <data name="Landing_BenefitRecord" xml:space="preserve"><value>Quickly record catches and photographs</value></data>
-  <data name="Landing_BenefitPrivate" xml:space="preserve"><value>Fishing spots stay private by default</value></data>
-  <data name="Landing_BenefitOffline" xml:space="preserve"><value>Designed for poor signal and offline use</value></data>
-  <data name="Modal_Save" xml:space="preserve"><value>Save</value></data>
-  <data name="Modal_Selected" xml:space="preserve"><value>Selected</value></data>
-  <data name="Modal_Available" xml:space="preserve"><value>Available</value></data>
-  <data name="Modal_NoneSelected" xml:space="preserve"><value>None selected</value></data>
-  <data name="Modal_ShowingLimited" xml:space="preserve"><value>Showing {0} of {1} {2}. Search to find more.</value></data>
-  <data name="Modal_Species" xml:space="preserve"><value>species</value></data>
-  <data name="Modal_FishingMethods" xml:space="preserve"><value>fishing methods</value></data>
-  <data name="Install_Title" xml:space="preserve"><value>Install Catch But Don’t Forget</value></data>
-  <data name="Install_Benefit" xml:space="preserve"><value>Install the app for quick access from your device and a more reliable experience when you are out fishing.</value></data>
-  <data name="Install_NativeAvailable" xml:space="preserve"><value>Your browser can install the app for you.</value></data>
-  <data name="Install_Action" xml:space="preserve"><value>Install app</value></data>
-  <data name="Install_Dismissed" xml:space="preserve"><value>The app was not installed. You can try again, or follow the steps for your device below.</value></data>
-  <data name="Install_ManualIntro" xml:space="preserve"><value>Choose your device below for step-by-step instructions.</value></data>
-  <data name="Install_InstalledTitle" xml:space="preserve"><value>App is installed</value></data>
-  <data name="Install_InstalledBody" xml:space="preserve"><value>You are using the installed app. Open the Catch But Don’t Forget app from your Home Screen whenever you go fishing.</value></data>
-  <data name="Install_InstalledDesktop" xml:space="preserve"><value>You are using the installed app. Open the Catch But Don’t Forget app from your Start menu, Dock or app list, and pin it where convenient.</value></data>
-  <data name="Install_InstalledOtherDevices" xml:space="preserve"><value>Installing on another phone, tablet or computer? The steps for every device are below.</value></data>
-  <data name="Install_IosPanel" xml:space="preserve"><value>iPhone / iPad</value></data>
-  <data name="Install_AndroidPanel" xml:space="preserve"><value>Android</value></data>
-  <data name="Install_ComputerPanel" xml:space="preserve"><value>Computer</value></data>
-  <data name="Install_IosHeading" xml:space="preserve"><value>Add the app to your Home Screen</value></data>
-  <data name="Install_IosUseSafari" xml:space="preserve"><value>You are not using Safari. Open Catch But Don’t Forget in Safari first, then follow the steps below.</value></data>
-  <data name="Install_IphoneHeading" xml:space="preserve"><value>iPhone</value></data>
-  <data name="Install_IphoneStep1" xml:space="preserve"><value>Open Catch But Don’t Forget in Safari.</value></data>
-  <data name="Install_IphoneStep2" xml:space="preserve"><value>Tap ⋯ More in the Safari toolbar.</value></data>
-  <data name="Install_IphoneStep3" xml:space="preserve"><value>Tap Share.</value></data>
-  <data name="Install_IphoneStep4" xml:space="preserve"><value>If a Share button is already visible in your Safari layout, you can tap it directly instead.</value></data>
-  <data name="Install_IphoneStep5" xml:space="preserve"><value>Choose Add to Home Screen.</value></data>
-  <data name="Install_IphoneStep6" xml:space="preserve"><value>If Safari shows Open as Web App, make sure it is enabled.</value></data>
-  <data name="Install_IphoneStep7" xml:space="preserve"><value>Tap Add.</value></data>
-  <data name="Install_IphoneStep8" xml:space="preserve"><value>Open the Catch But Don’t Forget app from the new Home Screen icon.</value></data>
-  <data name="Install_IpadHeading" xml:space="preserve"><value>iPad</value></data>
-  <data name="Install_IpadStep1" xml:space="preserve"><value>Open Catch But Don’t Forget in Safari.</value></data>
-  <data name="Install_IpadStep2" xml:space="preserve"><value>Tap Share in the top toolbar.</value></data>
-  <data name="Install_IpadStep3" xml:space="preserve"><value>Choose Add to Home Screen. If Safari shows it through More, open More first.</value></data>
-  <data name="Install_IpadStep4" xml:space="preserve"><value>If Safari shows Open as Web App, make sure it is enabled.</value></data>
-  <data name="Install_IpadStep5" xml:space="preserve"><value>Tap Add.</value></data>
-  <data name="Install_IpadStep6" xml:space="preserve"><value>Open the Catch But Don’t Forget app from your Home Screen.</value></data>
-  <data name="Install_IosFallbackHeading" xml:space="preserve"><value>No Add to Home Screen option?</value></data>
-  <data name="Install_IosFallbackBody" xml:space="preserve"><value>You have probably opened the page in another browser, or inside another app such as a messaging app. Choose Open in Safari if it is offered, or copy the web address, paste it into Safari, then follow the iPhone or iPad steps above.</value></data>
-  <data name="Install_AndroidHeading" xml:space="preserve"><value>Install with Chrome or another Chromium browser</value></data>
-  <data name="Install_AndroidStep1" xml:space="preserve"><value>Open the browser menu, the three dots (⋮) at the top of the screen.</value></data>
-  <data name="Install_AndroidStep2" xml:space="preserve"><value>Choose Install app, or Add to Home screen if that is the wording you see.</value></data>
-  <data name="Install_AndroidStep3" xml:space="preserve"><value>Confirm the installation when your browser asks.</value></data>
-  <data name="Install_AndroidStep4" xml:space="preserve"><value>Open the Catch But Don’t Forget app from its new Home Screen icon.</value></data>
-  <data name="Install_SamsungHeading" xml:space="preserve"><value>Samsung Internet</value></data>
-  <data name="Install_SamsungStep1" xml:space="preserve"><value>Open the browser menu at the bottom of the screen.</value></data>
-  <data name="Install_SamsungStep2" xml:space="preserve"><value>Choose Add page to.</value></data>
-  <data name="Install_SamsungStep3" xml:space="preserve"><value>Choose Home screen, then confirm.</value></data>
-  <data name="Install_ComputerHeading" xml:space="preserve"><value>Install on your computer</value></data>
-  <data name="Install_ComputerStep1" xml:space="preserve"><value>In Chrome or Edge, look for the install icon at the right-hand end of the address bar and select it.</value></data>
-  <data name="Install_ComputerStep2" xml:space="preserve"><value>No icon in Chrome? Open the browser menu (⋮), then choose Cast, save and share, then Install page as app.</value></data>
-  <data name="Install_ComputerStep3" xml:space="preserve"><value>In Edge, open the browser menu, then choose Apps, then Install this site as an app.</value></data>
-  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirm the installation, then open the Catch But Don’t Forget app from your Start menu, Dock or app list.</value></data>
-  <data name="Install_Later" xml:space="preserve"><value>Installation is optional. You can continue now and find this guidance again from the app menu.</value></data>
-  <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choose at least one fishing method.</value></data>
-  <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choose at least one species for {0}.</value></data>
-  <data name="Onboarding_ValidationSpeciesForMethods" xml:space="preserve"><value>Choose at least one species for each of these fishing methods: {0}.</value></data>
-  <data name="Build_About" xml:space="preserve"><value>About</value></data>
-  <data name="Build_App" xml:space="preserve"><value>App</value></data>
+  <data name="Install_ComputerStep1" xml:space="preserve"><value>Dans Chrome ou Edge, recherchez l’icône d’installation à droite de la barre d’adresse et sélectionnez-la.</value></data>
+  <data name="Install_ComputerStep2" xml:space="preserve"><value>Aucune icône dans Chrome ? Ouvrez le menu du navigateur (⋮), puis choisissez Diffuser, enregistrer et partager, puis Installer la page en tant qu’application.</value></data>
+  <data name="Install_ComputerStep3" xml:space="preserve"><value>Dans Edge, ouvrez le menu du navigateur, puis choisissez Applications, puis Installer ce site en tant qu’application.</value></data>
+  <data name="Install_ComputerStep4" xml:space="preserve"><value>Confirmez l’installation, puis ouvrez l’application Catch But Don’t Forget depuis le menu Démarrer, le Dock ou votre liste d’applications.</value></data>
+  <data name="Install_Later" xml:space="preserve"><value>L’installation est facultative. Vous pouvez continuer et retrouver ces instructions plus tard depuis le menu de l’application.</value></data>
+  <data name="Onboarding_ValidationFishingMethod" xml:space="preserve"><value>Choisissez au moins une méthode de pêche.</value></data>
+  <data name="Onboarding_ValidationSpeciesForMethod" xml:space="preserve"><value>Choisissez au moins une espèce pour {0}.</value></data>
+  <data name="Onboarding_ValidationSpeciesForMethods" xml:space="preserve"><value>Choisissez au moins une espèce pour chacune de ces méthodes de pêche : {0}.</value></data>
+  <data name="Build_About" xml:space="preserve"><value>À propos</value></data>
+  <data name="Build_App" xml:space="preserve"><value>Application</value></data>
   <data name="Build_Api" xml:space="preserve"><value>API</value></data>
   <data name="Build_Version" xml:space="preserve"><value>Version</value></data>
   <data name="Build_Commit" xml:space="preserve"><value>Build</value></data>
-  <data name="Build_Environment" xml:space="preserve"><value>Environment</value></data>
-  <data name="Build_Unavailable" xml:space="preserve"><value>Unavailable</value></data>
-  <data name="Update_BannerTitle" xml:space="preserve"><value>New version available</value></data>
-  <data name="Update_BannerBody" xml:space="preserve"><value>Get the latest fixes and features.</value></data>
-  <data name="Update_Action" xml:space="preserve"><value>Update now</value></data>
-  <data name="Update_ActivatingTitle" xml:space="preserve"><value>Updating</value></data>
-  <data name="Update_ActivatingBody" xml:space="preserve"><value>The app will reopen on the new version in a moment.</value></data>
-  <data name="Update_FailedTitle" xml:space="preserve"><value>Update could not be completed</value></data>
-  <data name="Update_FailedBody" xml:space="preserve"><value>You can keep using the app as normal and try again.</value></data>
-  <data name="Update_StatusLabel" xml:space="preserve"><value>Update</value></data>
-  <data name="Update_StatusCurrent" xml:space="preserve"><value>Up to date</value></data>
-  <data name="Update_StatusAvailable" xml:space="preserve"><value>New version available</value></data>
-  <data name="WebAuthnProbe_PageTitle" xml:space="preserve"><value>WebAuthn capability probe</value></data>
-  <data name="WebAuthnProbe_Title" xml:space="preserve"><value>Offline device unlock capability probe</value></data>
-  <data name="WebAuthnProbe_Scope" xml:space="preserve"><value>This disposable diagnostic checks device authentication only. It cannot sign you in, access fishing data or call the API.</value></data>
-  <data name="WebAuthnProbe_ProvisionTitle" xml:space="preserve"><value>Provision while online</value></data>
-  <data name="WebAuthnProbe_ProvisionBody" xml:space="preserve"><value>Run this inside the installed app while online. First create the test credential, then tap Verify online credential so each device-authentication request has its own explicit action.</value></data>
-  <data name="WebAuthnProbe_ProvisionAction" xml:space="preserve"><value>Provision test credential</value></data>
-  <data name="WebAuthnProbe_VerifyOnlineAction" xml:space="preserve"><value>Verify online credential</value></data>
-  <data name="WebAuthnProbe_OfflineTitle" xml:space="preserve"><value>Test after a cold offline start</value></data>
-  <data name="WebAuthnProbe_OfflineBody" xml:space="preserve"><value>Kill the installed app, enable Airplane Mode, reopen it from the app icon, return here from Landing, then tap the button. Device authentication never starts automatically.</value></data>
-  <data name="WebAuthnProbe_OfflineAction" xml:space="preserve"><value>Test offline device unlock</value></data>
-  <data name="WebAuthnProbe_OpenAction" xml:space="preserve"><value>Open device unlock capability probe</value></data>
-  <data name="WebAuthnProbe_CleanupNote" xml:space="preserve"><value>Removing probe metadata removes only this app’s harmless test values. The test passkey may need to be removed manually from Apple Passwords, Google Password Manager or your device credential settings.</value></data>
-  <data name="WebAuthnProbe_RemoveMetadataAction" xml:space="preserve"><value>Remove probe metadata</value></data>
-  <data name="WebAuthnProbe_LeaveAction" xml:space="preserve"><value>Leave probe</value></data>
-  <data name="WebAuthnProbe_WebAuthnAvailable" xml:space="preserve"><value>WebAuthn API available</value></data>
-  <data name="WebAuthnProbe_PlatformAvailable" xml:space="preserve"><value>Platform authenticator available</value></data>
-  <data name="WebAuthnProbe_CreateSucceeded" xml:space="preserve"><value>CREATE succeeded</value></data>
-  <data name="WebAuthnProbe_CreatePrfEnabled" xml:space="preserve"><value>PRF enabled on CREATE</value></data>
-  <data name="WebAuthnProbe_CreatePrfResult" xml:space="preserve"><value>PRF result on CREATE</value></data>
-  <data name="WebAuthnProbe_ImmediateGetSucceeded" xml:space="preserve"><value>Immediate GET succeeded</value></data>
-  <data name="WebAuthnProbe_GetSucceeded" xml:space="preserve"><value>GET succeeded</value></data>
-  <data name="WebAuthnProbe_UserVerified" xml:space="preserve"><value>User verification true</value></data>
-  <data name="WebAuthnProbe_GetPrfReported" xml:space="preserve"><value>PRF extension reported on GET</value></data>
-  <data name="WebAuthnProbe_GetPrfResult" xml:space="preserve"><value>PRF result on GET</value></data>
-  <data name="WebAuthnProbe_PayloadVerified" xml:space="preserve"><value>Harmless payload decrypted</value></data>
-  <data name="WebAuthnProbe_NetworkHint" xml:space="preserve"><value>Browser network hint</value></data>
-  <data name="WebAuthnProbe_NetworkHintOnline" xml:space="preserve"><value>Online (browser-reported; not authoritative)</value></data>
-  <data name="WebAuthnProbe_NetworkHintOffline" xml:space="preserve"><value>Offline (browser-reported)</value></data>
-  <data name="WebAuthnProbe_PayloadEnvelopeAvailable" xml:space="preserve"><value>Encrypted payload ready</value></data>
-  <data name="WebAuthnProbe_PrfResultBranch" xml:space="preserve"><value>PRF result representation</value></data>
+  <data name="Build_Environment" xml:space="preserve"><value>Environnement</value></data>
+  <data name="Build_Unavailable" xml:space="preserve"><value>Indisponible</value></data>
+  <data name="Update_BannerTitle" xml:space="preserve"><value>Nouvelle version disponible</value></data>
+  <data name="Update_BannerBody" xml:space="preserve"><value>Obtenez les derniers correctifs et nouveautés.</value></data>
+  <data name="Update_Action" xml:space="preserve"><value>Mettre à jour</value></data>
+  <data name="Update_ActivatingTitle" xml:space="preserve"><value>Mise à jour en cours</value></data>
+  <data name="Update_ActivatingBody" xml:space="preserve"><value>L’application va rouvrir sur la nouvelle version dans un instant.</value></data>
+  <data name="Update_FailedTitle" xml:space="preserve"><value>La mise à jour n’a pas pu être effectuée</value></data>
+  <data name="Update_FailedBody" xml:space="preserve"><value>Vous pouvez continuer à utiliser l’application normalement et réessayer.</value></data>
+  <data name="Update_StatusLabel" xml:space="preserve"><value>Mise à jour</value></data>
+  <data name="Update_StatusCurrent" xml:space="preserve"><value>À jour</value></data>
+  <data name="Update_StatusAvailable" xml:space="preserve"><value>Nouvelle version disponible</value></data>
+  <data name="WebAuthnProbe_PageTitle" xml:space="preserve"><value>Test de capacité WebAuthn</value></data>
+  <data name="WebAuthnProbe_Title" xml:space="preserve"><value>Test de capacité de déverrouillage hors ligne</value></data>
+  <data name="WebAuthnProbe_Scope" xml:space="preserve"><value>Ce diagnostic temporaire vérifie uniquement l’authentification de l’appareil. Il ne peut pas vous connecter, accéder aux données de pêche ni appeler l’API.</value></data>
+  <data name="WebAuthnProbe_ProvisionTitle" xml:space="preserve"><value>Configurer en ligne</value></data>
+  <data name="WebAuthnProbe_ProvisionBody" xml:space="preserve"><value>Effectuez ce test dans l’application installée lorsque vous êtes en ligne. Créez d’abord l’identifiant de test, puis appuyez sur Vérifier l’identifiant en ligne afin que chaque authentification de l’appareil ait sa propre action explicite.</value></data>
+  <data name="WebAuthnProbe_ProvisionAction" xml:space="preserve"><value>Configurer l’identifiant de test</value></data>
+  <data name="WebAuthnProbe_VerifyOnlineAction" xml:space="preserve"><value>Vérifier l’identifiant en ligne</value></data>
+  <data name="WebAuthnProbe_OfflineTitle" xml:space="preserve"><value>Tester après un démarrage à froid hors ligne</value></data>
+  <data name="WebAuthnProbe_OfflineBody" xml:space="preserve"><value>Fermez complètement l’application installée, activez le mode Avion, rouvrez-la depuis son icône, revenez ici depuis l’accueil, puis appuyez sur le bouton. L’authentification de l’appareil ne démarre jamais automatiquement.</value></data>
+  <data name="WebAuthnProbe_OfflineAction" xml:space="preserve"><value>Tester le déverrouillage hors ligne</value></data>
+  <data name="WebAuthnProbe_OpenAction" xml:space="preserve"><value>Ouvrir le test de déverrouillage de l’appareil</value></data>
+  <data name="WebAuthnProbe_CleanupNote" xml:space="preserve"><value>La suppression des métadonnées du test retire uniquement les valeurs de test inoffensives de l’application. La clé d’accès de test devra peut-être être supprimée manuellement dans Mots de passe Apple, Google Password Manager ou les réglages d’identifiants de votre appareil.</value></data>
+  <data name="WebAuthnProbe_RemoveMetadataAction" xml:space="preserve"><value>Supprimer les métadonnées du test</value></data>
+  <data name="WebAuthnProbe_LeaveAction" xml:space="preserve"><value>Quitter le test</value></data>
+  <data name="WebAuthnProbe_WebAuthnAvailable" xml:space="preserve"><value>API WebAuthn disponible</value></data>
+  <data name="WebAuthnProbe_PlatformAvailable" xml:space="preserve"><value>Authentificateur de plateforme disponible</value></data>
+  <data name="WebAuthnProbe_CreateSucceeded" xml:space="preserve"><value>CREATE réussi</value></data>
+  <data name="WebAuthnProbe_CreatePrfEnabled" xml:space="preserve"><value>PRF activée lors de CREATE</value></data>
+  <data name="WebAuthnProbe_CreatePrfResult" xml:space="preserve"><value>Résultat PRF lors de CREATE</value></data>
+  <data name="WebAuthnProbe_ImmediateGetSucceeded" xml:space="preserve"><value>GET immédiat réussi</value></data>
+  <data name="WebAuthnProbe_GetSucceeded" xml:space="preserve"><value>GET réussi</value></data>
+  <data name="WebAuthnProbe_UserVerified" xml:space="preserve"><value>Vérification de l’utilisateur confirmée</value></data>
+  <data name="WebAuthnProbe_GetPrfReported" xml:space="preserve"><value>Extension PRF indiquée lors de GET</value></data>
+  <data name="WebAuthnProbe_GetPrfResult" xml:space="preserve"><value>Résultat PRF lors de GET</value></data>
+  <data name="WebAuthnProbe_PayloadVerified" xml:space="preserve"><value>Contenu inoffensif déchiffré</value></data>
+  <data name="WebAuthnProbe_NetworkHint" xml:space="preserve"><value>Indication réseau du navigateur</value></data>
+  <data name="WebAuthnProbe_NetworkHintOnline" xml:space="preserve"><value>En ligne (signalé par le navigateur, non fiable)</value></data>
+  <data name="WebAuthnProbe_NetworkHintOffline" xml:space="preserve"><value>Hors ligne (signalé par le navigateur)</value></data>
+  <data name="WebAuthnProbe_PayloadEnvelopeAvailable" xml:space="preserve"><value>Contenu chiffré prêt</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch" xml:space="preserve"><value>Représentation du résultat PRF</value></data>
   <data name="WebAuthnProbe_PrfResultBranch_array-buffer" xml:space="preserve"><value>ArrayBuffer</value></data>
-  <data name="WebAuthnProbe_PrfResultBranch_typed-array" xml:space="preserve"><value>Typed array view</value></data>
-  <data name="WebAuthnProbe_PrfResultBranch_missing" xml:space="preserve"><value>Not returned</value></data>
-  <data name="WebAuthnProbe_PrfResultLength" xml:space="preserve"><value>PRF result length</value></data>
-  <data name="WebAuthnProbe_Bytes" xml:space="preserve"><value>{0} bytes</value></data>
-  <data name="WebAuthnProbe_PrfFingerprintMatches" xml:space="preserve"><value>PRF comparison fingerprint matches</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome" xml:space="preserve"><value>Payload verification detail</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_not-attempted" xml:space="preserve"><value>Not attempted</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_missing-envelope" xml:space="preserve"><value>Run online verification first</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_prf-mismatch" xml:space="preserve"><value>PRF material differed from online verification</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_invalid-envelope" xml:space="preserve"><value>Stored payload metadata is invalid</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_decrypt-failed" xml:space="preserve"><value>AES-GCM decryption failed</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_plaintext-mismatch" xml:space="preserve"><value>Decrypted payload did not match</value></data>
-  <data name="WebAuthnProbe_PayloadVerificationOutcome_verified" xml:space="preserve"><value>Payload decrypted and matched</value></data>
-  <data name="WebAuthnProbe_Outcome" xml:space="preserve"><value>Outcome</value></data>
-  <data name="WebAuthnProbe_Yes" xml:space="preserve"><value>Yes</value></data>
-  <data name="WebAuthnProbe_No" xml:space="preserve"><value>No</value></data>
-  <data name="WebAuthnProbe_NotReported" xml:space="preserve"><value>Not reported</value></data>
-  <data name="WebAuthnProbe_Outcome_unknown" xml:space="preserve"><value>Not run</value></data>
-  <data name="WebAuthnProbe_Outcome_ready" xml:space="preserve"><value>Ready</value></data>
-  <data name="WebAuthnProbe_Outcome_unsupported" xml:space="preserve"><value>WebAuthn is not supported</value></data>
-  <data name="WebAuthnProbe_Outcome_platform-unavailable" xml:space="preserve"><value>No platform authenticator is available</value></data>
-  <data name="WebAuthnProbe_Outcome_provisioned" xml:space="preserve"><value>Provisioning completed</value></data>
-  <data name="WebAuthnProbe_Outcome_verified-online" xml:space="preserve"><value>Online verification completed</value></data>
-  <data name="WebAuthnProbe_Outcome_retrieved" xml:space="preserve"><value>Credential retrieval completed</value></data>
-  <data name="WebAuthnProbe_Outcome_missing-metadata" xml:space="preserve"><value>No probe metadata is stored</value></data>
-  <data name="WebAuthnProbe_Outcome_cancelled" xml:space="preserve"><value>Device authentication was cancelled</value></data>
-  <data name="WebAuthnProbe_Outcome_failed" xml:space="preserve"><value>The capability check failed</value></data>
-  <data name="OfflineAccess_Title" xml:space="preserve"><value>Offline access</value></data>
-  <data name="OfflineAccess_Description" xml:space="preserve"><value>Set up this device so you can securely open your own saved fishing data without a connection. Your device will ask you to verify it is you.</value></data>
-  <data name="OfflineAccess_Setup" xml:space="preserve"><value>Set up offline access</value></data>
-  <data name="OfflineAccess_Ready" xml:space="preserve"><value>Offline access is ready on this device.</value></data>
-  <data name="OfflineAccess_NotConfigured" xml:space="preserve"><value>Offline access is not set up on this device.</value></data>
-  <data name="OfflineAccess_EnabledOtherDevice" xml:space="preserve"><value>Offline access is enabled for your account. Set up this device to use it here.</value></data>
-  <data name="OfflineAccess_Unsupported" xml:space="preserve"><value>This device or browser cannot set up secure offline access.</value></data>
-  <data name="OfflineAccess_InstallRequired" xml:space="preserve"><value>On iPhone or iPad, first install Catch But Don’t Forget and open it from your Home Screen. You can then set up offline access here.</value></data>
-  <data name="OfflineAccess_Repair" xml:space="preserve"><value>Offline access needs to be set up again on this device.</value></data>
-  <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>Device verification was cancelled. You can try again or continue without offline access.</value></data>
-  <data name="OfflineAccess_Failed" xml:space="preserve"><value>Offline access could not be set up. Please try again.</value></data>
-  <data name="OfflineAccess_Diagnostic" xml:space="preserve"><value>Validation stage: {0}. Safe error: {1}</value></data>
-  <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Remove from this device</value></data>
-  <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Turn off for my account</value></data>
-  <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Offline Access</value></data>
-  <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>Offline access is optional. Choose Open my Logbook to continue without setting it up.</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_typed-array" xml:space="preserve"><value>Vue de tableau typé</value></data>
+  <data name="WebAuthnProbe_PrfResultBranch_missing" xml:space="preserve"><value>Non renvoyé</value></data>
+  <data name="WebAuthnProbe_PrfResultLength" xml:space="preserve"><value>Longueur du résultat PRF</value></data>
+  <data name="WebAuthnProbe_Bytes" xml:space="preserve"><value>{0} octets</value></data>
+  <data name="WebAuthnProbe_PrfFingerprintMatches" xml:space="preserve"><value>Empreinte de comparaison PRF identique</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome" xml:space="preserve"><value>Détail de la vérification du contenu</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_not-attempted" xml:space="preserve"><value>Non tenté</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_missing-envelope" xml:space="preserve"><value>Exécutez d’abord la vérification en ligne</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_prf-mismatch" xml:space="preserve"><value>Le matériel PRF diffère de la vérification en ligne</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_invalid-envelope" xml:space="preserve"><value>Les métadonnées du contenu enregistré sont invalides</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_decrypt-failed" xml:space="preserve"><value>Le déchiffrement AES-GCM a échoué</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_plaintext-mismatch" xml:space="preserve"><value>Le contenu déchiffré ne correspond pas</value></data>
+  <data name="WebAuthnProbe_PayloadVerificationOutcome_verified" xml:space="preserve"><value>Contenu déchiffré et conforme</value></data>
+  <data name="WebAuthnProbe_Outcome" xml:space="preserve"><value>Résultat</value></data>
+  <data name="WebAuthnProbe_Yes" xml:space="preserve"><value>Oui</value></data>
+  <data name="WebAuthnProbe_No" xml:space="preserve"><value>Non</value></data>
+  <data name="WebAuthnProbe_NotReported" xml:space="preserve"><value>Non indiqué</value></data>
+  <data name="WebAuthnProbe_Outcome_unknown" xml:space="preserve"><value>Non exécuté</value></data>
+  <data name="WebAuthnProbe_Outcome_ready" xml:space="preserve"><value>Prêt</value></data>
+  <data name="WebAuthnProbe_Outcome_unsupported" xml:space="preserve"><value>WebAuthn n’est pas pris en charge</value></data>
+  <data name="WebAuthnProbe_Outcome_platform-unavailable" xml:space="preserve"><value>Aucun authentificateur de plateforme n’est disponible</value></data>
+  <data name="WebAuthnProbe_Outcome_provisioned" xml:space="preserve"><value>Configuration terminée</value></data>
+  <data name="WebAuthnProbe_Outcome_verified-online" xml:space="preserve"><value>Vérification en ligne terminée</value></data>
+  <data name="WebAuthnProbe_Outcome_retrieved" xml:space="preserve"><value>Récupération de l’identifiant terminée</value></data>
+  <data name="WebAuthnProbe_Outcome_missing-metadata" xml:space="preserve"><value>Aucune métadonnée de test n’est enregistrée</value></data>
+  <data name="WebAuthnProbe_Outcome_cancelled" xml:space="preserve"><value>L’authentification de l’appareil a été annulée</value></data>
+  <data name="WebAuthnProbe_Outcome_failed" xml:space="preserve"><value>Le test de capacité a échoué</value></data>
+  <data name="OfflineAccess_Title" xml:space="preserve"><value>Accès hors ligne</value></data>
+  <data name="OfflineAccess_Description" xml:space="preserve"><value>Configurez cet appareil pour ouvrir en toute sécurité vos propres données de pêche enregistrées sans connexion. Votre appareil vous demandera de confirmer votre identité.</value></data>
+  <data name="OfflineAccess_Setup" xml:space="preserve"><value>Configurer l’accès hors ligne</value></data>
+  <data name="OfflineAccess_Ready" xml:space="preserve"><value>L’accès hors ligne est prêt sur cet appareil.</value></data>
+  <data name="OfflineAccess_NotConfigured" xml:space="preserve"><value>L’accès hors ligne n’est pas configuré sur cet appareil.</value></data>
+  <data name="OfflineAccess_EnabledOtherDevice" xml:space="preserve"><value>L’accès hors ligne est activé pour votre compte. Configurez cet appareil pour l’utiliser ici.</value></data>
+  <data name="OfflineAccess_Unsupported" xml:space="preserve"><value>Cet appareil ou navigateur ne permet pas de configurer un accès hors ligne sécurisé.</value></data>
+  <data name="OfflineAccess_InstallRequired" xml:space="preserve"><value>Sur iPhone ou iPad, installez d’abord Catch But Don’t Forget et ouvrez l’app depuis votre écran d’accueil. Vous pourrez ensuite configurer l’accès hors ligne ici.</value></data>
+  <data name="OfflineAccess_Repair" xml:space="preserve"><value>L’accès hors ligne doit être reconfiguré sur cet appareil.</value></data>
+  <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>La vérification de l’appareil a été annulée. Vous pouvez réessayer ou continuer sans accès hors ligne.</value></data>
+  <data name="OfflineAccess_Failed" xml:space="preserve"><value>Impossible de configurer l’accès hors ligne. Veuillez réessayer.</value></data>
+  <data name="OfflineAccess_Diagnostic" xml:space="preserve"><value>Étape de validation : {0}. Erreur sûre : {1}</value></data>
+  <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Supprimer de cet appareil</value></data>
+  <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Désactiver pour mon compte</value></data>
+  <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Accès hors ligne</value></data>
+  <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>L’accès hors ligne est facultatif. Choisissez Ouvrir mon carnet pour continuer sans le configurer.</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -800,6 +800,7 @@
   <data name="OfflineAccess_Repair" xml:space="preserve"><value>Offline access needs to be set up again on this device.</value></data>
   <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>Device verification was cancelled. You can try again or continue without offline access.</value></data>
   <data name="OfflineAccess_Failed" xml:space="preserve"><value>Offline access could not be set up. Please try again.</value></data>
+  <data name="OfflineAccess_Diagnostic" xml:space="preserve"><value>Validation stage: {0}. Safe error: {1}</value></data>
   <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Remove from this device</value></data>
   <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Turn off for my account</value></data>
   <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Offline Access</value></data>

--- a/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.js
@@ -14,29 +14,59 @@ export async function getDeviceStatus(identity) {
 export async function setupDevice(identity) {
     if (!isSupported()) return { state: 'unsupported' };
     const ownerKey = await createOwnerKey(identity.provider, identity.subject);
+    let stage = 'TrustedIdentityLoaded';
+    let createPrfMatchesGet = null;
     try {
         const salt = randomBytes(32);
+        stage = 'CredentialCreated';
         const credential = await navigator.credentials.create({ publicKey: createOptions(salt) });
-        if (!credential) return { state: 'failed' };
+        if (!credential) return failure('failed', 'CredentialCreated', 'MissingCredential');
+        stage = completed('CredentialCreated');
         const createPrf = getPrfResult(credential);
-        if (!createPrf) return { state: 'unsupported' };
+        completed('PrfCreateAvailable', { available: createPrf !== null });
 
-        const record = await encryptCandidate(identity, ownerKey, credential, salt, createPrf);
+        let record = createCandidate(ownerKey, credential, salt);
+        stage = 'CandidateStored';
         await putRecord(record);
+        stage = completed('CandidateStored');
 
+        stage = 'CredentialRetrieved';
         const assertion = await getCredential(record);
-        if (!assertion || !userVerified(assertion)) return { state: 'repair' };
+        if (!assertion) return failure('repair', 'CredentialRetrieved', 'MissingCredential');
+        if (!userVerified(assertion)) return failure('repair', 'CredentialRetrieved', 'UserVerificationMissing');
+        stage = completed('CredentialRetrieved');
+        stage = 'PrfGetAvailable';
         const getPrf = getPrfResult(assertion);
-        if (!getPrf) return { state: 'repair' };
+        if (!getPrf) return failure('repair', 'PrfGetAvailable', 'MissingPrfResult');
+        stage = completed('PrfGetAvailable');
+        createPrfMatchesGet = createPrf === null ? null : equalBytes(createPrf, getPrf);
+        completed('PrfCreateCompared', { matches: createPrfMatchesGet });
+
+        stage = 'EntitlementEncrypted';
+        record = await encryptCandidate(identity, record, getPrf);
+        await putRecord(record);
+        completed('EntitlementEncrypted');
+        stage = 'EntitlementDecrypted';
         const recovered = await decryptEntitlement(record, getPrf);
-        if (!sameIdentity(identity, recovered)) return { state: 'repair' };
+        completed('EntitlementDecrypted');
+        stage = 'IdentityVerified';
+        if (!sameIdentity(identity, recovered))
+            return failure('repair', 'IdentityVerified', 'IdentityMismatch', null, createPrfMatchesGet);
+        completed('IdentityVerified');
 
         record.state = 'ready';
         record.verifiedOn = new Date().toISOString();
+        stage = 'EntitlementReady';
         await putRecord(record);
-        return { state: 'ready' };
+        completed('EntitlementReady');
+        return { state: 'ready', stage, createPrfMatchesGet };
     } catch (error) {
-        return { state: error?.name === 'NotAllowedError' ? 'cancelled' : 'failed' };
+        return failure(
+            error?.name === 'NotAllowedError' ? 'cancelled' : 'failed',
+            stage,
+            error?.name,
+            error?.message,
+            createPrfMatchesGet);
     }
 }
 
@@ -83,9 +113,20 @@ async function getCredential(record) {
     }});
 }
 
-async function encryptCandidate(identity, ownerKey, credential, salt, prf) {
+function createCandidate(ownerKey, credential, salt) {
+    return {
+        ownerKey,
+        version: envelopeVersion,
+        state: 'candidate',
+        credentialId: toBase64Url(credential.rawId),
+        prfSalt: toBase64Url(salt),
+        transports: credential.response.getTransports?.() ?? []
+    };
+}
+
+async function encryptCandidate(identity, record, prf) {
     const iv = randomBytes(12);
-    const aad = new TextEncoder().encode(`${purpose}:${envelopeVersion}:${ownerKey}:${toBase64Url(credential.rawId)}`);
+    const aad = new TextEncoder().encode(`${purpose}:${record.version}:${record.ownerKey}:${record.credentialId}`);
     const key = await crypto.subtle.importKey('raw', prf, 'AES-GCM', false, ['encrypt']);
     const plaintext = new TextEncoder().encode(JSON.stringify({
         version: envelopeVersion,
@@ -97,12 +138,7 @@ async function encryptCandidate(identity, ownerKey, credential, salt, prf) {
     }));
     const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv, additionalData: aad }, key, plaintext);
     return {
-        ownerKey,
-        version: envelopeVersion,
-        state: 'candidate',
-        credentialId: toBase64Url(credential.rawId),
-        prfSalt: toBase64Url(salt),
-        transports: credential.response.getTransports?.() ?? [],
+        ...record,
         iv: toBase64Url(iv),
         ciphertext: toBase64Url(ciphertext)
     };
@@ -134,6 +170,28 @@ function getPrfResult(credential) {
 function userVerified(assertion) {
     const data = new Uint8Array(assertion.response.authenticatorData);
     return data.length > 32 && (data[32] & 0x04) !== 0;
+}
+
+function equalBytes(first, second) {
+    if (first.byteLength !== second.byteLength) return false;
+    return first.every((value, index) => value === second[index]);
+}
+
+function completed(stage, details) {
+    console.info('[FLB] OfflineAccessSetup', { stage, ...details });
+    return stage;
+}
+
+function failure(state, stage, errorName, errorMessage, createPrfMatchesGet = null) {
+    const safeMessage = typeof errorMessage === 'string' ? errorMessage.slice(0, 160) : null;
+    console.warn('[FLB] OfflineAccessSetup', {
+        state,
+        failedStage: stage,
+        errorName: errorName ?? null,
+        errorMessage: safeMessage,
+        createPrfMatchesGet
+    });
+    return { state, stage, errorName: errorName ?? null, errorMessage: safeMessage, createPrfMatchesGet };
 }
 
 async function createOwnerKey(provider, subject) {

--- a/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.test.js
@@ -51,7 +51,7 @@ describe('production offline access entitlement', () => {
         expect(JSON.stringify(persisted)).not.toContain(identity.userId);
     });
 
-    it('fails closed when GET returns different PRF material', async () => {
+    it('uses GET material when CREATE returns different PRF material', async () => {
         Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
             create: vi.fn(async () => credential(new Uint8Array(32).fill(1).buffer)),
             get: vi.fn(async () => assertion(new Uint8Array(32).fill(2).buffer))
@@ -59,8 +59,51 @@ describe('production offline access entitlement', () => {
 
         const result = await setupDevice(identity);
 
-        expect(result.state).toBe('failed');
+        expect(result.state).toBe('ready');
+        expect(result.stage).toBe('EntitlementReady');
+        expect(result.createPrfMatchesGet).toBe(false);
+        expect((await getDeviceStatus(identity)).state).toBe('ready');
+    });
+
+    it('reports the safe stage when GET does not return PRF material', async () => {
+        Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
+            create: vi.fn(async () => credential(new Uint8Array(32).fill(1).buffer)),
+            get: vi.fn(async () => assertion(null))
+        }});
+
+        const result = await setupDevice(identity);
+
+        expect(result).toMatchObject({
+            state: 'repair',
+            stage: 'PrfGetAvailable',
+            errorName: 'MissingPrfResult'
+        });
+        expect(result).not.toHaveProperty('prf');
         expect((await getDeviceStatus(identity)).state).toBe('repair');
+    });
+
+    it('reports a safe decrypt stage without exposing identity or PRF material', async () => {
+        const prf = new Uint8Array(32).fill(6).buffer;
+        Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
+            create: vi.fn(async () => credential(prf)),
+            get: vi.fn(async () => assertion(prf))
+        }});
+        const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const operationError = new Error('AES-GCM operation failed.');
+        operationError.name = 'OperationError';
+        vi.spyOn(webcrypto.subtle, 'decrypt').mockRejectedValueOnce(operationError);
+
+        const result = await setupDevice(identity);
+
+        expect(result).toMatchObject({
+            state: 'failed',
+            stage: 'EntitlementDecrypted',
+            errorName: 'OperationError'
+        });
+        const diagnostic = JSON.stringify([result, warning.mock.calls]);
+        expect(diagnostic).not.toContain(identity.subject);
+        expect(diagnostic).not.toContain(identity.userId);
+        expect(diagnostic).not.toContain(new Uint8Array(prf).toString());
     });
 
     it('removes only the matching owner record', async () => {

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
@@ -49,6 +49,29 @@ public class WhenTestingActions
         });
     }
 
+    [Fact]
+    public async Task ItShouldShowSafeSetupFailureDiagnostics()
+    {
+        var service = Substitute.For<IOfflineAccessService>();
+        service.GetStatusAsync(Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessStatusModel(false, "not-configured"));
+        service.SetupAsync(Arg.Any<CancellationToken>())
+            .Returns(new OfflineAccessStatusModel(
+                false,
+                "failed",
+                new OfflineAccessDeviceResultModel("failed", "EntitlementDecrypted", "OperationError", "The operation failed.")));
+        await using var context = CreateContext(service);
+        var cut = context.Render<OfflineAccessSetup>();
+        cut.WaitForAssertion(() => cut.Find("#offline-access-enable"));
+
+        await cut.Find("#offline-access-enable").ClickAsync();
+
+        cut.WaitForAssertion(() => cut.Find("#offline-access-diagnostic").TextContent.Should()
+            .Contain("EntitlementDecrypted")
+            .And.Contain("OperationError"));
+        await service.Received(1).SetupAsync(Arg.Any<CancellationToken>());
+    }
+
     private static BunitContext CreateContext(IOfflineAccessService service)
     {
         var context = new BunitContext();

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessServiceTests/WhenTestingLifecycle.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessServiceTests/WhenTestingLifecycle.cs
@@ -19,7 +19,10 @@ public class WhenTestingLifecycle
 
         var status = await fixture.Sut.SetupAsync(CancellationToken.None);
 
-        status.Should().Be(new OfflineAccessStatusModel(true, "ready"));
+        status.Should().Be(new OfflineAccessStatusModel(
+            true,
+            "ready",
+            new OfflineAccessDeviceResultModel("ready")));
         await fixture.Preference.Received(1).SetAsync(true, Arg.Any<CancellationToken>());
     }
 
@@ -30,7 +33,10 @@ public class WhenTestingLifecycle
 
         var status = await fixture.Sut.SetupAsync(CancellationToken.None);
 
-        status.Should().Be(new OfflineAccessStatusModel(false, "cancelled"));
+        status.Should().Be(new OfflineAccessStatusModel(
+            false,
+            "cancelled",
+            new OfflineAccessDeviceResultModel("cancelled")));
         await fixture.Preference.DidNotReceive().SetAsync(true, Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## Diagnosis

Physical Samsung validation exposed a deterministic difference between the production setup introduced by #144 and the known-working #140 probe.

Production encrypted the entitlement with the PRF result returned by WebAuthn CREATE, then attempted to decrypt it with the PRF result returned by the separate GET. The #140 probe does not use CREATE-derived material for its envelope: it creates the envelope from a verified GET result and proves recovery with later GET results.

The existing production test explicitly modelled different CREATE/GET PRF material but treated setup failure as correct. This matches the observed Samsung failure, most likely at AES-GCM authentication during `EntitlementDecrypted`.

## Fix

- keep the intended two device prompts: CREATE followed by a separate verified GET
- persist credential ID, salt and transports as candidate metadata after CREATE
- use the verified GET PRF result to encrypt and immediately decrypt/validate the trusted entitlement
- mark the candidate ready only after trusted provider, Cognito subject and internal UserId comparisons succeed
- retain CREATE-vs-GET equality only as a safe Boolean diagnostic; neither PRF value is logged or persisted
- add safe temporary stage/error diagnostics to the UI and console
- leave the #140 capability probe unchanged

Safe stages include `CredentialCreated`, `CandidateStored`, `CredentialRetrieved`, `PrfGetAvailable`, `EntitlementEncrypted`, `EntitlementDecrypted`, `IdentityVerified`, and `EntitlementReady`.

Diagnostics never include raw PRF output, key material, plaintext entitlement, Cognito tokens, credential secrets, subject or UserId.

## Tests

- different CREATE and GET PRF material now succeeds using GET-derived material
- missing GET PRF fails closed at `PrfGetAvailable`
- AES-GCM decrypt failure reports `EntitlementDecrypted` without exposing identity or PRF material
- component shows the safe failure stage/error
- existing account preference and explicit enablement lifecycle remains green

## Validation

- focused offline-access JS tests: 5 passed
- focused Web tests: 6 passed
- Release build: passed with 0 warnings and 0 errors
- .NET tests: 1,291 passed
- JS/Vitest tests: 231 passed
- browser tests: 27 passed, 1 existing WebKit service-worker test skipped
- formatting verification: passed

## Self Review

- Issue/AC: PASS — deterministic Samsung setup defect addressed without expanding into offline authentication
- Architecture/CQRS: PASS — server/API preference path is unchanged
- Rules: PASS
- Security/privacy: PASS — diagnostics are stage-only and crypto/identity secrets remain excluded
- Database/migrations: N/A
- Tests/coverage: PASS — mismatch, missing PRF, decrypt failure and UI diagnostic paths covered
- Browser: PASS with physical validation pending — automated crypto/IndexedDB tests pass; real Samsung retest is still required
- Web/UI/localisation: PASS — diagnostic label has EN/FR parity
- Code smells: PASS
- CI/deployment: PASS — no infrastructure or configuration changes

Findings discovered during self-review:
1. The initial diagnostic tests did not exercise the likely AES-GCM failure boundary.
2. The remote integrity check caught an omitted English resource and French UTF-8 transfer churn before handoff.

Fixes made:
1. Added deterministic decrypt-stage and secret-exclusion coverage.
2. Restored the French resource from exact `main`, added only the intended EN/FR entries, and verified the remote 172-addition/23-deletion diff matches the validated local change.

Remaining deliberate gaps:
- Repeat physical Samsung validation before iPhone validation.
- Production offline principal/routes remain out of scope.
- The #140 capability probe remains in place.

References #141.