### PR TITLE
FLB#141 | Restore original offline entitlement verification

### DIFF
--- a/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
@@ -17,12 +17,6 @@
         else
         {
             <MudAlert Severity="@StatusSeverity" id="offline-access-status">@StatusText</MudAlert>
-            @if (_status?.Diagnostic is { State: not "ready", Stage: not null } diagnostic)
-            {
-                <MudText Typo="Typo.caption" id="offline-access-diagnostic">
-                    @Loc["OfflineAccess_Diagnostic", diagnostic.Stage, DiagnosticError(diagnostic)]
-                </MudText>
-            }
             @if (_status?.IsReady == true)
             {
                 <MudButton Variant="Variant.Outlined" OnClick="RemoveAsync" Disabled="_busy" id="offline-access-remove-device">
@@ -92,9 +86,6 @@
         "unsupported" or "install-required" or "repair" or "failed" => Severity.Warning,
         _ => Severity.Info
     };
-
-    private static string DiagnosticError(FishingLogBook.Web.Features.OfflineAccess.Models.OfflineAccessDeviceResultModel diagnostic) =>
-        string.Join(": ", new[] { diagnostic.ErrorName, diagnostic.ErrorMessage }.Where(value => !string.IsNullOrWhiteSpace(value)));
 
     private IOfflineAccessService Service => Services.GetRequiredService<IOfflineAccessService>();
 

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Models/OfflineAccessStatusModel.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Models/OfflineAccessStatusModel.cs
@@ -1,18 +1,10 @@
 namespace FishingLogBook.Web.Features.OfflineAccess.Models;
 
-public sealed record OfflineAccessStatusModel(
-    bool AccountEnabled,
-    string DeviceState,
-    OfflineAccessDeviceResultModel? Diagnostic = null)
+public sealed record OfflineAccessStatusModel(bool AccountEnabled, string DeviceState)
 {
     public bool IsReady => DeviceState == "ready";
 }
 
-public sealed record OfflineAccessDeviceResultModel(
-    string State,
-    string? Stage = null,
-    string? ErrorName = null,
-    string? ErrorMessage = null,
-    bool? CreatePrfMatchesGet = null);
+public sealed record OfflineAccessDeviceResultModel(string State);
 
 public sealed record OfflineAccessIdentityModel(Guid UserId, string Provider, string Subject);

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessService.cs
@@ -36,7 +36,7 @@ public sealed class OfflineAccessService : IOfflineAccessService
         var identity = await IdentityAsync(cancellationToken);
         var device = await _deviceService.SetupAsync(identity, cancellationToken);
         if (device.State == "ready") await _preferenceClient.SetAsync(true, cancellationToken);
-        return new OfflineAccessStatusModel(device.State == "ready", device.State, device);
+        return new OfflineAccessStatusModel(device.State == "ready", device.State);
     }
 
     public async Task<OfflineAccessStatusModel> RemoveFromDeviceAsync(CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -800,7 +800,6 @@
   <data name="OfflineAccess_Repair" xml:space="preserve"><value>L’accès hors ligne doit être reconfiguré sur cet appareil.</value></data>
   <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>La vérification de l’appareil a été annulée. Vous pouvez réessayer ou continuer sans accès hors ligne.</value></data>
   <data name="OfflineAccess_Failed" xml:space="preserve"><value>Impossible de configurer l’accès hors ligne. Veuillez réessayer.</value></data>
-  <data name="OfflineAccess_Diagnostic" xml:space="preserve"><value>Étape de validation : {0}. Erreur sûre : {1}</value></data>
   <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Supprimer de cet appareil</value></data>
   <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Désactiver pour mon compte</value></data>
   <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Accès hors ligne</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -800,7 +800,6 @@
   <data name="OfflineAccess_Repair" xml:space="preserve"><value>Offline access needs to be set up again on this device.</value></data>
   <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>Device verification was cancelled. You can try again or continue without offline access.</value></data>
   <data name="OfflineAccess_Failed" xml:space="preserve"><value>Offline access could not be set up. Please try again.</value></data>
-  <data name="OfflineAccess_Diagnostic" xml:space="preserve"><value>Validation stage: {0}. Safe error: {1}</value></data>
   <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Remove from this device</value></data>
   <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Turn off for my account</value></data>
   <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Offline Access</value></data>

--- a/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.js
@@ -14,59 +14,29 @@ export async function getDeviceStatus(identity) {
 export async function setupDevice(identity) {
     if (!isSupported()) return { state: 'unsupported' };
     const ownerKey = await createOwnerKey(identity.provider, identity.subject);
-    let stage = 'TrustedIdentityLoaded';
-    let createPrfMatchesGet = null;
     try {
         const salt = randomBytes(32);
-        stage = 'CredentialCreated';
         const credential = await navigator.credentials.create({ publicKey: createOptions(salt) });
-        if (!credential) return failure('failed', 'CredentialCreated', 'MissingCredential');
-        stage = completed('CredentialCreated');
+        if (!credential) return { state: 'failed' };
         const createPrf = getPrfResult(credential);
-        completed('PrfCreateAvailable', { available: createPrf !== null });
+        if (!createPrf) return { state: 'unsupported' };
 
-        let record = createCandidate(ownerKey, credential, salt);
-        stage = 'CandidateStored';
+        const record = await encryptCandidate(identity, ownerKey, credential, salt, createPrf);
         await putRecord(record);
-        stage = completed('CandidateStored');
 
-        stage = 'CredentialRetrieved';
         const assertion = await getCredential(record);
-        if (!assertion) return failure('repair', 'CredentialRetrieved', 'MissingCredential');
-        if (!userVerified(assertion)) return failure('repair', 'CredentialRetrieved', 'UserVerificationMissing');
-        stage = completed('CredentialRetrieved');
-        stage = 'PrfGetAvailable';
+        if (!assertion || !userVerified(assertion)) return { state: 'repair' };
         const getPrf = getPrfResult(assertion);
-        if (!getPrf) return failure('repair', 'PrfGetAvailable', 'MissingPrfResult');
-        stage = completed('PrfGetAvailable');
-        createPrfMatchesGet = createPrf === null ? null : equalBytes(createPrf, getPrf);
-        completed('PrfCreateCompared', { matches: createPrfMatchesGet });
-
-        stage = 'EntitlementEncrypted';
-        record = await encryptCandidate(identity, record, getPrf);
-        await putRecord(record);
-        completed('EntitlementEncrypted');
-        stage = 'EntitlementDecrypted';
+        if (!getPrf) return { state: 'repair' };
         const recovered = await decryptEntitlement(record, getPrf);
-        completed('EntitlementDecrypted');
-        stage = 'IdentityVerified';
-        if (!sameIdentity(identity, recovered))
-            return failure('repair', 'IdentityVerified', 'IdentityMismatch', null, createPrfMatchesGet);
-        completed('IdentityVerified');
+        if (!sameIdentity(identity, recovered)) return { state: 'repair' };
 
         record.state = 'ready';
         record.verifiedOn = new Date().toISOString();
-        stage = 'EntitlementReady';
         await putRecord(record);
-        completed('EntitlementReady');
-        return { state: 'ready', stage, createPrfMatchesGet };
+        return { state: 'ready' };
     } catch (error) {
-        return failure(
-            error?.name === 'NotAllowedError' ? 'cancelled' : 'failed',
-            stage,
-            error?.name,
-            error?.message,
-            createPrfMatchesGet);
+        return { state: error?.name === 'NotAllowedError' ? 'cancelled' : 'failed' };
     }
 }
 
@@ -113,20 +83,9 @@ async function getCredential(record) {
     }});
 }
 
