### PR TITLE
FLB#134 | Capture weight and length with angler-friendly controls

### DIFF
--- a/src/FishingLogBook.Web/Features/Catch/Components/CatchEditEditor/CatchEditEditor.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/CatchEditEditor/CatchEditEditor.razor
@@ -1,4 +1,5 @@
 @using FishingLogBook.Shared.Constants
+@using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor
 
 <MudExpansionPanels Elevation="1" MultiExpansion="true" id="@(IdPrefix + "-sections")">
     <MudExpansionPanel Text="@Loc["Catch_EditDetailsSection"]"
@@ -51,16 +52,20 @@
                 </MudStack>
             </MudStack>
 
-            <MudTextField @bind-Value="_weightText"
-                          Label="@WeightLabel"
-                          Immediate="true"
-                          InputType="InputType.Number"
-                          id="@(IdPrefix + "-weight")" />
-            <MudTextField @bind-Value="_lengthText"
-                          Label="@LengthLabel"
-                          Immediate="true"
-                          InputType="InputType.Number"
-                          id="@(IdPrefix + "-length")" />
+            <MudStack Row="true" Spacing="2" Class="catch-edit-measurements">
+                <MeasurementField IsWeight="true"
+                                  Value="_weight"
+                                  ValueChanged="SetWeight"
+                                  WeightUnit="Preferences.WeightUnit"
+                                  LengthUnit="Preferences.LengthUnit"
+                                  Id="@(IdPrefix + "-weight")" />
+                <MeasurementField IsWeight="false"
+                                  Value="_length"
+                                  ValueChanged="SetLength"
+                                  WeightUnit="Preferences.WeightUnit"
+                                  LengthUnit="Preferences.LengthUnit"
+                                  Id="@(IdPrefix + "-length")" />
+            </MudStack>
             <MudTextField @bind-Value="_baitOrLure"
                           Label="@Loc["Catch_EditBaitOrLure"]"
                           MaxLength="@CatchDetailConstants.MaxBaitOrLureLength"

--- a/src/FishingLogBook.Web/Features/Catch/Components/CatchEditEditor/CatchEditEditor.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/CatchEditEditor/CatchEditEditor.razor.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
@@ -22,8 +21,8 @@ public partial class CatchEditEditor : ComponentBase
     private Guid _boundCatchId;
     private CatchModel _catch = default!;
     private string _speciesName = string.Empty;
-    private string _weightText = string.Empty;
-    private string _lengthText = string.Empty;
+    private decimal? _weight;
+    private decimal? _length;
     private string _method = string.Empty;
     private string _baitOrLure = string.Empty;
     private string _notes = string.Empty;
@@ -66,42 +65,6 @@ public partial class CatchEditEditor : ComponentBase
 
     [Inject]
     private IModalService ModalService { get; set; } = default!;
-
-    private string WeightUnitLabel
-    {
-        get
-        {
-            return Preferences.WeightUnit == WeightUnitEnum.Lb
-                ? Loc["Catch_WeightUnitShort_Lb"]
-                : Loc["Catch_WeightUnitShort_Kg"];
-        }
-    }
-
-    private string LengthUnitLabel
-    {
-        get
-        {
-            return Preferences.LengthUnit == LengthUnitEnum.In
-                ? Loc["Catch_LengthUnitShort_In"]
-                : Loc["Catch_LengthUnitShort_Cm"];
-        }
-    }
-
-    private string WeightLabel
-    {
-        get
-        {
-            return $"{Loc["Catch_EditWeight"]} ({WeightUnitLabel})";
-        }
-    }
-
-    private string LengthLabel
-    {
-        get
-        {
-            return $"{Loc["Catch_EditLength"]} ({LengthUnitLabel})";
-        }
-    }
 
     private IReadOnlyList<CatchChipOptionModel> MethodOptions
     {
@@ -287,29 +250,15 @@ public partial class CatchEditEditor : ComponentBase
             return null;
         }
 
-        if (!TryParseMeasurement(_weightText, out var displayWeight))
+        if (!CatchDetailConstants.IsWeightValid(_weight))
         {
-            _validationMessage = Loc["Catch_EditWeightInvalid", WeightUnitLabel, Measurement.MaxDisplayWeight(Preferences.WeightUnit)];
+            _validationMessage = Loc["Catch_MeasurementInvalid"];
             return null;
         }
 
-        var weight = Measurement.ToCanonicalWeight(displayWeight, Preferences.WeightUnit, _catch.Weight);
-        if (!CatchDetailConstants.IsWeightValid(weight))
+        if (!CatchDetailConstants.IsLengthValid(_length))
         {
-            _validationMessage = Loc["Catch_EditWeightInvalid", WeightUnitLabel, Measurement.MaxDisplayWeight(Preferences.WeightUnit)];
-            return null;
-        }
-
-        if (!TryParseMeasurement(_lengthText, out var displayLength))
-        {
-            _validationMessage = Loc["Catch_EditLengthInvalid", LengthUnitLabel, Measurement.MaxDisplayLength(Preferences.LengthUnit)];
-            return null;
-        }
-
-        var length = Measurement.ToCanonicalLength(displayLength, Preferences.LengthUnit, _catch.Length);
-        if (!CatchDetailConstants.IsLengthValid(length))
-        {
-            _validationMessage = Loc["Catch_EditLengthInvalid", LengthUnitLabel, Measurement.MaxDisplayLength(Preferences.LengthUnit)];
+            _validationMessage = Loc["Catch_MeasurementInvalid"];
             return null;
         }
 
@@ -326,12 +275,12 @@ public partial class CatchEditEditor : ComponentBase
             return null;
         }
 
-        var metadataChanged = HasDetailsChanged(speciesName, weight, length, method, baitOrLure, notes, caughtOn.Value);
+        var metadataChanged = HasDetailsChanged(speciesName, _weight, _length, method, baitOrLure, notes, caughtOn.Value);
         var updated = _catch with
         {
             SpeciesName = speciesName,
-            Weight = weight,
-            Length = length,
+            Weight = _weight,
+            Length = _length,
             Method = method,
             BaitOrLure = baitOrLure,
             Notes = notes,
@@ -364,10 +313,8 @@ public partial class CatchEditEditor : ComponentBase
     {
         _speciesName = catchRecord.SpeciesName ?? string.Empty;
         _speciesIsExplicit = !string.IsNullOrWhiteSpace(catchRecord.SpeciesName);
-        var displayWeight = Measurement.ToDisplayWeight(catchRecord.Weight, Preferences.WeightUnit);
-        var displayLength = Measurement.ToDisplayLength(catchRecord.Length, Preferences.LengthUnit);
-        _weightText = displayWeight?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
-        _lengthText = displayLength?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+        _weight = catchRecord.Weight;
+        _length = catchRecord.Length;
         _method = catchRecord.Method ?? string.Empty;
         _baitOrLure = catchRecord.BaitOrLure ?? string.Empty;
         _notes = catchRecord.Notes ?? string.Empty;
@@ -401,22 +348,14 @@ public partial class CatchEditEditor : ComponentBase
             : null;
     }
 
-    private static bool TryParseMeasurement(string text, out decimal? value)
+    private void SetWeight(decimal? value)
     {
-        value = null;
-        if (string.IsNullOrWhiteSpace(text))
-        {
-            return true;
-        }
+        _weight = value;
+    }
 
-        if (!decimal.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, out var parsed)
-            && !decimal.TryParse(text, NumberStyles.Number, CultureInfo.CurrentCulture, out parsed))
-        {
-            return false;
-        }
-
-        value = parsed;
-        return true;
+    private void SetLength(decimal? value)
+    {
+        _length = value;
     }
 
     private static string? TrimToNull(string? value)

--- a/src/FishingLogBook.Web/Features/Catch/Components/CatchEditEditor/CatchEditEditor.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/CatchEditEditor/CatchEditEditor.razor.css
@@ -1,1 +1,9 @@
+.catch-edit-measurements > * {
+    flex: 1 1 0;
+}
 
