### PR TITLE
FLB#141 | Clarify Profile offline access controls

### DIFF
--- a/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
@@ -6,9 +6,12 @@
 @inject IServiceProvider Services
 @inject IStringLocalizer<UiStrings> Loc
 
-<MudPaper Class="pa-4" Elevation="1" id="offline-access-setup">
+<MudPaper Class="@(ShowTitle ? "pa-4" : "pa-0")" Elevation="@(ShowTitle ? 1 : 0)" id="offline-access-setup">
     <MudStack Spacing="2">
-        <MudText Typo="Typo.h5">@Loc["OfflineAccess_Title"]</MudText>
+        @if (ShowTitle)
+        {
+            <MudText Typo="Typo.h5">@Loc["OfflineAccess_Title"]</MudText>
+        }
         <MudText>@Loc["OfflineAccess_Description"]</MudText>
         @if (_loading)
         {
@@ -19,12 +22,29 @@
             <MudAlert Severity="@StatusSeverity" id="offline-access-status">@StatusText</MudAlert>
             @if (_status?.IsReady == true)
             {
-                <MudButton Variant="Variant.Outlined" OnClick="RemoveAsync" Disabled="_busy" id="offline-access-remove-device">
-                    @Loc["OfflineAccess_RemoveDevice"]
-                </MudButton>
-                <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="TurnOffAsync" Disabled="_busy" id="offline-access-turn-off">
-                    @Loc["OfflineAccess_TurnOffAccount"]
-                </MudButton>
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                    <MudButton Variant="Variant.Outlined" FullWidth="true" OnClick="RemoveAsync" Disabled="_busy" id="offline-access-remove-device">
+                        @Loc["OfflineAccess_TurnOffDevice"]
+                    </MudButton>
+                    <MudTooltip Text="@Loc["OfflineAccess_TurnOffDeviceHelp"]">
+                        <MudIconButton Icon="@Icons.Material.Filled.HelpOutline"
+                                       Size="Size.Small"
+                                       aria-label="@Loc["OfflineAccess_TurnOffDeviceHelpLabel"]"
+                                       id="offline-access-device-help" />
+                    </MudTooltip>
+                </MudStack>
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                    <MudButton Variant="Variant.Outlined" Color="Color.Error" FullWidth="true" OnClick="TurnOffAsync" Disabled="_busy" id="offline-access-turn-off">
+                        @Loc["OfflineAccess_TurnOffAccount"]
+                    </MudButton>
+                    <MudTooltip Text="@Loc["OfflineAccess_TurnOffAccountHelp"]">
+                        <MudIconButton Icon="@Icons.Material.Filled.HelpOutline"
+                                       Size="Size.Small"
+                                       Color="Color.Error"
+                                       aria-label="@Loc["OfflineAccess_TurnOffAccountHelpLabel"]"
+                                       id="offline-access-account-help" />
+                    </MudTooltip>
+                </MudStack>
             }
             else
             {
@@ -39,6 +59,7 @@
 
 @code {
     [Parameter] public EventCallback<bool> ReadyChanged { get; set; }
+    [Parameter] public bool ShowTitle { get; set; } = true;
 
     private FishingLogBook.Web.Features.OfflineAccess.Models.OfflineAccessStatusModel? _status;
     private bool _loading = true;
@@ -105,3 +126,4 @@
         finally { _busy = false; }
     }
 }
+

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Components/OfflineAccessSetup.razor
@@ -126,4 +126,3 @@
         finally { _busy = false; }
     }
 }
-

