### PR TITLE
FLB#155 | Reconnect verified offline owners safely

### DIFF
--- a/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/CatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/CatchSynchroniser.cs
@@ -44,7 +44,28 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
     {
         try
         {
-            await SynchronisePendingCoreAsync(cancellationToken);
+            var ownerUserId = await TryGetOwnerUserIdAsync(cancellationToken);
+            if (ownerUserId is not null)
+            {
+                await SynchronisePendingCoreAsync(ownerUserId.Value, cancellationToken);
+            }
+        }
+        finally
+        {
+            StateChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public async Task SynchronisePendingAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (ownerUserId == Guid.Empty)
+            {
+                throw new ArgumentException("The catch owner is required.", nameof(ownerUserId));
+            }
+
+            await SynchronisePendingCoreAsync(ownerUserId, cancellationToken);
         }
         finally
         {
@@ -64,15 +85,11 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
         }
     }
 
-    private async Task SynchronisePendingCoreAsync(CancellationToken cancellationToken)
+    private async Task SynchronisePendingCoreAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
     {
-        var ownerUserId = await TryGetOwnerUserIdAsync(cancellationToken);
-        if (ownerUserId is null)
-        {
-            return;
-        }
-
-        var catches = await _store.GetAllAsync(ownerUserId.Value, cancellationToken);
+        var catches = await _store.GetAllAsync(ownerUserId, cancellationToken);
         catches = await RecoverInterruptedAsync(catches, cancellationToken);
         var pending = catches.Where(NeedsSynchronisation).ToArray();
         if (!await _networkService.IsOnlineAsync(cancellationToken))
@@ -90,7 +107,7 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
             cancellationToken.ThrowIfCancellationRequested();
             try
             {
-                await SynchroniseGuardedAsync(ownerUserId.Value, catchRecord.Id, cancellationToken);
+                await SynchroniseGuardedAsync(ownerUserId, catchRecord.Id, cancellationToken);
             }
             catch (Exception exception) when (exception is not OperationCanceledException)
             {

--- a/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/ICatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/ICatchSynchroniser.cs
@@ -6,5 +6,7 @@ public interface ICatchSynchroniser
 
     Task SynchronisePendingAsync(CancellationToken cancellationToken);
 
+    Task SynchronisePendingAsync(Guid ownerUserId, CancellationToken cancellationToken);
+
     Task RetryAsync(Guid catchId, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Enums/OfflineReconnectStateEnum.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Enums/OfflineReconnectStateEnum.cs
@@ -1,0 +1,14 @@
+namespace FishingLogBook.Web.Features.OfflineAccess.Enums;
+
+public enum OfflineReconnectStateEnum
+{
+    Offline = 0,
+    ConnectivityRestored = 1,
+    RecoveringAuthentication = 2,
+    AuthenticationRequired = 3,
+    VerifyingOwner = 4,
+    OwnerMismatch = 5,
+    Synchronising = 6,
+    Online = 7,
+    RetryableFailure = 8
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/IOfflineReconnectService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/IOfflineReconnectService.cs
@@ -1,0 +1,16 @@
+using FishingLogBook.Web.Features.OfflineAccess.Enums;
+
+namespace FishingLogBook.Web.Features.OfflineAccess.Services;
+
+public interface IOfflineReconnectService
+{
+    event EventHandler? StateChanged;
+
+    OfflineReconnectStateEnum State { get; }
+
+    Task StartAsync(CancellationToken cancellationToken);
+
+    Task AttemptAsync(CancellationToken cancellationToken);
+
+    void Stop();
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineReconnectService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineReconnectService.cs
@@ -17,7 +17,10 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
     private readonly IOfflineOwnerContextService _offlineOwnerContext;
     private readonly ILoggingService _logging;
     private readonly INetworkService _networkService;
+    private readonly object _attemptLock = new();
+    private CancellationTokenSource? _activeAttemptCancellationTokenSource;
     private CancellationTokenSource? _monitoringCancellationTokenSource;
+    private long _attemptGeneration;
     private int _automaticAttempted;
     private int _attempting;
     private bool _monitoring;
@@ -77,32 +80,35 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
             return;
         }
 
+        var attempt = BeginAttempt(cancellationToken);
         try
         {
-            await AttemptCoreAsync(cancellationToken);
+            await AttemptCoreAsync(attempt.Generation, attempt.CancellationTokenSource.Token);
         }
         finally
         {
+            CompleteAttempt(attempt);
             Interlocked.Exchange(ref _attempting, 0);
         }
     }
 
     public void Stop()
     {
-        if (!_monitoring)
+        InvalidateActiveAttempt();
+        if (_monitoring)
         {
-            return;
+            _networkService.ConnectivityChanged -= OnConnectivityChanged;
+            _monitoringCancellationTokenSource?.Cancel();
+            _monitoringCancellationTokenSource?.Dispose();
+            _monitoringCancellationTokenSource = null;
+            Interlocked.Exchange(ref _automaticAttempted, 0);
+            _monitoring = false;
         }
 
-        _networkService.ConnectivityChanged -= OnConnectivityChanged;
-        _monitoringCancellationTokenSource?.Cancel();
-        _monitoringCancellationTokenSource?.Dispose();
-        _monitoringCancellationTokenSource = null;
-        Interlocked.Exchange(ref _automaticAttempted, 0);
-        _monitoring = false;
+        SetState(OfflineReconnectStateEnum.Offline);
     }
 
-    private async Task AttemptCoreAsync(CancellationToken cancellationToken)
+    private async Task AttemptCoreAsync(long generation, CancellationToken cancellationToken)
     {
         var offlineOwner = _offlineOwnerContext.Owner;
         if (offlineOwner is null)
@@ -111,8 +117,11 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
             return;
         }
 
-        SetState(OfflineReconnectStateEnum.ConnectivityRestored);
-        SetState(OfflineReconnectStateEnum.RecoveringAuthentication);
+        if (!TrySetAttemptState(generation, cancellationToken, OfflineReconnectStateEnum.ConnectivityRestored)
+            || !TrySetAttemptState(generation, cancellationToken, OfflineReconnectStateEnum.RecoveringAuthentication))
+        {
+            return;
+        }
 
         AuthenticationState authentication;
         try
@@ -126,17 +135,26 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
         }
         catch (Exception exception)
         {
-            await FailAsync("offline reconnect authentication", exception);
+            await FailAttemptAsync(generation, cancellationToken, "offline reconnect authentication", exception);
+            return;
+        }
+
+        if (!IsCurrentAttempt(generation, cancellationToken))
+        {
             return;
         }
 
         if (authentication.User.Identity?.IsAuthenticated != true)
         {
-            SetState(OfflineReconnectStateEnum.AuthenticationRequired);
+            TrySetAttemptState(generation, cancellationToken, OfflineReconnectStateEnum.AuthenticationRequired);
             return;
         }
 
-        SetState(OfflineReconnectStateEnum.VerifyingOwner);
+        if (!TrySetAttemptState(generation, cancellationToken, OfflineReconnectStateEnum.VerifyingOwner))
+        {
+            return;
+        }
+
         Guid authenticatedUserId;
         try
         {
@@ -153,31 +171,44 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
         }
         catch (Exception exception) when (IsAuthenticationRequired(exception))
         {
-            SetState(OfflineReconnectStateEnum.AuthenticationRequired);
+            TrySetAttemptState(generation, cancellationToken, OfflineReconnectStateEnum.AuthenticationRequired);
             return;
         }
         catch (Exception exception)
         {
-            await FailAsync("offline reconnect owner verification", exception);
+            await FailAttemptAsync(generation, cancellationToken, "offline reconnect owner verification", exception);
+            return;
+        }
+
+        if (!IsCurrentAttempt(generation, cancellationToken))
+        {
             return;
         }
 
         if (authenticatedUserId != offlineOwner.UserId)
         {
-            SetState(OfflineReconnectStateEnum.OwnerMismatch);
+            TrySetAttemptState(generation, cancellationToken, OfflineReconnectStateEnum.OwnerMismatch);
             return;
         }
 
         if (!HasSameUnlockedOwner(offlineOwner.UserId))
         {
-            SetState(OfflineReconnectStateEnum.Offline);
+            TrySetAttemptState(generation, cancellationToken, OfflineReconnectStateEnum.Offline);
             return;
         }
 
-        SetState(OfflineReconnectStateEnum.Synchronising);
         try
         {
-            await _catchSynchroniser.SynchronisePendingAsync(authenticatedUserId, cancellationToken);
+            if (!TryStartSynchronisation(
+                    generation,
+                    cancellationToken,
+                    authenticatedUserId,
+                    out var synchronisation))
+            {
+                return;
+            }
+
+            await synchronisation;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -185,18 +216,11 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
         }
         catch (Exception exception)
         {
-            await FailAsync("offline reconnect synchronisation", exception);
+            await FailAttemptAsync(generation, cancellationToken, "offline reconnect synchronisation", exception);
             return;
         }
 
-        if (!HasSameUnlockedOwner(offlineOwner.UserId))
-        {
-            SetState(OfflineReconnectStateEnum.Offline);
-            return;
-        }
-
-        _offlineOwnerContext.Lock();
-        SetState(OfflineReconnectStateEnum.Online);
+        TryCompleteOnline(generation, cancellationToken, offlineOwner.UserId);
     }
 
     private void OnConnectivityChanged(bool isOnline)
@@ -208,6 +232,7 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
             return;
         }
 