+@media (max-width: 340px) {
+    .catch-edit-measurements {
+        flex-direction: column;
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor
@@ -1,0 +1,105 @@
+@namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor
+
+<MudDialog id="measurement-editor-modal">
+    <TitleContent>
+        <MudText Typo="Typo.h6" id="measurement-editor-title">@Title</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3" Class="measurement-editor">
+            <div class="measurement-visual @(Model.IsWeight ? "measurement-scale" : "measurement-tape")"
+                 aria-hidden="true">
+                @if (Model.IsWeight)
+                {
+                    <svg class="measurement-dial" viewBox="0 0 240 150">
+                        <path class="measurement-scale-handle" d="M 98 18 C 98 1, 142 1, 142 18 L 135 18 C 135 9, 105 9, 105 18 Z" />
+                        <rect class="measurement-scale-neck" x="112" y="14" width="16" height="10" rx="4" />
+                        <circle class="measurement-scale-case" cx="120" cy="70" r="53" />
+                        <circle class="measurement-dial-face" cx="120" cy="70" r="46" />
+                        @foreach (var angle in DialTickAngles)
+                        {
+                            <line class="measurement-dial-tick"
+                                  x1="120" y1="24" x2="120" y2="@(IsMajorDialTick(angle) ? 36 : 31)"
+                                  transform="rotate(@angle 120 70)" />
+                        }
+                        <line class="measurement-dial-needle" x1="120" y1="70" x2="120" y2="37"
+                              transform="rotate(@DialAngle 120 70)" />
+                        <circle class="measurement-dial-pin" cx="120" cy="70" r="6" />
+                        <rect class="measurement-scale-stem" x="114" y="121" width="12" height="9" rx="3" />
+                        <path class="measurement-scale-hook" d="M 120 128 v 5 c 0 9 15 9 15 0 v -2" />
+                    </svg>
+                }
+                else
+                {
+                    <svg class="measurement-tape-visual" viewBox="0 0 240 92" preserveAspectRatio="none">
+                        <rect class="measurement-tape-case" x="10" y="16" width="48" height="60" rx="12" />
+                        <image class="measurement-tape-logo" href="images/brand/brand-mark-transparent.png"
+                               x="17" y="27" width="34" height="38" preserveAspectRatio="xMidYMid meet" />
+                        <rect class="measurement-tape-strip" x="50" y="27" width="@TapeWidth" height="38" rx="3" />
+                        @foreach (var tick in TapeTickPositions)
+                        {
+                            <line class="measurement-tape-tick"
+                                  x1="@tick" y1="27" x2="@tick" y2="@(IsMajorTapeTick(tick) ? 48 : 40)" />
+                        }
+                        <path class="measurement-tape-hook" d="@TapeHookPath" />
+                    </svg>
+                }
+            </div>
+
+            @if (IsImperialWeight)
+            {
+                <MudStack Row="true" Spacing="2">
+                    <MudNumericField T="int" Value="_pounds" ValueChanged="SetPounds"
+                                     Min="0" Label="@Loc["Catch_MeasurementPounds"]"
+                                     Variant="Variant.Outlined" Immediate="true"
+                                     id="measurement-exact-pounds" />
+                    <MudNumericField T="int" Value="_ounces" ValueChanged="SetOunces"
+                                     Min="0" Max="15" Label="@Loc["Catch_MeasurementOunces"]"
+                                     Variant="Variant.Outlined" Immediate="true"
+                                     id="measurement-exact-ounces" />
+                </MudStack>
+            }
+            else
+            {
+                <MudTextField T="string" Value="_exactText" ValueChanged="SetExactValue"
+                              Label="@ExactLabel" InputType="InputType.Number"
+                              Variant="Variant.Outlined" Immediate="true"
+                              id="measurement-exact-value" />
+            }
+
+            <MudText Typo="Typo.subtitle2">@Loc["Catch_MeasurementCoarseAdjustment"]</MudText>
+            <MudSlider T="decimal" Value="SliderValue" ValueChanged="SetSliderValue"
+                       Min="0" Max="SliderMaximum" Step="SliderStep"
+                       ValueLabel="true" Immediate="true"
+                       aria-label="@Loc["Catch_MeasurementSliderLabel", Title]"
+                       id="measurement-slider" />
+
+            <div class="measurement-fine-controls">
+                <MudIconButton Icon="@Icons.Material.Filled.Remove" Size="Size.Large"
+                               Color="Color.Primary" Variant="Variant.Outlined"
+                               OnClick="Decrease" aria-label="@DecreaseLabel"
+                               id="measurement-decrease" />
+                <MudText Typo="Typo.body1" Align="Align.Center" id="measurement-step-label">
+                    @FineStepDisplay
+                </MudText>
+                <MudIconButton Icon="@Icons.Material.Filled.Add" Size="Size.Large"
+                               Color="Color.Primary" Variant="Variant.Outlined"
+                               OnClick="Increase" aria-label="@IncreaseLabel"
+                               id="measurement-increase" />
+            </div>
+
+            @if (_validationMessage is not null)
+            {
+                <MudAlert Severity="Severity.Warning" id="measurement-validation">@_validationMessage</MudAlert>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="Clear"
+                   id="measurement-clear">@Loc["Catch_MeasurementClear"]</MudButton>
+        <MudSpacer />
+        <MudButton Variant="Variant.Text" OnClick="Cancel"
+                   id="measurement-cancel">@Loc["Modal_Cancel"]</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Apply"
+                   id="measurement-apply">@Loc["Catch_MeasurementApply"]</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.cs
@@ -60,7 +60,7 @@ public partial class MeasurementEditorModal : ComponentBase
         }
     }
 
-    private decimal SliderValue => Math.Min(DisplayValue ?? 0m, SliderMaximum);
+    private decimal SliderValue => Math.Clamp(DisplayValue ?? 0m, 0m, SliderMaximum);
 
     private static IEnumerable<int> DialTickAngles => Enumerable.Range(0, 24).Select(index => index * 15);
 

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.cs
@@ -1,0 +1,303 @@
+using System.Globalization;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+
+namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+
+public partial class MeasurementEditorModal : ComponentBase
+{
+    private const decimal MetricWeightSliderMaximum = 100m;
+    private const decimal ImperialWeightSliderMaximum = 220m;
+    private const decimal MetricLengthSliderMaximum = 300m;
+    private const decimal ImperialLengthSliderMaximum = 120m;
+    private decimal? _canonicalValue;
+    private string _exactText = string.Empty;
+    private string? _validationMessage;
+    private bool _exactEntryValid = true;
+    private int _pounds;
+    private int _ounces;
+
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter]
+    public MeasurementEditorModel Model { get; set; } = default!;
+
+    [Inject]
+    private IMeasurementService Measurement { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    protected override void OnParametersSet()
+    {
+        _canonicalValue = Model.CanonicalValue;
+        SynchroniseInputs();
+    }
+
+    private bool IsImperialWeight => Model.IsWeight && Model.WeightUnit == WeightUnitEnum.Lb;
+
+    private string Title => Model.IsWeight ? Loc["Catch_EditWeight"] : Loc["Catch_EditLength"];
+
+    private string ExactLabel
+    {
+        get
+        {
+            if (Model.IsWeight)
+            {
+                return Loc["Catch_MeasurementExactWithUnit", Loc["Catch_WeightUnitShort_Kg"]];
+            }
+
+            var unit = Model.LengthUnit == LengthUnitEnum.In
+                ? Loc["Catch_LengthUnitShort_In"]
+                : Loc["Catch_LengthUnitShort_Cm"];
+            return Loc["Catch_MeasurementExactWithUnit", unit];
+        }
+    }
+
+    private decimal SliderValue => Math.Min(DisplayValue ?? 0m, SliderMaximum);
+
+    private static IEnumerable<int> DialTickAngles => Enumerable.Range(0, 24).Select(index => index * 15);
+
+    private static IEnumerable<decimal> TapeTickPositions => Enumerable.Range(0, 18).Select(index => 56m + (index * 10m));
+
+    private decimal DialAngle => SliderValue / SliderMaximum * 359m;
+
+    private decimal TapeWidth => 12m + (SliderValue / SliderMaximum * 166m);
+
+    private string TapeHookPath
+    {
+        get
+        {
+            var end = 50m + TapeWidth;
+            return FormattableString.Invariant($"M {end} 24 v 45 h 8 v -8 h -3 v -29 h 3 v -8 z");
+        }
+    }
+
+    private decimal SliderMaximum
+    {
+        get
+        {
+            if (Model.IsWeight)
+            {
+                return Model.WeightUnit == WeightUnitEnum.Lb
+                    ? ImperialWeightSliderMaximum
+                    : MetricWeightSliderMaximum;
+            }
+
+            return Model.LengthUnit == LengthUnitEnum.In
+                ? ImperialLengthSliderMaximum
+                : MetricLengthSliderMaximum;
+        }
+    }
+
+    private decimal SliderStep
+    {
+        get
+        {
+            if (Model.IsWeight)
+            {
+                return Model.WeightUnit == WeightUnitEnum.Lb ? 0.25m : 0.1m;
+            }
+
+            return Model.LengthUnit == LengthUnitEnum.In ? 0.5m : 1m;
+        }
+    }
+
+    private decimal FineStep
+    {
+        get
+        {
+            if (Model.IsWeight)
+            {
+                return Model.WeightUnit == WeightUnitEnum.Lb ? 1m / 16m : 0.1m;
+            }
+
+            return Model.LengthUnit == LengthUnitEnum.In ? 0.25m : 1m;
+        }
+    }
+
+    private string FineStepDisplay
+    {
+        get
+        {
+            if (IsImperialWeight)
+            {
+                return Loc["Catch_MeasurementOneOunceStep"];
+            }
+
+            var unit = Model.IsWeight
+                ? Model.WeightUnit == WeightUnitEnum.Lb
+                    ? Loc["Catch_WeightUnitShort_Lb"]
+                    : Loc["Catch_WeightUnitShort_Kg"]
+                : Model.LengthUnit == LengthUnitEnum.In
+                    ? Loc["Catch_LengthUnitShort_In"]
+                    : Loc["Catch_LengthUnitShort_Cm"];
+            return Loc["Catch_MeasurementStep", FineStep, unit];
+        }
+    }
+
+    private string DecreaseLabel => Loc["Catch_MeasurementDecrease", FineStepDisplay];
+
+    private string IncreaseLabel => Loc["Catch_MeasurementIncrease", FineStepDisplay];
+
+    private decimal? DisplayValue => Model.IsWeight
+        ? Measurement.ToDisplayWeight(_canonicalValue, Model.WeightUnit)
+        : Measurement.ToDisplayLength(_canonicalValue, Model.LengthUnit);
+
+    private void SetSliderValue(decimal value)
+    {
+        SetDisplayValue(value);
+    }
+
+    private void SetExactValue(string value)
+    {
+        _exactText = value;
+        if (!TryParse(value, out var parsed))
+        {
+            _exactEntryValid = false;
+            _validationMessage = Loc["Catch_MeasurementInvalid"];
+            return;
+        }
+
+        _exactEntryValid = true;
+        SetDisplayValue(parsed);
+    }
+
+    private void SetPounds(int value)
+    {
+        _pounds = Math.Max(0, value);
+        SetImperialWeight();
+    }
+
+    private void SetOunces(int value)
+    {
+        _ounces = Math.Clamp(value, 0, 15);
+        SetImperialWeight();
+    }
+
+    private void SetImperialWeight()
+    {
+        _canonicalValue = _pounds == 0 && _ounces == 0
+            ? null
+            : Measurement.FromPoundsAndOunces(_pounds, _ounces);
+        ValidateCanonicalValue();
+    }
+
+    private void Increase()
+    {
+        if (IsImperialWeight)
+        {
+            SetImperialOunces((_pounds * 16) + _ounces + 1);
+            return;
+        }
+
+        SetDisplayValue((DisplayValue ?? 0m) + FineStep);
+    }
+
+    private void Decrease()
+    {
+        if (IsImperialWeight)
+        {
+            SetImperialOunces(Math.Max(0, (_pounds * 16) + _ounces - 1));
+            return;
+        }
+
+        SetDisplayValue(Math.Max(0m, (DisplayValue ?? 0m) - FineStep));
+    }
+
+    private void SetImperialOunces(int totalOunces)
+    {
+        _pounds = totalOunces / 16;
+        _ounces = totalOunces % 16;
+        SetImperialWeight();
+    }
+
+    private void SetDisplayValue(decimal? displayValue)
+    {
+        _exactEntryValid = true;
+        _canonicalValue = Model.IsWeight
+            ? Measurement.ToCanonicalWeight(displayValue, Model.WeightUnit, _canonicalValue)
+            : Measurement.ToCanonicalLength(displayValue, Model.LengthUnit, _canonicalValue);
+        ValidateCanonicalValue();
+        SynchroniseInputs();
+    }
+
+    private void ValidateCanonicalValue()
+    {
+        var valid = Model.IsWeight
+            ? CatchDetailConstants.IsWeightValid(_canonicalValue)
+            : CatchDetailConstants.IsLengthValid(_canonicalValue);
+        _validationMessage = valid ? null : Loc["Catch_MeasurementInvalid"].Value;
+    }
+
+    private void SynchroniseInputs()
+    {
+        if (IsImperialWeight)
+        {
+            (_pounds, _ounces) = Measurement.ToPoundsAndOunces(_canonicalValue);
+            return;
+        }
+
+        _exactText = DisplayValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+
+    private void Apply()
+    {
+        if (!_exactEntryValid)
+        {
+            return;
+        }
+
+        ValidateCanonicalValue();
+        if (_validationMessage is not null)
+        {
+            return;
+        }
+
+        MudDialog.Close(DialogResult.Ok(new MeasurementEditorResult(_canonicalValue)));
+    }
+
+    private void Clear()
+    {
+        MudDialog.Close(DialogResult.Ok(new MeasurementEditorResult(null)));
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+
+    private static bool IsMajorDialTick(int angle)
+    {
+        return angle % 45 == 0;
+    }
+
+    private static bool IsMajorTapeTick(decimal position)
+    {
+        return (position - 56m) % 50m == 0;
+    }
+
+    private static bool TryParse(string value, out decimal? parsed)
+    {
+        parsed = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        if (!decimal.TryParse(value, NumberStyles.Number, CultureInfo.CurrentCulture, out var number)
+            && !decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out number))
+        {
+            return false;
+        }
+
+        parsed = number;
+        return true;
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.css
@@ -1,0 +1,115 @@
+.measurement-editor {
+    padding-top: 0.25rem;
+}
+
+.measurement-visual {
+    position: relative;
+    display: flex;
+    min-height: 8rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border-radius: 1rem;
+    background: var(--mud-palette-background-gray);
+    color: var(--mud-palette-primary);
+}
+
+.measurement-dial {
+    position: absolute;
+    inset: 0.1rem auto auto;
+    width: min(15rem, 82%);
+    height: 7.8rem;
+}
+
+.measurement-scale-handle,
+.measurement-scale-neck,
+.measurement-scale-case,
+.measurement-scale-stem {
+    fill: var(--mud-palette-primary);
+}
+
+.measurement-scale-case {
+    opacity: 0.92;
+}
+
+.measurement-scale-hook {
+    fill: none;
+    stroke: var(--mud-palette-primary);
+    stroke-linecap: round;
+    stroke-width: 5;
+}
+
+.measurement-dial-face {
+    fill: var(--mud-palette-surface);
+    stroke: color-mix(in srgb, var(--mud-palette-primary) 28%, transparent);
+    stroke-width: 2;
+}
+
+.measurement-dial-tick {
+    stroke: var(--mud-palette-primary);
+    stroke-linecap: round;
+    stroke-width: 3;
+}
+
+.measurement-dial-needle {
+    stroke: var(--mud-palette-primary);
+    stroke-linecap: round;
+    stroke-width: 3.5;
+    transition: transform 180ms ease-out;
+}
+
+.measurement-dial-pin {
+    fill: var(--mud-palette-primary);
+}
+
+.measurement-tape-visual {
+    position: absolute;
+    inset: 0.65rem auto auto;
+    width: min(21rem, 94%);
+    height: 5.4rem;
+}
+
+.measurement-tape-case {
+    fill: var(--mud-palette-primary);
+    opacity: 0.92;
+}
+
+.measurement-tape-logo {
+    pointer-events: none;
+}
+
+.measurement-tape-strip {
+    fill: color-mix(in srgb, var(--mud-palette-primary) 14%, var(--mud-palette-surface));
+    stroke: var(--mud-palette-primary);
+    stroke-width: 1.5;
+    transition: width 180ms ease-out;
+}
+
+.measurement-tape-tick {
+    stroke: color-mix(in srgb, var(--mud-palette-primary) 70%, var(--mud-palette-text-primary));
+    stroke-width: 1.5;
+}
+
+.measurement-tape-hook {
+    fill: var(--mud-palette-primary);
+    transition: d 180ms ease-out;
+}
+
+.measurement-fine-controls {
+    display: grid;
+    grid-template-columns: 3.25rem 1fr 3.25rem;
+    align-items: center;
+    gap: 1rem;
+}
+
+::deep .measurement-fine-controls .mud-icon-button {
+    width: 3.25rem;
+    height: 3.25rem;
+}
+
+@media (max-width: 480px) {
+    .measurement-visual {
+        min-height: 7.5rem;
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModel.cs
@@ -1,0 +1,9 @@
+using FishingLogBook.Shared.Enums;
+
+namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+
+public sealed record MeasurementEditorModel(
+    bool IsWeight,
+    decimal? CanonicalValue,
+    WeightUnitEnum WeightUnit,
+    LengthUnitEnum LengthUnit);

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorResult.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorResult.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+
+public sealed record MeasurementEditorResult(decimal? CanonicalValue);

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementField.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementField.razor
@@ -1,0 +1,13 @@
+<button type="button"
+        class="measurement-field"
+        aria-label="@AccessibleLabel"
+        @onclick="OpenAsync"
+        id="@Id">
+    <span class="measurement-field-copy">
+        <MudText Typo="Typo.caption">@Label</MudText>
+        <MudText Typo="Typo.body2" Class="measurement-field-value" id="@(Id + "-value")">
+            @DisplayValue
+        </MudText>
+    </span>
+    <MudIcon Icon="@Icon" Color="Color.Primary" Size="Size.Small" aria-hidden="true" />
+</button>

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementField.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementField.razor.cs
@@ -1,0 +1,80 @@
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+
+namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+
+public partial class MeasurementField : ComponentBase
+{
+    [Parameter]
+    public bool IsWeight { get; set; }
+
+    [Parameter]
+    public decimal? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<decimal?> ValueChanged { get; set; }
+
+    [Parameter]
+    public WeightUnitEnum WeightUnit { get; set; } = WeightUnitEnum.Kg;
+
+    [Parameter]
+    public LengthUnitEnum LengthUnit { get; set; } = LengthUnitEnum.Cm;
+
+    [Parameter, EditorRequired]
+    public string Id { get; set; } = string.Empty;
+
+    [Inject]
+    private IMeasurementService Measurement { get; set; } = default!;
+
+    [Inject]
+    private IModalService ModalService { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private string Label => IsWeight ? Loc["Catch_EditWeight"] : Loc["Catch_EditLength"];
+
+    private string Icon => IsWeight ? Icons.Material.Filled.Scale : Icons.Material.Filled.Straighten;
+
+    private string DisplayValue
+    {
+        get
+        {
+            if (Value is null)
+            {
+                return Loc["Catch_MeasurementNotRecorded"];
+            }
+
+            return IsWeight
+                ? Measurement.FormatWeight(Value, WeightUnit, WeightUnitLabel, Loc["Catch_WeightUnitShort_Oz"])
+                : Measurement.FormatLength(Value, LengthUnit, LengthUnitLabel);
+        }
+    }
+
+    private string AccessibleLabel => Loc["Catch_MeasurementOpen", Label, DisplayValue];
+
+    private string WeightUnitLabel => WeightUnit == WeightUnitEnum.Lb
+        ? Loc["Catch_WeightUnitShort_Lb"]
+        : Loc["Catch_WeightUnitShort_Kg"];
+
+    private string LengthUnitLabel => LengthUnit == LengthUnitEnum.In
+        ? Loc["Catch_LengthUnitShort_In"]
+        : Loc["Catch_LengthUnitShort_Cm"];
+
+    private async Task OpenAsync()
+    {
+        var result = await ModalService
+            .ShowAsync<MeasurementEditorModal, MeasurementEditorModel, MeasurementEditorResult>(
+                new MeasurementEditorModel(IsWeight, Value, WeightUnit, LengthUnit),
+                CancellationToken.None);
+        if (result is not null)
+        {
+            await ValueChanged.InvokeAsync(result.CanonicalValue);
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementField.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementField.razor.css
@@ -1,0 +1,29 @@
+.measurement-field {
+    display: flex;
+    width: 100%;
+    min-height: 3.25rem;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    background: var(--mud-palette-surface);
+    color: var(--mud-palette-text-primary);
+    cursor: pointer;
+    text-align: left;
+}
+
+.measurement-field:focus-visible {
+    outline: 3px solid var(--mud-palette-primary);
+    outline-offset: 2px;
+}
+
+.measurement-field-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+
+.measurement-field-value {
+    font-weight: 600;
+}

--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor
@@ -1,4 +1,5 @@
 @using Microsoft.AspNetCore.Components.Forms
+@using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor
 
 <PageTitle>@Loc["Catch_RecordPageTitle"]</PageTitle>
 
@@ -70,6 +71,20 @@
                         </MudStack>
                     </MudStack>
 
+                    @if (_photographs.Count > 0)
+                    {
+                        <div id="catch-photo-carousel">
+                            <CatchPhotographCarousel Photographs="CarouselPhotographs"
+                                                      Editable="@(!_isSaved)"
+                                                      ActivePhotographId="_activePhotographId"
+                                                      ActivePhotographIdChanged="OnActivePhotographChanged"
+                                                      OnRemovePhotograph="RemovePhotograph"
+                                                      ShowSinglePhotographCount="true"
+                                                      IdPrefix="catch" />
+                        </div>
+                        <MudText Typo="Typo.body2" id="catch-caught-on">@CaughtOnDisplay</MudText>
+                    }
+
                     @if (!_isSaved)
                     {
                         <div class="record-catch-photo-actions">
@@ -95,6 +110,26 @@
                                        id="catch-photo-gallery" />
                         </div>
                     }
+
+                    @if (_unsupportedFormat && !_isSaved)
+                    {
+                        <MudAlert Severity="Severity.Error" id="catch-photo-unsupported">@Loc["Catch_PhotoUnsupported"]</MudAlert>
+                    }
+
+                    <MudStack Row="true" Spacing="2" Class="record-catch-measurements">
+                        <MeasurementField IsWeight="true"
+                                          Value="_weight"
+                                          ValueChanged="SetWeight"
+                                          WeightUnit="Preferences.WeightUnit"
+                                          LengthUnit="Preferences.LengthUnit"
+                                          Id="record-catch-weight" />
+                        <MeasurementField IsWeight="false"
+                                          Value="_length"
+                                          ValueChanged="SetLength"
+                                          WeightUnit="Preferences.WeightUnit"
+                                          LengthUnit="Preferences.LengthUnit"
+                                          Id="record-catch-length" />
+                    </MudStack>
 
                     @if (!_isSaved && _locationPrompt.ShowExplainer)
                     {
@@ -136,25 +171,6 @@
                                    id="catch-location-try-again">
                             @Loc["Catch_LocationTryAgain"]
                         </MudButton>
-                    }
-
-                    @if (_unsupportedFormat && !_isSaved)
-                    {
-                        <MudAlert Severity="Severity.Error" id="catch-photo-unsupported">@Loc["Catch_PhotoUnsupported"]</MudAlert>
-                    }
-
-                    @if (_photographs.Count > 0)
-                    {
-                        <div id="catch-photo-carousel">
-                            <CatchPhotographCarousel Photographs="CarouselPhotographs"
-                                                      Editable="@(!_isSaved)"
-                                                      ActivePhotographId="_activePhotographId"
-                                                      ActivePhotographIdChanged="OnActivePhotographChanged"
-                                                      OnRemovePhotograph="RemovePhotograph"
-                                                      ShowSinglePhotographCount="true"
-                                                      IdPrefix="catch" />
-                        </div>
-                        <MudText Typo="Typo.body2" id="catch-caught-on">@CaughtOnDisplay</MudText>
                     }
 
                     @if (_isSaved)

--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.cs
@@ -23,6 +23,8 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly List<PendingPhotograph> _photographs = [];
     private DateTimeOffset? _caughtOn;
+    private decimal? _weight;
+    private decimal? _length;
     private Guid? _activePhotographId;
     private string _selectedMethod = string.Empty;
     private string _selectedSpecies = string.Empty;
@@ -326,7 +328,9 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
                     SyncStatus.SavedLocally,
                     OwnerUserId,
                     OwnerUserId,
-                    Method: method),
+                    Method: method,
+                    Weight: _weight,
+                    Length: _length),
                 _cancellationTokenSource.Token);
             _carriedMethod = method;
             _carriedSpecies = species;
@@ -357,6 +361,8 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
     {
         _photographs.Clear();
         _caughtOn = null;
+        _weight = null;
+        _length = null;
         _activePhotographId = null;
         _isSaved = false;
         _saveFailed = false;
@@ -367,6 +373,16 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
         _selectedMethod = _carriedMethod ?? string.Empty;
         _selectedSpecies = _carriedSpecies ?? string.Empty;
         _speciesIsExplicit = _carriedSpeciesWasExplicit;
+    }
+
+    private void SetWeight(decimal? value)
+    {
+        _weight = value;
+    }
+
+    private void SetLength(decimal? value)
+    {
+        _length = value;
     }
 
     private async Task AllowLocationAsync()
@@ -462,4 +478,3 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
 
     private sealed record PendingPhotograph(Guid Id, string ContentType, byte[] Bytes);
 }
-

--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.css
@@ -4,6 +4,16 @@
     gap: 0.75rem;
 }
 
+.record-catch-measurements > * {
+    flex: 1 1 0;
+}
+
+@media (max-width: 340px) {
+    .record-catch-measurements {
+        flex-direction: column;
+    }
+}
+
 .record-catch-photo-picker {
     flex: 1;
     display: inline-flex;

--- a/src/FishingLogBook.Web/Features/Catch/Services/IMeasurementService.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/IMeasurementService.cs
@@ -15,4 +15,16 @@ public interface IMeasurementService
     decimal MaxDisplayWeight(WeightUnitEnum unit);
 
     decimal MaxDisplayLength(LengthUnitEnum unit);
+
+    string FormatWeight(
+        decimal? canonicalKilograms,
+        WeightUnitEnum unit,
+        string unitLabel,
+        string ounceUnitLabel);
+
+    string FormatLength(decimal? canonicalCentimetres, LengthUnitEnum unit, string unitLabel);
+
+    (int Pounds, int Ounces) ToPoundsAndOunces(decimal? canonicalKilograms);
+
+    decimal? FromPoundsAndOunces(int pounds, int ounces);
 }

--- a/src/FishingLogBook.Web/Features/Catch/Services/MeasurementService.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Services/MeasurementService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Enums;
 
@@ -95,6 +96,65 @@ public sealed class MeasurementService : IMeasurementService
         return unit == LengthUnitEnum.In
             ? Round(CatchDetailConstants.MaxLengthCentimetres / CentimetresPerInch, ImperialDecimals)
             : CatchDetailConstants.MaxLengthCentimetres;
+    }
+
+    public string FormatWeight(
+        decimal? canonicalKilograms,
+        WeightUnitEnum unit,
+        string unitLabel,
+        string ounceUnitLabel)
+    {
+        if (canonicalKilograms is null)
+        {
+            return string.Empty;
+        }
+
+        if (unit == WeightUnitEnum.Lb)
+        {
+            var (pounds, ounces) = ToPoundsAndOunces(canonicalKilograms);
+            return $"{pounds} {unitLabel} {ounces} {ounceUnitLabel}";
+        }
+
+        return $"{ToDisplayWeight(canonicalKilograms, unit):0.##} {unitLabel}";
+    }
+
+    public string FormatLength(decimal? canonicalCentimetres, LengthUnitEnum unit, string unitLabel)
+    {
+        if (canonicalCentimetres is null)
+        {
+            return string.Empty;
+        }
+
+        return $"{ToDisplayLength(canonicalCentimetres, unit)?.ToString("0.##", CultureInfo.CurrentCulture)} {unitLabel}";
+    }
+
+    public (int Pounds, int Ounces) ToPoundsAndOunces(decimal? canonicalKilograms)
+    {
+        if (canonicalKilograms is null)
+        {
+            return (0, 0);
+        }
+
+        var totalOunces = (int)Math.Round(
+            canonicalKilograms.Value / KilogramsPerPound * 16m,
+            MidpointRounding.AwayFromZero);
+        return (totalOunces / 16, totalOunces % 16);
+    }
+
+    public decimal? FromPoundsAndOunces(int pounds, int ounces)
+    {
+        if (pounds < 0 || ounces < 0)
+        {
+            return null;
+        }
+
+        var totalOunces = (pounds * 16m) + ounces;
+        if (totalOunces <= 0)
+        {
+            return null;
+        }
+
+        return Round(totalOunces / 16m * KilogramsPerPound, CanonicalWeightDecimals);
     }
 
     private static decimal Round(decimal value, int decimals)

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -354,6 +354,9 @@
   <data name="Catch_WeightUnitShort_Lb" xml:space="preserve">
     <value>lb</value>
   </data>
+  <data name="Catch_WeightUnitShort_Oz" xml:space="preserve">
+    <value>oz</value>
+  </data>
   <data name="Catch_EditLength" xml:space="preserve">
     <value>Longueur</value>
   </data>
@@ -796,4 +799,46 @@
   <data name="OfflineDiagnostics_LastError" xml:space="preserve"><value>Dernière erreur enregistrée</value></data>
   <data name="OfflineDiagnostics_FailedStage" xml:space="preserve"><value>Étape ayant échoué</value></data>
   <data name="OfflineDiagnostics_Error" xml:space="preserve"><value>Erreur sûre</value></data>
+  <data name="Catch_MeasurementNotRecorded" xml:space="preserve">
+    <value>Non renseigné</value>
+  </data>
+  <data name="Catch_MeasurementOpen" xml:space="preserve">
+    <value>Modifier {0}. Valeur actuelle : {1}</value>
+  </data>
+  <data name="Catch_MeasurementPounds" xml:space="preserve">
+    <value>Livres</value>
+  </data>
+  <data name="Catch_MeasurementOunces" xml:space="preserve">
+    <value>Onces</value>
+  </data>
+  <data name="Catch_MeasurementExactWithUnit" xml:space="preserve">
+    <value>Valeur exacte ({0})</value>
+  </data>
+  <data name="Catch_MeasurementCoarseAdjustment" xml:space="preserve">
+    <value>Faites glisser pour ajuster</value>
+  </data>
+  <data name="Catch_MeasurementSliderLabel" xml:space="preserve">
+    <value>Régler {0}</value>
+  </data>
+  <data name="Catch_MeasurementOneOunceStep" xml:space="preserve">
+    <value>1 oz à la fois</value>
+  </data>
+  <data name="Catch_MeasurementStep" xml:space="preserve">
+    <value>{0} {1} à la fois</value>
+  </data>
+  <data name="Catch_MeasurementDecrease" xml:space="preserve">
+    <value>Diminuer de {0}</value>
+  </data>
+  <data name="Catch_MeasurementIncrease" xml:space="preserve">
+    <value>Augmenter de {0}</value>
+  </data>
+  <data name="Catch_MeasurementInvalid" xml:space="preserve">
+    <value>Saisissez une mesure supérieure à zéro et dans la plage prise en charge.</value>
+  </data>
+  <data name="Catch_MeasurementClear" xml:space="preserve">
+    <value>Effacer</value>
+  </data>
+  <data name="Catch_MeasurementApply" xml:space="preserve">
+    <value>Appliquer</value>
+  </data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -354,6 +354,9 @@
   <data name="Catch_WeightUnitShort_Lb" xml:space="preserve">
     <value>lb</value>
   </data>
+  <data name="Catch_WeightUnitShort_Oz" xml:space="preserve">
+    <value>oz</value>
+  </data>
   <data name="Catch_EditLength" xml:space="preserve">
     <value>Length</value>
   </data>
@@ -796,4 +799,46 @@
   <data name="OfflineDiagnostics_LastError" xml:space="preserve"><value>Last recorded error</value></data>
   <data name="OfflineDiagnostics_FailedStage" xml:space="preserve"><value>Failed stage</value></data>
   <data name="OfflineDiagnostics_Error" xml:space="preserve"><value>Safe error</value></data>
+  <data name="Catch_MeasurementNotRecorded" xml:space="preserve">
+    <value>Not recorded</value>
+  </data>
+  <data name="Catch_MeasurementOpen" xml:space="preserve">
+    <value>Edit {0}. Current value: {1}</value>
+  </data>
+  <data name="Catch_MeasurementPounds" xml:space="preserve">
+    <value>Pounds</value>
+  </data>
+  <data name="Catch_MeasurementOunces" xml:space="preserve">
+    <value>Ounces</value>
+  </data>
+  <data name="Catch_MeasurementExactWithUnit" xml:space="preserve">
+    <value>Exact value ({0})</value>
+  </data>
+  <data name="Catch_MeasurementCoarseAdjustment" xml:space="preserve">
+    <value>Slide to adjust</value>
+  </data>
+  <data name="Catch_MeasurementSliderLabel" xml:space="preserve">
+    <value>Adjust {0}</value>
+  </data>
+  <data name="Catch_MeasurementOneOunceStep" xml:space="preserve">
+    <value>1 oz at a time</value>
+  </data>
+  <data name="Catch_MeasurementStep" xml:space="preserve">
+    <value>{0} {1} at a time</value>
+  </data>
+  <data name="Catch_MeasurementDecrease" xml:space="preserve">
+    <value>Decrease by {0}</value>
+  </data>
+  <data name="Catch_MeasurementIncrease" xml:space="preserve">
+    <value>Increase by {0}</value>
+  </data>
+  <data name="Catch_MeasurementInvalid" xml:space="preserve">
+    <value>Enter a measurement greater than zero and within the supported range.</value>
+  </data>
+  <data name="Catch_MeasurementClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="Catch_MeasurementApply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
 </root>

--- a/tests/FishingLogBook.E2E/specs/filters-preferences-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/filters-preferences-online.spec.mjs
@@ -51,8 +51,14 @@ test('uses saved Profile measurement units when editing a catch', async ({ page 
 
         const id = await createCatch(page, true);
         await openCatchEdit(page, id);
-        await expect(page.locator('label[for="catch-edit-weight"]')).toContainText('lb');
-        await expect(page.locator('label[for="catch-edit-length"]')).toContainText('cm');
+        await page.locator('#catch-edit-weight').click();
+        await expect(page.locator('#measurement-exact-pounds')).toBeVisible();
+        await page.locator('#measurement-cancel').click();
+        await page.locator('#catch-edit-length').click();
+        await expect(page.locator('#measurement-exact-value')
+            .locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " mud-input-control ")]'))
+            .toContainText('Exact value (cm)');
+        await page.locator('#measurement-cancel').click();
     });
 });
 
@@ -110,4 +116,5 @@ async function saveProfile(page) {
             && response.ok()),
         page.locator('#profile-save-button').click()
     ]);