--- a/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor
+++ b/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor
@@ -27,6 +27,9 @@
         {
             <MudPaper Class="pa-4" Elevation="2">
                 <MudStack Spacing="3">
+                    <MudExpansionPanels MultiExpansion="true" Elevation="1" id="profile-sections">
+                        <MudExpansionPanel Text="@Loc["Profile_YourDetailsSection"]" Expanded="true" id="profile-your-details-section">
+                            <MudStack Spacing="3">
                     <MudTextField @bind-Value="_displayName"
                                   Label="@Loc["Profile_DisplayName"]"
                                   Variant="Variant.Outlined"
@@ -46,6 +49,34 @@
                                Color="Color.Primary"
                                Label="@Loc["Profile_ShowHomeRegion"]"
                                id="profile-show-home-region" />
+
+                    <div class="profile-photo-actions">
+                        <label for="profile-photo-input" class="profile-photo-picker" id="profile-choose-photo">
+                            @Loc["Profile_ChoosePhoto"]
+                        </label>
+                        <InputFile OnChange="OnPhotographSelected"
+                                   accept="image/jpeg,image/png,image/webp"
+                                   class="profile-photo-input"
+                                   id="profile-photo-input" />
+                    </div>
+                    @if (_photographUrl is not null)
+                    {
+                        <img src="@_photographUrl"
+                             alt="@Loc["Profile_PhotographAlt"]"
+                             class="profile-photo-preview"
+                             id="profile-photo-preview" />
+                    }
+                    <MudSwitch @bind-Value="_showPhotograph"
+                               Color="Color.Primary"
+                               Label="@Loc["Profile_ShowPhotograph"]"
+                               id="profile-show-photograph" />
+
+                    <MudText Typo="Typo.caption" id="profile-privacy-caption">@Loc["Profile_LocationPrivacy"]</MudText>
+                            </MudStack>
+                        </MudExpansionPanel>
+
+                        <MudExpansionPanel Text="@Loc["Profile_FishingDetailsSection"]" id="profile-fishing-details-section">
+                            <MudStack Spacing="3">
 
                     <MudStack Spacing="1">
                         <MudText Typo="Typo.subtitle2">@Loc["Profile_FishingMethods"]</MudText>
@@ -162,29 +193,13 @@
                         <MudSelectItem Value="LengthUnitEnum.Cm">@Loc["Profile_LengthUnit_Cm"]</MudSelectItem>
                         <MudSelectItem Value="LengthUnitEnum.In">@Loc["Profile_LengthUnit_In"]</MudSelectItem>
                     </MudSelect>
+                            </MudStack>
+                        </MudExpansionPanel>
 
-                    <div class="profile-photo-actions">
-                        <label for="profile-photo-input" class="profile-photo-picker" id="profile-choose-photo">
-                            @Loc["Profile_ChoosePhoto"]
-                        </label>
-                        <InputFile OnChange="OnPhotographSelected"
-                                   accept="image/jpeg,image/png,image/webp"
-                                   class="profile-photo-input"
-                                   id="profile-photo-input" />
-                    </div>
-                    @if (_photographUrl is not null)
-                    {
-                        <img src="@_photographUrl"
-                             alt="@Loc["Profile_PhotographAlt"]"
-                             class="profile-photo-preview"
-                             id="profile-photo-preview" />
-                    }
-                    <MudSwitch @bind-Value="_showPhotograph"
-                               Color="Color.Primary"
-                               Label="@Loc["Profile_ShowPhotograph"]"
-                               id="profile-show-photograph" />
-
-                    <MudText Typo="Typo.caption" id="profile-privacy-caption">@Loc["Profile_LocationPrivacy"]</MudText>
+                        <MudExpansionPanel Text="@Loc["Profile_OfflineAccessSection"]" id="profile-offline-access-section">
+                            <OfflineAccessSetup ShowTitle="false" />
+                        </MudExpansionPanel>
+                    </MudExpansionPanels>
 
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Primary"
@@ -214,5 +229,5 @@
             </MudPaper>
         }
     </MudStack>
-    <OfflineAccessSetup />
 </MudContainer>
+

--- a/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor
+++ b/src/FishingLogBook.Web/Features/Profile/Pages/Profile/Profile.razor
@@ -230,4 +230,3 @@
         }
     </MudStack>
 </MudContainer>
-

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -492,6 +492,9 @@
   <data name="Profile_Title" xml:space="preserve">
     <value>Votre profil</value>
   </data>
+  <data name="Profile_YourDetailsSection" xml:space="preserve"><value>Vos informations</value></data>
+  <data name="Profile_FishingDetailsSection" xml:space="preserve"><value>Informations de pêche</value></data>
+  <data name="Profile_OfflineAccessSection" xml:space="preserve"><value>Accès hors connexion</value></data>
   <data name="Profile_PublicTitle" xml:space="preserve">
     <value>Profil pêcheur</value>
   </data>
