### PR TITLE
FLB#157 | Expand online E2E journey coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test-coverage": "vitest run --config src/FishingLogBook.Web/vitest.config.js --coverage",
     "test-e2e": "npm --prefix tests/FishingLogBook.E2E run test-e2e",
     "test-e2e-debug": "npm --prefix tests/FishingLogBook.E2E run test-e2e-debug",
+    "test-e2e-report": "npm --prefix tests/FishingLogBook.E2E run test-e2e-report",
     "test-e2e-single": "npm --prefix tests/FishingLogBook.E2E run test-e2e-single --"
   },
   "devDependencies": {

--- a/tests/FishingLogBook.E2E/package.json
+++ b/tests/FishingLogBook.E2E/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "install:browsers": "playwright install chromium",
-    "test:config": "node --test tests/config.test.mjs",
+    "test:config": "node --test tests/config.test.mjs tests/profile-state.test.mjs",
     "test": "playwright test",
     "test:smoke": "playwright test --grep @smoke",
     "test-e2e": "playwright test --headed --workers=1",

--- a/tests/FishingLogBook.E2E/package.json
+++ b/tests/FishingLogBook.E2E/package.json
@@ -9,6 +9,7 @@
     "test:smoke": "playwright test --grep @smoke",
     "test-e2e": "playwright test --headed --workers=1",
     "test-e2e-debug": "playwright test --debug --workers=1",
+    "test-e2e-report": "playwright show-report artifacts/report",
     "test-e2e-single": "playwright test --headed --workers=1 --grep"
   },
   "devDependencies": {

--- a/tests/FishingLogBook.E2E/specs/catch-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/catch-online.spec.mjs
@@ -1,8 +1,53 @@
 import { test, expect } from '../support/fixtures.mjs';
-import { recordCatch, testName } from '../support/catch-journey.mjs';
+import {
+    createCatch,
+    editCatch,
+    reloadServerCatches,
+    testName
+} from '../support/catch-journey.mjs';
 
-test('@smoke records and edits a catch through the real application', async ({ page }) => {
-    const notes = testName('online');
-    const id = await recordCatch(page, notes, true);
-    await expect(page.locator(`#catch-card-${id}`)).toContainText(notes);
+test('@smoke records a catch and retains its catalogue values and photo after reload', async ({ page }) => {
+    const id = await createCatch(page, true);
+
+    const persisted = await reloadServerCatches(page);
+    expect(persisted).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id, method: 'Fly', speciesName: 'Brown Trout' })
+    ]));
+    await expect(page.locator(`#catch-card-${id}`)).toBeVisible();
+    await expect(page.locator(`#catch-card-method-${id}`)).toHaveText('Fly');
+    await expect(page.locator(`#catch-card-species-${id}`)).toHaveText('Brown Trout');
+    await expect(page.locator(`#catch-card-photo-${id}`)).toBeVisible();
+    await expect(page.locator(`#catch-card-no-photo-${id}`)).toHaveCount(0);
+});
+
+test('@smoke edits catch details and retains them after server reload', async ({ page }) => {
+    const id = await createCatch(page, true);
+    const notes = testName('edited-notes');
+    const bait = testName('bait');
+
+    await editCatch(page, id, { notes, bait, weight: '5', length: '12' }, true);
+    const persisted = await reloadServerCatches(page);
+    expect(persisted).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id, notes, baitOrLure: bait })
+    ]));
+    const card = page.locator(`#catch-card-${id}`);
+    await expect(card).toContainText(notes);
+    await expect(card).toContainText(bait);
+    await expect(page.locator(`#catch-card-measurements-${id}`)).toBeVisible();
+});
+
+test('search finds a known catch and clearing it restores the Catch List', async ({ page }) => {
+    const id = await createCatch(page, true);
+    const bait = testName('search-target');
+    await editCatch(page, id, { bait }, true);
+    await page.goto('/catches');
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
+
+    await page.locator('#catch-search').fill(bait);
+    await expect(page.locator('.catch-card')).toHaveCount(1);
+    await expect(page.locator(`#catch-card-${id}`)).toBeVisible();
+    await page.locator('#catch-clear-all-filters').click();
+    await expect(page.locator(`#catch-card-${id}`)).toBeVisible();
+    await expect(page.locator('#catch-search')).toHaveValue('');
+    await expect(page.locator('#catch-active-filters')).toHaveCount(0);
 });

--- a/tests/FishingLogBook.E2E/specs/filters-preferences-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/filters-preferences-online.spec.mjs
@@ -1,0 +1,112 @@
+import { test, expect } from '../support/fixtures.mjs';
+import { createCatch, reloadServerCatches } from '../support/catch-journey.mjs';
+
+test('filters the Catch List by fishing method and clears the filter', async ({ page }) => {
+    const flyId = await createCatch(page, true);
+    const baitId = await createCatch(page, true, { methodCode: 'Bait', speciesCode: 'Tench' });
+
+    await page.locator('#catch-filter-method-Bait').click();
+    await expect(page.locator(`#catch-card-${baitId}`)).toBeVisible();
+    await expect(page.locator(`#catch-card-${flyId}`)).toHaveCount(0);
+    await page.locator('#catch-filter-method-all').click();
+    await expect(page.locator(`#catch-card-${baitId}`)).toBeVisible();
+    await expect(page.locator(`#catch-card-${flyId}`)).toBeVisible();
+});
+
+test('filters the Catch List by species and clears the filter', async ({ page }) => {
+    const troutId = await createCatch(page, true);
+    const tenchId = await createCatch(page, true, { speciesCode: 'Tench' });
+
+    await page.locator('#catch-filters-button').click();
+    await page.locator('#catch-filter-species-Tench').click();
+    await expect(page.locator(`#catch-card-${tenchId}`)).toBeVisible();
+    await expect(page.locator(`#catch-card-${troutId}`)).toHaveCount(0);
+    await page.locator('#catch-clear-all-filters').click();
+    await expect(page.locator(`#catch-card-${tenchId}`)).toBeVisible();
+    await expect(page.locator(`#catch-card-${troutId}`)).toBeVisible();
+});
+
+test('filters an older catch out of the Today view without changing its date', async ({ page }) => {
+    const id = await createCatch(page, true);
+    await openCatchEdit(page, id);
+    await page.locator('#catch-edit-caught-on').fill('2020-01-02T12:00');
+    await saveCatchEdit(page);
+    const persisted = await reloadServerCatches(page);
+    expect(persisted.find(candidate => candidate.id === id)?.caughtOn).toContain('2020-01-02');
+
+    await page.locator('#catch-filters-button').click();
+    await page.locator('#catch-filter-date-Today').click();
+    await expect(page.locator(`#catch-card-${id}`)).toHaveCount(0);
+    await page.locator('#catch-clear-all-filters').click();
+    await expect(page.locator(`#catch-card-${id}`)).toBeVisible();
+});
+
+test('uses saved Profile measurement units when editing a catch', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    await page.locator('#profile-fishing-details-section').click();
+    await chooseSelectOption(page, '#profile-weight-unit', 'Pounds (lb)');
+    await chooseSelectOption(page, '#profile-length-unit', 'Centimetres (cm)');
+    await saveProfile(page);
+
+    const id = await createCatch(page, true);
+    await openCatchEdit(page, id);
+    await expect(page.locator('label[for="catch-edit-weight"]')).toContainText('lb');
+    await expect(page.locator('label[for="catch-edit-length"]')).toContainText('cm');
+});
+
+test('cancelling the Profile species picker preserves the saved selection', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    await page.locator('#profile-fishing-details-section').click();
+    if (await page.locator('#profile-species-section-Bait').count() === 0) {
+        await page.locator('#profile-method-Bait').click();
+    }
+    if (await page.locator('#profile-species-pill-Bait-Tench').count() === 0) {
+        await page.locator('#profile-species-more-Bait').click();
+        await page.locator('#catalogue-picker-modal-search').fill('Tench');
+        await page.locator('#catalogue-picker-modal-option-Tench').click();
+        await page.locator('#catalogue-picker-modal-save').click();
+        await saveProfile(page);
+    }
+
+    await page.locator('#profile-species-more-Bait').click();
+    await page.locator('#catalogue-picker-modal-search').fill('Tench');
+    await page.locator('#catalogue-picker-modal-option-Tench').click();
+    await page.locator('#catalogue-picker-modal-cancel').click();
+    await expect(page.locator('#profile-species-pill-Bait-Tench')).toBeVisible();
+});
+
+async function openCatchEdit(page, id) {
+    await page.locator(`#catch-card-menu-${id}`).click();
+    await page.locator(`#catch-card-edit-${id}`).click();
+    await expect(page.locator('#catch-edit-loading')).toBeHidden();
+}
+
+async function saveCatchEdit(page) {
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().endsWith('/api/catches')
+            && response.request().method() === 'POST'
+            && response.ok()),
+        page.locator('#catch-edit-save').click()
+    ]);
+    await expect(page.locator('#catch-edit-saved')).toBeVisible();
+}
+
+async function chooseSelectOption(page, selector, optionName) {
+    await page.locator(selector)
+        .locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " mud-input-control ")]')
+        .click();
+    await page.getByRole('option', { name: optionName, exact: true }).click();
+}
+
+async function saveProfile(page) {
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().endsWith('/api/profiles/me/fishing-preferences')
+            && response.request().method() === 'PUT'
+            && response.ok()),
+        page.locator('#profile-save-button').click()
+    ]);
+}