+    await expect(page.locator('#profile-save-button')).toBeEnabled();
 }

--- a/tests/FishingLogBook.E2E/specs/measurements-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/measurements-online.spec.mjs
@@ -1,0 +1,104 @@
+import { test, expect } from '../support/fixtures.mjs';
+import { createCatch, editCatch, reloadServerCatches } from '../support/catch-journey.mjs';
+import { withRestoredProfileState } from '../support/profile-state.mjs';
+
+test('records a catch with weight only and retains it after reload', async ({ page }) => {
+    const id = await createCatch(page, true, { weight: '3.75' });
+
+    const persisted = await reloadServerCatches(page);
+
+    expect(persisted.find(candidate => candidate.id === id)?.weight).toBe(3.75);
+    expect(persisted.find(candidate => candidate.id === id)?.length).toBeNull();
+});
+
+test('records a catch with length only and retains it after reload', async ({ page }) => {
+    const id = await createCatch(page, true, { length: '72' });
+
+    const persisted = await reloadServerCatches(page);
+
+    expect(persisted.find(candidate => candidate.id === id)?.weight).toBeNull();
+    expect(persisted.find(candidate => candidate.id === id)?.length).toBe(72);
+});
+
+test('records both measurements and shows them when reopened for editing', async ({ page }) => {
+    const id = await createCatch(page, true, { weight: '2.5', length: '64' });
+
+    await openCatchEdit(page, id);
+
+    await expect(page.locator('#catch-edit-weight-value')).toContainText('2.5 kg');
+    await expect(page.locator('#catch-edit-length-value')).toContainText('64 cm');
+});
+
+test('edits existing catch measurements and retains the updates', async ({ page }) => {
+    const id = await createCatch(page, true, { weight: '1.25', length: '40' });
+
+    await editCatch(page, id, { weight: '4.5', length: '88' }, true);
+    const persisted = await reloadServerCatches(page);
+
+    expect(persisted.find(candidate => candidate.id === id)?.weight).toBe(4.5);
+    expect(persisted.find(candidate => candidate.id === id)?.length).toBe(88);
+});
+
+test('uses metric Profile preferences for measurement entry', async ({ page }) => {
+    await withRestoredProfileState(page, async () => {
+        await setProfileUnits(page, 'Kilograms (kg)', 'Centimetres (cm)');
+
+        const id = await createCatch(page, true, { weight: '5.2', length: '91' });
+        const persisted = await reloadServerCatches(page);
+
+        expect(persisted.find(candidate => candidate.id === id)?.weight).toBe(5.2);
+        expect(persisted.find(candidate => candidate.id === id)?.length).toBe(91);
+    });
+});
+
+test('uses natural imperial Profile preferences while retaining canonical values', async ({ page }) => {
+    await withRestoredProfileState(page, async () => {
+        await setProfileUnits(page, 'Pounds (lb)', 'Inches (in)');
+
+        const id = await createCatch(page, true, {
+            weight: { pounds: 3, ounces: 12 },
+            length: '24'
+        });
+        const persisted = await reloadServerCatches(page);
+        const catchRecord = persisted.find(candidate => candidate.id === id);
+
+        expect(catchRecord?.weight).toBeCloseTo(1.701, 3);
+        expect(catchRecord?.length).toBeCloseTo(60.96, 2);
+    });
+});
+
+test('records a catch without either optional measurement', async ({ page }) => {
+    const id = await createCatch(page, true);
+
+    const persisted = await reloadServerCatches(page);
+
+    expect(persisted.find(candidate => candidate.id === id)?.weight).toBeNull();
+    expect(persisted.find(candidate => candidate.id === id)?.length).toBeNull();
+});
+
+async function openCatchEdit(page, id) {
+    await page.locator(`#catch-card-menu-${id}`).click();
+    await page.locator(`#catch-card-edit-${id}`).click();
+    await expect(page.locator('#catch-edit-loading')).toBeHidden();
+}
+
+async function setProfileUnits(page, weight, length) {
+    await page.locator('#profile-fishing-details-section').click();
+    await chooseSelectOption(page, '#profile-weight-unit', weight);
+    await chooseSelectOption(page, '#profile-length-unit', length);
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().endsWith('/api/profiles/me/fishing-preferences')
+            && response.request().method() === 'PUT'
+            && response.ok()),
+        page.locator('#profile-save-button').click()
+    ]);
+    await expect(page.locator('#profile-save-button')).toBeEnabled();
+}
+
+async function chooseSelectOption(page, selector, optionName) {
+    await page.locator(selector)
+        .locator('xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " mud-input-control ")]')
+        .click();
+    await page.getByRole('option', { name: optionName, exact: true }).click();
+}