+        InvalidateActiveAttempt();
         Interlocked.Exchange(ref _automaticAttempted, 0);
         SetState(OfflineReconnectStateEnum.Offline);
     }
@@ -227,6 +252,120 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
         return _offlineOwnerContext.Owner?.UserId == userId;
     }
 
+    private AttemptLifecycle BeginAttempt(CancellationToken cancellationToken)
+    {
+        lock (_attemptLock)
+        {
+            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _activeAttemptCancellationTokenSource = cancellationTokenSource;
+            _attemptGeneration++;
+            return new AttemptLifecycle(_attemptGeneration, cancellationTokenSource);
+        }
+    }
+
+    private void CompleteAttempt(AttemptLifecycle attempt)
+    {
+        lock (_attemptLock)
+        {
+            if (ReferenceEquals(_activeAttemptCancellationTokenSource, attempt.CancellationTokenSource))
+            {
+                _activeAttemptCancellationTokenSource = null;
+            }
+        }
+
+        attempt.CancellationTokenSource.Dispose();
+    }
+
+    private void InvalidateActiveAttempt()
+    {
+        CancellationTokenSource? cancellationTokenSource;
+        lock (_attemptLock)
+        {
+            _attemptGeneration++;
+            cancellationTokenSource = _activeAttemptCancellationTokenSource;
+            _activeAttemptCancellationTokenSource = null;
+        }
+
+        cancellationTokenSource?.Cancel();
+    }
+
+    private bool IsCurrentAttempt(long generation, CancellationToken cancellationToken)
+    {
+        lock (_attemptLock)
+        {
+            return !cancellationToken.IsCancellationRequested
+                && generation == _attemptGeneration;
+        }
+    }
+
+    private bool TrySetAttemptState(
+        long generation,
+        CancellationToken cancellationToken,
+        OfflineReconnectStateEnum state)
+    {
+        if (!IsCurrentAttempt(generation, cancellationToken))
+        {
+            return false;
+        }
+
+        SetState(state);
+        return true;
+    }
+
+    private bool TryCompleteOnline(long generation, CancellationToken cancellationToken, Guid ownerUserId)
+    {
+        lock (_attemptLock)
+        {
+            if (cancellationToken.IsCancellationRequested
+                || generation != _attemptGeneration
+                || !HasSameUnlockedOwner(ownerUserId))
+            {
+                return false;
+            }
+
+            _offlineOwnerContext.Lock();
+            SetState(OfflineReconnectStateEnum.Online);
+            return true;
+        }
+    }
+
+    private bool TryStartSynchronisation(
+        long generation,
+        CancellationToken cancellationToken,
+        Guid ownerUserId,
+        out Task synchronisation)
+    {
+        lock (_attemptLock)
+        {
+            if (cancellationToken.IsCancellationRequested
+                || generation != _attemptGeneration
+                || !HasSameUnlockedOwner(ownerUserId))
+            {
+                synchronisation = Task.CompletedTask;
+                return false;
+            }
+
+            SetState(OfflineReconnectStateEnum.Synchronising);
+            synchronisation = _catchSynchroniser.SynchronisePendingAsync(ownerUserId, cancellationToken);
+            return true;
+        }
+    }
+
+    private async Task FailAttemptAsync(
+        long generation,
+        CancellationToken cancellationToken,
+        string operation,
+        Exception exception)
+    {
+        if (!IsCurrentAttempt(generation, cancellationToken))
+        {
+            return;
+        }
+
+        await _logging.LogErrorAsync(operation, exception, CancellationToken.None);
+        TrySetAttemptState(generation, cancellationToken, OfflineReconnectStateEnum.RetryableFailure);
+    }
+
     private async Task FailAsync(string operation, Exception exception)
     {
         await _logging.LogErrorAsync(operation, exception, CancellationToken.None);
@@ -244,4 +383,8 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
         return exception is AccessTokenNotAvailableException
             || exception is HttpRequestException { StatusCode: HttpStatusCode.Unauthorized };
     }