@@ -800,8 +803,13 @@
   <data name="OfflineAccess_Repair" xml:space="preserve"><value>L’accès hors ligne doit être reconfiguré sur cet appareil.</value></data>
   <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>La vérification de l’appareil a été annulée. Vous pouvez réessayer ou continuer sans accès hors ligne.</value></data>
   <data name="OfflineAccess_Failed" xml:space="preserve"><value>Impossible de configurer l’accès hors ligne. Veuillez réessayer.</value></data>
-  <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Supprimer de cet appareil</value></data>
+  <data name="OfflineAccess_TurnOffDevice" xml:space="preserve"><value>Désactiver pour cet appareil</value></data>
+  <data name="OfflineAccess_TurnOffDeviceHelp" xml:space="preserve"><value>Désactive l’accès hors connexion uniquement sur cet appareil. Il reste activé pour votre compte et vos données de pêche ne sont pas supprimées.</value></data>
+  <data name="OfflineAccess_TurnOffDeviceHelpLabel" xml:space="preserve"><value>À propos de la désactivation de l’accès hors connexion sur cet appareil</value></data>
   <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Désactiver pour mon compte</value></data>
+  <data name="OfflineAccess_TurnOffAccountHelp" xml:space="preserve"><value>Désactive l’accès hors connexion pour votre compte et cet appareil. Vos données de pêche ne sont pas supprimées.</value></data>
+  <data name="OfflineAccess_TurnOffAccountHelpLabel" xml:space="preserve"><value>À propos de la désactivation de l’accès hors connexion pour votre compte</value></data>
   <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Accès hors ligne</value></data>
   <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>L’accès hors ligne est facultatif. Choisissez Ouvrir mon carnet pour continuer sans le configurer.</value></data>
 </root>
+

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -812,4 +812,3 @@
   <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Accès hors ligne</value></data>
   <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>L’accès hors ligne est facultatif. Choisissez Ouvrir mon carnet pour continuer sans le configurer.</value></data>
 </root>
-

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -812,4 +812,3 @@
   <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Offline Access</value></data>
   <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>Offline access is optional. Choose Open my Logbook to continue without setting it up.</value></data>
 </root>
-

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -492,6 +492,9 @@
   <data name="Profile_Title" xml:space="preserve">
     <value>Your profile</value>
   </data>
+  <data name="Profile_YourDetailsSection" xml:space="preserve"><value>Your details</value></data>
+  <data name="Profile_FishingDetailsSection" xml:space="preserve"><value>Fishing details</value></data>
+  <data name="Profile_OfflineAccessSection" xml:space="preserve"><value>Offline access</value></data>
   <data name="Profile_PublicTitle" xml:space="preserve">
     <value>Angler profile</value>
   </data>
@@ -800,8 +803,13 @@
   <data name="OfflineAccess_Repair" xml:space="preserve"><value>Offline access needs to be set up again on this device.</value></data>
   <data name="OfflineAccess_Cancelled" xml:space="preserve"><value>Device verification was cancelled. You can try again or continue without offline access.</value></data>
   <data name="OfflineAccess_Failed" xml:space="preserve"><value>Offline access could not be set up. Please try again.</value></data>
-  <data name="OfflineAccess_RemoveDevice" xml:space="preserve"><value>Remove from this device</value></data>
+  <data name="OfflineAccess_TurnOffDevice" xml:space="preserve"><value>Turn off for this device</value></data>
+  <data name="OfflineAccess_TurnOffDeviceHelp" xml:space="preserve"><value>Stops offline access on this device only. Offline access stays enabled for your account, and your fishing data is not deleted.</value></data>
+  <data name="OfflineAccess_TurnOffDeviceHelpLabel" xml:space="preserve"><value>About turning off offline access for this device</value></data>
   <data name="OfflineAccess_TurnOffAccount" xml:space="preserve"><value>Turn off for my account</value></data>
+  <data name="OfflineAccess_TurnOffAccountHelp" xml:space="preserve"><value>Turns off offline access for your account and this device. Your fishing data is not deleted.</value></data>
+  <data name="OfflineAccess_TurnOffAccountHelpLabel" xml:space="preserve"><value>About turning off offline access for your account</value></data>
   <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Offline Access</value></data>
   <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>Offline access is optional. Choose Open my Logbook to continue without setting it up.</value></data>
 </root>