--- a/tests/FishingLogBook.E2E/support/catch-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/catch-journey.mjs
@@ -42,6 +42,12 @@ export async function createCatch(page, waitForServer = false, options = {}) {
     const speciesCode = options.speciesCode ?? 'BrownTrout';
     await selectCatalogueValue(page, 'method', methodCode);
     await selectCatalogueValue(page, 'species', speciesCode);
+    if (options.weight !== undefined) {
+        await setMeasurement(page, 'record-catch', 'weight', options.weight);
+    }
+    if (options.length !== undefined) {
+        await setMeasurement(page, 'record-catch', 'length', options.length);
+    }
     const photoCount = options.photoCount ?? 1;
     await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles(
         Array.from({ length: photoCount }, (_, index) => ({
@@ -107,7 +113,11 @@ export async function editCatch(page, id, changes, waitForServer = false) {
     await page.locator(`#catch-card-edit-${id}`).click();
     await expect(page.locator('#catch-edit-loading')).toBeHidden();
     for (const [field, value] of Object.entries(changes)) {
-        await page.locator(`#catch-edit-${field}`).fill(value);
+        if (field === 'weight' || field === 'length') {
+            await setMeasurement(page, 'catch-edit', field, value);
+        } else {
+            await page.locator(`#catch-edit-${field}`).fill(value);
+        }
     }
     const save = page.locator('#catch-edit-save');
     if (waitForServer) {
@@ -122,4 +132,17 @@ export async function editCatch(page, id, changes, waitForServer = false) {
         await save.click();
     }
     await expect(page.locator('#catch-edit-saved')).toBeVisible();
+}
+
+export async function setMeasurement(page, prefix, type, value) {
+    await page.locator(`#${prefix}-${type}`).click();
+    await expect(page.locator('#measurement-editor-modal')).toBeVisible();
+    if (typeof value === 'object') {
+        await page.locator('#measurement-exact-pounds input, #measurement-exact-pounds').fill(String(value.pounds));
+        await page.locator('#measurement-exact-ounces input, #measurement-exact-ounces').fill(String(value.ounces));
+    } else {
+        await page.locator('#measurement-exact-value').fill(String(value));
+    }
+    await page.locator('#measurement-apply').click();
+    await expect(page.locator('#measurement-editor-modal')).toBeHidden();
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/BaseMeasurementEditorTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/BaseMeasurementEditorTest.cs
@@ -1,0 +1,52 @@
+using Bunit;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Components.MeasurementEditorTests;
+
+public class BaseMeasurementEditorTest
+{
+    protected static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton<IMeasurementService, MeasurementService>();
+        context.Services.AddTransient<MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+
+    protected static async Task<(IRenderedComponent<MudDialogProvider> Cut, IDialogReference Dialog)> ShowAsync(
+        BunitContext context,
+        MeasurementEditorModel model)
+    {
+        var cut = context.Render<MudDialogProvider>();
+        var dialogs = context.Services.GetRequiredService<IDialogService>();
+        var parameters = new DialogParameters<MeasurementEditorModal>
+        {
+            { modal => modal.Model, model }
+        };
+        var dialog = await dialogs.ShowAsync<MeasurementEditorModal>(parameters);
+        return (cut, dialog);
+    }
+
+    protected static MeasurementEditorModel Weight(
+        decimal? canonicalValue = null,
+        WeightUnitEnum unit = WeightUnitEnum.Kg)
+    {
+        return new MeasurementEditorModel(true, canonicalValue, unit, LengthUnitEnum.Cm);
+    }
+
+    protected static MeasurementEditorModel Length(
+        decimal? canonicalValue = null,
+        LengthUnitEnum unit = LengthUnitEnum.Cm)
+    {
+        return new MeasurementEditorModel(false, canonicalValue, WeightUnitEnum.Kg, unit);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/WhenTestingEditing.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/WhenTestingEditing.cs
@@ -1,0 +1,169 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Components.MeasurementEditorTests;
+
+public class WhenTestingEditing : BaseMeasurementEditorTest
+{
+    [Fact]
+    public async Task ItShouldNotApplyAnInvalidExactValue()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Weight(2.5m));
+        cut.Find("#measurement-exact-value").Input("invalid");
+
+        // Act
+        await cut.Find("#measurement-apply").ClickAsync();
+
+        // Assert
+        cut.Find("#measurement-validation").Should().NotBeNull();
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldRenderTheWeightDialAtTheCurrentValue()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Weight(50m));
+
+        // Assert
+        cut.Find(".measurement-dial").Should().NotBeNull();
+        cut.Find(".measurement-dial-needle").GetAttribute("transform").Should().Be("rotate(179.5 120 70)");
+        cut.FindAll(".measurement-dial-tick").Should().HaveCount(24);
+        cut.Find(".measurement-scale-hook").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldExpandTheLengthTapeWithTheCurrentValue()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, _) = await ShowAsync(context, Length());
+        var initialWidth = cut.Find(".measurement-tape-strip").GetAttribute("width");
+
+        // Act
+        cut.Find("#measurement-slider").Input("150");
+
+        // Assert
+        cut.Find(".measurement-tape-visual").Should().NotBeNull();
+        cut.Find(".measurement-tape-logo").GetAttribute("href").Should().Be("images/brand/brand-mark-transparent.png");
+        cut.Find(".measurement-tape-strip").GetAttribute("width").Should().NotBe(initialWidth);
+    }
+
+    [Fact]
+    public async Task ItShouldCancelWithoutApplyingAChange()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Weight(2.5m));
+
+        // Act
+        await cut.Find("#measurement-increase").ClickAsync();
+        await cut.Find("#measurement-cancel").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Canceled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldClearAnExistingMeasurement()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Length(64m));
+
+        // Act
+        await cut.Find("#measurement-clear").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Canceled.Should().BeFalse();
+        result.Data.Should().BeOfType<MeasurementEditorResult>().Which.CanonicalValue.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldApplyExactMetricWeight()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Weight());
+        cut.Find("#measurement-exact-value").Input("3.75");
+
+        // Act
+        await cut.Find("#measurement-apply").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Data.Should().BeOfType<MeasurementEditorResult>().Which.CanonicalValue.Should().Be(3.75m);
+    }
+
+    [Fact]
+    public async Task ItShouldRollImperialWeightFromFifteenOuncesToTheNextPound()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var service = new FishingLogBook.Web.Features.Catch.Services.MeasurementService();
+        var starting = service.FromPoundsAndOunces(3, 15);
+        var (cut, dialog) = await ShowAsync(context, Weight(starting, FishingLogBook.Shared.Enums.WeightUnitEnum.Lb));
+
+        // Act
+        await cut.Find("#measurement-increase").ClickAsync();
+        await cut.Find("#measurement-apply").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        cut.FindAll("#measurement-editor-modal").Should().BeEmpty();
+        var canonical = result!.Data.Should().BeOfType<MeasurementEditorResult>().Which.CanonicalValue;
+        service.ToPoundsAndOunces(canonical).Should().Be((4, 0));
+    }
+
+    [Fact]
+    public async Task ItShouldApplySixteenImperialFineAdjustmentsAsOnePound()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var service = new FishingLogBook.Web.Features.Catch.Services.MeasurementService();
+        var (cut, dialog) = await ShowAsync(context, Weight(null, FishingLogBook.Shared.Enums.WeightUnitEnum.Lb));
+
+        // Act
+        for (var adjustment = 0; adjustment < 16; adjustment++)
+        {
+            await cut.Find("#measurement-increase").ClickAsync();
+        }
+        await cut.Find("#measurement-apply").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        var canonical = result!.Data.Should().BeOfType<MeasurementEditorResult>().Which.CanonicalValue;
+        service.ToPoundsAndOunces(canonical).Should().Be((1, 0));
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheSliderAndExactEntrySynchronized()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Length());
+
+        // Act
+        cut.Find("#measurement-slider").Input("72");
+        var exactValue = cut.Find("#measurement-exact-value").GetAttribute("value");
+        var tapeWidth = cut.Find(".measurement-tape-strip").GetAttribute("width");
+        await cut.Find("#measurement-apply").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        exactValue.Should().Be("72");
+        tapeWidth.Should().NotBe("12.0");
+        result!.Data.Should().BeOfType<MeasurementEditorResult>().Which.CanonicalValue.Should().Be(72m);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/WhenTestingEditing.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/WhenTestingEditing.cs
@@ -23,6 +23,42 @@ public class WhenTestingEditing : BaseMeasurementEditorTest
     }
 
     [Fact]