-function createCandidate(ownerKey, credential, salt) {
-    return {
-        ownerKey,
-        version: envelopeVersion,
-        state: 'candidate',
-        credentialId: toBase64Url(credential.rawId),
-        prfSalt: toBase64Url(salt),
-        transports: credential.response.getTransports?.() ?? []
-    };
-}
-
-async function encryptCandidate(identity, record, prf) {
+async function encryptCandidate(identity, ownerKey, credential, salt, prf) {
     const iv = randomBytes(12);
-    const aad = new TextEncoder().encode(`${purpose}:${record.version}:${record.ownerKey}:${record.credentialId}`);
+    const aad = new TextEncoder().encode(`${purpose}:${envelopeVersion}:${ownerKey}:${toBase64Url(credential.rawId)}`);
     const key = await crypto.subtle.importKey('raw', prf, 'AES-GCM', false, ['encrypt']);
     const plaintext = new TextEncoder().encode(JSON.stringify({
         version: envelopeVersion,
@@ -138,7 +97,12 @@ async function encryptCandidate(identity, record, prf) {
     }));
     const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv, additionalData: aad }, key, plaintext);
     return {
-        ...record,
+        ownerKey,
+        version: envelopeVersion,
+        state: 'candidate',
+        credentialId: toBase64Url(credential.rawId),
+        prfSalt: toBase64Url(salt),
+        transports: credential.response.getTransports?.() ?? [],
         iv: toBase64Url(iv),
         ciphertext: toBase64Url(ciphertext)
     };
@@ -170,28 +134,6 @@ function getPrfResult(credential) {
 function userVerified(assertion) {
     const data = new Uint8Array(assertion.response.authenticatorData);
     return data.length > 32 && (data[32] & 0x04) !== 0;
-}
-
-function equalBytes(first, second) {
-    if (first.byteLength !== second.byteLength) return false;
-    return first.every((value, index) => value === second[index]);
-}
-
-function completed(stage, details) {
-    console.info('[FLB] OfflineAccessSetup', { stage, ...details });
-    return stage;
-}
-
-function failure(state, stage, errorName, errorMessage, createPrfMatchesGet = null) {
-    const safeMessage = typeof errorMessage === 'string' ? errorMessage.slice(0, 160) : null;
-    console.warn('[FLB] OfflineAccessSetup', {
-        state,
-        failedStage: stage,
-        errorName: errorName ?? null,
-        errorMessage: safeMessage,
-        createPrfMatchesGet
-    });
-    return { state, stage, errorName: errorName ?? null, errorMessage: safeMessage, createPrfMatchesGet };
 }
 
 async function createOwnerKey(provider, subject) {

--- a/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.test.js
@@ -51,7 +51,7 @@ describe('production offline access entitlement', () => {
         expect(JSON.stringify(persisted)).not.toContain(identity.userId);
     });
 
-    it('uses GET material when CREATE returns different PRF material', async () => {
+    it('fails closed when GET returns different PRF material', async () => {
         Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
             create: vi.fn(async () => credential(new Uint8Array(32).fill(1).buffer)),
             get: vi.fn(async () => assertion(new Uint8Array(32).fill(2).buffer))
@@ -59,51 +59,8 @@ describe('production offline access entitlement', () => {
 
         const result = await setupDevice(identity);
 
-        expect(result.state).toBe('ready');
-        expect(result.stage).toBe('EntitlementReady');
-        expect(result.createPrfMatchesGet).toBe(false);
-        expect((await getDeviceStatus(identity)).state).toBe('ready');
-    });
-
-    it('reports the safe stage when GET does not return PRF material', async () => {
-        Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
-            create: vi.fn(async () => credential(new Uint8Array(32).fill(1).buffer)),
-            get: vi.fn(async () => assertion(null))
-        }});
-
-        const result = await setupDevice(identity);
-
-        expect(result).toMatchObject({
-            state: 'repair',
-            stage: 'PrfGetAvailable',
-            errorName: 'MissingPrfResult'
-        });
-        expect(result).not.toHaveProperty('prf');
+        expect(result.state).toBe('failed');
         expect((await getDeviceStatus(identity)).state).toBe('repair');
-    });
-
-    it('reports a safe decrypt stage without exposing identity or PRF material', async () => {
-        const prf = new Uint8Array(32).fill(6).buffer;
-        Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
-            create: vi.fn(async () => credential(prf)),
-            get: vi.fn(async () => assertion(prf))
-        }});
-        const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const operationError = new Error('AES-GCM operation failed.');
-        operationError.name = 'OperationError';
-        vi.spyOn(webcrypto.subtle, 'decrypt').mockRejectedValueOnce(operationError);
-
-        const result = await setupDevice(identity);
-
-        expect(result).toMatchObject({
-            state: 'failed',
-            stage: 'EntitlementDecrypted',
-            errorName: 'OperationError'
-        });
-        const diagnostic = JSON.stringify([result, warning.mock.calls]);
-        expect(diagnostic).not.toContain(identity.subject);
-        expect(diagnostic).not.toContain(identity.userId);
-        expect(diagnostic).not.toContain(new Uint8Array(prf).toString());
     });
 
     it('removes only the matching owner record', async () => {

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
@@ -49,29 +49,6 @@ public class WhenTestingActions
         });
     }
 