+

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
@@ -44,8 +44,16 @@ public class WhenTestingActions
 
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#offline-access-remove-device").Should().NotBeNull();
-            cut.Find("#offline-access-turn-off").Should().NotBeNull();
+            var deviceButton = cut.Find("#offline-access-remove-device");
+            deviceButton.TextContent.Should().Contain("Turn off for this device");
+            cut.Find("#offline-access-device-help").GetAttribute("aria-label").Should()
+                .Be("About turning off offline access for this device");
+
+            var accountButton = cut.Find("#offline-access-turn-off");
+            accountButton.TextContent.Should().Contain("Turn off for my account");
+            accountButton.ClassList.Should().Contain("mud-button-outlined-error");
+            cut.Find("#offline-access-account-help").GetAttribute("aria-label").Should()
+                .Be("About turning off offline access for your account");
         });
     }
 
@@ -61,3 +69,4 @@ public class WhenTestingActions
         return context;
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Components/OfflineAccessSetupTests/WhenTestingActions.cs
@@ -69,4 +69,3 @@ public class WhenTestingActions
         return context;
     }
 }
-

--- a/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingRender.cs
@@ -101,6 +101,10 @@ public class WhenTestingRender : BaseProfileTest
         {
             cut.Markup.Should().Contain("Your profile");
             cut.Markup.Should().Contain("Choose what other anglers can see.");
+            cut.Find("#profile-sections").Should().NotBeNull();
+            cut.Find("#profile-your-details-section").TextContent.Should().Contain("Your details");
+            cut.Find("#profile-fishing-details-section").TextContent.Should().Contain("Fishing details");
+            cut.Find("#profile-offline-access-section").TextContent.Should().Contain("Offline access");
             cut.Find("#profile-display-name").Should().NotBeNull();
             cut.Find("#profile-home-region").Should().NotBeNull();
             cut.Find("#profile-weight-unit").Should().NotBeNull();
@@ -144,3 +148,4 @@ public class WhenTestingRender : BaseProfileTest
         await profileClient.Received(1).GetOwnAsync(Arg.Any<CancellationToken>());
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Profile/Pages/ProfileTests/WhenTestingRender.cs
@@ -148,4 +148,3 @@ public class WhenTestingRender : BaseProfileTest
         await profileClient.Received(1).GetOwnAsync(Arg.Any<CancellationToken>());
     }
 }
-


### PR DESCRIPTION
Follow-up to #141.

## Summary
- groups Profile into collapsible **Your details**, **Fishing details**, and **Offline access** sections
- renames the device-only action to **Turn off for this device**
- adds accessible help affordances explaining the device-only and account-wide actions
- gives the destructive account-wide action a visible red outline
- preserves the existing offline-access service behaviour and onboarding presentation
- adds complete English/French localisation and focused component tests

## Validation
- `dotnet format FishingLogBook.sln`
- `dotnet build FishingLogBook.sln --no-restore` — 0 warnings, 0 errors
- `dotnet test FishingLogBook.sln --no-build` — 1,290 passed
- `npm test` — 229 passed
- `npm run test:browser` — 27 passed, 1 existing WebKit service-worker test skipped

## Self review
- Issue/AC: PASS — implements only the requested Profile/offline-action UX follow-up
- Architecture/CQRS: PASS — presentation/localisation only; existing service actions are unchanged
- Rules: PASS
- Security/privacy: PASS — no entitlement, identity, storage, authentication, or sync semantics changed
- Database/migrations: N/A
- Tests/coverage: PASS — Profile grouping and explicit action presentation are covered
- Browser: PASS — existing browser suite remains green; physical visual review remains with the reviewer after deployment
- Web/UI/localisation: PASS — EN/FR parity retained and help controls have accessible labels
- Code smells: PASS
- CI/deployment: PASS — no infrastructure or manual deployment changes

## Findings discovered during self-review
1. Embedding the existing Offline Access card inside an expansion panel initially produced unnecessary nested elevation and padding.

## Fixes made
1. The embedded Profile instance now suppresses the duplicate heading and nested card treatment; onboarding retains its existing presentation.

## Remaining deliberate gaps
- No offline-access behaviour changes are included.
- The #140 capability probe remains untouched.