+    public async Task ItShouldKeepTheWeightVisualWithinRangeForANegativeExactValue()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Weight());
+
+        // Act
+        cut.Find("#measurement-exact-value").Input("-5");
+        await cut.Find("#measurement-apply").ClickAsync();
+
+        // Assert
+        cut.Find("#measurement-validation").Should().NotBeNull();
+        cut.Find("#measurement-slider").GetAttribute("value").Should().Be("0");
+        cut.Find(".measurement-dial-needle").GetAttribute("transform").Should().Be("rotate(0 120 70)");
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheLengthVisualWithinRangeForANegativeExactValue()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Length());
+
+        // Act
+        cut.Find("#measurement-exact-value").Input("-5");
+        await cut.Find("#measurement-apply").ClickAsync();
+
+        // Assert
+        cut.Find("#measurement-validation").Should().NotBeNull();
+        cut.Find("#measurement-slider").GetAttribute("value").Should().Be("0");
+        cut.Find(".measurement-tape-strip").GetAttribute("width").Should().Be("12");
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task ItShouldRenderTheWeightDialAtTheCurrentValue()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/BaseCatchEditTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/BaseCatchEditTest.cs
@@ -7,6 +7,7 @@ using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
@@ -88,6 +89,14 @@ public class BaseCatchEditTest
     protected static IModalService QuietModalService()
     {
         return Substitute.For<IModalService>();
+    }
+
+    protected static void AnswerMeasurement(IModalService modal, bool isWeight, decimal? canonicalValue)
+    {
+        modal.ShowAsync<MeasurementEditorModal, MeasurementEditorModel, MeasurementEditorResult>(
+                Arg.Is<MeasurementEditorModel>(model => model.IsWeight == isWeight),
+                Arg.Any<CancellationToken>())
+            .Returns(new MeasurementEditorResult(canonicalValue));
     }
 
     protected static FishingCatalogueDto SampleCatalogue()

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingSave.cs
@@ -3,6 +3,7 @@ using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
@@ -24,12 +25,11 @@ public class WhenTestingSave : BaseCatchEditTest
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
         store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
