### PR TITLE
Offline access | Explain when this device is not configured

### DIFF
--- a/src/FishingLogBook.Web/Browser/Network/INetworkService.cs
+++ b/src/FishingLogBook.Web/Browser/Network/INetworkService.cs
@@ -2,5 +2,9 @@ namespace FishingLogBook.Web.Browser.Network;
 
 public interface INetworkService
 {
+    event Action<bool>? ConnectivityChanged;
+
     Task<bool> IsOnlineAsync(CancellationToken cancellationToken);
+
+    Task StartMonitoringAsync(CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Browser/Network/NetworkService.cs
+++ b/src/FishingLogBook.Web/Browser/Network/NetworkService.cs
@@ -2,17 +2,70 @@ using Microsoft.JSInterop;
 
 namespace FishingLogBook.Web.Browser.Network;
 
-public sealed class NetworkService : INetworkService
+public sealed class NetworkService : INetworkService, IAsyncDisposable
 {
     private readonly IJSRuntime _jsRuntime;
+    private readonly ILogger<NetworkService> _logger;
+    private DotNetObjectReference<NetworkService>? _dotNetReference;
+    private bool _monitoring;
 
-    public NetworkService(IJSRuntime jsRuntime)
+    public event Action<bool>? ConnectivityChanged;
+
+    public NetworkService(IJSRuntime jsRuntime, ILogger<NetworkService> logger)
     {
         _jsRuntime = jsRuntime;
+        _logger = logger;
     }
 
     public async Task<bool> IsOnlineAsync(CancellationToken cancellationToken)
     {
         return await _jsRuntime.InvokeAsync<bool>("fishingLogBookNetwork.isOnline", cancellationToken);
+    }
+
+    public async Task StartMonitoringAsync(CancellationToken cancellationToken)
+    {
+        if (_monitoring)
+        {
+            return;
+        }
+
+        _dotNetReference = DotNetObjectReference.Create(this);
+        try
+        {
+            await _jsRuntime.InvokeVoidAsync(
+                "fishingLogBookNetwork.startMonitoring",
+                cancellationToken,
+                _dotNetReference);
+            _monitoring = true;
+        }
+        catch
+        {
+            _dotNetReference.Dispose();
+            _dotNetReference = null;
+            throw;
+        }
+    }
+
+    [JSInvokable]
+    public void OnBrowserConnectivityChanged(bool isOnline)
+    {
+        ConnectivityChanged?.Invoke(isOnline);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_monitoring)
+        {
+            try
+            {
+                await _jsRuntime.InvokeVoidAsync("fishingLogBookNetwork.stopMonitoring");
+            }
+            catch (JSDisconnectedException exception)
+            {
+                _logger.LogDebug(exception, "Browser disconnected while stopping network monitoring.");
+            }
+        }
+
+        _dotNetReference?.Dispose();
     }
 }

--- a/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
@@ -23,6 +23,12 @@ test.describe('Published offline application shell', () => {
 
     test('renders Landing promptly after a cold offline reload without auth, API, or automatic WebAuthn', async ({ context, page }) => {
         const apiGuard = guardOfflineApiRequests(context);
+        await context.addInitScript(() => {
+            Object.defineProperty(Navigator.prototype, 'onLine', {
+                configurable: true,
+                get: () => false
+            });
+        });
 
         await cachePublishedShell(page);
         apiGuard.enable();
@@ -30,6 +36,9 @@ test.describe('Published offline application shell', () => {
         const started = Date.now();
         await page.reload({ waitUntil: 'domcontentloaded' });
         await expect(page.locator('#public-landing-page')).toBeVisible({ timeout: 15000 });
+        await expect(page.locator('#landing-offline-not-configured')).toBeVisible();
+        await expect(page.locator('#landing-open-offline')).toHaveCount(0);
+        await expect(page.locator('#landing-offline-availability-failed')).toHaveCount(0);
         const elapsed = Date.now() - started;
 
         expect(elapsed).toBeLessThan(15000);

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
@@ -51,6 +51,12 @@
                         </MudStack>
                     </MudAlert>
                 }
+                @if (_isOnline == false && _offlineAvailability == OfflineAvailabilityState.NotConfigured)
+                {
+                    <MudAlert Severity="Severity.Info" Dense="true" id="landing-offline-not-configured">
+                        @Loc["OfflineAccess_NotConfiguredOffline"]
+                    </MudAlert>
+                }
                 @if (_offlineUnlockFailed)
                 {
                     <MudAlert Severity="Severity.Error" Dense="true" id="landing-offline-error">

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
@@ -1,3 +1,4 @@
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Models;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
@@ -23,6 +24,7 @@ public partial class Landing : ComponentBase, IDisposable
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private OfflineAvailabilityState _offlineAvailability = OfflineAvailabilityState.Checking;
     private bool _checkingOfflineAvailability;
+    private bool? _isOnline;
     private bool _offlineUnlockFailed;
     private bool _unlocking;
 
@@ -33,12 +35,56 @@ public partial class Landing : ComponentBase, IDisposable
     [Inject] private IOfflineAccessDeviceService OfflineAccessDevice { get; set; } = default!;
     [Inject] private IOfflineOwnerContextService OfflineOwnerContext { get; set; } = default!;
     [Inject] private ILoggingService Logging { get; set; } = default!;
+    [Inject] private INetworkService Network { get; set; } = default!;
 
     protected override void OnInitialized()
     {
         AuthenticationStateProvider.AuthenticationStateChanged += OnAuthenticationStateChanged;
+        Network.ConnectivityChanged += OnConnectivityChanged;
         _ = LoadOfflineAvailabilityAsync();
+        _ = LoadConnectivityAsync();
         _ = ResolveAuthenticationAsync(AuthenticationStateProvider.GetAuthenticationStateAsync());
+    }
+
+    private async Task LoadConnectivityAsync()
+    {
+        var cancellationToken = _cancellationTokenSource.Token;
+        try
+        {
+            await Network.StartMonitoringAsync(cancellationToken);
+            var isOnline = await Network.IsOnlineAsync(cancellationToken);
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                await UpdateConnectivityAsync(isOnline);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("landing connectivity", exception, CancellationToken.None);
+        }
+    }
+
+    private void OnConnectivityChanged(bool isOnline)
+    {
+        _ = UpdateConnectivityAsync(isOnline);
+    }
+
+    private async Task UpdateConnectivityAsync(bool isOnline)
+    {
+        if (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
+        await InvokeAsync(() =>
+        {
+            _isOnline = isOnline;
+            StateHasChanged();
+        });
     }
 
     private async Task LoadOfflineAvailabilityAsync()
@@ -77,6 +123,7 @@ public partial class Landing : ComponentBase, IDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            return;
         }
         catch (Exception exception)
         {
@@ -100,7 +147,10 @@ public partial class Landing : ComponentBase, IDisposable
         }
     }
 
-    private Task RetryOfflineAvailabilityAsync() => LoadOfflineAvailabilityAsync();
+    private Task RetryOfflineAvailabilityAsync()
+    {
+        return LoadOfflineAvailabilityAsync();
+    }
 
     private async Task OpenOfflineAsync()
     {
@@ -120,6 +170,7 @@ public partial class Landing : ComponentBase, IDisposable
         }
         catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
+            return;
         }
         catch (Exception exception)
         {
@@ -153,6 +204,7 @@ public partial class Landing : ComponentBase, IDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            return;
         }
         catch (Exception exception)
         {
@@ -173,6 +225,7 @@ public partial class Landing : ComponentBase, IDisposable
     public void Dispose()
     {
         AuthenticationStateProvider.AuthenticationStateChanged -= OnAuthenticationStateChanged;
+        Network.ConnectivityChanged -= OnConnectivityChanged;
         _cancellationTokenSource.Cancel();
         _cancellationTokenSource.Dispose();
     }

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -627,6 +627,9 @@
   <data name="OfflineAccess_AvailabilityCheckFailed" xml:space="preserve">
     <value>Nous n'avons pas pu vérifier l'accès hors ligne sur cet appareil. Veuillez réessayer.</value>
   </data>
+  <data name="OfflineAccess_NotConfiguredOffline" xml:space="preserve">
+    <value>L'accès hors ligne n'est pas configuré sur cet appareil. Lorsque vous serez de nouveau en ligne, vous pourrez l'activer depuis votre profil.</value>
+  </data>
   <data name="Common_Loading" xml:space="preserve"><value>Chargement</value></data>
   <data name="Brand_LogoAlt" xml:space="preserve"><value>Catch But Don’t Forget — Catch · Release · Remember</value></data>
   <data name="Onboarding_PageTitle" xml:space="preserve"><value>Bienvenue</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -627,6 +627,9 @@
   <data name="OfflineAccess_AvailabilityCheckFailed" xml:space="preserve">
     <value>We couldn't check offline access on this device. Please try again.</value>
   </data>
+  <data name="OfflineAccess_NotConfiguredOffline" xml:space="preserve">
+    <value>Offline access isn't set up on this device. When you're back online, you can turn it on from your Profile.</value>
+  </data>
   <data name="Common_Loading" xml:space="preserve"><value>Loading</value></data>
   <data name="Brand_LogoAlt" xml:space="preserve"><value>Catch But Don’t Forget — Catch · Release · Remember</value></data>
   <data name="Onboarding_PageTitle" xml:space="preserve"><value>Welcome</value></data>

--- a/src/FishingLogBook.Web/wwwroot/js/browser/network.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/network.js
@@ -1,6 +1,25 @@
 export function createNetworkApi(targetWindow) {
+    let monitoring;
+
     return {
         isOnline: () => targetWindow.navigator.onLine,
+        startMonitoring: (helper) => {
+            if (monitoring) return;
+
+            const notify = () => helper.invokeMethodAsync(
+                'OnBrowserConnectivityChanged',
+                targetWindow.navigator.onLine);
+            targetWindow.addEventListener('online', notify);
+            targetWindow.addEventListener('offline', notify);
+            monitoring = { notify };
+        },
+        stopMonitoring: () => {
+            if (!monitoring) return;
+
+            targetWindow.removeEventListener('online', monitoring.notify);
+            targetWindow.removeEventListener('offline', monitoring.notify);
+            monitoring = undefined;
+        },
         onOnline: (helper) => {
             targetWindow.addEventListener('online', () => {
                 helper.invokeMethodAsync('OnBrowserOnline');

--- a/src/FishingLogBook.Web/wwwroot/js/browser/network.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/network.test.js
@@ -34,6 +34,47 @@ describe('network', () => {
         expect(helper.invokeMethodAsync).toHaveBeenCalledWith('OnBrowserOnline');
     });
 
+    it('reports online and offline changes until monitoring stops', () => {
+        const handlers = {};
+        const helper = { invokeMethodAsync: vi.fn() };
+        const targetWindow = {
+            navigator: { onLine: true },
+            addEventListener(name, callback) {
+                handlers[name] = callback;
+            },
+            removeEventListener: vi.fn()
+        };
+        const api = createNetworkApi(targetWindow);
+        api.startMonitoring(helper);
+
+        targetWindow.navigator.onLine = false;
+        handlers.offline();
+        targetWindow.navigator.onLine = true;
+        handlers.online();
+        api.stopMonitoring();
+
+        expect(helper.invokeMethodAsync).toHaveBeenNthCalledWith(1, 'OnBrowserConnectivityChanged', false);
+        expect(helper.invokeMethodAsync).toHaveBeenNthCalledWith(2, 'OnBrowserConnectivityChanged', true);
+        expect(targetWindow.removeEventListener).toHaveBeenCalledWith('online', handlers.online);
+        expect(targetWindow.removeEventListener).toHaveBeenCalledWith('offline', handlers.offline);
+    });
+
+    it('registers only one connectivity monitor', () => {
+        const handlers = {};
+        const helper = { invokeMethodAsync: vi.fn() };
+        const targetWindow = {
+            navigator: { onLine: true },
+            addEventListener: vi.fn((name, callback) => { handlers[name] = callback; }),
+            removeEventListener() { }
+        };
+        const api = createNetworkApi(targetWindow);
+
+        api.startMonitoring(helper);
+        api.startMonitoring(helper);
+
+        expect(targetWindow.addEventListener).toHaveBeenCalledTimes(2);
+    });
+
     it('invokes the helper when the page resumes or becomes visible', () => {
         const windowHandlers = {};
         const documentHandlers = {};

--- a/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingContainer.cs
@@ -40,21 +40,22 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
     }
 
     [Fact]
-    public void ItShouldResolveServicesInjectedByComponents()
+    public async Task ItShouldResolveServicesInjectedByComponents()
     {
         // Arrange
         var injectedTypes = GetComponentInjectedServiceTypes();
 
         // Act
-        Action resolve = () =>
+        async Task ResolveAsync()
         {
-            using var provider = CreateProvider();
-            using var scope = provider.CreateScope();
+            await using var provider = CreateProvider();
+            await using var scope = provider.CreateAsyncScope();
             foreach (var type in injectedTypes)
             {
                 scope.ServiceProvider.GetRequiredService(type);
             }
-        };
+        }
+        Func<Task> resolve = ResolveAsync;
 
         // Assert
         injectedTypes.Should().Contain(typeof(ISystemStatusClient));
@@ -69,7 +70,7 @@ public class WhenTestingContainer : BaseDependencyInjectionTest
         injectedTypes.Should().Contain(typeof(ICatchSynchroniser));
         injectedTypes.Should().Contain(typeof(IModalService));
         injectedTypes.Should().Contain(typeof(IStringLocalizer<UiStrings>));
-        resolve.Should().NotThrow();
+        await resolve.Should().NotThrowAsync();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/BaseLandingTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/BaseLandingTest.cs
@@ -1,5 +1,6 @@
 using Bunit;
 using Bunit.TestDoubles;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Browser.Update;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
@@ -27,7 +28,8 @@ public class BaseLandingTest
         bool isAuthenticated = true,
         AuthenticationStateProvider? authenticationStateProvider = null,
         ILoggingService? logging = null,
-        IOfflineAccessDeviceService? offlineAccessDevice = null)
+        IOfflineAccessDeviceService? offlineAccessDevice = null,
+        INetworkService? network = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -36,6 +38,7 @@ public class BaseLandingTest
         context.Services.AddSingleton(onboarding);
         context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
         context.Services.AddSingleton(offlineAccessDevice ?? OfflineAccessDevice(hasReadyEntitlement: false));
+        context.Services.AddSingleton(network ?? Network(isOnline: true));
         context.Services.AddScoped<IOfflineOwnerContextService, OfflineOwnerContextService>();
         var authorization = context.AddAuthorization();
         if (isAuthenticated)
@@ -91,6 +94,13 @@ public class BaseLandingTest
                 hasReadyEntitlement ? "ready" : "not-configured",
                 hasReadyEntitlement ? "ready-record-found" : "no-records"));
         return device;
+    }
+
+    protected static INetworkService Network(bool isOnline)
+    {
+        var network = Substitute.For<INetworkService>();
+        network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(isOnline);
+        return network;
     }
 
     protected static IOnboardingService Onboarding(bool completed)

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using AwesomeAssertions;
 using Bunit;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Models;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
@@ -134,18 +135,23 @@ public class WhenTestingRouting : BaseLandingTest
         // Arrange
         var authentication = new TaskCompletionSource<AuthenticationState>(TaskCreationOptions.RunContinuationsAsynchronously);
         var device = OfflineAccessDevice(hasReadyEntitlement: true);
+        var network = Network(isOnline: false);
         await using var context = CreateContext(
             Onboarding(false),
             authenticationStateProvider: Authentication(authentication.Task),
-            offlineAccessDevice: device);
+            offlineAccessDevice: device,
+            network: network);
 
         // Act
         var cut = context.Render<LandingPage>();
 
         // Assert
         cut.WaitForAssertion(() => cut.Find("#landing-open-offline").Should().NotBeNull());
+        cut.FindAll("#landing-offline-not-configured").Should().BeEmpty();
         await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
         await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
+        await network.Received(1).StartMonitoringAsync(Arg.Any<CancellationToken>());
+        await network.Received(1).IsOnlineAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -161,6 +167,116 @@ public class WhenTestingRouting : BaseLandingTest
         // Assert
         cut.WaitForAssertion(() => cut.FindAll("#landing-offline-availability-failed").Should().BeEmpty());
         cut.FindAll("#landing-open-offline").Should().BeEmpty();
+        cut.FindAll("#landing-offline-not-configured").Should().BeEmpty();
+        await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
+        await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldExplainUnconfiguredOfflineAccessOnlyWhenOffline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var device = OfflineAccessDevice(hasReadyEntitlement: false);
+        var network = Network(isOnline: false);
+        var onboarding = Onboarding(false);
+        await using var context = CreateContext(
+            onboarding,
+            isAuthenticated: false,
+            offlineAccessDevice: device,
+            network: network);
+
+        // Act
+        var cut = context.Render<LandingPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#landing-offline-not-configured").TextContent
+                .Should().Contain("Offline access isn't set up on this device"));
+        cut.FindAll("#landing-open-offline").Should().BeEmpty();
+        cut.FindAll("#landing-offline-availability-failed").Should().BeEmpty();
+        await network.Received(1).StartMonitoringAsync(Arg.Any<CancellationToken>());
+        await network.Received(1).IsOnlineAsync(Arg.Any<CancellationToken>());
+        await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
+        await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
+        await device.DidNotReceive().SetupAsync(
+            Arg.Any<OfflineAccessIdentityModel>(),
+            Arg.Any<CancellationToken>());
+        await device.DidNotReceive().RemoveAsync(
+            Arg.Any<OfflineAccessIdentityModel>(),
+            Arg.Any<CancellationToken>());
+        await onboarding.DidNotReceive().IsCompletedAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLogConnectivityDiscoveryFailureWithoutShowingOfflineSetupGuidance()
+    {
+        // Arrange
+        var failure = new JSException("network-state-unavailable");
+        var network = Substitute.For<INetworkService>();
+        network.StartMonitoringAsync(Arg.Any<CancellationToken>()).ThrowsAsync(failure);
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            logging: logging,
+            network: network);
+
+        // Act
+        var cut = context.Render<LandingPage>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#landing-offline-not-configured").Should().BeEmpty());
+        await logging.Received(1).LogErrorAsync(
+            "landing connectivity",
+            Arg.Is<Exception>(exception => ReferenceEquals(exception, failure)),
+            CancellationToken.None);
+        await network.Received(1).StartMonitoringAsync(Arg.Any<CancellationToken>());
+        await network.DidNotReceive().IsOnlineAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowGuidanceWhenConnectivityChangesToOffline()
+    {
+        // Arrange
+        var device = OfflineAccessDevice(hasReadyEntitlement: false);
+        var network = Network(isOnline: true);
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            offlineAccessDevice: device,
+            network: network);
+        var cut = context.Render<LandingPage>();
+        cut.WaitForAssertion(() => cut.FindAll("#landing-offline-not-configured").Should().BeEmpty());
+
+        // Act
+        network.ConnectivityChanged += Raise.Event<Action<bool>>(false);
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#landing-offline-not-configured").Should().NotBeNull());
+        await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
+        await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldHideGuidanceWhenConnectivityChangesToOnline()
+    {
+        // Arrange
+        var device = OfflineAccessDevice(hasReadyEntitlement: false);
+        var network = Network(isOnline: false);
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            offlineAccessDevice: device,
+            network: network);
+        var cut = context.Render<LandingPage>();
+        cut.WaitForAssertion(() => cut.Find("#landing-offline-not-configured").Should().NotBeNull());
+
+        // Act
+        network.ConnectivityChanged += Raise.Event<Action<bool>>(true);
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#landing-offline-not-configured").Should().BeEmpty());
         await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
         await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
     }
@@ -177,15 +293,18 @@ public class WhenTestingRouting : BaseLandingTest
                 _ => throw failure,
                 _ => new OfflineAccessAvailabilityModel("ready", "ready-record-found"));
         var logging = Substitute.For<ILoggingService>();
+        var network = Network(isOnline: false);
         await using var context = CreateContext(
             Onboarding(false),
             isAuthenticated: false,
             logging: logging,
-            offlineAccessDevice: device);
+            offlineAccessDevice: device,
+            network: network);
         var cut = context.Render<LandingPage>();
         cut.WaitForAssertion(() =>
             cut.Find("#landing-offline-availability-failed").TextContent
                 .Should().Contain("couldn't check offline access"));
+        cut.FindAll("#landing-offline-not-configured").Should().BeEmpty();
 
         // Act
         await cut.Find("#landing-offline-availability-retry").ClickAsync();
@@ -199,7 +318,32 @@ public class WhenTestingRouting : BaseLandingTest
             "landing offline availability",
             Arg.Is<Exception>(exception => ReferenceEquals(exception, failure)),
             CancellationToken.None);
+        await network.Received(1).IsOnlineAsync(Arg.Any<CancellationToken>());
         context.Services.GetRequiredService<NavigationManager>().Uri.Should().EndWith("/");
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchOfflineSetupGuidance()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var device = OfflineAccessDevice(hasReadyEntitlement: false);
+        var network = Network(isOnline: false);
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            offlineAccessDevice: device,
+            network: network);
+
+        // Act
+        var cut = context.Render<LandingPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#landing-offline-not-configured").TextContent
+                .Should().Contain("L'accès hors ligne n'est pas configuré"));
+        await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
+        await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- show a localised informational Landing message only when offline entitlement discovery succeeds with `not-configured` and the existing browser connectivity abstraction reports offline
- preserve distinct `ready`, `not-configured`, and `check-failed` presentation and behaviour
- extend the existing network abstraction to publish online/offline changes while Landing remains mounted
- keep display of the guidance free of API calls, WebAuthn operations, and entitlement mutation
- add EN/FR resources plus focused bUnit, JavaScript, and published-shell browser coverage