+
+    private sealed record AttemptLifecycle(
+        long Generation,
+        CancellationTokenSource CancellationTokenSource);
 }

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineReconnectService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineReconnectService.cs
@@ -1,0 +1,247 @@
+using System.Net;
+using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.OfflineAccess.Enums;
+using FishingLogBook.Web.Features.Users.Clients;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+
+namespace FishingLogBook.Web.Features.OfflineAccess.Services;
+
+public sealed class OfflineReconnectService : IOfflineReconnectService
+{
+    private readonly AuthenticationStateProvider _authenticationStateProvider;
+    private readonly ICurrentUserClient _currentUserClient;
+    private readonly ICatchSynchroniser _catchSynchroniser;
+    private readonly IOfflineOwnerContextService _offlineOwnerContext;
+    private readonly ILoggingService _logging;
+    private readonly INetworkService _networkService;
+    private CancellationTokenSource? _monitoringCancellationTokenSource;
+    private int _automaticAttempted;
+    private int _attempting;
+    private bool _monitoring;
+
+    public OfflineReconnectService(
+        AuthenticationStateProvider authenticationStateProvider,
+        ICurrentUserClient currentUserClient,
+        ICatchSynchroniser catchSynchroniser,
+        IOfflineOwnerContextService offlineOwnerContext,
+        ILoggingService logging,
+        INetworkService networkService)
+    {
+        _authenticationStateProvider = authenticationStateProvider;
+        _currentUserClient = currentUserClient;
+        _catchSynchroniser = catchSynchroniser;
+        _offlineOwnerContext = offlineOwnerContext;
+        _logging = logging;
+        _networkService = networkService;
+    }
+
+    public event EventHandler? StateChanged;
+
+    public OfflineReconnectStateEnum State { get; private set; } = OfflineReconnectStateEnum.Offline;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_monitoring)
+        {
+            _monitoringCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _networkService.ConnectivityChanged += OnConnectivityChanged;
+            _monitoring = true;
+        }
+
+        var monitoringToken = _monitoringCancellationTokenSource?.Token ?? cancellationToken;
+        try
+        {
+            await _networkService.StartMonitoringAsync(monitoringToken);
+            if (await _networkService.IsOnlineAsync(monitoringToken))
+            {
+                await AttemptAutomaticallyAsync(monitoringToken);
+            }
+        }
+        catch (OperationCanceledException) when (monitoringToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await FailAsync("offline reconnect connectivity", exception);
+        }
+    }
+
+    public async Task AttemptAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.CompareExchange(ref _attempting, 1, 0) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await AttemptCoreAsync(cancellationToken);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _attempting, 0);
+        }
+    }
+
+    public void Stop()
+    {
+        if (!_monitoring)
+        {
+            return;
+        }
+
+        _networkService.ConnectivityChanged -= OnConnectivityChanged;
+        _monitoringCancellationTokenSource?.Cancel();
+        _monitoringCancellationTokenSource?.Dispose();
+        _monitoringCancellationTokenSource = null;
+        Interlocked.Exchange(ref _automaticAttempted, 0);
+        _monitoring = false;
+    }
+
+    private async Task AttemptCoreAsync(CancellationToken cancellationToken)
+    {
+        var offlineOwner = _offlineOwnerContext.Owner;
+        if (offlineOwner is null)
+        {
+            SetState(OfflineReconnectStateEnum.Offline);
+            return;
+        }
+
+        SetState(OfflineReconnectStateEnum.ConnectivityRestored);
+        SetState(OfflineReconnectStateEnum.RecoveringAuthentication);
+
+        AuthenticationState authentication;
+        try
+        {
+            authentication = await _authenticationStateProvider.GetAuthenticationStateAsync()
+                .WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await FailAsync("offline reconnect authentication", exception);
+            return;
+        }
+
+        if (authentication.User.Identity?.IsAuthenticated != true)
+        {
+            SetState(OfflineReconnectStateEnum.AuthenticationRequired);
+            return;
+        }
+
+        SetState(OfflineReconnectStateEnum.VerifyingOwner);
+        Guid authenticatedUserId;
+        try
+        {
+            var currentUser = await _currentUserClient.GetCurrentAsync(cancellationToken);
+            authenticatedUserId = currentUser.UserId;
+            if (authenticatedUserId == Guid.Empty)
+            {
+                throw new InvalidOperationException("The authenticated user could not be resolved.");
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception) when (IsAuthenticationRequired(exception))
+        {
+            SetState(OfflineReconnectStateEnum.AuthenticationRequired);
+            return;
+        }
+        catch (Exception exception)
+        {
+            await FailAsync("offline reconnect owner verification", exception);
+            return;
+        }
+
+        if (authenticatedUserId != offlineOwner.UserId)
+        {
+            SetState(OfflineReconnectStateEnum.OwnerMismatch);
+            return;
+        }
+
+        if (!HasSameUnlockedOwner(offlineOwner.UserId))
+        {
+            SetState(OfflineReconnectStateEnum.Offline);
+            return;
+        }
+
+        SetState(OfflineReconnectStateEnum.Synchronising);
+        try
+        {
+            await _catchSynchroniser.SynchronisePendingAsync(authenticatedUserId, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await FailAsync("offline reconnect synchronisation", exception);
+            return;
+        }
+
+        if (!HasSameUnlockedOwner(offlineOwner.UserId))
+        {
+            SetState(OfflineReconnectStateEnum.Offline);
+            return;
+        }
+
+        _offlineOwnerContext.Lock();
+        SetState(OfflineReconnectStateEnum.Online);
+    }
+
+    private void OnConnectivityChanged(bool isOnline)
+    {
+        if (isOnline)
+        {
+            var cancellationToken = _monitoringCancellationTokenSource?.Token ?? CancellationToken.None;
+            _ = AttemptAutomaticallyAsync(cancellationToken);
+            return;
+        }
+
+        Interlocked.Exchange(ref _automaticAttempted, 0);
+        SetState(OfflineReconnectStateEnum.Offline);
+    }
+
+    private Task AttemptAutomaticallyAsync(CancellationToken cancellationToken)
+    {
+        if (Interlocked.CompareExchange(ref _automaticAttempted, 1, 0) != 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        return AttemptAsync(cancellationToken);
+    }
+
+    private bool HasSameUnlockedOwner(Guid userId)
+    {
+        return _offlineOwnerContext.Owner?.UserId == userId;
+    }
+
+    private async Task FailAsync(string operation, Exception exception)
+    {
+        await _logging.LogErrorAsync(operation, exception, CancellationToken.None);
+        SetState(OfflineReconnectStateEnum.RetryableFailure);
+    }
+
+    private void SetState(OfflineReconnectStateEnum state)
+    {
+        State = state;
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static bool IsAuthenticationRequired(Exception exception)
+    {
+        return exception is AccessTokenNotAvailableException
+            || exception is HttpRequestException { StatusCode: HttpStatusCode.Unauthorized };
+    }
+}

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
@@ -15,10 +15,10 @@ public partial class Landing : ComponentBase, IDisposable
 {
     private enum OfflineAvailabilityState
     {
-        Checking,
-        Ready,
-        NotConfigured,
-        CheckFailed
+        Checking = 0,
+        Ready = 1,
+        NotConfigured = 2,
+        CheckFailed = 3
     }
 
     private readonly CancellationTokenSource _cancellationTokenSource = new();
@@ -36,6 +36,9 @@ public partial class Landing : ComponentBase, IDisposable
     [Inject] private IOfflineOwnerContextService OfflineOwnerContext { get; set; } = default!;
     [Inject] private ILoggingService Logging { get; set; } = default!;
     [Inject] private INetworkService Network { get; set; } = default!;
+
+    [SupplyParameterFromQuery(Name = "reconnect")]
+    public string? Reconnect { get; set; }
 
     protected override void OnInitialized()
     {
@@ -195,6 +198,11 @@ public partial class Landing : ComponentBase, IDisposable
         {
             var authentication = await authenticationState.WaitAsync(cancellationToken);
             if (authentication.User.Identity?.IsAuthenticated != true)
+            {
+                return;
+            }
+
+            if (string.Equals(Reconnect, "offline", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }

--- a/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor
@@ -1,4 +1,5 @@
 @inherits LayoutComponentBase
+@using FishingLogBook.Web.Features.OfflineAccess.Enums
 
 <MudThemeProvider Theme="_theme" IsDarkMode="_isDarkMode" />
 <MudPopoverProvider />
@@ -36,6 +37,45 @@
     </MudDrawer>
     <MudMainContent>
         <div class="offline-mode-banner" id="offline-mode-banner">@Loc["OfflineAccess_Mode"]</div>
+        @if (OfflineReconnect.State is OfflineReconnectStateEnum.ConnectivityRestored
+             or OfflineReconnectStateEnum.RecoveringAuthentication
+             or OfflineReconnectStateEnum.VerifyingOwner
+             or OfflineReconnectStateEnum.Synchronising)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true" Class="offline-reconnect-status" id="offline-reconnect-progress">
+                @(OfflineReconnect.State == OfflineReconnectStateEnum.Synchronising
+                    ? Loc["OfflineReconnect_Synchronising"]
+                    : Loc["OfflineReconnect_Reconnecting"])
+            </MudAlert>
+        }
+        @if (OfflineReconnect.State == OfflineReconnectStateEnum.AuthenticationRequired)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true" Class="offline-reconnect-status" id="offline-reconnect-authentication-required">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                    <MudText Typo="Typo.body2">@Loc["OfflineReconnect_AuthenticationRequired"]</MudText>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SignInToSynchronise" id="offline-reconnect-sign-in">
+                        @Loc["OfflineReconnect_SignIn"]
+                    </MudButton>
+                </MudStack>
+            </MudAlert>
+        }
+        @if (OfflineReconnect.State == OfflineReconnectStateEnum.OwnerMismatch)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Class="offline-reconnect-status" id="offline-reconnect-owner-mismatch">
+                @Loc["OfflineReconnect_OwnerMismatch"]
+            </MudAlert>
+        }
+        @if (OfflineReconnect.State == OfflineReconnectStateEnum.RetryableFailure)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Class="offline-reconnect-status" id="offline-reconnect-failed">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                    <MudText Typo="Typo.body2">@Loc["OfflineReconnect_Failed"]</MudText>
+                    <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="RetryReconnectAsync" id="offline-reconnect-retry">
+                        @Loc["Action_TryAgain"]
+                    </MudButton>
+                </MudStack>
+            </MudAlert>
+        }
         <div class="app-shell-content" id="offline-shell-content">
             @Body
         </div>

--- a/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.cs
+++ b/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.cs
@@ -1,20 +1,35 @@
+using FishingLogBook.Web.Features.OfflineAccess.Enums;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.Extensions.Localization;
 using MudBlazor;
 
 namespace FishingLogBook.Web.Layouts.OfflineLayout;
 
-public partial class OfflineLayout : LayoutComponentBase
+public partial class OfflineLayout : LayoutComponentBase, IDisposable
 {
     private readonly MudTheme _theme = new();
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
     private bool _drawerOpen = true;
     private bool _isDarkMode;
 
     [Inject] private IOfflineOwnerContextService OfflineOwnerContext { get; set; } = default!;
+    [Inject] private IOfflineReconnectService OfflineReconnect { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        OfflineReconnect.StateChanged += OnReconnectStateChanged;
+        await OfflineReconnect.StartAsync(_cancellationTokenSource.Token);
+    }
 
     private void ToggleDarkMode()
     {
@@ -31,5 +46,42 @@ public partial class OfflineLayout : LayoutComponentBase
         OfflineOwnerContext.Lock();
         Navigation.NavigateTo("/", replace: true);
     }
-}
 
+    private void OnReconnectStateChanged(object? sender, EventArgs args)
+    {
+        _ = InvokeAsync(() =>
+        {
+            if (OfflineReconnect.State == OfflineReconnectStateEnum.Online)
+            {
+                Navigation.NavigateTo("/catches", replace: true);
+                return;
+            }
+
+            StateHasChanged();
+        });
+    }
+
+    private Task RetryReconnectAsync()
+    {
+        return OfflineReconnect.AttemptAsync(_cancellationTokenSource.Token);
+    }
+
+    private void SignInToSynchronise()
+    {
+        Navigation.NavigateToLogin(
+            "authentication/login",
+            new InteractiveRequestOptions
+            {
+                Interaction = InteractionType.SignIn,
+                ReturnUrl = "/?reconnect=offline"
+            });
+    }
+
+    public void Dispose()
+    {
+        OfflineReconnect.StateChanged -= OnReconnectStateChanged;
+        OfflineReconnect.Stop();
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.css
+++ b/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.css
@@ -6,3 +6,8 @@
     padding: 0.35rem 0.75rem;
     text-align: center;
 }
+
+.offline-reconnect-status {
+    border-radius: 0;
+    margin: 0;
+}

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -765,6 +765,12 @@
   <data name="OfflineAccess_OpenOffline" xml:space="preserve"><value>Ouvrir hors ligne</value></data>
   <data name="OfflineAccess_UnlockFailed" xml:space="preserve"><value>Impossible d’ouvrir l’accès hors ligne. Réessayez ou connectez-vous lorsque vous avez une connexion.</value></data>
   <data name="OfflineAccess_Mode" xml:space="preserve"><value>Mode hors ligne</value></data>
+  <data name="OfflineReconnect_Reconnecting" xml:space="preserve"><value>Connexion rétablie. Reconnexion en cours…</value></data>
+  <data name="OfflineReconnect_Synchronising" xml:space="preserve"><value>Synchronisation de vos prises enregistrées…</value></data>
+  <data name="OfflineReconnect_AuthenticationRequired" xml:space="preserve"><value>Vous êtes de nouveau en ligne. Connectez-vous pour synchroniser vos prises.</value></data>
+  <data name="OfflineReconnect_SignIn" xml:space="preserve"><value>Se connecter pour synchroniser</value></data>
+  <data name="OfflineReconnect_OwnerMismatch" xml:space="preserve"><value>Vous avez enregistré ces prises avec un autre compte hors ligne. Connectez-vous avec le compte correspondant pour les synchroniser.</value></data>
+  <data name="OfflineReconnect_Failed" xml:space="preserve"><value>Nous n’avons pas encore pu nous reconnecter. Vos prises sont toujours enregistrées sur cet appareil.</value></data>
   <data name="OfflineAccess_Lock" xml:space="preserve"><value>Verrouiller l’accès hors ligne</value></data>
   <data name="OfflineDiagnostics_PageTitle" xml:space="preserve"><value>Diagnostic hors ligne</value></data>
   <data name="OfflineDiagnostics_Title" xml:space="preserve"><value>Diagnostic hors ligne</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -765,6 +765,12 @@
   <data name="OfflineAccess_OpenOffline" xml:space="preserve"><value>Open offline</value></data>
   <data name="OfflineAccess_UnlockFailed" xml:space="preserve"><value>Offline access could not be opened. Try again, or sign in when you have a connection.</value></data>
   <data name="OfflineAccess_Mode" xml:space="preserve"><value>Offline mode</value></data>
+  <data name="OfflineReconnect_Reconnecting" xml:space="preserve"><value>Connection restored. Reconnecting…</value></data>
+  <data name="OfflineReconnect_Synchronising" xml:space="preserve"><value>Synchronising your saved catches…</value></data>
+  <data name="OfflineReconnect_AuthenticationRequired" xml:space="preserve"><value>You’re back online. Sign in to sync your catches.</value></data>
+  <data name="OfflineReconnect_SignIn" xml:space="preserve"><value>Sign in to sync</value></data>
+  <data name="OfflineReconnect_OwnerMismatch" xml:space="preserve"><value>You recorded these catches using a different offline account. Sign in with the matching account to sync them.</value></data>
+  <data name="OfflineReconnect_Failed" xml:space="preserve"><value>We couldn’t reconnect yet. Your catches are still saved on this device.</value></data>
   <data name="OfflineAccess_Lock" xml:space="preserve"><value>Lock offline access</value></data>
   <data name="OfflineDiagnostics_PageTitle" xml:space="preserve"><value>Offline diagnostics</value></data>
   <data name="OfflineDiagnostics_Title" xml:space="preserve"><value>Offline diagnostics</value></data>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IOfflineAccessDeviceService, OfflineAccessDeviceService>();
         services.AddScoped<IOfflineAccessService, OfflineAccessService>();
         services.AddScoped<IOfflineOwnerContextService, OfflineOwnerContextService>();
+        services.AddScoped<IOfflineReconnectService, OfflineReconnectService>();
         services.AddScoped<ITimeService, TimeService>();
         services.AddScoped<ICatchStore, IndexedDbCatchStore>();
         services.AddScoped<ICatchSynchroniser, CatchSynchroniser>();

--- a/tests/FishingLogBook.E2E/specs/catch-offline.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/catch-offline.spec.mjs
@@ -2,8 +2,13 @@ import { test, expect } from '../support/fixtures.mjs';
 import { recordCatch, reloadServerCatches, testName } from '../support/catch-journey.mjs';
 
 test('records and edits locally offline, then synchronises once after reconnect', async ({ page, context }) => {
+    await page.goto('/catches/record');
+    await expect(page.locator('#record-catch-title')).toBeVisible();
+    await expect(page.locator('#record-catch-method-Fly')).toBeVisible();
+    await expect(page.locator('#record-catch-species-BrownTrout')).toBeVisible();
     await page.goto('/catches');
     await expect(page.locator('#catch-list-title')).toBeVisible();
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
     await page.evaluate(() => navigator.serviceWorker?.ready);
     await context.setOffline(true);
     const notes = testName('offline-edited');

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
@@ -12,6 +12,33 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Offline.Synchronisers.CatchSyn
 public class WhenTestingSynchronisePending : BaseCatchSynchroniserTest
 {
     [Fact]
+    public async Task ItShouldSynchroniseOnlyTheExplicitlyVerifiedOwnerPartition()
+    {
+        // Arrange
+        var ownerCatch = CreateCatch();
+        var otherCatch = CreateCatch(
+            catchId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            userId: OtherUserId);
+        var store = await CreateStoreAsync(ownerCatch, otherCatch);
+        MockLocalCatchOwner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(OtherUserId);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockLocalCatchOwner.DidNotReceive().GetUserIdAsync(Arg.Any<CancellationToken>());
+        await MockCatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(dto => dto.UserId == OwnerUserId && dto.Id == ownerCatch.Id),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive().UpsertAsync(
+            Arg.Is<CatchDto>(dto => dto.UserId == OtherUserId),
+            Arg.Any<CancellationToken>());
+        var untouched = await store.GetAsync(OtherUserId, otherCatch.Id, CancellationToken.None);
+        untouched!.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+    }
+
+    [Fact]
     public async Task ItShouldNotCallTheServerWhenOffline()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/OfflineArchitectureTests/WhenTestingDependencies.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/OfflineArchitectureTests/WhenTestingDependencies.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Web.Features.OfflineAccess;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using OfflineDiagnosticsPage = FishingLogBook.Web.Features.Diagnostics.Pages.OfflineDiagnostics.OfflineDiagnostics;
+using OfflineLayoutPage = FishingLogBook.Web.Layouts.OfflineLayout.OfflineLayout;
 using PublicDiagnosticsLayout = FishingLogBook.Web.Layouts.PublicLayout.PublicLayout;
 
 namespace FishingLogBook.Web.Tests.Features.OfflineAccess.OfflineArchitectureTests;
@@ -24,10 +25,11 @@ public class WhenTestingDependencies : BaseOfflineArchitectureTest
     ];
 
     [Fact]
-    public void ItShouldKeepTheOfflineSurfaceFreeOfOnlineAuthenticationApiAndSyncDependencies()
+    public void ItShouldKeepOfflinePagesAndEditorsFreeOfOnlineAuthenticationApiAndSyncDependencies()
     {
         // Arrange
         var injectedTypes = OfflineSurfaceTypes
+            .Where(type => type != typeof(OfflineLayoutPage))
             .SelectMany(type => type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             .Where(property => property.GetCustomAttribute<InjectAttribute>() is not null)
             .Select(property => property.PropertyType)
@@ -42,6 +44,26 @@ public class WhenTestingDependencies : BaseOfflineArchitectureTest
 
         // Assert
         forbidden.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItShouldLimitTheOfflineLayoutToTheReconnectGateway()
+    {
+        // Arrange
+        var injectedTypes = typeof(OfflineLayoutPage)
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(property => property.GetCustomAttribute<InjectAttribute>() is not null)
+            .Select(property => property.PropertyType)
+            .ToArray();
+
+        // Act
+        var directOnlineDependencies = injectedTypes.Where(type =>
+            IsOnlineDependencyCategory(type)
+            && type.Name != "IOfflineReconnectService");
+
+        // Assert
+        directOnlineDependencies.Should().BeEmpty();
+        injectedTypes.Should().Contain(type => type.Name == "IOfflineReconnectService");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/BaseOfflineReconnectServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/BaseOfflineReconnectServiceTest.cs
@@ -1,0 +1,60 @@
+using System.Security.Claims;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Features.Users.Clients;
+using Microsoft.AspNetCore.Components.Authorization;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.OfflineAccess.Services.OfflineReconnectServiceTests;
+
+public class BaseOfflineReconnectServiceTest
+{
+    protected static readonly Guid OfflineUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    protected readonly AuthenticationStateProvider MockAuthenticationStateProvider =
+        Substitute.For<AuthenticationStateProvider>();
+    protected readonly ICurrentUserClient MockCurrentUserClient = Substitute.For<ICurrentUserClient>();
+    protected readonly ICatchSynchroniser MockCatchSynchroniser = Substitute.For<ICatchSynchroniser>();
+    protected readonly ILoggingService MockLoggingService = Substitute.For<ILoggingService>();
+    protected readonly INetworkService MockNetworkService = Substitute.For<INetworkService>();
+    protected readonly OfflineOwnerContextService OfflineOwnerContext = new();
+    protected readonly OfflineReconnectService Sut;
+
+    protected BaseOfflineReconnectServiceTest()
+    {
+        OfflineOwnerContext.Unlock(new OfflineOwnerModel(OfflineUserId, 1));
+        MockAuthenticationStateProvider.GetAuthenticationStateAsync().Returns(Authenticated());
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .Returns(CurrentUser(OfflineUserId));
+        Sut = new OfflineReconnectService(
+            MockAuthenticationStateProvider,
+            MockCurrentUserClient,
+            MockCatchSynchroniser,
+            OfflineOwnerContext,
+            MockLoggingService,
+            MockNetworkService);
+    }
+
+    protected static AuthenticationState Authenticated()
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim("sub", "owner-subject")],
+            "test");
+        return new AuthenticationState(new ClaimsPrincipal(identity));
+    }
+
+    protected static AuthenticationState Anonymous()
+    {
+        return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+    }
+
+    protected static CurrentUserDto CurrentUser(Guid userId)
+    {
+        return new CurrentUserDto(userId, "owner@example.test", "Cognito", "owner-subject");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingAttempt.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingAttempt.cs
@@ -1,0 +1,200 @@
+using System.Net;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.OfflineAccess.Enums;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.OfflineAccess.Services.OfflineReconnectServiceTests;
+
+public class WhenTestingAttempt : BaseOfflineReconnectServiceTest
+{
+    [Fact]
+    public async Task ItShouldRequireAuthenticationWithoutResolvingOrSynchronisingAnOwner()
+    {
+        // Arrange
+        MockAuthenticationStateProvider.GetAuthenticationStateAsync().Returns(Anonymous());
+
+        // Act
+        await Sut.AttemptAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.AuthenticationRequired);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCurrentUserClient.DidNotReceive().GetCurrentAsync(Arg.Any<CancellationToken>());
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRequireAuthenticationWhenTheTrustedRequestIsUnauthorized()
+    {
+        // Arrange
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("unauthorized", null, HttpStatusCode.Unauthorized));
+
+        // Act
+        await Sut.AttemptAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.AuthenticationRequired);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await MockLoggingService.DidNotReceive().LogErrorAsync(
+            Arg.Any<string>(),
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailClosedWhenTheAuthenticatedOwnerDoesNotMatch()
+    {
+        // Arrange
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .Returns(CurrentUser(OtherUserId));
+
+        // Act
+        await Sut.AttemptAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.OwnerMismatch);
+        OfflineOwnerContext.Owner!.UserId.Should().Be(OfflineUserId);
+        await MockCurrentUserClient.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPreserveTheOfflineOwnerWhenTrustedOwnerResolutionFails()
+    {
+        // Arrange
+        var failure = new HttpRequestException("unreachable");
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>()).ThrowsAsync(failure);
+
+        // Act
+        await Sut.AttemptAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.RetryableFailure);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await MockLoggingService.Received(1).LogErrorAsync(
+            "offline reconnect owner verification",
+            failure,
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ItShouldPreserveTheOfflineOwnerWhenSynchronisationFails()
+    {
+        // Arrange
+        var failure = new InvalidOperationException("sync failed");
+        MockCatchSynchroniser.SynchronisePendingAsync(OfflineUserId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(failure);
+
+        // Act
+        await Sut.AttemptAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.RetryableFailure);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCatchSynchroniser.Received(1).SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>());
+        await MockLoggingService.Received(1).LogErrorAsync(
+            "offline reconnect synchronisation",
+            failure,
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ItShouldNotSynchroniseWhenTheOfflineContextIsLockedDuringOwnerVerification()
+    {
+        // Arrange
+        var ownerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOwner = new TaskCompletionSource<CurrentUserDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            ownerStarted.SetResult();
+            return releaseOwner.Task;
+        });
+
+        // Act
+        var attempt = Sut.AttemptAsync(CancellationToken.None);
+        await ownerStarted.Task;
+        OfflineOwnerContext.Lock();
+        releaseOwner.SetResult(CurrentUser(OfflineUserId));
+        await attempt;
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Offline);
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPreventDuplicateReconnectAndSynchronisationAttempts()
+    {
+        // Arrange
+        var syncStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSync = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockCatchSynchroniser.SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>()).Returns(async _ =>
+        {
+            syncStarted.SetResult();
+            await releaseSync.Task;
+        });
+
+        // Act
+        var first = Sut.AttemptAsync(CancellationToken.None);
+        await syncStarted.Task;
+        var second = Sut.AttemptAsync(CancellationToken.None);
+        releaseSync.SetResult();
+        await Task.WhenAll(first, second);
+
+        // Assert
+        await MockCurrentUserClient.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        await MockCatchSynchroniser.Received(1).SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLockOnlyAfterTheMatchingOwnerSynchronisationCompletes()
+    {
+        // Arrange
+        var syncStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSync = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockCatchSynchroniser.SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>()).Returns(async _ =>
+        {
+            syncStarted.SetResult();
+            await releaseSync.Task;
+        });
+
+        // Act
+        var attempt = Sut.AttemptAsync(CancellationToken.None);
+        await syncStarted.Task;
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Synchronising);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        releaseSync.SetResult();
+        await attempt;
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Online);
+        OfflineOwnerContext.IsUnlocked.Should().BeFalse();
+        await MockCurrentUserClient.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        await MockCatchSynchroniser.Received(1).SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStart.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStart.cs
@@ -1,0 +1,91 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.OfflineAccess.Enums;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.OfflineAccess.Services.OfflineReconnectServiceTests;
+
+public class WhenTestingStart : BaseOfflineReconnectServiceTest
+{
+    [Fact]
+    public async Task ItShouldRemainOfflineWithoutResolvingAuthenticationWhenTheNetworkIsOffline()
+    {
+        // Arrange
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+
+        // Act
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Offline);
+        await MockNetworkService.Received(1).StartMonitoringAsync(Arg.Any<CancellationToken>());
+        await MockAuthenticationStateProvider.DidNotReceive().GetAuthenticationStateAsync();
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldExposeARetryableFailureWhenConnectivityCannotBeChecked()
+    {
+        // Arrange
+        var failure = new InvalidOperationException("network unavailable");
+        MockNetworkService.StartMonitoringAsync(Arg.Any<CancellationToken>()).ThrowsAsync(failure);
+
+        // Act
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.RetryableFailure);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockAuthenticationStateProvider.DidNotReceive().GetAuthenticationStateAsync();
+        await MockLoggingService.Received(1).LogErrorAsync(
+            "offline reconnect connectivity",
+            failure,
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ItShouldAttemptRecoveryWhenTheCurrentConnectivityHintIsOnline()
+    {
+        // Arrange
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(true);
+
+        // Act
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Online);
+        await MockCurrentUserClient.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        await MockCatchSynchroniser.Received(1).SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAttemptAutomaticallyOnlyOnceUntilConnectivityIsLostAgain()
+    {
+        // Arrange
+        var failure = new HttpRequestException("unreachable");
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(true);
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>()).ThrowsAsync(failure);
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Act
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(true);
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(true);
+        await Task.Yield();
+
+        // Assert
+        await MockCurrentUserClient.Received(1).GetCurrentAsync(Arg.Any<CancellationToken>());
+        Sut.State.Should().Be(OfflineReconnectStateEnum.RetryableFailure);
+
+        // Act
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(false);
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(true);
+        await Task.Yield();
+
+        // Assert
+        await MockCurrentUserClient.Received(2).GetCurrentAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStart.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStart.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.OfflineAccess.Enums;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -7,6 +8,97 @@ namespace FishingLogBook.Web.Tests.Features.OfflineAccess.Services.OfflineReconn
 
 public class WhenTestingStart : BaseOfflineReconnectServiceTest
 {
+    [Fact]
+    public async Task ItShouldInvalidateOwnerVerificationWhenConnectivityIsLost()
+    {
+        // Arrange
+        var ownerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOwner = new TaskCompletionSource<CurrentUserDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            ownerStarted.SetResult();
+            return releaseOwner.Task;
+        });
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Act
+        var attempt = Sut.AttemptAsync(CancellationToken.None);
+        await ownerStarted.Task;
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(false);
+        releaseOwner.SetResult(CurrentUser(OfflineUserId));
+        await attempt;
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Offline);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldInvalidateSynchronisationWhenConnectivityIsLost()
+    {
+        // Arrange
+        var syncStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSync = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        MockCatchSynchroniser.SynchronisePendingAsync(OfflineUserId, Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                syncStarted.SetResult();
+                await releaseSync.Task;
+            });
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Act
+        var attempt = Sut.AttemptAsync(CancellationToken.None);
+        await syncStarted.Task;
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(false);
+        releaseSync.SetResult();
+        await attempt;
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Offline);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCatchSynchroniser.Received(1).SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAllowAnExplicitRetryAfterAStaleAttemptCompletes()
+    {
+        // Arrange
+        var ownerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOwner = new TaskCompletionSource<CurrentUserDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            ownerStarted.SetResult();
+            return releaseOwner.Task;
+        });
+        await Sut.StartAsync(CancellationToken.None);
+        var staleAttempt = Sut.AttemptAsync(CancellationToken.None);
+        await ownerStarted.Task;
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(false);
+        releaseOwner.SetResult(CurrentUser(OfflineUserId));
+        await staleAttempt;
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .Returns(CurrentUser(OfflineUserId));
+
+        // Act
+        await Sut.AttemptAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Online);
+        OfflineOwnerContext.IsUnlocked.Should().BeFalse();
+        await MockCatchSynchroniser.Received(1).SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task ItShouldRemainOfflineWithoutResolvingAuthenticationWhenTheNetworkIsOffline()
     {

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStop.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStop.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.OfflineAccess.Enums;
 using NSubstitute;
 
@@ -6,6 +7,65 @@ namespace FishingLogBook.Web.Tests.Features.OfflineAccess.Services.OfflineReconn
 
 public class WhenTestingStop : BaseOfflineReconnectServiceTest
 {
+    [Fact]
+    public async Task ItShouldPreventOwnerVerificationFromStartingLateSynchronisationAfterStop()
+    {
+        // Arrange
+        var ownerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseOwner = new TaskCompletionSource<CurrentUserDto>(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            ownerStarted.SetResult();
+            return releaseOwner.Task;
+        });
+        await Sut.StartAsync(CancellationToken.None);
+        var attempt = Sut.AttemptAsync(CancellationToken.None);
+        await ownerStarted.Task;
+
+        // Act
+        Sut.Stop();
+        releaseOwner.SetResult(CurrentUser(OfflineUserId));
+        await attempt;
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Offline);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPreventSynchronisationFromLockingTheOwnerAfterStop()
+    {
+        // Arrange
+        var syncStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSync = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        MockCatchSynchroniser.SynchronisePendingAsync(OfflineUserId, Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                syncStarted.SetResult();
+                await releaseSync.Task;
+            });
+        await Sut.StartAsync(CancellationToken.None);
+        var attempt = Sut.AttemptAsync(CancellationToken.None);
+        await syncStarted.Task;
+
+        // Act
+        Sut.Stop();
+        releaseSync.SetResult();
+        await attempt;
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Offline);
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCatchSynchroniser.Received(1).SynchronisePendingAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task ItShouldCancelAnInFlightConnectivityRecoveryBeforeLockingTheOwner()
     {

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStop.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStop.cs
@@ -1,0 +1,55 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.OfflineAccess.Enums;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.OfflineAccess.Services.OfflineReconnectServiceTests;
+
+public class WhenTestingStop : BaseOfflineReconnectServiceTest
+{
+    [Fact]
+    public async Task ItShouldCancelAnInFlightConnectivityRecoveryBeforeLockingTheOwner()
+    {
+        // Arrange
+        var ownerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        MockCurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>()).Returns(async call =>
+        {
+            ownerStarted.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, call.Arg<CancellationToken>());
+            return CurrentUser(OfflineUserId);
+        });
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Act
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(true);
+        await ownerStarted.Task;
+        Sut.Stop();
+        await Task.Yield();
+
+        // Assert
+        OfflineOwnerContext.IsUnlocked.Should().BeTrue();
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStopRespondingToConnectivityChanges()
+    {
+        // Arrange
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Act
+        Sut.Stop();
+        MockNetworkService.ConnectivityChanged += Raise.Event<Action<bool>>(true);
+        await Task.Yield();
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Offline);
+        await MockAuthenticationStateProvider.DidNotReceive().GetAuthenticationStateAsync();
+        await MockCatchSynchroniser.DidNotReceive().SynchronisePendingAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -130,6 +130,24 @@ public class WhenTestingRouting : BaseLandingTest
     }
 
     [Fact]
+    public async Task ItShouldRequireExplicitOfflineUnlockAfterReconnectSignInReturns()
+    {
+        // Arrange
+        var onboarding = Onboarding(true);
+        await using var context = CreateContext(onboarding, isAuthenticated: true);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/?reconnect=offline");
+
+        // Act
+        var cut = context.Render<LandingPage>();
+        await Task.Yield();
+
+        // Assert
+        cut.Find("#public-landing-page").Should().NotBeNull();
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().Be("http://localhost/?reconnect=offline");
+        await onboarding.DidNotReceive().IsCompletedAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldOfferOfflineUnlockWithoutWaitingForAuthentication()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/BaseOfflineLayoutTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/BaseOfflineLayoutTest.cs
@@ -10,7 +10,9 @@ namespace FishingLogBook.Web.Tests.Layouts.OfflineLayoutTests;
 
 public class BaseOfflineLayoutTest
 {
-    protected static BunitContext CreateContext(out OfflineOwnerContextService owner)
+    protected static BunitContext CreateContext(
+        out OfflineOwnerContextService owner,
+        IOfflineReconnectService? reconnect = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -21,6 +23,7 @@ public class BaseOfflineLayoutTest
         owner = new OfflineOwnerContextService();
         owner.Unlock(new OfflineOwnerModel(Guid.Parse("11111111-1111-1111-1111-111111111111"), 1));
         context.Services.AddSingleton<IOfflineOwnerContextService>(owner);
+        context.Services.AddSingleton(reconnect ?? Substitute.For<IOfflineReconnectService>());
         return context;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/WhenTestingRender.cs
@@ -1,8 +1,12 @@
 using AwesomeAssertions;
 using Bunit;
+using Bunit.TestDoubles;
+using FishingLogBook.Web.Features.OfflineAccess.Enums;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Layouts.OfflineLayout;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 
 namespace FishingLogBook.Web.Tests.Layouts.OfflineLayoutTests;
 
@@ -41,5 +45,93 @@ public class WhenTestingRender : BaseOfflineLayoutTest
         // Assert
         owner.IsUnlocked.Should().BeFalse();
         context.Services.GetRequiredService<NavigationManager>().Uri.Should().Be("http://localhost/");
+    }
+
+    [Fact]
+    public async Task ItShouldStartReconnectMonitoringWithoutStartingOnlineLayoutHooks()
+    {
+        // Arrange
+        var reconnect = Substitute.For<IOfflineReconnectService>();
+        await using var context = CreateContext(out _, reconnect);
+
+        // Act
+        context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+        await Task.Yield();
+
+        // Assert
+        await reconnect.Received(1).StartAsync(Arg.Any<CancellationToken>());
+        await reconnect.DidNotReceive().AttemptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepOfflineNavigationAvailableWhenAuthenticationIsRequired()
+    {
+        // Arrange
+        var reconnect = Substitute.For<IOfflineReconnectService>();
+        reconnect.State.Returns(OfflineReconnectStateEnum.AuthenticationRequired);
+        await using var context = CreateContext(out _, reconnect);
+
+        // Act
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Assert
+        cut.Find("#offline-reconnect-authentication-required").Should().NotBeNull();
+        cut.Find("#offline-reconnect-sign-in").Should().NotBeNull();
+        cut.Find("#offline-catches-nav-link").Should().NotBeNull();
+        cut.Find("#offline-record-nav-link").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldUseNormalSignInAndReturnForAnExplicitOfflineUnlock()
+    {
+        // Arrange
+        var reconnect = Substitute.For<IOfflineReconnectService>();
+        reconnect.State.Returns(OfflineReconnectStateEnum.AuthenticationRequired);
+        await using var context = CreateContext(out _, reconnect);
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Act
+        await cut.Find("#offline-reconnect-sign-in").ClickAsync();
+
+        // Assert
+        var navigation = (BunitNavigationManager)context.Services.GetRequiredService<NavigationManager>();
+        navigation.Uri.Should().Contain("authentication/login");
+        navigation.History.Should().ContainSingle();
+        navigation.History.Single().Options.HistoryEntryState.Should().Contain("reconnect=offline");
+        await reconnect.DidNotReceive().AttemptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNavigateOnlyAfterTheCoordinatorReportsSafeCompletion()
+    {
+        // Arrange
+        var reconnect = Substitute.For<IOfflineReconnectService>();
+        reconnect.State.Returns(OfflineReconnectStateEnum.Synchronising);
+        await using var context = CreateContext(out _, reconnect);
+        context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Act
+        reconnect.State.Returns(OfflineReconnectStateEnum.Synchronising);
+        reconnect.StateChanged += Raise.Event<EventHandler>();
+        await Task.Yield();
+
+        // Assert
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().Be("http://localhost/");
+
+        // Act
+        reconnect.State.Returns(OfflineReconnectStateEnum.Online);
+        reconnect.StateChanged += Raise.Event<EventHandler>();
+        await Task.Yield();
+
+        // Assert
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().Be("http://localhost/catches");
     }
 }


### PR DESCRIPTION
## Summary

Implements the focused reconnect coordinator for #155.

- treats browser connectivity as a hint and makes only one automatic recovery attempt per restored-online period
- reuses the normal Cognito session when one already exists and never launches Cognito automatically
- requires a direct trusted `/api/users/current` owner match with the unlocked `OfflineOwnerContext` before synchronisation
- synchronises the exact verified owner partition through the existing catch synchroniser
- keeps offline mode and owner context intact for authentication-required, owner-mismatch, retryable, and coordinator-level failures
- clears the offline owner context and transitions to normal `/catches` only after owner verification and the reconnect sync attempt reach their safe completion point
- routes an expired session through normal Sign in, then requires explicit offline unlock again after redirect
- adds localized EN/FR reconnect states and explicit retry/sign-in actions
- corrects the offline E2E setup so preferred method/species data is cached before Playwright disables networking

## Security and ownership boundary

- the server-derived authenticated UserId is compared directly with the unlocked offline owner
- mismatched owners never trigger sync
- no client-supplied identity is trusted
- no Cognito tokens or additional plaintext reconnect identity are persisted
- offline owner context remains established until the verified sync boundary completes, preventing a race with normal `MainLayout` sync hooks

## Validation

Completed locally:

- focused OfflineReconnect, OfflineLayout, Landing, architecture, and CatchSynchroniser tests: 65 passed
- FishingLogBook.Web.Tests: 738 passed
- JavaScript/Vitest: 231 passed
- browser suite: 39 passed, 5 expected WebKit skips
- Release build: passed with 0 warnings
- `dotnet format`: clean
- `git diff --check`: clean
- complete solution: all non-container suites passed; infrastructure container tests could not run locally because the Docker named pipe was unavailable
- Playwright E2E definitions: 3 tests discovered successfully
- authenticated E2E execution requires the local Cognito test credentials; final E2E execution is being verified from the credentialed developer environment

## Self review

- Issue/AC: PASS — approved reconnect states, triggers, explicit actions, and transition ordering implemented
- Architecture/CQRS: PASS — coordination remains in Web; existing auth, owner context, and synchroniser boundaries are reused
- Rules: PASS — enums are in the Enums feature folder, use the Enum suffix, and have explicit numeric values
- Security/privacy: PASS — exact trusted owner match is mandatory before sync
- Database/migrations: N/A
- Tests/coverage: PASS with the Docker and credentialed-E2E environment limitations stated above
- Browser: PASS for the feasible browser suite; Samsung/iPhone physical reconnect validation remains outstanding
- Web/UI/localisation: PASS — EN/FR parity included
- Code smells: PASS — no broad reconnect redesign or duplicated sync implementation
- CI/deployment: PASS — no infrastructure, service-worker, authentication configuration, or deployment changes

## Deliberately out of scope

- reconnect/sync redesign
- automatic Cognito launch
- new identity persistence
- WebAuthn/PRF changes
- service-worker changes
- infrastructure changes

Physical Samsung and iPhone acceptance remains the next gate and is not claimed complete.

Relates to #155.