-            .Returns(StoredCatch(catchId, SyncStatus.Synchronised, SyncStatus.Synchronised));
+            .Returns(StoredCatch(catchId, SyncStatus.Synchronised, SyncStatus.Synchronised, weight: 0m));
         var synchroniser = QuietSynchroniser();
         await using var context = CreateContext(store, synchroniser: synchroniser);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, catchId));
         cut.WaitForAssertion(() => cut.Find("#catch-edit-weight").Should().NotBeNull());
-        cut.Find("#catch-edit-weight").Input("0");
 
         // Act
         await cut.Find("#catch-edit-save").ClickAsync();
@@ -38,7 +38,7 @@ public class WhenTestingSave : BaseCatchEditTest
         cut.WaitForAssertion(() =>
             cut.Find("#catch-edit-validation").TextContent
                 .Should()
-                .Contain("Weight must be greater than 0 kg"));
+                .Contain("Enter a measurement greater than zero"));
         cut.FindAll("#catch-edit-saved").Should().BeEmpty();
         await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
         await synchroniser.DidNotReceive().SynchronisePendingAsync(Arg.Any<CancellationToken>());
@@ -346,16 +346,20 @@ public class WhenTestingSave : BaseCatchEditTest
         var synchroniser = QuietSynchroniser();
         var time = UtcTime();
         var preferences = QuietAnglerPreferences(SamplePreferences(), SampleCatalogue());
