### PR TITLE
Offline access | Surface entitlement discovery failures

### DIFF
--- a/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
@@ -38,6 +38,42 @@ test.describe('Published offline application shell', () => {
         expect(apiGuard.requests).toEqual([]);
     });
 
+    test('shows and retries an offline entitlement discovery failure without unlocking or using the API', async ({ context, page }) => {
+        const apiGuard = guardOfflineApiRequests(context);
+        await addPrfAuthenticator(page);
+        await cachePublishedShell(page);
+        await provisionOfflineOwner(page);
+        await context.addInitScript(() => {
+            window.__failOfflineEntitlementDiscovery = true;
+            const originalOpen = indexedDB.open.bind(indexedDB);
+            Object.defineProperty(indexedDB, 'open', {
+                configurable: true,
+                value: (...args) => {
+                    if (window.__failOfflineEntitlementDiscovery
+                        && args[0] === 'FishingLogBookOfflineAccess') {
+                        throw new DOMException('Simulated discovery failure', 'UnknownError');
+                    }
+                    return originalOpen(...args);
+                }
+            });
+        });
+
+        apiGuard.enable();
+        await reopenColdOffline(context, page);
+        await expect(page.locator('#landing-offline-availability-failed')).toBeVisible({ timeout: 15000 });
+        await expect(page.locator('#landing-open-offline')).toHaveCount(0);
+        expect(await credentialGetCalls(page)).toBe(0);
+        expect(apiGuard.requests).toEqual([]);
+
+        await page.evaluate(() => { window.__failOfflineEntitlementDiscovery = false; });
+        await page.locator('#landing-offline-availability-retry').click();
+
+        await expect(page.locator('#landing-open-offline')).toBeVisible();
+        await expect(page.locator('#landing-offline-availability-failed')).toHaveCount(0);
+        expect(await credentialGetCalls(page)).toBe(0);
+        expect(apiGuard.requests).toEqual([]);
+    });
+
     test('unlocks explicitly, keeps owner data isolated, and records and edits across cold offline reloads', async ({ context, page }) => {
         test.setTimeout(120000);
         const apiGuard = guardOfflineApiRequests(context);

--- a/src/FishingLogBook.Web/Features/Diagnostics/Services/LoggingService.cs
+++ b/src/FishingLogBook.Web/Features/Diagnostics/Services/LoggingService.cs
@@ -10,6 +10,7 @@ public sealed class LoggingService : ILoggingService
 {
     private const string SetLastError = "fishingLogBookDiagnostics.setLastError";
     private const string GetLastError = "fishingLogBookDiagnostics.getLastError";
+    private const string WriteDiagnostic = "fishingLogBookDiagnostics.console";
     private const int MaxMessageLength = 500;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -67,7 +68,19 @@ public sealed class LoggingService : ILoggingService
             Message = DiagnosticMetadata.Truncate(message, MaxMessageLength)
         };
 
-        Console.Error.WriteLine($"[FLB] {lastError.Source}: {lastError.ErrorType}: {lastError.Message}");
+        try
+        {
+            await _jsRuntime.InvokeVoidAsync(
+                WriteDiagnostic,
+                cancellationToken,
+                "Error",
+                lastError.Source,
+                $"{lastError.ErrorType}: {lastError.Message}");
+        }
+        catch
+        {
+            // Diagnostics must never replace the original application failure.
+        }
 
         try
         {
@@ -78,6 +91,7 @@ public sealed class LoggingService : ILoggingService
         }
         catch
         {
+            // Persisting diagnostics is best effort and must not recurse into logging.
         }
     }
 }

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Models/OfflineAccessAvailabilityModel.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Models/OfflineAccessAvailabilityModel.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Web.Features.OfflineAccess.Models;
+
+public sealed record OfflineAccessAvailabilityModel(string State, string Detail)
+{
+    public bool IsReady => State == "ready";
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/IOfflineAccessDeviceService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/IOfflineAccessDeviceService.cs
@@ -4,7 +4,7 @@ namespace FishingLogBook.Web.Features.OfflineAccess.Services;
 
 public interface IOfflineAccessDeviceService
 {
-    Task<bool> HasReadyEntitlementAsync(CancellationToken cancellationToken);
+    Task<OfflineAccessAvailabilityModel> HasReadyEntitlementAsync(CancellationToken cancellationToken);
     Task<OfflineAccessUnlockResultModel> UnlockAsync(CancellationToken cancellationToken);
     Task<OfflineAccessDeviceResultModel> GetStatusAsync(OfflineAccessIdentityModel identity, CancellationToken cancellationToken);
     Task<OfflineAccessDeviceResultModel> SetupAsync(OfflineAccessIdentityModel identity, CancellationToken cancellationToken);

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessDeviceService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessDeviceService.cs
@@ -10,10 +10,10 @@ public sealed class OfflineAccessDeviceService : IOfflineAccessDeviceService
 
     public OfflineAccessDeviceService(IJSRuntime jsRuntime) => _jsRuntime = jsRuntime;
 
-    public async Task<bool> HasReadyEntitlementAsync(CancellationToken cancellationToken)
+    public async Task<OfflineAccessAvailabilityModel> HasReadyEntitlementAsync(CancellationToken cancellationToken)
     {
         var module = await ImportAsync(cancellationToken);
-        return await module.InvokeAsync<bool>("hasReadyEntitlement", cancellationToken);
+        return await module.InvokeAsync<OfflineAccessAvailabilityModel>("hasReadyEntitlement", cancellationToken);
     }
 
     public async Task<OfflineAccessUnlockResultModel> UnlockAsync(CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessDiscoveryException.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineAccessDiscoveryException.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Web.Features.OfflineAccess.Services;
+
+public sealed class OfflineAccessDiscoveryException : Exception
+{
+    public OfflineAccessDiscoveryException(string detail)
+        : base(detail)
+    {
+    }
+}

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
@@ -23,7 +23,7 @@
             <MudStack Spacing="2" Class="landing-actions">
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginCreateAccount" id="landing-create-account">@Loc["Auth_CreateAccount"]</MudButton>
                 <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginSignIn" id="landing-sign-in">@Loc["Auth_SignIn"]</MudButton>
-                @if (_showOfflineAction)
+                @if (_offlineAvailability == OfflineAvailabilityState.Ready)
                 {
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Secondary"
@@ -35,6 +35,21 @@
                                id="landing-open-offline">
                         @Loc["OfflineAccess_OpenOffline"]
                     </MudButton>
+                }
+                @if (_offlineAvailability == OfflineAvailabilityState.CheckFailed)
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" id="landing-offline-availability-failed">
+                        <MudStack Spacing="2">
+                            <MudText Typo="Typo.body2">@Loc["OfflineAccess_AvailabilityCheckFailed"]</MudText>
+                            <MudButton Variant="Variant.Text"
+                                       Color="Color.Primary"
+                                       Disabled="_checkingOfflineAvailability"
+                                       OnClick="RetryOfflineAvailabilityAsync"
+                                       id="landing-offline-availability-retry">
+                                @Loc["Action_TryAgain"]
+                            </MudButton>
+                        </MudStack>
+                    </MudAlert>
                 }
                 @if (_offlineUnlockFailed)
                 {

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
@@ -57,22 +57,25 @@ public partial class Landing : ComponentBase, IDisposable
                 return;
             }
 
-            if (availability.State == "check-failed")
+            var state = availability.State switch
+            {
+                "ready" => OfflineAvailabilityState.Ready,
+                "not-configured" => OfflineAvailabilityState.NotConfigured,
+                "check-failed" => OfflineAvailabilityState.CheckFailed,
+                _ => OfflineAvailabilityState.CheckFailed
+            };
+            if (state == OfflineAvailabilityState.CheckFailed)
             {
                 await Logging.LogErrorAsync(
                     "landing offline availability",
-                    new OfflineAccessDiscoveryException(availability.Detail),
+                    new OfflineAccessDiscoveryException(
+                        availability.State == "check-failed" ? availability.Detail : "unexpected-state"),
                     CancellationToken.None);
             }
 
             await InvokeAsync(() =>
             {
-                _offlineAvailability = availability.State switch
-                {
-                    "ready" => OfflineAvailabilityState.Ready,
-                    "check-failed" => OfflineAvailabilityState.CheckFailed,
-                    _ => OfflineAvailabilityState.NotConfigured
-                };
+                _offlineAvailability = state;
                 StateHasChanged();
             });
         }

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
@@ -13,9 +13,18 @@ namespace FishingLogBook.Web.Features.Onboarding.Pages.Landing;
 
 public partial class Landing : ComponentBase, IDisposable
 {
+    private enum OfflineAvailabilityState
+    {
+        Checking,
+        Ready,
+        NotConfigured,
+        CheckFailed
+    }
+
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private bool _showWebAuthnProbeAction;
-    private bool _showOfflineAction;
+    private OfflineAvailabilityState _offlineAvailability = OfflineAvailabilityState.Checking;
+    private bool _checkingOfflineAvailability;
     private bool _offlineUnlockFailed;
     private bool _unlocking;
 
@@ -39,22 +48,33 @@ public partial class Landing : ComponentBase, IDisposable
     private async Task LoadOfflineAvailabilityAsync()
     {
         var cancellationToken = _cancellationTokenSource.Token;
+        _checkingOfflineAvailability = true;
         try
         {
-            var showAction = await OfflineAccessDevice.HasReadyEntitlementAsync(cancellationToken);
+            var availability = await OfflineAccessDevice.HasReadyEntitlementAsync(cancellationToken);
             if (cancellationToken.IsCancellationRequested)
             {
                 return;
             }
 
+            if (availability.State == "check-failed")
+            {
+                await Logging.LogErrorAsync(
+                    "landing offline availability",
+                    new OfflineAccessDiscoveryException(availability.Detail),
+                    CancellationToken.None);
+            }
+
             await InvokeAsync(() =>
             {
-                _showOfflineAction = showAction;
+                _offlineAvailability = availability.State switch
+                {
+                    "ready" => OfflineAvailabilityState.Ready,
+                    "check-failed" => OfflineAvailabilityState.CheckFailed,
+                    _ => OfflineAvailabilityState.NotConfigured
+                };
                 StateHasChanged();
             });
-        }
-        catch (JSException)
-        {
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -62,8 +82,22 @@ public partial class Landing : ComponentBase, IDisposable
         catch (Exception exception)
         {
             await Logging.LogErrorAsync("landing offline availability", exception, CancellationToken.None);
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                await InvokeAsync(() =>
+                {
+                    _offlineAvailability = OfflineAvailabilityState.CheckFailed;
+                    StateHasChanged();
+                });
+            }
+        }
+        finally
+        {
+            _checkingOfflineAvailability = false;
         }
     }
+
+    private Task RetryOfflineAvailabilityAsync() => LoadOfflineAvailabilityAsync();
 
     private async Task OpenOfflineAsync()
     {

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -624,6 +624,9 @@
   <data name="Action_TryAgain" xml:space="preserve">
     <value>Réessayer</value>
   </data>
+  <data name="OfflineAccess_AvailabilityCheckFailed" xml:space="preserve">
+    <value>Nous n'avons pas pu vérifier l'accès hors ligne sur cet appareil. Veuillez réessayer.</value>
+  </data>
   <data name="Common_Loading" xml:space="preserve"><value>Chargement</value></data>
   <data name="Brand_LogoAlt" xml:space="preserve"><value>Catch But Don’t Forget — Catch · Release · Remember</value></data>
   <data name="Onboarding_PageTitle" xml:space="preserve"><value>Bienvenue</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -624,6 +624,9 @@
   <data name="Action_TryAgain" xml:space="preserve">
     <value>Try again</value>
   </data>
+  <data name="OfflineAccess_AvailabilityCheckFailed" xml:space="preserve">
+    <value>We couldn't check offline access on this device. Please try again.</value>
+  </data>
   <data name="Common_Loading" xml:space="preserve"><value>Loading</value></data>
   <data name="Brand_LogoAlt" xml:space="preserve"><value>Catch But Don’t Forget — Catch · Release · Remember</value></data>
   <data name="Onboarding_PageTitle" xml:space="preserve"><value>Welcome</value></data>

--- a/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.js
@@ -12,9 +12,13 @@ export async function getDeviceStatus(identity) {
 }
 
 export async function hasReadyEntitlement() {
-    if (!isSupported()) return false;
-    const records = await getAllRecords();
-    return records.some(isReadyRecord);
+    try {
+        const records = await getAllRecords();
+        if (records.some(isReadyRecord)) return discoveryResult('ready', 'ready-record-found');
+        return discoveryResult('not-configured', records.length === 0 ? 'no-records' : 'records-present-none-ready');
+    } catch (error) {
+        return discoveryResult('check-failed', discoveryFailureDetail('indexeddb-read', error));
+    }
 }
 
 export async function unlockDevice() {
@@ -232,7 +236,18 @@ async function openDatabase() {
         };
         request.onsuccess = () => resolve(request.result);
         request.onerror = () => reject(request.error);
+        request.onblocked = () => reject(new Error('database-open-blocked'));
     });
+}
+
+function discoveryResult(state, detail) {
+    console.info(`[FLB] OfflineAccessDiscovery: ${detail}`);
+    return { state, detail };
+}
+
+function discoveryFailureDetail(stage, error) {
+    const safeType = typeof error?.name === 'string' && error.name.length > 0 ? error.name : 'Error';
+    return `${stage}:${safeType}`;
 }
 
 async function transact(mode, action) {

--- a/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/offline-access.test.js
@@ -93,7 +93,7 @@ describe('production offline access entitlement', () => {
         const available = await hasReadyEntitlement();
         const result = await unlockDevice();
 
-        expect(available).toBe(true);
+        expect(available).toEqual({ state: 'ready', detail: 'ready-record-found' });
         expect(result).toEqual({ state: 'unlocked', userId: identity.userId, version: 1 });
         expect(navigator.credentials.get).toHaveBeenCalledOnce();
         expect(navigator.credentials.get.mock.calls[0][0].publicKey.allowCredentials).toHaveLength(1);
@@ -181,8 +181,42 @@ describe('production offline access entitlement', () => {
         const available = await hasReadyEntitlement();
         const result = await unlockDevice();
 
-        expect(available).toBe(false);
+        expect(available).toEqual({ state: 'not-configured', detail: 'records-present-none-ready' });
         expect(result.state).toBe('not-configured');
+    });
+
+    it('discovers a ready record without requiring WebAuthn setup APIs', async () => {
+        const prf = new Uint8Array(32).fill(5).buffer;
+        Object.defineProperty(navigator, 'credentials', { configurable: true, value: {
+            create: vi.fn(async () => credential(prf)),
+            get: vi.fn(async () => assertion(prf))
+        }});
+        await setupDevice(identity);
+        vi.stubGlobal('PublicKeyCredential', undefined);
+        Object.defineProperty(navigator, 'credentials', { configurable: true, value: undefined });
+
+        const available = await hasReadyEntitlement();
+
+        expect(available).toEqual({ state: 'ready', detail: 'ready-record-found' });
+    });
+
+    it('reports no entitlement only after a successful empty database read', async () => {
+        const available = await hasReadyEntitlement();
+
+        expect(available).toEqual({ state: 'not-configured', detail: 'no-records' });
+    });
+
+    it('throws a safe stage-specific error when IndexedDB discovery fails', async () => {
+        vi.spyOn(indexedDB, 'open').mockImplementation(() => {
+            const failure = new Error('browser detail must not escape');
+            failure.name = 'UnknownError';
+            throw failure;
+        });
+
+        await expect(hasReadyEntitlement()).resolves.toEqual({
+            state: 'check-failed',
+            detail: 'indexeddb-read:UnknownError'
+        });
     });
 });
 

--- a/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Services/LoggingServiceTests/WhenTestingLogError.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Diagnostics/Services/LoggingServiceTests/WhenTestingLogError.cs
@@ -26,6 +26,7 @@ public class WhenTestingLogError
         lastError.ErrorType.Should().Be(nameof(TimeoutException));
         lastError.Message.Should().Be("queue read timed out");
         js.SetCalls.Should().Be(2);
+        js.ConsoleCalls.Should().Be(2);
     }
 
     [Fact]
@@ -58,6 +59,8 @@ public class WhenTestingLogError
     {
         public int SetCalls { get; private set; }
 
+        public int ConsoleCalls { get; private set; }
+
         public bool ThrowOnSet { get; init; }
 
         private string? _json;
@@ -78,6 +81,12 @@ public class WhenTestingLogError
 
                 SetCalls++;
                 _json = args?[0] as string;
+                return default!;
+            }
+
+            if (identifier == "fishingLogBookDiagnostics.console")
+            {
+                ConsoleCalls++;
                 return default!;
             }
 

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessDeviceServiceTests/BaseOfflineAccessDeviceServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessDeviceServiceTests/BaseOfflineAccessDeviceServiceTest.cs
@@ -11,7 +11,7 @@ public class BaseOfflineAccessDeviceServiceTest
     {
         private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
 
-        public bool HasReadyEntitlement { get; set; }
+        public OfflineAccessAvailabilityModel Availability { get; set; } = new("not-configured", "no-records");
         public OfflineAccessUnlockResultModel UnlockResult { get; set; } = new("not-configured", null, null);
         public List<string> Invocations { get; } = [];
 
@@ -28,7 +28,7 @@ public class BaseOfflineAccessDeviceServiceTest
 
             object result = identifier switch
             {
-                "hasReadyEntitlement" => HasReadyEntitlement,
+                "hasReadyEntitlement" => Availability,
                 "unlockDevice" => UnlockResult,
                 _ => throw new InvalidOperationException(identifier)
             };

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessDeviceServiceTests/WhenTestingDiscoveryAndUnlock.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineAccessDeviceServiceTests/WhenTestingDiscoveryAndUnlock.cs
@@ -9,14 +9,34 @@ public class WhenTestingDiscoveryAndUnlock : BaseOfflineAccessDeviceServiceTest
     public async Task ItShouldDiscoverReadyEntitlementsWithoutRequestingUnlock()
     {
         // Arrange
-        var js = new FakeOfflineAccessJsRuntime { HasReadyEntitlement = true };
+        var expected = new OfflineAccessAvailabilityModel("ready", "ready-record-found");
+        var js = new FakeOfflineAccessJsRuntime { Availability = expected };
         var sut = CreateSut(js);
 
         // Act
         var available = await sut.HasReadyEntitlementAsync(CancellationToken.None);
 
         // Assert
-        available.Should().BeTrue();
+        available.Should().Be(expected);
+        available.IsReady.Should().BeTrue();
+        js.Invocations.Should().Equal("import", "hasReadyEntitlement");
+    }
+
+    [Fact]
+    public async Task ItShouldReturnSafeDiscoveryFailuresFromTheBrowserModule()
+    {
+        // Arrange
+        var js = new FakeOfflineAccessJsRuntime
+        {
+            Availability = new OfflineAccessAvailabilityModel("check-failed", "indexeddb-read:UnknownError")
+        };
+        var sut = CreateSut(js);
+
+        // Act
+        var result = await sut.HasReadyEntitlementAsync(CancellationToken.None);
+
+        // Assert
+        result.Should().Be(js.Availability);
         js.Invocations.Should().Equal("import", "hasReadyEntitlement");
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/BaseLandingTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/BaseLandingTest.cs
@@ -6,6 +6,7 @@ using FishingLogBook.Web.Features.Authentication.Services;
 using FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Synchronisers;
+using FishingLogBook.Web.Features.OfflineAccess.Models;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Features.Onboarding.Services;
 using FishingLogBook.Web.Features.Profile.Models;
@@ -94,7 +95,10 @@ public class BaseLandingTest
     protected static IOfflineAccessDeviceService OfflineAccessDevice(bool hasReadyEntitlement)
     {
         var device = Substitute.For<IOfflineAccessDeviceService>();
-        device.HasReadyEntitlementAsync(Arg.Any<CancellationToken>()).Returns(hasReadyEntitlement);
+        device.HasReadyEntitlementAsync(Arg.Any<CancellationToken>()).Returns(
+            new OfflineAccessAvailabilityModel(
+                hasReadyEntitlement ? "ready" : "not-configured",
+                hasReadyEntitlement ? "ready-record-found" : "no-records"));
         return device;
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -229,6 +229,39 @@ public class WhenTestingRouting : BaseLandingTest
     }
 
     [Fact]
+    public async Task ItShouldTreatAnUnexpectedOfflineAvailabilityStateAsARetryableFailure()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var device = Substitute.For<IOfflineAccessDeviceService>();
+        device.HasReadyEntitlementAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                _ => new OfflineAccessAvailabilityModel("future-state", "ignored-detail"),
+                _ => new OfflineAccessAvailabilityModel("ready", "ready-record-found"));
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            logging: logging,
+            offlineAccessDevice: device);
+        var cut = context.Render<LandingPage>();
+        cut.WaitForAssertion(() => cut.Find("#landing-offline-availability-failed").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#landing-offline-availability-retry").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#landing-open-offline").Should().NotBeNull());
+        cut.FindAll("#landing-offline-availability-failed").Should().BeEmpty();
+        await device.Received(2).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
+        await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "landing offline availability",
+            Arg.Is<OfflineAccessDiscoveryException>(exception => exception.Message == "unexpected-state"),
+            CancellationToken.None);
+    }
+
+    [Fact]
     public async Task ItShouldUnlockOnlyAfterTheExplicitAction()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -4,12 +4,15 @@ using Bunit;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Models;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using LandingPage = FishingLogBook.Web.Features.Onboarding.Pages.Landing.Landing;
 
 namespace FishingLogBook.Web.Tests.Features.Onboarding.Pages.LandingTests;