-    [Fact]
-    public async Task ItShouldShowSafeSetupFailureDiagnostics()
-    {
-        var service = Substitute.For<IOfflineAccessService>();
-        service.GetStatusAsync(Arg.Any<CancellationToken>())
-            .Returns(new OfflineAccessStatusModel(false, "not-configured"));
-        service.SetupAsync(Arg.Any<CancellationToken>())
-            .Returns(new OfflineAccessStatusModel(
-                false,
-                "failed",
-                new OfflineAccessDeviceResultModel("failed", "EntitlementDecrypted", "OperationError", "The operation failed.")));
-        await using var context = CreateContext(service);
-        var cut = context.Render<OfflineAccessSetup>();
-        cut.WaitForAssertion(() => cut.Find("#offline-access-enable"));
-
-        await cut.Find("#offline-access-enable").ClickAsync();
-
-        cut.WaitForAssertion(() => cut.Find("#offline-access-diagnostic").TextContent.Should()
-            .Contain("EntitlementDecrypted")
-            .And.Contain("OperationError"));
-        await service.Received(1).SetupAsync(Arg.Any<CancellationToken>());
-    }
-
     private static BunitContext CreateContext(IOfflineAccessService service)
     {
         var context = new BunitContext();

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessServiceTests/WhenTestingLifecycle.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessServiceTests/WhenTestingLifecycle.cs
@@ -19,10 +19,7 @@ public class WhenTestingLifecycle
 
         var status = await fixture.Sut.SetupAsync(CancellationToken.None);
 
-        status.Should().Be(new OfflineAccessStatusModel(
-            true,
-            "ready",
-            new OfflineAccessDeviceResultModel("ready")));
+        status.Should().Be(new OfflineAccessStatusModel(true, "ready"));
         await fixture.Preference.Received(1).SetAsync(true, Arg.Any<CancellationToken>());
     }
 