+        var modal = Substitute.For<IModalService>();
+        AnswerMeasurement(modal, true, 2.5m);
+        AnswerMeasurement(modal, false, 64m);
         await using var context = CreateContext(
             store,
             synchroniser: synchroniser,
             time: time,
-            anglerPreferences: preferences);
+            anglerPreferences: preferences,
+            modalService: modal);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, catchId));
         cut.WaitForAssertion(() => cut.Find("#catch-edit-method-Spinning"));
         await cut.Find("#catch-edit-method-Spinning").ClickAsync();
-        cut.Find("#catch-edit-weight").Input("2.5");
-        cut.Find("#catch-edit-length").Input("64");
+        await cut.Find("#catch-edit-weight").ClickAsync();
+        await cut.Find("#catch-edit-length").ClickAsync();
         cut.Find("#catch-edit-bait").Input("Spinner");
         cut.Find("#catch-edit-notes").Input("Weedline");
         cut.Find("#catch-edit-caught-on").Input("2026-08-17T09:15");
@@ -409,10 +413,13 @@ public class WhenTestingSave : BaseCatchEditTest
         synchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException());
         var preferences = QuietAnglerPreferences(SamplePreferences(), SampleCatalogue());
+        var modal = Substitute.For<IModalService>();
+        AnswerMeasurement(modal, true, 1.5m);
         await using var context = CreateContext(
             store,
             synchroniser: synchroniser,
-            anglerPreferences: preferences);
+            anglerPreferences: preferences,
+            modalService: modal);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, catchId));
         cut.WaitForAssertion(() => cut.Find("#catch-edit-method-Spinning"));
         await cut.Find("#catch-edit-method-Spinning").ClickAsync();
@@ -452,7 +459,7 @@ public class WhenTestingSave : BaseCatchEditTest
             anglerPreferences: preferences);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, catchId));
         cut.WaitForAssertion(() => cut.Find("#catch-edit-species-BrownTrout"));
-        cut.Find("#catch-edit-weight").Input("1.5");
+        await cut.Find("#catch-edit-weight").ClickAsync();
 
         // Act
         await cut.Find("#catch-edit-save").ClickAsync();

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingUnits.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingUnits.cs
@@ -3,6 +3,7 @@ using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Enums;
 using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Pages.CatchEdit;
@@ -31,10 +32,8 @@ public class WhenTestingUnits : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-weight").GetAttribute("value").Should().Be("2.041");
-            cut.Find("#catch-edit-length").GetAttribute("value").Should().Be("46.36");
-            cut.Markup.Should().Contain("Weight (kg)");
-            cut.Markup.Should().Contain("Length (cm)");
+            cut.Find("#catch-edit-weight-value").TextContent.Should().Be("2.04 kg");
+            cut.Find("#catch-edit-length-value").TextContent.Should().Be("46.36 cm");
         });
     }
 
@@ -55,16 +54,14 @@ public class WhenTestingUnits : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Find("#catch-edit-weight").GetAttribute("value").Should().Be("4.50");
-            cut.Find("#catch-edit-length").GetAttribute("value").Should().Be("18.25");
-            cut.Markup.Should().Contain("Weight (lb)");
-            cut.Markup.Should().Contain("Length (in)");
+            cut.Find("#catch-edit-weight-value").TextContent.Should().Be("4 lb 8 oz");
+            cut.Find("#catch-edit-length-value").TextContent.Should().Be("18.25 in");
         });
         await preferences.Received(1).GetAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ItShouldStateTheWeightLimitInTheAnglersPreferredUnit()
+    public async Task ItShouldNotChangeTheWeightWhenTheMeasurementEditorIsCancelled()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
@@ -75,15 +72,16 @@ public class WhenTestingUnits : BaseCatchEditTest
         await using var context = CreateContext(store, anglerPreferences: preferences);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(page => page.CatchId, EditedCatchId));
         cut.WaitForAssertion(() => cut.Find("#catch-edit-weight"));