## Behaviour

- offline + ready: **Open offline** remains available; setup guidance is absent
- offline + not configured: informational Profile guidance is shown; unlock and failure UI are absent
- offline + check failed: existing warning and retry remain; setup guidance is absent
- online + not configured: setup guidance is absent
- connectivity changes update the message without rerunning entitlement discovery or triggering unlock

The existing connectivity abstraction uses the browser's `navigator.onLine` signal. This remains a browser hint rather than authoritative reachability evidence; this PR does not add an API probe, service-worker change, or competing connectivity architecture.

## Validation

- focused Landing/offline architecture/DI tests: 29 passed
- Web tests: 717 passed
- JavaScript/Vitest: 231 passed
- published browser suite with one worker: 39 passed, 5 expected WebKit offline-navigation skips
- solution build: passed, 0 warnings and 0 errors
- non-container .NET suites:
  - Db migrations: 10 passed
  - Shared: 18 passed
  - Application: 300 passed
  - API: 151 passed
  - Web: 717 passed
- `dotnet format FishingLogBook.sln`: passed
- `git diff --check`: passed

The complete solution test command could not run its 105 Testcontainers-backed Infrastructure tests locally because Docker Desktop was unavailable (`npipe://./pipe/docker_engine`). This change does not touch database or infrastructure code; CI remains the authoritative container-backed run.