--- a/tests/FishingLogBook.E2E/specs/filters-preferences-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/filters-preferences-online.spec.mjs
@@ -1,5 +1,6 @@
 import { test, expect } from '../support/fixtures.mjs';
 import { createCatch, reloadServerCatches } from '../support/catch-journey.mjs';
+import { withRestoredProfileState } from '../support/profile-state.mjs';
 
 test('filters the Catch List by fishing method and clears the filter', async ({ page }) => {
     const flyId = await createCatch(page, true);
@@ -42,39 +43,39 @@ test('filters an older catch out of the Today view without changing its date', a
 });
 
 test('uses saved Profile measurement units when editing a catch', async ({ page }) => {
-    await page.goto('/profile');
-    await expect(page.locator('#profile-loading')).toBeHidden();
-    await page.locator('#profile-fishing-details-section').click();
-    await chooseSelectOption(page, '#profile-weight-unit', 'Pounds (lb)');
-    await chooseSelectOption(page, '#profile-length-unit', 'Centimetres (cm)');
-    await saveProfile(page);
+    await withRestoredProfileState(page, async () => {
+        await page.locator('#profile-fishing-details-section').click();
+        await chooseSelectOption(page, '#profile-weight-unit', 'Pounds (lb)');
+        await chooseSelectOption(page, '#profile-length-unit', 'Centimetres (cm)');
+        await saveProfile(page);
 
-    const id = await createCatch(page, true);
-    await openCatchEdit(page, id);
-    await expect(page.locator('label[for="catch-edit-weight"]')).toContainText('lb');
-    await expect(page.locator('label[for="catch-edit-length"]')).toContainText('cm');
+        const id = await createCatch(page, true);
+        await openCatchEdit(page, id);
+        await expect(page.locator('label[for="catch-edit-weight"]')).toContainText('lb');
+        await expect(page.locator('label[for="catch-edit-length"]')).toContainText('cm');
+    });
 });
 
 test('cancelling the Profile species picker preserves the saved selection', async ({ page }) => {
-    await page.goto('/profile');
-    await expect(page.locator('#profile-loading')).toBeHidden();
-    await page.locator('#profile-fishing-details-section').click();
-    if (await page.locator('#profile-species-section-Bait').count() === 0) {
-        await page.locator('#profile-method-Bait').click();
-    }
-    if (await page.locator('#profile-species-pill-Bait-Tench').count() === 0) {
+    await withRestoredProfileState(page, async () => {
+        await page.locator('#profile-fishing-details-section').click();
+        if (await page.locator('#profile-species-section-Bait').count() === 0) {
+            await page.locator('#profile-method-Bait').click();
+        }
+        if (await page.locator('#profile-species-pill-Bait-Tench').count() === 0) {
+            await page.locator('#profile-species-more-Bait').click();
+            await page.locator('#catalogue-picker-modal-search').fill('Tench');
+            await page.locator('#catalogue-picker-modal-option-Tench').click();
+            await page.locator('#catalogue-picker-modal-save').click();
+            await saveProfile(page);
+        }
+
         await page.locator('#profile-species-more-Bait').click();
         await page.locator('#catalogue-picker-modal-search').fill('Tench');
         await page.locator('#catalogue-picker-modal-option-Tench').click();
-        await page.locator('#catalogue-picker-modal-save').click();
-        await saveProfile(page);
-    }
-
-    await page.locator('#profile-species-more-Bait').click();
-    await page.locator('#catalogue-picker-modal-search').fill('Tench');
-    await page.locator('#catalogue-picker-modal-option-Tench').click();
-    await page.locator('#catalogue-picker-modal-cancel').click();
-    await expect(page.locator('#profile-species-pill-Bait-Tench')).toBeVisible();
+        await page.locator('#catalogue-picker-modal-cancel').click();
+        await expect(page.locator('#profile-species-pill-Bait-Tench')).toBeVisible();
+    });
 });
 
 async function openCatchEdit(page, id) {

--- a/tests/FishingLogBook.E2E/specs/navigation-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/navigation-online.spec.mjs
@@ -1,0 +1,41 @@
+import { test, expect } from '../support/fixtures.mjs';
+
+test('authenticated navigation reaches core online journeys and survives deep-link refresh', async ({ page }) => {
+    await page.goto('/catches');
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+
+    await page.locator('#record-catch-nav-link').click();
+    await expect(page).toHaveURL(/\/catches\/record$/);
+    await expect(page.locator('#record-catch-title')).toBeVisible();
+
+    await page.locator('#profile-nav-link').click();
+    await expect(page).toHaveURL(/\/profile$/);
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    await page.reload();
+    await expect(page).toHaveURL(/\/profile$/);
+    await expect(page.locator('#profile-save-button')).toBeVisible();
+
+    await page.locator('#catch-logbook-nav-link').click();
+    await expect(page).toHaveURL(/\/catches$/);
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+});
+
+test('authenticated user can reach support surfaces through primary navigation', async ({ page }) => {
+    await page.goto('/catches');
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+
+    await page.locator('#system-status-nav-link').click();
+    await expect(page).toHaveURL(/\/system-status$/);
+    await expect(page.locator('#build-information')).toBeVisible();
+    await expect(page.locator('#web-build-information')).toBeVisible();
+    await expect(page.locator('#api-build-information')).toBeVisible();
+
+    await page.locator('#diagnostics-nav-button').click();
+    await expect(page).toHaveURL(/\/diagnostics$/);
+    await expect(page.locator('#diagnostics-online')).toBeVisible();
+    await expect(page.locator('#refresh-diagnostics-button')).toBeVisible();
+
+    await page.locator('#install-nav-link').click();
+    await expect(page).toHaveURL(/\/install$/);
+    await expect(page.getByRole('heading', { name: /install catch but don.t forget/i })).toBeVisible();
+});

--- a/tests/FishingLogBook.E2E/specs/online-boundaries.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/online-boundaries.spec.mjs
@@ -1,0 +1,121 @@
+import { test, expect } from '../support/fixtures.mjs';
+import {
+    createCatch,
+    editCatch,
+    reloadServerCatches,
+    testName
+} from '../support/catch-journey.mjs';
+
+test('prevents an incomplete catch from being saved', async ({ page }) => {
+    await page.goto('/catches');
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
+    await expect(page.locator('#catch-list, #catch-list-empty')).toBeVisible();
+    const existingCount = await page.locator('.catch-card').count();
+
+    await page.locator('#catch-record-link').click();
+    await page.locator('#record-catch-method-Fly').click();
+    await page.locator('#record-catch-species-BrownTrout').click();
+    await expect(page.locator('#save-catch-button')).toBeDisabled();
+
+    await page.locator('#catch-logbook-nav-link').click();
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
+    await expect(page.locator('#catch-list, #catch-list-empty')).toBeVisible();
+    await expect(page.locator('.catch-card')).toHaveCount(existingCount);
+});
+
+test('records a canonical species selected through More search', async ({ page }) => {
+    const id = await createCatch(page, true, { speciesCode: 'Tench' });
+
+    const persisted = await reloadServerCatches(page);
+    expect(persisted).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id, method: 'Fly', speciesName: 'Tench' })
+    ]));
+    await expect(page.locator(`#catch-card-species-${id}`)).toHaveText('Tench');
+});
+
+test('changes a catch to canonical method and species values through More search', async ({ page }) => {
+    const id = await createCatch(page, true);
+    await openCatchEdit(page, id);
+    await chooseEditCatalogueValue(page, 'method', 'Bait');
+    await chooseEditCatalogueValue(page, 'species', 'Tench');
+    await Promise.all([
+        waitForCatchUpdate(page),
+        page.locator('#catch-edit-save').click()
+    ]);
+    await expect(page.locator('#catch-edit-saved')).toBeVisible();
+
+    const persisted = await reloadServerCatches(page);
+    expect(persisted).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id, method: 'Bait', speciesName: 'Tench' })
+    ]));
+    await expect(page.locator(`#catch-card-method-${id}`)).toHaveText('Bait');
+    await expect(page.locator(`#catch-card-species-${id}`)).toHaveText('Tench');
+});
+
+test('editing one catch does not change another catch', async ({ page }) => {
+    const firstId = await createCatch(page, true);
+    const secondId = await createCatch(page, true, { speciesCode: 'Tench' });
+    const firstBait = testName('first-only');
+
+    await editCatch(page, firstId, { bait: firstBait }, true);
+    const persisted = await reloadServerCatches(page);
+    expect(persisted).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: firstId, baitOrLure: firstBait }),
+        expect.objectContaining({ id: secondId, baitOrLure: null })
+    ]));
+    await expect(page.locator(`#catch-card-${firstId}`)).toContainText(firstBait);
+    await expect(page.locator(`#catch-card-${secondId}`)).not.toContainText(firstBait);
+});
+
+test('saved Profile method and species preferences appear in Record Catch', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    await page.locator('#profile-fishing-details-section').click();
+    if (await page.locator('#profile-species-section-Bait').count() === 0) {
+        await page.locator('#profile-method-Bait').click();
+    }
+    if (await page.locator('#profile-species-pill-Bait-Tench').count() === 0) {
+        await page.locator('#profile-species-more-Bait').click();
+        await page.locator('#catalogue-picker-modal-search').fill('Tench');
+        await page.locator('#catalogue-picker-modal-option-Tench').click();
+        await page.locator('#catalogue-picker-modal-save').click();
+    }
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().endsWith('/api/profiles/me/fishing-preferences')
+            && response.request().method() === 'PUT'
+            && response.ok()),
+        page.locator('#profile-save-button').click()
+    ]);
+
+    await page.reload();
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    await page.locator('#profile-fishing-details-section').click();
+    await expect(page.locator('#profile-species-pill-Bait-Tench')).toBeVisible();
+    await page.goto('/catches/record');
+    await expect(page.locator('#record-catch-title')).toBeVisible();
+    await page.locator('#record-catch-method-Bait').click();
+    await expect(page.locator('#record-catch-species-Tench')).toBeVisible();
+});
+
+async function openCatchEdit(page, id) {
+    await page.locator(`#catch-card-menu-${id}`).click();
+    await page.locator(`#catch-card-edit-${id}`).click();
+    await expect(page.locator('#catch-edit-loading')).toBeHidden();
+}
+
+async function chooseEditCatalogueValue(page, type, code) {
+    await page.locator(`#catch-edit-${type}-more`).click();
+    await page.locator('#catalogue-picker-modal-search').fill(code);
+    await page.locator(`#catalogue-picker-modal-option-${code}`).click();
+    await page.locator('#catalogue-picker-modal-save').click();
+}
+
+function waitForCatchUpdate(page) {
+    return page.waitForResponse(response =>
+        response.url().endsWith('/api/catches')
+        && response.request().method() === 'POST'
+        && response.ok());
+}