-        cut.Find("#catch-edit-weight").Input("5000");
+        await cut.Find("#catch-edit-weight").ClickAsync();
 
         // Act
         await cut.Find("#catch-edit-save").ClickAsync();
 
         // Assert
-        cut.WaitForAssertion(() => cut.Find("#catch-edit-validation").TextContent
-            .Should().Contain("Weight must be greater than 0 lb and at most 2204.62 lb."));
-        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-saved").Should().NotBeNull());
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.Weight == 2.041m),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -96,11 +94,14 @@ public class WhenTestingUnits : BaseCatchEditTest
             .Returns(StoredCatch(EditedCatchId));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
         var preferences = QuietAnglerPreferences(weightUnit: WeightUnitEnum.Lb, lengthUnit: LengthUnitEnum.In);
-        await using var context = CreateContext(store, anglerPreferences: preferences);
+        var modal = Substitute.For<IModalService>();
+        AnswerMeasurement(modal, true, 2.041m);
+        AnswerMeasurement(modal, false, 46.36m);
+        await using var context = CreateContext(store, anglerPreferences: preferences, modalService: modal);
         var cut = context.Render<CatchEdit>(parameters => parameters.Add(page => page.CatchId, EditedCatchId));
         cut.WaitForAssertion(() => cut.Find("#catch-edit-weight"));
-        cut.Find("#catch-edit-weight").Input("4.50");
-        cut.Find("#catch-edit-length").Input("18.25");
+        await cut.Find("#catch-edit-weight").ClickAsync();
+        await cut.Find("#catch-edit-length").ClickAsync();
 
         // Act
         await cut.Find("#catch-edit-save").ClickAsync();
@@ -162,8 +163,8 @@ public class WhenTestingUnits : BaseCatchEditTest
         // Assert
         cut.WaitForAssertion(() =>
         {
-            cut.Markup.Should().Contain("(lb)");
-            cut.Markup.Should().Contain("(po)");
+            cut.Find("#catch-edit-weight-value").TextContent.Should().Be("4 lb 8 oz");
+            cut.Find("#catch-edit-length-value").TextContent.Should().Contain("18,25");
         });
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineRecordCatchTests/BaseOfflineRecordCatchTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineRecordCatchTests/BaseOfflineRecordCatchTest.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Models;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
@@ -34,6 +35,7 @@ public class BaseOfflineRecordCatchTest
         context.Services.AddSingleton(preferencesStore);
         context.Services.AddSingleton(logging ?? QuietLogging());
         context.Services.AddSingleton(Substitute.For<IModalService>());
+        context.Services.AddSingleton<IMeasurementService, MeasurementService>();
         var location = Substitute.For<ILocationService>();
         location.GetPromptStatusAsync(Arg.Any<CancellationToken>()).Returns(new LocationPromptStatus(false, false, false));
         context.Services.AddSingleton(location);

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/BaseRecordCatchTest.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Shared.Enums;
 using FishingLogBook.Web.Browser.Location;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
@@ -51,6 +52,7 @@ public class BaseRecordCatchTest
         context.Services.AddSingleton(logging ?? QuietLogging());
         context.Services.AddSingleton(anglerPreferences ?? QuietAnglerPreferences());
         context.Services.AddSingleton(modalService ?? QuietModalService());
+        context.Services.AddSingleton<IMeasurementService, MeasurementService>();
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
     }
@@ -97,6 +99,15 @@ public class BaseRecordCatchTest
                     model.Options.Any(option => option.Code == offeredOptionCode)),
                 Arg.Any<CancellationToken>())
             .Returns(new CataloguePickerModalResult(chosen));
+    }
+
+    protected static void AnswerMeasurement(IModalService modalService, bool isWeight, decimal? canonicalValue)
+    {
+        modalService
+            .ShowAsync<MeasurementEditorModal, MeasurementEditorModel, MeasurementEditorResult>(
+                Arg.Is<MeasurementEditorModel>(model => model.IsWeight == isWeight),
+                Arg.Any<CancellationToken>())
+            .Returns(new MeasurementEditorResult(canonicalValue));
     }
 
     protected static string SelectedMethod(IRenderedComponent<RecordCatch> cut)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingMeasurements.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingMeasurements.cs
@@ -1,0 +1,89 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
+using Microsoft.AspNetCore.Components.Forms;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.RecordCatchTests;
+
+public class WhenTestingMeasurements : BaseRecordCatchTest
+{
+    [Fact]
+    public async Task ItShouldShowThePhotographBeforeTheSupportingMeasurements()
+    {
+        // Arrange
+        var store = Substitute.For<ICatchStore>();
+        await using var context = CreateContext(store);
+        var cut = context.Render<RecordCatch>();
+        cut.WaitForAssertion(() => cut.Find("#record-catch-weight").Should().NotBeNull());
+
+        // Act
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 1, 2, 3));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-carousel").Should().NotBeNull());
+        cut.Markup.IndexOf("catch-photo-carousel", StringComparison.Ordinal)
+            .Should().BeLessThan(cut.Markup.IndexOf("catch-take-photo", StringComparison.Ordinal));
+        cut.Markup.IndexOf("catch-photo-carousel", StringComparison.Ordinal)
+            .Should().BeLessThan(cut.Markup.IndexOf("record-catch-weight", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ItShouldSaveWithoutOptionalMeasurements()
+    {
+        // Arrange
+        var store = Substitute.For<ICatchStore>();
+        await using var context = CreateContext(store);
+        var cut = context.Render<RecordCatch>();
+        cut.WaitForAssertion(() => cut.Find("#record-catch-weight-value").TextContent.Should().Contain("Not recorded"));
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 1, 2, 3));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-saved").Should().NotBeNull());
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.Weight == null && catchRecord.Length == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSaveCanonicalWeightAndLengthSelectedThroughTheSharedEditor()
+    {
+        // Arrange
+        var store = Substitute.For<ICatchStore>();
+        var modal = Substitute.For<IModalService>();
+        AnswerMeasurement(modal, true, 3.75m);
+        AnswerMeasurement(modal, false, 72m);
+        await using var context = CreateContext(store, modalService: modal);
+        var cut = context.Render<RecordCatch>();
+        cut.WaitForAssertion(() => cut.Find("#record-catch-weight"));
+        await cut.Find("#record-catch-weight").ClickAsync();
+        await cut.Find("#record-catch-length").ClickAsync();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 1, 2, 3));
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-saved").Should().NotBeNull());
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.Weight == 3.75m && catchRecord.Length == 72m),
+            Arg.Any<CancellationToken>());
+        await modal.Received(1).ShowAsync<MeasurementEditorModal,
+            MeasurementEditorModel,
+            MeasurementEditorResult>(
+                Arg.Is<MeasurementEditorModel>(model => model.IsWeight),
+                Arg.Any<CancellationToken>());
+        await modal.Received(1).ShowAsync<MeasurementEditorModal,
+            MeasurementEditorModel,
+            MeasurementEditorResult>(
+                Arg.Is<MeasurementEditorModel>(model => !model.IsWeight),
+                Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Services/MeasurementServiceTests/WhenTestingImperialWeight.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Services/MeasurementServiceTests/WhenTestingImperialWeight.cs
@@ -1,0 +1,44 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Enums;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Services.MeasurementServiceTests;
+
+public class WhenTestingImperialWeight : BaseMeasurementServiceTest
+{
+    [Fact]
+    public void ItShouldRollSixteenOuncesIntoTheNextPound()
+    {
+        // Arrange
+        var canonical = Sut.FromPoundsAndOunces(3, 16);
+
+        // Act
+        var displayed = Sut.ToPoundsAndOunces(canonical);
+
+        // Assert
+        displayed.Should().Be((4, 0));
+    }
+
+    [Fact]
+    public void ItShouldFormatImperialWeightForAnglers()
+    {
+        // Arrange
+        var canonical = Sut.FromPoundsAndOunces(3, 12);
+
+        // Act
+        var displayed = Sut.FormatWeight(canonical, WeightUnitEnum.Lb, "lb", "oz");
+
+        // Assert
+        displayed.Should().Be("3 lb 12 oz");
+    }
+
+    [Fact]
+    public void ItShouldTreatZeroAsNoMeasurement()
+    {
+        // Arrange
+        // Act
+        var canonical = Sut.FromPoundsAndOunces(0, 0);
+
+        // Assert
+        canonical.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- adds reusable, mobile-first weight and length controls shared by Record Catch and Catch Edit
- provides a fishing-scale weight interaction and tape-measure length interaction with slider, exact-entry and fine-adjustment paths
- respects kilogram/pound-and-ounce and centimetre/inch preferences while preserving the existing canonical kg/cm storage model
- captures optional measurements in the existing local-first record/edit flows without changing API or persistence contracts
- places the catch photograph ahead of the compact measurement controls so the fish remains the visual focus
- maintains English/French localisation and accessible labelled controls

## Imperial behaviour

- coarse weight slider: 0.25 lb increments
- fine −/+ controls: 1 oz per tap
- natural pounds-and-ounces exact entry and display

## Validation

- focused measurement component/service tests: 12 passed
- dedicated seven-journey measurement E2E coverage passed
- Record Catch and Catch Edit measurement regression coverage added/updated
- offline/local persistence and existing sync boundaries remain unchanged

Closes #134
Contributes to #157