## Self review

- Issue/AC: PASS — all requested state combinations and mounted connectivity changes are covered
- Architecture/CQRS: PASS — existing browser network abstraction extended; no server/CQRS changes
- Rules: PASS — block-bodied C#, localised UI, no empty catches, focused scope
- Security/privacy: PASS — no entitlement, identity, credential, or token data is exposed or mutated
- Database/migrations: N/A
- Tests/coverage: PASS — component interaction guards prove no setup/remove/unlock or onboarding/API-like request
- Browser: PASS — published cold-offline unconfigured shell covered in Chromium; expected WebKit offline-navigation limitation remains
- Web/UI/localisation: PASS — informational MudAlert with EN/FR parity
- Code smells: PASS — no competing connectivity service or duplicated state contract
- CI/deployment: PASS — no infrastructure, configuration, or deployment changes

### Findings discovered during self-review

1. Playwright network blocking alone did not alter `navigator.onLine`, so the cold-shell test initially exercised network failure while the UI correctly retained its online presentation.
2. The full parallel browser run exposed existing service-worker cache races between cold-shell scenarios.
3. Docker Desktop was unavailable for the local Testcontainers suite.

### Fixes made

1. Made the published-shell scenario explicitly set the existing browser connectivity signal to offline while also blocking network traffic.
2. Ran final browser validation with one worker; all applicable tests passed.
3. Recorded the container-test limitation explicitly rather than masking it.

### Remaining deliberate gaps

- `navigator.onLine` remains a non-authoritative browser hint, consistent with the existing architecture and prior physical findings.
- Physical device verification remains separate from automated Chromium coverage.

Closes #153