@@ -169,6 +172,60 @@ public class WhenTestingRouting : BaseLandingTest
         cut.WaitForAssertion(() => cut.Find("#landing-open-offline").Should().NotBeNull());
         await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
         await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotShowOfflineAvailabilityFailureWhenNoEntitlementExists()
+    {
+        // Arrange
+        var device = OfflineAccessDevice(hasReadyEntitlement: false);
+        await using var context = CreateContext(Onboarding(false), isAuthenticated: false, offlineAccessDevice: device);
+
+        // Act
+        var cut = context.Render<LandingPage>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#landing-offline-availability-failed").Should().BeEmpty());
+        cut.FindAll("#landing-open-offline").Should().BeEmpty();
+        await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
+        await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLogAndRecoverWhenOfflineAvailabilityDiscoveryFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var failure = new JSException("indexeddb-read:UnknownError");
+        var device = Substitute.For<IOfflineAccessDeviceService>();
+        device.HasReadyEntitlementAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                _ => throw failure,
+                _ => new OfflineAccessAvailabilityModel("ready", "ready-record-found"));
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            logging: logging,
+            offlineAccessDevice: device);
+        var cut = context.Render<LandingPage>();
+        cut.WaitForAssertion(() =>
+            cut.Find("#landing-offline-availability-failed").TextContent
+                .Should().Contain("couldn't check offline access"));
+
+        // Act
+        await cut.Find("#landing-offline-availability-retry").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#landing-open-offline").Should().NotBeNull());
+        cut.FindAll("#landing-offline-availability-failed").Should().BeEmpty();
+        await device.Received(2).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
+        await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "landing offline availability",
+            Arg.Is<Exception>(exception => ReferenceEquals(exception, failure)),
+            CancellationToken.None);
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().EndWith("/");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- fixes the iPhone-risk entitlement discovery path found during physical validation after PR #149
- represents Landing discovery explicitly as ready, not configured, or check failed
- shows a localised retryable warning when IndexedDB/browser discovery fails
- keeps retry limited to entitlement discovery: no WebAuthn, Cognito, navigation, API access, or entitlement mutation
- removes the incorrect dependency between ready-entitlement discovery and the full WebAuthn setup API surface
- adds safe discovery-stage diagnostics without logging credential, PRF, entitlement, token, or identity material
- prevents handled diagnostic logging from activating Blazor's fatal error overlay

## Root cause

`hasReadyEntitlement()` returned `false` before opening IndexedDB whenever the full WebAuthn setup capability check failed. Entitlement discovery only requires IndexedDB, so a Safari/iOS cold-start difference in any WebAuthn predicate was incorrectly presented as “not configured.” Landing then swallowed the resulting `JSException`, making the failure indistinguishable from a genuinely absent entitlement.

The deployed build did not contain stage diagnostics, so the exact iPhone predicate that differed cannot be proven retrospectively. The corrected path now reports safe stages for no records, records with no ready entitlement, ready entitlement found, and IndexedDB read/open failure.

## Validation

- focused Landing/offline service tests: 22 passed
- Web test project: 719 passed
- JavaScript/Vitest: 238 passed across 26 files
- published-shell Playwright: 30 passed, 4 documented WebKit skips
- failure/retry browser journey proves no automatic WebAuthn and zero API requests
- `dotnet format --verify-no-changes`: passed
- `git diff --check`: passed
- complete solution run was attempted; database-backed Infrastructure tests could not start because local Docker was unavailable. All non-container projects reached by that run passed.

## Remaining gate

Repeat the installed iPhone cold-offline physical validation. Samsung's previously successful unlock architecture is unchanged.

Follow-up to #149.
Refs #148.