### PR TITLE
FLB#155 | Hide online actions from offline Landing

### DIFF
--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
@@ -21,8 +21,11 @@
                 </MudItem>
             </MudGrid>
             <MudStack Spacing="2" Class="landing-actions">
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginCreateAccount" id="landing-create-account">@Loc["Auth_CreateAccount"]</MudButton>
-                <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginSignIn" id="landing-sign-in">@Loc["Auth_SignIn"]</MudButton>
+                @if (_isOnline != false)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginCreateAccount" id="landing-create-account">@Loc["Auth_CreateAccount"]</MudButton>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginSignIn" id="landing-sign-in">@Loc["Auth_SignIn"]</MudButton>
+                }
                 @if (_offlineAvailability == OfflineAvailabilityState.Ready)
                 {
                     <MudButton Variant="Variant.Filled"

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -166,6 +166,8 @@ public class WhenTestingRouting : BaseLandingTest
         // Assert
         cut.WaitForAssertion(() => cut.Find("#landing-open-offline").Should().NotBeNull());
         cut.FindAll("#landing-offline-not-configured").Should().BeEmpty();
+        cut.FindAll("#landing-create-account").Should().BeEmpty();
+        cut.FindAll("#landing-sign-in").Should().BeEmpty();
         await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
         await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
         await network.Received(1).StartMonitoringAsync(Arg.Any<CancellationToken>());
@@ -213,6 +215,8 @@ public class WhenTestingRouting : BaseLandingTest
                 .Should().Contain("Offline access isn't set up on this device"));
         cut.FindAll("#landing-open-offline").Should().BeEmpty();
         cut.FindAll("#landing-offline-availability-failed").Should().BeEmpty();
+        cut.FindAll("#landing-create-account").Should().BeEmpty();
+        cut.FindAll("#landing-sign-in").Should().BeEmpty();
         await network.Received(1).StartMonitoringAsync(Arg.Any<CancellationToken>());
         await network.Received(1).IsOnlineAsync(Arg.Any<CancellationToken>());
         await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
@@ -272,6 +276,8 @@ public class WhenTestingRouting : BaseLandingTest
 
         // Assert
         cut.WaitForAssertion(() => cut.Find("#landing-offline-not-configured").Should().NotBeNull());
+        cut.FindAll("#landing-create-account").Should().BeEmpty();
+        cut.FindAll("#landing-sign-in").Should().BeEmpty();
         await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
         await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
     }
@@ -295,6 +301,8 @@ public class WhenTestingRouting : BaseLandingTest
 
         // Assert
         cut.WaitForAssertion(() => cut.FindAll("#landing-offline-not-configured").Should().BeEmpty());
+        cut.Find("#landing-create-account").Should().NotBeNull();
+        cut.Find("#landing-sign-in").Should().NotBeNull();
         await device.Received(1).HasReadyEntitlementAsync(Arg.Any<CancellationToken>());
         await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
     }
@@ -323,6 +331,8 @@ public class WhenTestingRouting : BaseLandingTest
             cut.Find("#landing-offline-availability-failed").TextContent
                 .Should().Contain("couldn't check offline access"));
         cut.FindAll("#landing-offline-not-configured").Should().BeEmpty();
+        cut.FindAll("#landing-create-account").Should().BeEmpty();
+        cut.FindAll("#landing-sign-in").Should().BeEmpty();
 
         // Act
         await cut.Find("#landing-offline-availability-retry").ClickAsync();


### PR DESCRIPTION
## Summary

Small physical-acceptance follow-up to #155 and merged PR #156.

- hides **Create Account** and **Sign In** when Landing has confirmed the browser is offline
- keeps normal authentication actions unchanged while online or while connectivity is still being determined
- preserves the validated offline discovery states:
  - ready entitlement: shows **Open offline**
  - not configured: shows the existing informational setup guidance
  - check failed: shows the existing warning and retry action
- restores the normal authentication actions if connectivity returns while Landing remains mounted

No authentication, Cognito, entitlement discovery, WebAuthn/PRF, reconnect owner verification, or synchronisation behaviour changed.

## Validation

- focused Landing tests: 23 passed
- complete FishingLogBook.Web.Tests: 743 passed
- `dotnet format FishingLogBook.sln --no-restore`: clean
- `git diff --check`: clean

## Self review

- Issue/AC: PASS — all four requested online/offline Landing states are covered
- Architecture/CQRS: PASS — presentation uses the existing connectivity state only
- Rules: PASS
- Security/privacy: PASS — no identity or entitlement changes
- Database/migrations: N/A
- Tests/coverage: PASS
- Browser: N/A — no browser implementation changed; physical Android finding drove this cleanup
- Web/UI/localisation: PASS — existing localized copy is reused; no new strings
- Code smells: PASS — two-file conditional presentation change only
- CI/deployment: PASS — no configuration or infrastructure changes

Relates to #155.