--- a/tests/FishingLogBook.E2E/specs/online-boundaries.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/online-boundaries.spec.mjs
@@ -5,6 +5,7 @@ import {
     reloadServerCatches,
     testName
 } from '../support/catch-journey.mjs';
+import { withRestoredProfileState } from '../support/profile-state.mjs';
 
 test('prevents an incomplete catch from being saved', async ({ page }) => {
     await page.goto('/catches');
@@ -70,34 +71,34 @@ test('editing one catch does not change another catch', async ({ page }) => {
 });
 
 test('saved Profile method and species preferences appear in Record Catch', async ({ page }) => {
-    await page.goto('/profile');
-    await expect(page.locator('#profile-loading')).toBeHidden();
-    await page.locator('#profile-fishing-details-section').click();
-    if (await page.locator('#profile-species-section-Bait').count() === 0) {
-        await page.locator('#profile-method-Bait').click();
-    }
-    if (await page.locator('#profile-species-pill-Bait-Tench').count() === 0) {
-        await page.locator('#profile-species-more-Bait').click();
-        await page.locator('#catalogue-picker-modal-search').fill('Tench');
-        await page.locator('#catalogue-picker-modal-option-Tench').click();
-        await page.locator('#catalogue-picker-modal-save').click();
-    }
-    await Promise.all([
-        page.waitForResponse(response =>
-            response.url().endsWith('/api/profiles/me/fishing-preferences')
-            && response.request().method() === 'PUT'
-            && response.ok()),
-        page.locator('#profile-save-button').click()
-    ]);
+    await withRestoredProfileState(page, async () => {
+        await page.locator('#profile-fishing-details-section').click();
+        if (await page.locator('#profile-species-section-Bait').count() === 0) {
+            await page.locator('#profile-method-Bait').click();
+        }
+        if (await page.locator('#profile-species-pill-Bait-Tench').count() === 0) {
+            await page.locator('#profile-species-more-Bait').click();
+            await page.locator('#catalogue-picker-modal-search').fill('Tench');
+            await page.locator('#catalogue-picker-modal-option-Tench').click();
+            await page.locator('#catalogue-picker-modal-save').click();
+        }
+        await Promise.all([
+            page.waitForResponse(response =>
+                response.url().endsWith('/api/profiles/me/fishing-preferences')
+                && response.request().method() === 'PUT'
+                && response.ok()),
+            page.locator('#profile-save-button').click()
+        ]);
 
-    await page.reload();
-    await expect(page.locator('#profile-loading')).toBeHidden();
-    await page.locator('#profile-fishing-details-section').click();
-    await expect(page.locator('#profile-species-pill-Bait-Tench')).toBeVisible();
-    await page.goto('/catches/record');
-    await expect(page.locator('#record-catch-title')).toBeVisible();
-    await page.locator('#record-catch-method-Bait').click();
-    await expect(page.locator('#record-catch-species-Tench')).toBeVisible();
+        await page.reload();
+        await expect(page.locator('#profile-loading')).toBeHidden();
+        await page.locator('#profile-fishing-details-section').click();
+        await expect(page.locator('#profile-species-pill-Bait-Tench')).toBeVisible();
+        await page.goto('/catches/record');
+        await expect(page.locator('#record-catch-title')).toBeVisible();
+        await page.locator('#record-catch-method-Bait').click();
+        await expect(page.locator('#record-catch-species-Tench')).toBeVisible();
+    });
 });
 
 async function openCatchEdit(page, id) {

--- a/tests/FishingLogBook.E2E/specs/photo-location-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/photo-location-online.spec.mjs
@@ -1,5 +1,6 @@
 import { test, expect } from '../support/fixtures.mjs';
 import { createCatch, reloadServerCatches, testName } from '../support/catch-journey.mjs';
+import { withRestoredProfileState } from '../support/profile-state.mjs';
 
 test('records multiple photographs and retains their association after reload', async ({ page }) => {
     const id = await createCatch(page, true, { photoCount: 2 });
@@ -44,34 +45,30 @@ test('keeps Record Catch usable when browser location is denied', async ({ page 
 });
 
 test('publishes only the Profile details selected by the angler', async ({ page }) => {
-    const profileResponse = page.waitForResponse(response =>
-        response.url().endsWith('/api/profiles/me')
-        && response.request().method() === 'GET'
-        && response.ok());
-    await page.goto('/profile');
-    const profile = await profileResponse.then(response => response.json());
-    await expect(page.locator('#profile-loading')).toBeHidden();
-    const displayName = testName('public-angler');
-    const homeRegion = testName('public-water');
-    await page.locator('#profile-display-name').fill(displayName);
-    await page.locator('#profile-home-region').fill(homeRegion);
-    await ensureChecked(page.locator('#profile-show-display-name'));
-    await ensureChecked(page.locator('#profile-show-home-region'));
-    await Promise.all([
-        page.waitForResponse(response =>
-            response.url().endsWith('/api/profiles/me/fishing-preferences')
-            && response.request().method() === 'PUT'
-            && response.ok()),
-        page.locator('#profile-save-button').click()
-    ]);
+    await withRestoredProfileState(page, async snapshot => {
+        const profile = snapshot.profile;
+        const displayName = testName('public-angler');
+        const homeRegion = testName('public-water');
+        await page.locator('#profile-display-name').fill(displayName);
+        await page.locator('#profile-home-region').fill(homeRegion);
+        await ensureChecked(page.locator('#profile-show-display-name'));
+        await ensureChecked(page.locator('#profile-show-home-region'));
+        await Promise.all([
+            page.waitForResponse(response =>
+                response.url().endsWith('/api/profiles/me/fishing-preferences')
+                && response.request().method() === 'PUT'
+                && response.ok()),
+            page.locator('#profile-save-button').click()
+        ]);
 
-    await page.goto(`/profile/${profile.userId}`);
-    await expect(page.locator('#public-profile-loading')).toBeHidden();
-    await expect(page.locator('#public-profile-display-name')).toHaveText(displayName);
-    await expect(page.locator('#public-profile-home-region')).toHaveText(homeRegion);
-    await expect(page.locator('#public-profile-photo')).toHaveCount(0);
-    await expect(page.locator('#public-profile-fishing-methods')).toHaveCount(0);
-    await expect(page.locator('#public-profile-preferred-species')).toHaveCount(0);
+        await page.goto(`/profile/${profile.userId}`);
+        await expect(page.locator('#public-profile-loading')).toBeHidden();
+        await expect(page.locator('#public-profile-display-name')).toHaveText(displayName);
+        await expect(page.locator('#public-profile-home-region')).toHaveText(homeRegion);
+        await expect(page.locator('#public-profile-photo')).toHaveCount(0);
+        await expect(page.locator('#public-profile-fishing-methods')).toHaveCount(0);
+        await expect(page.locator('#public-profile-preferred-species')).toHaveCount(0);
+    });
 });
 
 async function openCatchEdit(page, id) {

--- a/tests/FishingLogBook.E2E/specs/photo-location-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/photo-location-online.spec.mjs
@@ -1,0 +1,121 @@
+import { test, expect } from '../support/fixtures.mjs';
+import { createCatch, reloadServerCatches, testName } from '../support/catch-journey.mjs';
+
+test('records multiple photographs and retains their association after reload', async ({ page }) => {
+    const id = await createCatch(page, true, { photoCount: 2 });
+
+    const persisted = await reloadServerCatches(page);
+    const catchRecord = persisted.find(candidate => candidate.id === id);
+    expect(catchRecord?.photographs).toHaveLength(2);
+    await expect(page.locator(`#catch-card-photo-count-${id}`)).toContainText('1');
+    await expect(page.locator(`#catch-card-photo-next-${id}`)).toBeVisible();
+});
+
+test('prevents removal of the only catch photograph', async ({ page }) => {
+    const id = await createCatch(page, true);
+    await openCatchEdit(page, id);
+
+    await page.locator('#catch-edit-photo-remove').click();
+    await expect(page.locator('#catch-edit-photo-last')).toBeVisible();
+    const persisted = await reloadServerCatches(page);
+    expect(persisted.find(candidate => candidate.id === id)?.photographs).toHaveLength(1);
+});
+
+test('stores granted browser location with the catch', async ({ page, context }) => {
+    const latitude = 53.3498;
+    const longitude = -6.2603;
+    await prepareGrantedLocation(page, context, latitude, longitude);
+    const id = await createCatch(page, true, { waitForLocation: true });
+
+    const persisted = await reloadServerCatches(page);
+    const location = persisted.find(candidate => candidate.id === id)?.location;
+    expect(location).toEqual(expect.objectContaining({ latitude, longitude }));
+});
+
+test('keeps Record Catch usable when browser location is denied', async ({ page }) => {
+    await prepareDeniedLocation(page);
+    const id = await createCatch(page, true, { allowLocation: true });
+
+    const persisted = await reloadServerCatches(page);
+    const catchRecord = persisted.find(candidate => candidate.id === id);
+    expect(catchRecord).toBeDefined();
+    expect(catchRecord.location).toBeNull();
+    await expect(page.locator(`#catch-card-${id}`)).toBeVisible();
+});
+
+test('publishes only the Profile details selected by the angler', async ({ page }) => {
+    const profileResponse = page.waitForResponse(response =>
+        response.url().endsWith('/api/profiles/me')
+        && response.request().method() === 'GET'
+        && response.ok());
+    await page.goto('/profile');
+    const profile = await profileResponse.then(response => response.json());
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    const displayName = testName('public-angler');
+    const homeRegion = testName('public-water');
+    await page.locator('#profile-display-name').fill(displayName);
+    await page.locator('#profile-home-region').fill(homeRegion);
+    await ensureChecked(page.locator('#profile-show-display-name'));
+    await ensureChecked(page.locator('#profile-show-home-region'));
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().endsWith('/api/profiles/me/fishing-preferences')
+            && response.request().method() === 'PUT'
+            && response.ok()),
+        page.locator('#profile-save-button').click()
+    ]);
+
+    await page.goto(`/profile/${profile.userId}`);
+    await expect(page.locator('#public-profile-loading')).toBeHidden();
+    await expect(page.locator('#public-profile-display-name')).toHaveText(displayName);
+    await expect(page.locator('#public-profile-home-region')).toHaveText(homeRegion);
+    await expect(page.locator('#public-profile-photo')).toHaveCount(0);
+    await expect(page.locator('#public-profile-fishing-methods')).toHaveCount(0);
+    await expect(page.locator('#public-profile-preferred-species')).toHaveCount(0);
+});
+
+async function openCatchEdit(page, id) {
+    await page.locator(`#catch-card-menu-${id}`).click();
+    await page.locator(`#catch-card-edit-${id}`).click();
+    await expect(page.locator('#catch-edit-loading')).toBeHidden();
+}
+
+async function prepareGrantedLocation(page, context, latitude, longitude) {
+    await context.grantPermissions(['geolocation'], { origin: 'http://localhost:5019' });
+    await context.setGeolocation({ latitude, longitude, accuracy: 8 });
+    await page.addInitScript(() => {
+        globalThis.e2eLocationCompleted = false;
+        const original = navigator.geolocation.getCurrentPosition.bind(navigator.geolocation);
+        navigator.geolocation.getCurrentPosition = (success, error, options) => original(
+            position => {
+                globalThis.e2eLocationCompleted = true;
+                success(position);
+            },
+            error,
+            options);
+    });
+    await clearLocationPromptDismissal(page);
+}
+
+async function prepareDeniedLocation(page) {
+    await page.addInitScript(() => {
+        globalThis.e2eLocationCompleted = false;
+        navigator.geolocation.getCurrentPosition = (_success, error) => {
+            globalThis.e2eLocationCompleted = true;
+            error({ code: 1, message: 'Permission denied by E2E browser fixture.' });
+        };
+    });
+    await clearLocationPromptDismissal(page);
+}
+
+async function clearLocationPromptDismissal(page) {
+    await page.goto('/catches/record');
+    await expect(page.locator('#record-catch-title')).toBeVisible();
+    await page.evaluate(() => localStorage.removeItem('flb-location-prompt-dismissed'));
+}
+
+async function ensureChecked(locator) {
+    if (!await locator.isChecked()) {
+        await locator.check();
+    }
+}

--- a/tests/FishingLogBook.E2E/specs/profile-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/profile-online.spec.mjs
@@ -1,0 +1,39 @@
+import { test, expect } from '../support/fixtures.mjs';
+import { testName } from '../support/catch-journey.mjs';
+
+test('updates personal profile details and retains them after reload', async ({ page }) => {
+    const displayName = testName('angler');
+    const homeRegion = testName('water');
+    await page.goto('/profile');
+    await expect(page.locator('#profile-loading')).toBeHidden();
+
+    await page.locator('#profile-display-name').fill(displayName);
+    await page.locator('#profile-home-region').fill(homeRegion);
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().endsWith('/api/profiles/me/fishing-preferences')
+            && response.request().method() === 'PUT'
+            && response.ok()),
+        page.locator('#profile-save-button').click()
+    ]);
+
+    await page.reload();
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    await expect(page.locator('#profile-display-name')).toHaveValue(displayName);
+    await expect(page.locator('#profile-home-region')).toHaveValue(homeRegion);
+});
+
+test('leaving Profile does not persist unsaved personal-detail changes', async ({ page }) => {
+    await page.goto('/profile');
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    const savedDisplayName = await page.locator('#profile-display-name').inputValue();
+    const unsavedDisplayName = testName('unsaved');
+
+    await page.locator('#profile-display-name').fill(unsavedDisplayName);
+    await page.goto('/catches');
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
+    await page.goto('/profile');
+    await expect(page.locator('#profile-loading')).toBeHidden();
+    await expect(page.locator('#profile-display-name')).toHaveValue(savedDisplayName);
+    await expect(page.locator('#profile-display-name')).not.toHaveValue(unsavedDisplayName);
+});

--- a/tests/FishingLogBook.E2E/specs/profile-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/profile-online.spec.mjs
@@ -1,26 +1,27 @@
 import { test, expect } from '../support/fixtures.mjs';
 import { testName } from '../support/catch-journey.mjs';
+import { withRestoredProfileState } from '../support/profile-state.mjs';
 
 test('updates personal profile details and retains them after reload', async ({ page }) => {
-    const displayName = testName('angler');
-    const homeRegion = testName('water');
-    await page.goto('/profile');
-    await expect(page.locator('#profile-loading')).toBeHidden();
+    await withRestoredProfileState(page, async () => {
+        const displayName = testName('angler');
+        const homeRegion = testName('water');
 
-    await page.locator('#profile-display-name').fill(displayName);
-    await page.locator('#profile-home-region').fill(homeRegion);
-    await Promise.all([
-        page.waitForResponse(response =>
-            response.url().endsWith('/api/profiles/me/fishing-preferences')
-            && response.request().method() === 'PUT'
-            && response.ok()),
-        page.locator('#profile-save-button').click()
-    ]);
+        await page.locator('#profile-display-name').fill(displayName);
+        await page.locator('#profile-home-region').fill(homeRegion);
+        await Promise.all([
+            page.waitForResponse(response =>
+                response.url().endsWith('/api/profiles/me/fishing-preferences')
+                && response.request().method() === 'PUT'
+                && response.ok()),
+            page.locator('#profile-save-button').click()
+        ]);
 
-    await page.reload();
-    await expect(page.locator('#profile-loading')).toBeHidden();
-    await expect(page.locator('#profile-display-name')).toHaveValue(displayName);
-    await expect(page.locator('#profile-home-region')).toHaveValue(homeRegion);
+        await page.reload();
+        await expect(page.locator('#profile-loading')).toBeHidden();
+        await expect(page.locator('#profile-display-name')).toHaveValue(displayName);
+        await expect(page.locator('#profile-home-region')).toHaveValue(homeRegion);
+    });
 });
 
 test('leaving Profile does not persist unsaved personal-detail changes', async ({ page }) => {

--- a/tests/FishingLogBook.E2E/support/catch-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/catch-journey.mjs
@@ -28,7 +28,7 @@ export async function recordCatch(page, notes, waitForServer = false) {
     return id;
 }
 
-export async function createCatch(page, waitForServer = false) {
+export async function createCatch(page, waitForServer = false, options = {}) {
     if (new URL(page.url()).pathname !== '/catches') {
         await page.goto('/catches');
     }
@@ -38,8 +38,10 @@ export async function createCatch(page, waitForServer = false) {
         cards.map(card => card.id.replace('catch-card-', ''))));
     await page.locator('#catch-record-link').click();
     await expect(page.locator('#record-catch-title')).toBeVisible();
-    await page.locator('#record-catch-method-Fly').click();
-    await page.locator('#record-catch-species-BrownTrout').click();
+    const methodCode = options.methodCode ?? 'Fly';
+    const speciesCode = options.speciesCode ?? 'BrownTrout';
+    await selectCatalogueValue(page, 'method', methodCode);
+    await selectCatalogueValue(page, 'species', speciesCode);
     await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles({
         name: 'e2e-catch.png', mimeType: 'image/png', buffer: png
     });
@@ -68,6 +70,19 @@ export async function createCatch(page, waitForServer = false) {
     const card = page.locator(`#catch-card-${id}`);
     await expect(card).toBeVisible();
     return id;
+}
+
+async function selectCatalogueValue(page, type, code) {
+    const chip = page.locator(`#record-catch-${type}-${code}`);
+    if (await chip.count() > 0) {
+        await chip.click();
+        return;
+    }
+
+    await page.locator(`#record-catch-${type}-more`).click();
+    await page.locator('#catalogue-picker-modal-search').fill(code);
+    await page.locator(`#catalogue-picker-modal-option-${code}`).click();
+    await page.locator('#catalogue-picker-modal-save').click();
 }
 
 export async function editCatch(page, id, changes, waitForServer = false) {

--- a/tests/FishingLogBook.E2E/support/catch-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/catch-journey.mjs
@@ -12,11 +12,23 @@ export async function reloadServerCatches(page) {
         && response.request().method() === 'GET'
         && response.ok())
         .then(response => response.json());
-    await page.reload();
+    if (new URL(page.url()).pathname === '/catches') {
+        await page.reload();
+    } else {
+        await page.goto('/catches');
+    }
     return catches;
 }
 
 export async function recordCatch(page, notes, waitForServer = false) {
+    const id = await createCatch(page, waitForServer);
+    await editCatch(page, id, { notes }, waitForServer);
+    await page.locator('a[href="/catches"]').first().click();
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+    return id;
+}
+
+export async function createCatch(page, waitForServer = false) {
     if (new URL(page.url()).pathname !== '/catches') {
         await page.goto('/catches');
     }
@@ -31,8 +43,21 @@ export async function recordCatch(page, notes, waitForServer = false) {
     await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles({
         name: 'e2e-catch.png', mimeType: 'image/png', buffer: png
     });
+    const synchronised = waitForServer
+        ? Promise.all([
+            page.waitForResponse(response =>
+                response.url().endsWith('/api/catches')
+                && response.request().method() === 'POST'
+                && response.ok()),
+            page.waitForResponse(response =>
+                /\/api\/catches\/[0-9a-f-]+\/photographs$/i.test(new URL(response.url()).pathname)
+                && response.request().method() === 'POST'
+                && response.ok())
+        ])
+        : null;
     await page.locator('#save-catch-button').click();
     await expect(page.locator('#catch-saved')).toBeVisible();
+    if (synchronised) await synchronised;
     await page.locator('#catch-view-catches').click();
     await expect(page.locator('#catch-list-loading')).toBeHidden();
     await expect(page.locator('.catch-card')).toHaveCount(existingIds.size + 1);
@@ -42,15 +67,26 @@ export async function recordCatch(page, notes, waitForServer = false) {
     if (!id) throw new Error('The newly recorded Catch could not be identified.');
     const card = page.locator(`#catch-card-${id}`);
     await expect(card).toBeVisible();
+    return id;
+}
+
+export async function editCatch(page, id, changes, waitForServer = false) {
+    if (new URL(page.url()).pathname !== '/catches') {
+        await page.goto('/catches');
+        await expect(page.locator('#catch-list-loading')).toBeHidden();
+    }
     await page.locator(`#catch-card-menu-${id}`).click();
     await page.locator(`#catch-card-edit-${id}`).click();
-    await page.locator('#catch-edit-notes').fill(notes);
+    await expect(page.locator('#catch-edit-loading')).toBeHidden();
+    for (const [field, value] of Object.entries(changes)) {
+        await page.locator(`#catch-edit-${field}`).fill(value);
+    }
     const save = page.locator('#catch-edit-save');
     if (waitForServer) {
         await Promise.all([
             page.waitForResponse(response =>
-                response.url().includes('/api/catches')
-                && ['POST', 'PUT'].includes(response.request().method())
+                response.url().endsWith('/api/catches')
+                && response.request().method() === 'POST'
                 && response.ok()),
             save.click()
         ]);
@@ -58,7 +94,4 @@ export async function recordCatch(page, notes, waitForServer = false) {
         await save.click();
     }
     await expect(page.locator('#catch-edit-saved')).toBeVisible();
-    await page.locator('a[href="/catches"]').first().click();
-    await expect(page.locator('#catch-list-title')).toBeVisible();
-    return id;
 }

--- a/tests/FishingLogBook.E2E/support/catch-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/catch-journey.mjs
@@ -42,19 +42,32 @@ export async function createCatch(page, waitForServer = false, options = {}) {
     const speciesCode = options.speciesCode ?? 'BrownTrout';
     await selectCatalogueValue(page, 'method', methodCode);
     await selectCatalogueValue(page, 'species', speciesCode);
-    await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles({
-        name: 'e2e-catch.png', mimeType: 'image/png', buffer: png
-    });
+    const photoCount = options.photoCount ?? 1;
+    await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles(
+        Array.from({ length: photoCount }, (_, index) => ({
+            name: `e2e-catch-${index + 1}.png`, mimeType: 'image/png', buffer: png
+        })));
+    if (options.allowLocation) {
+        await page.locator('#catch-location-allow').click();
+    }
+    if (options.allowLocation || options.waitForLocation) {
+        await page.waitForFunction(() => globalThis.e2eLocationCompleted === true);
+    }
+    let uploadedPhotographs = 0;
     const synchronised = waitForServer
         ? Promise.all([
             page.waitForResponse(response =>
                 response.url().endsWith('/api/catches')
                 && response.request().method() === 'POST'
                 && response.ok()),
-            page.waitForResponse(response =>
-                /\/api\/catches\/[0-9a-f-]+\/photographs$/i.test(new URL(response.url()).pathname)
-                && response.request().method() === 'POST'
-                && response.ok())
+            page.waitForResponse(response => {
+                const isPhotographUpload =
+                    /\/api\/catches\/[0-9a-f-]+\/photographs$/i.test(new URL(response.url()).pathname)
+                    && response.request().method() === 'POST'
+                    && response.ok();
+                if (isPhotographUpload) uploadedPhotographs += 1;
+                return isPhotographUpload && uploadedPhotographs === photoCount;
+            })
         ])
         : null;
     await page.locator('#save-catch-button').click();

--- a/tests/FishingLogBook.E2E/support/profile-state.mjs
+++ b/tests/FishingLogBook.E2E/support/profile-state.mjs
@@ -1,0 +1,81 @@
+export async function withRestoredProfileState(page, journey) {
+    const snapshot = await captureProfileState(page);
+    try {
+        await journey(snapshot);
+    } finally {
+        await restoreProfileState(page, snapshot);
+    }
+}
+
+export async function captureProfileState(page) {
+    const profileResponse = page.waitForResponse(response =>
+        response.url().endsWith('/api/profiles/me')
+        && response.request().method() === 'GET'
+        && response.ok());
+    const preferencesResponse = page.waitForResponse(response =>
+        response.url().endsWith('/api/profiles/me/fishing-preferences')
+        && response.request().method() === 'GET'
+        && response.ok());
+
+    await page.goto('/profile');
+    const [profileResult, preferencesResult] = await Promise.all([profileResponse, preferencesResponse]);
+    await page.locator('#profile-loading').waitFor({ state: 'hidden' });
+    const authorization = profileResult.request().headers().authorization;
+    if (!authorization) {
+        throw new Error('Authenticated Profile request did not contain an authorization header.');
+    }
+
+    return {
+        authorization,
+        profileUrl: profileResult.url(),
+        preferencesUrl: preferencesResult.url(),
+        profile: await profileResult.json(),
+        preferences: await preferencesResult.json()
+    };
+}
+
+export async function restoreProfileState(page, snapshot) {
+    const headers = { authorization: snapshot.authorization };
+    const profileResponse = await page.request.put(snapshot.profileUrl, {
+        headers,
+        data: buildProfileUpdate(snapshot.profile)
+    });
+    if (!profileResponse.ok()) {
+        throw new Error(`Profile cleanup failed with HTTP ${profileResponse.status()}.`);
+    }
+
+    const preferencesResponse = await page.request.put(snapshot.preferencesUrl, {
+        headers,
+        data: buildPreferencesUpdate(snapshot.preferences)
+    });
+    if (!preferencesResponse.ok()) {
+        throw new Error(`Fishing-preferences cleanup failed with HTTP ${preferencesResponse.status()}.`);
+    }
+}
+
+export function buildProfileUpdate(profile) {
+    return {
+        displayName: profile.displayName,
+        homeRegion: profile.homeRegion,
+        showDisplayName: profile.showDisplayName,
+        showPhotograph: profile.showPhotograph,
+        showHomeRegion: profile.showHomeRegion,
+        showPreferredFishingMethods: profile.showPreferredFishingMethods,
+        showPreferredSpecies: profile.showPreferredSpecies,
+        preferredWeightUnit: profile.preferredWeightUnit,
+        preferredLengthUnit: profile.preferredLengthUnit
+    };
+}
+
+export function buildPreferencesUpdate(preferences) {
+    return {
+        methods: preferences.methods.map(method => ({
+            fishingMethodId: method.fishingMethodId,
+            isDefault: method.isDefault,
+            species: method.species.map(species => ({
+                speciesId: species.speciesId,
+                isDefault: species.isDefault
+            }))
+        }))
+    };
+}

--- a/tests/FishingLogBook.E2E/tests/config.test.mjs
+++ b/tests/FishingLogBook.E2E/tests/config.test.mjs
@@ -20,15 +20,17 @@ test('requires explicit enablement and dedicated Cognito secrets', async () => {
     assert.match(workflow, /secrets\.E2E_COGNITO_PASSWORD/);
 });
 
-test('provides project-local headed, debug and single-test commands', async () => {
+test('provides project-local headed, debug, report and single-test commands', async () => {
     const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
     const rootPackageJson = JSON.parse(await readFile(new URL('../../../package.json', import.meta.url), 'utf8'));
 
     assert.equal(packageJson.scripts['test-e2e'], 'playwright test --headed --workers=1');
     assert.equal(packageJson.scripts['test-e2e-debug'], 'playwright test --debug --workers=1');
+    assert.equal(packageJson.scripts['test-e2e-report'], 'playwright show-report artifacts/report');
     assert.equal(packageJson.scripts['test-e2e-single'], 'playwright test --headed --workers=1 --grep');
     assert.equal(rootPackageJson.scripts['test-e2e'], 'npm --prefix tests/FishingLogBook.E2E run test-e2e');
     assert.equal(rootPackageJson.scripts['test-e2e-debug'], 'npm --prefix tests/FishingLogBook.E2E run test-e2e-debug');
+    assert.equal(rootPackageJson.scripts['test-e2e-report'], 'npm --prefix tests/FishingLogBook.E2E run test-e2e-report');
     assert.equal(rootPackageJson.scripts['test-e2e-single'], 'npm --prefix tests/FishingLogBook.E2E run test-e2e-single --');
 });
 

--- a/tests/FishingLogBook.E2E/tests/profile-state.test.mjs
+++ b/tests/FishingLogBook.E2E/tests/profile-state.test.mjs
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildPreferencesUpdate,
+    buildProfileUpdate,
+    restoreProfileState,
+    withRestoredProfileState
+} from '../support/profile-state.mjs';
+
+const profile = {
+    userId: 'ignored',
+    displayName: 'Original angler',
+    photographId: 'ignored',
+    photographUrl: 'ignored',
+    photographContentType: 'ignored',
+    homeRegion: 'Original water',
+    showDisplayName: true,
+    showPhotograph: false,
+    showHomeRegion: true,
+    showPreferredFishingMethods: false,
+    showPreferredSpecies: true,
+    preferredWeightUnit: 1,
+    preferredLengthUnit: 0,
+    onboardingCompleted: true
+};
+
+const preferences = {
+    methods: [{
+        fishingMethodId: 'method-id',
+        code: 'Fly',
+        name: 'Fly',
+        isDefault: true,
+        species: [{
+            speciesId: 'species-id',
+            code: 'BrownTrout',
+            name: 'Brown Trout',
+            isDefault: true
+        }]
+    }]
+};
+
+test('builds cleanup payloads without response-only Profile and catalogue fields', () => {
+    assert.deepEqual(buildProfileUpdate(profile), {
+        displayName: 'Original angler',
+        homeRegion: 'Original water',
+        showDisplayName: true,
+        showPhotograph: false,
+        showHomeRegion: true,
+        showPreferredFishingMethods: false,
+        showPreferredSpecies: true,
+        preferredWeightUnit: 1,
+        preferredLengthUnit: 0
+    });
+    assert.deepEqual(buildPreferencesUpdate(preferences), {
+        methods: [{
+            fishingMethodId: 'method-id',
+            isDefault: true,
+            species: [{ speciesId: 'species-id', isDefault: true }]
+        }]
+    });
+});
+
+test('restores both persisted Profile boundaries with the captured authorization', async () => {
+    const calls = [];
+    const page = {
+        request: {
+            put: async (url, options) => {
+                calls.push({ url, options });
+                return { ok: () => true, status: () => 200 };
+            }
+        }
+    };
+    const snapshot = {
+        authorization: 'Bearer hidden-test-token',
+        profileUrl: 'https://api.test/api/profiles/me',
+        preferencesUrl: 'https://api.test/api/profiles/me/fishing-preferences',
+        profile,
+        preferences
+    };
+
+    await restoreProfileState(page, snapshot);
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].url, snapshot.profileUrl);
+    assert.equal(calls[1].url, snapshot.preferencesUrl);
+    assert.equal(calls[0].options.headers.authorization, snapshot.authorization);
+    assert.deepEqual(calls[0].options.data, buildProfileUpdate(profile));
+    assert.deepEqual(calls[1].options.data, buildPreferencesUpdate(preferences));
+});
+
+test('fails cleanup when either persisted boundary rejects restoration', async () => {
+    const page = {
+        request: {
+            put: async url => ({
+                ok: () => !url.endsWith('/fishing-preferences'),
+                status: () => 503
+            })
+        }
+    };
+    const snapshot = {
+        authorization: 'Bearer hidden-test-token',
+        profileUrl: 'https://api.test/api/profiles/me',
+        preferencesUrl: 'https://api.test/api/profiles/me/fishing-preferences',
+        profile,
+        preferences
+    };
+
+    await assert.rejects(
+        restoreProfileState(page, snapshot),
+        /Fishing-preferences cleanup failed with HTTP 503/);
+});
+
+test('restores captured state when the journey fails', async () => {
+    const calls = [];
+    const responses = [
+        response('https://api.test/api/profiles/me', profile),
+        response('https://api.test/api/profiles/me/fishing-preferences', preferences)
+    ];
+    const page = {
+        waitForResponse: predicate => Promise.resolve(responses.find(predicate)),
+        goto: async () => undefined,
+        locator: () => ({ waitFor: async () => undefined }),
+        request: {
+            put: async (url, options) => {
+                calls.push({ url, options });
+                return { ok: () => true, status: () => 200 };
+            }
+        }
+    };
+
+    await assert.rejects(
+        withRestoredProfileState(page, async () => {
+            throw new Error('Journey failed.');
+        }),
+        /Journey failed/);
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].url, 'https://api.test/api/profiles/me');
+    assert.equal(calls[1].url, 'https://api.test/api/profiles/me/fishing-preferences');
+});
+
+function response(url, payload) {
+    return {
+        url: () => url,
+        ok: () => true,
+        json: async () => payload,
+        request: () => ({
+            method: () => 'GET',
+            headers: () => ({ authorization: 'Bearer hidden-test-token' })
+        })
+    };
+}


### PR DESCRIPTION
## Summary

Expands the living authenticated online E2E backlog from 3 to 24 Playwright journeys using the existing disposable PostgreSQL, real API/Web, and credentialed Cognito harness.

Coverage added includes:

- canonical Catch recording, server re-read, supported photograph upload, multiple photographs, search and filtering;
- Catch Edit persistence for method/species, caught-on, weight, length, bait/lure and notes;
- validation boundaries, final-photograph protection, and catch independence;
- granted and denied location journeys;
- Profile details, privacy, preferences, units, transactional picker cancellation and public-profile visibility;
- authenticated navigation, deep-link refresh, About, Diagnostics and Install;
- root/project-local headed, debug, single-test and HTML-report commands.

Contributes to #157. The issue intentionally remains open as a living coverage backlog.

## Validation

- E2E harness/configuration tests: **8/8 passed**
- Targeted batches: **5/5 passed** for each batch
- Full expanded E2E suite: **24/24 passed**
- Solution build during the implementation pass: succeeded with 0 warnings and 0 errors
- `git diff --check`: passed

The E2E report can now be opened from the repository root with:

```powershell
npm run test-e2e-report
```

## Deliberate boundaries

- No production application code was changed.
- The harness uploads tiny fixture PNGs through local test infrastructure; it does not populate DEV or PROD R2.
- Native camera UI is not browser-automatable.
- First-run onboarding still needs an isolated reported-user harness because global setup completes onboarding.
- Cross-owner security journeys still require a second dedicated Cognito E2E account.
- Offline implementation remains outside #157.

## Product finding

While backfilling the Edit Catch photograph journey, the existing application returned HTTP 404 from `POST /api/catches/{id}/photographs/upload-url` after initial Catch synchronisation. The failing journey was not encoded as expected behaviour. It is documented in #157 and remains unchecked pending a production fix.

## Self review

- Issue/AC: **PASS** — completed scoped online journeys were checked; #157 remains open.
- Architecture/CQRS: **PASS / N/A** — no production or CQRS changes.
- Rules: **PASS** — stable selectors, application-state waits, unique test data and no arbitrary sleeps.
- Security/privacy: **PASS** — existing credentialed auth path retained; private/public Profile assertions added without exposing credentials.
- Database/migrations: **N/A** — disposable existing E2E database only; no migrations.
- Tests/coverage: **PASS** — 24/24 full E2E and 8/8 harness tests.
- Browser: **PASS** — journeys exercise the real browser, Web/API and persistence boundaries.
- Web/UI/localisation: **PASS / N/A** — no production UI or resource changes.
- Code smells: **PASS** — shared journey helpers extended narrowly; no test-only production hooks.
- CI/deployment: **PASS** — no deployment or infrastructure changes.

### Findings discovered during self-review

1. Edit Catch photograph addition currently reaches an API 404.
2. Native camera interaction, isolated onboarding, and multi-owner security remain harness limitations.

### Fixes made

1. Kept the broken Edit photograph journey unchecked and documented the product defect rather than normalising it.
2. Added deterministic root/project-local E2E commands, including HTML report access.

### Remaining deliberate gaps

- Physical native-camera validation.
- Isolated first-run onboarding coverage.
- Multi-user ownership coverage.
- Edit Catch photograph addition until the production 404 is resolved.