@@ -33,10 +30,7 @@ public class WhenTestingLifecycle
 
         var status = await fixture.Sut.SetupAsync(CancellationToken.None);
 
-        status.Should().Be(new OfflineAccessStatusModel(
-            false,
-            "cancelled",
-            new OfflineAccessDeviceResultModel("cancelled")));
+        status.Should().Be(new OfflineAccessStatusModel(false, "cancelled"));
         await fixture.Preference.DidNotReceive().SetAsync(true, Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## Summary

Reverts PR #145 and restores the exact production Offline Access implementation from merged PR #144.

Physical investigation established that the Samsung failure was caused by the #141 database migration not having been applied. Once the migration existed:

- offline access enabled successfully;
- `OfflineAccessEnabled` became `true`;
- disabling set the flag to `false` while preserving `OfflineAccessEnabledAt`;
- enabling again refreshed the server-generated timestamp.

The CREATE/GET PRF mismatch proposed in #145 was therefore not demonstrated as the device failure and should not remain as an unneeded change to the approved verification flow.

## Restored behaviour

- WebAuthn CREATE produces the encrypted candidate.
- A separate WebAuthn GET recovers PRF material and decrypts the candidate.
- Trusted provider, Cognito subject and internal UserId must match.
- Only then is the device entitlement marked ready and the account preference enabled.
- The #140 capability probe remains unchanged.
- The migration and `OfflineAccessEnabledAt` “most recently enabled at” semantics remain unchanged.

## Validation

- focused original offline-access JS tests: 3 passed
- focused Web lifecycle/component tests: 5 passed
- Release build: passed with 0 warnings and 0 errors
- .NET tests: 1,290 passed
- JS/Vitest tests: 229 passed
- browser tests: 27 passed, 1 existing WebKit service-worker test skipped
- formatting verification: passed
- remote diff verified as the exact inverse of #145: 9 files, 23 additions, 172 deletions

## Self Review

- Issue/AC: PASS — restores the approved #141 flow after confirming the operational migration cause
- Architecture/CQRS: PASS — no server/API/database architecture change
- Rules: PASS
- Security/privacy: PASS — removes the unproven alternative crypto flow and temporary diagnostics
- Database/migrations: PASS — migration and timestamp semantics are untouched
- Tests/coverage: PASS — restored code passes focused and complete validation
- Browser: PASS with physical validation pending — Samsung must be retested after deployment
- Web/UI/localisation: PASS — EN/FR temporary diagnostic entries are both removed
- Code smells: PASS
- CI/deployment: PASS — no infrastructure change; the already-applied production migration remains required

Findings discovered during self-review:
1. No additional blocker or should-fix finding.
2. Remote content was sourced directly from pre-#145 commit `2006a814` to prevent encoding or newline drift.

Fixes made:
1. Reverted all nine #145 files exactly.

Remaining deliberate gaps:
- Repeat Samsung physical validation against the restored implementation before iPhone validation.
- The #140 capability probe remains in place.

References #141.