### PR TITLE
FLB#163 | Add visual measurement ranges to the scale and tape controls

### DIFF
--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor
@@ -6,43 +6,49 @@
     </TitleContent>
     <DialogContent>
         <MudStack Spacing="3" Class="measurement-editor">
-            <div class="measurement-visual @(Model.IsWeight ? "measurement-scale" : "measurement-tape")"
-                 aria-hidden="true">
-                @if (Model.IsWeight)
-                {
-                    <svg class="measurement-dial" viewBox="0 0 240 150">
-                        <path class="measurement-scale-handle" d="M 98 18 C 98 1, 142 1, 142 18 L 135 18 C 135 9, 105 9, 105 18 Z" />
-                        <rect class="measurement-scale-neck" x="112" y="14" width="16" height="10" rx="4" />
-                        <circle class="measurement-scale-case" cx="120" cy="70" r="53" />
-                        <circle class="measurement-dial-face" cx="120" cy="70" r="46" />
-                        @foreach (var angle in DialTickAngles)
-                        {
-                            <line class="measurement-dial-tick"
-                                  x1="120" y1="24" x2="120" y2="@(IsMajorDialTick(angle) ? 36 : 31)"
-                                  transform="rotate(@angle 120 70)" />
-                        }
-                        <line class="measurement-dial-needle" x1="120" y1="70" x2="120" y2="37"
-                              transform="rotate(@DialAngle 120 70)" />
-                        <circle class="measurement-dial-pin" cx="120" cy="70" r="6" />
-                        <rect class="measurement-scale-stem" x="114" y="121" width="12" height="9" rx="3" />
-                        <path class="measurement-scale-hook" d="M 120 128 v 5 c 0 9 15 9 15 0 v -2" />
-                    </svg>
-                }
-                else
-                {
-                    <svg class="measurement-tape-visual" viewBox="0 0 240 92" preserveAspectRatio="none">
-                        <rect class="measurement-tape-case" x="10" y="16" width="48" height="60" rx="12" />
-                        <image class="measurement-tape-logo" href="images/brand/brand-mark-transparent.png"
-                               x="17" y="27" width="34" height="38" preserveAspectRatio="xMidYMid meet" />
-                        <rect class="measurement-tape-strip" x="50" y="27" width="@TapeWidth" height="38" rx="3" />
-                        @foreach (var tick in TapeTickPositions)
-                        {
-                            <line class="measurement-tape-tick"
-                                  x1="@tick" y1="27" x2="@tick" y2="@(IsMajorTapeTick(tick) ? 48 : 40)" />
-                        }
-                        <path class="measurement-tape-hook" d="@TapeHookPath" />
-                    </svg>
-                }
+            <div class="measurement-scale-layout">
+                <div class="measurement-visual @(Model.IsWeight ? "measurement-scale" : "measurement-tape")"
+                     aria-hidden="true">
+                    @if (Model.IsWeight)
+                    {
+                        <svg class="measurement-dial" viewBox="0 0 240 150">
+                            <path class="measurement-scale-handle" d="M 98 18 C 98 1, 142 1, 142 18 L 135 18 C 135 9, 105 9, 105 18 Z" />
+                            <rect class="measurement-scale-neck" x="112" y="14" width="16" height="10" rx="4" />
+                            <circle class="measurement-scale-case" cx="120" cy="70" r="53" />
+                            <circle class="measurement-dial-face" cx="120" cy="70" r="46" />
+                            @foreach (var angle in DialTickAngles)
+                            {
+                                <line class="measurement-dial-tick"
+                                      x1="120" y1="24" x2="120" y2="@(IsMajorDialTick(angle) ? 36 : 31)"
+                                      transform="rotate(@angle 120 70)" />
+                            }
+                            <line class="measurement-dial-needle" x1="120" y1="70" x2="120" y2="37"
+                                  transform="rotate(@DialAngle 120 70)" />
+                            <circle class="measurement-dial-pin" cx="120" cy="70" r="6" />
+                            <rect class="measurement-scale-stem" x="114" y="121" width="12" height="9" rx="3" />
+                            <path class="measurement-scale-hook" d="M 120 128 v 5 c 0 9 15 9 15 0 v -2" />
+                        </svg>
+                    }
+                    else
+                    {
+                        <svg class="measurement-tape-visual" viewBox="0 0 240 92" preserveAspectRatio="none">
+                            <rect class="measurement-tape-case" x="10" y="16" width="48" height="60" rx="12" />
+                            <image class="measurement-tape-logo" href="images/brand/brand-mark-transparent.png"
+                                   x="17" y="27" width="34" height="38" preserveAspectRatio="xMidYMid meet" />
+                            <rect class="measurement-tape-strip" x="50" y="27" width="@TapeWidth" height="38" rx="3" />
+                            @foreach (var tick in TapeTickPositions)
+                            {
+                                <line class="measurement-tape-tick"
+                                      x1="@tick" y1="27" x2="@tick" y2="@(IsMajorTapeTick(tick) ? 48 : 40)" />
+                            }
+                            <path class="measurement-tape-hook" d="@TapeHookPath" />
+                        </svg>
+                    }
+                </div>
+                <MeasurementRangeSelector Ranges="ScaleRanges"
+                                          Selected="_scaleRange"
+                                          CanonicalValue="_canonicalValue"
+                                          SelectedChanged="SelectScaleRange" />
             </div>
 
             @if (IsImperialWeight)
@@ -60,10 +66,10 @@
             }
             else
             {
-                <MudTextField T="string" Value="_exactText" ValueChanged="SetExactValue"
-                              Label="@ExactLabel" InputType="InputType.Number"
-                              Variant="Variant.Outlined" Immediate="true"
-                              id="measurement-exact-value" />
+                <MudNumericField T="decimal?" Value="DisplayValue" ValueChanged="SetExactDisplayValue"
+                                 Label="@ExactLabel" Step="FineStep"
+                                 Variant="Variant.Outlined" Immediate="true"
+                                 id="measurement-exact-value" />
             }
 
             <MudText Typo="Typo.subtitle2">@Loc["Catch_MeasurementCoarseAdjustment"]</MudText>
@@ -72,6 +78,11 @@
                        ValueLabel="true" Immediate="true"
                        aria-label="@Loc["Catch_MeasurementSliderLabel", Title]"
                        id="measurement-slider" />
+
+            <div class="measurement-slider-bounds" id="measurement-slider-bounds">
+                <MudText Typo="Typo.caption" id="measurement-slider-minimum">@SliderMinimumLabel</MudText>
+                <MudText Typo="Typo.caption" id="measurement-slider-maximum">@SliderMaximumLabel</MudText>
+            </div>
 
             <div class="measurement-fine-controls">
                 <MudIconButton Icon="@Icons.Material.Filled.Remove" Size="Size.Large"

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Enums;
 using FishingLogBook.Web.Features.Catch.Services;
@@ -11,14 +10,9 @@ namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
 
 public partial class MeasurementEditorModal : ComponentBase
 {
-    private const decimal MetricWeightSliderMaximum = 100m;
-    private const decimal ImperialWeightSliderMaximum = 220m;
-    private const decimal MetricLengthSliderMaximum = 300m;
-    private const decimal ImperialLengthSliderMaximum = 120m;
+    private MeasurementScaleRangeModel _scaleRange = MeasurementScaleRangeModel.Weights[0];
     private decimal? _canonicalValue;
-    private string _exactText = string.Empty;
     private string? _validationMessage;
-    private bool _exactEntryValid = true;
     private int _pounds;
     private int _ounces;
 
@@ -37,6 +31,7 @@ public partial class MeasurementEditorModal : ComponentBase
     protected override void OnParametersSet()
     {
         _canonicalValue = Model.CanonicalValue;
+        _scaleRange = MeasurementScaleRangeModel.SmallestFor(Model.IsWeight, _canonicalValue);
         SynchroniseInputs();
     }
 
@@ -66,7 +61,7 @@ public partial class MeasurementEditorModal : ComponentBase
 
     private static IEnumerable<decimal> TapeTickPositions => Enumerable.Range(0, 18).Select(index => 56m + (index * 10m));
 
-    private decimal DialAngle => SliderValue / SliderMaximum * 359m;
+    private decimal DialAngle => Math.Round(SliderValue / SliderMaximum * 359m, 2);
 
     private decimal TapeWidth => 12m + (SliderValue / SliderMaximum * 166m);
 
@@ -83,17 +78,62 @@ public partial class MeasurementEditorModal : ComponentBase
     {
         get
         {
-            if (Model.IsWeight)
-            {
-                return Model.WeightUnit == WeightUnitEnum.Lb
-                    ? ImperialWeightSliderMaximum
-                    : MetricWeightSliderMaximum;
-            }
-
-            return Model.LengthUnit == LengthUnitEnum.In
-                ? ImperialLengthSliderMaximum
-                : MetricLengthSliderMaximum;
+            return DisplayOf(_scaleRange.MaximumCanonical);
         }
+    }
+
+    private IReadOnlyList<MeasurementScaleRangeModel> ScaleRanges =>
+        MeasurementScaleRangeModel.For(Model.IsWeight);
+
+    private string SliderMinimumLabel => FormatCanonicalForDisplay(0m);
+
+    private string SliderMaximumLabel => FormatCanonicalForDisplay(_scaleRange.MaximumCanonical);
+
+    private decimal DisplayOf(decimal canonicalValue)
+    {
+        var display = Model.IsWeight
+            ? Measurement.ToDisplayWeight(canonicalValue, Model.WeightUnit)
+            : Measurement.ToDisplayLength(canonicalValue, Model.LengthUnit);
+        return display ?? canonicalValue;
+    }
+
+    private string FormatCanonicalForDisplay(decimal canonicalValue)
+    {
+        if (Model.IsWeight)
+        {
+            return Measurement.FormatWeight(
+                canonicalValue,
+                Model.WeightUnit,
+                Model.WeightUnit == WeightUnitEnum.Lb
+                    ? Loc["Catch_WeightUnitShort_Lb"]
+                    : Loc["Catch_WeightUnitShort_Kg"],
+                Loc["Catch_WeightUnitShort_Oz"]);
+        }
+
+        return Measurement.FormatLength(
+            canonicalValue,
+            Model.LengthUnit,
+            Model.LengthUnit == LengthUnitEnum.In
+                ? Loc["Catch_LengthUnitShort_In"]
+                : Loc["Catch_LengthUnitShort_Cm"]);
+    }
+
+    private void SelectScaleRange(MeasurementScaleRangeModel range)
+    {
+        if (!range.CanDisplay(_canonicalValue))
+        {
+            return;
+        }
+
+        _scaleRange = range;
+    }
+
+    private void ExpandScaleRangeForValue()
+    {
+        _scaleRange = MeasurementScaleRangeModel.ExpandedFor(
+            Model.IsWeight,
+            _scaleRange,
+            _canonicalValue);
     }
 
     private decimal SliderStep
@@ -150,23 +190,19 @@ public partial class MeasurementEditorModal : ComponentBase
         ? Measurement.ToDisplayWeight(_canonicalValue, Model.WeightUnit)
         : Measurement.ToDisplayLength(_canonicalValue, Model.LengthUnit);
 
-    private void SetSliderValue(decimal value)
+    private void SetExactDisplayValue(decimal? displayValue)
     {
-        SetDisplayValue(value);
-    }
-
-    private void SetExactValue(string value)
-    {
-        _exactText = value;
-        if (!TryParse(value, out var parsed))
+        if (displayValue is null)
         {
-            _exactEntryValid = false;
-            _validationMessage = Loc["Catch_MeasurementInvalid"];
             return;
         }
 
-        _exactEntryValid = true;
-        SetDisplayValue(parsed);
+        SetDisplayValue(displayValue);
+    }
+
+    private void SetSliderValue(decimal value)
+    {
+        SetDisplayValue(value);
     }
 
     private void SetPounds(int value)
@@ -220,7 +256,6 @@ public partial class MeasurementEditorModal : ComponentBase
 
     private void SetDisplayValue(decimal? displayValue)
     {
-        _exactEntryValid = true;
         _canonicalValue = Model.IsWeight
             ? Measurement.ToCanonicalWeight(displayValue, Model.WeightUnit, _canonicalValue)
             : Measurement.ToCanonicalLength(displayValue, Model.LengthUnit, _canonicalValue);
@@ -230,6 +265,7 @@ public partial class MeasurementEditorModal : ComponentBase
 
     private void ValidateCanonicalValue()
     {
+        ExpandScaleRangeForValue();
         var valid = Model.IsWeight
             ? CatchDetailConstants.IsWeightValid(_canonicalValue)
             : CatchDetailConstants.IsLengthValid(_canonicalValue);
@@ -241,19 +277,11 @@ public partial class MeasurementEditorModal : ComponentBase
         if (IsImperialWeight)
         {
             (_pounds, _ounces) = Measurement.ToPoundsAndOunces(_canonicalValue);
-            return;
         }
-
-        _exactText = DisplayValue?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
     }
 
     private void Apply()
     {
-        if (!_exactEntryValid)
-        {
-            return;
-        }
-
         ValidateCanonicalValue();
         if (_validationMessage is not null)
         {
@@ -265,7 +293,9 @@ public partial class MeasurementEditorModal : ComponentBase
 
     private void Clear()
     {
-        MudDialog.Close(DialogResult.Ok(new MeasurementEditorResult(null)));
+        _canonicalValue = null;
+        _validationMessage = null;
+        SynchroniseInputs();
     }
 
     private void Cancel()
@@ -283,21 +313,4 @@ public partial class MeasurementEditorModal : ComponentBase
         return (position - 56m) % 50m == 0;
     }
 
-    private static bool TryParse(string value, out decimal? parsed)
-    {
-        parsed = null;
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return true;
-        }
-
-        if (!decimal.TryParse(value, NumberStyles.Number, CultureInfo.CurrentCulture, out var number)
-            && !decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out number))
-        {
-            return false;
-        }
-
-        parsed = number;
-        return true;
-    }
 }

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementEditorModal.razor.css
@@ -5,7 +5,7 @@
 .measurement-visual {
     position: relative;
     display: flex;
-    min-height: 8rem;
+    min-height: 9.5rem;
     flex-direction: column;
     align-items: center;
     justify-content: center;
@@ -17,9 +17,9 @@
 
 .measurement-dial {
     position: absolute;
-    inset: 0.1rem auto auto;
+    inset: 0.35rem auto auto;
     width: min(15rem, 82%);
-    height: 7.8rem;
+    height: 8.8rem;
 }
 
 .measurement-scale-handle,
@@ -65,7 +65,7 @@
 
 .measurement-tape-visual {
     position: absolute;
-    inset: 0.65rem auto auto;
+    inset: 2.05rem auto auto;
     width: min(21rem, 94%);
     height: 5.4rem;
 }
@@ -110,6 +110,24 @@
 
 @media (max-width: 480px) {
     .measurement-visual {
-        min-height: 7.5rem;
+        min-height: 9.5rem;
     }
+}
+
+.measurement-scale-layout {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.measurement-scale-layout .measurement-visual {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.measurement-slider-bounds {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: -0.75rem;
 }

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementRangeSelector.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementRangeSelector.razor
@@ -1,0 +1,29 @@
+@namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor
+
+<div class="measurement-ranges"
+     role="group"
+     aria-label="@Loc["Catch_MeasurementRangeGroup"]"
+     id="measurement-ranges">
+    @foreach (var range in LargestFirst)
+    {
+        var isSelected = range.Range == Selected.Range;
+        <button type="button"
+                class="measurement-range @(isSelected ? "measurement-range-selected" : null)"
+                aria-pressed="@(isSelected ? "true" : "false")"
+                aria-label="@Label(range)"
+                title="@Label(range)"
+                disabled="@(!range.CanDisplay(CanonicalValue))"
+                @onclick="@(() => SelectAsync(range))"
+                id="@ElementId(range)">
+            <svg class="measurement-range-fish measurement-range-fish-@range.Range"
+                 viewBox="0 0 32 20"
+                 aria-hidden="true"
+                 focusable="false">
+                <path d="M2 10 C 7 2, 17 2, 22 10 C 17 18, 7 18, 2 10 Z" />
+                <path d="M22 10 L 30 4 L 30 16 Z" />
+                <circle cx="8" cy="8.5" r="1.2" class="measurement-range-eye" />
+            </svg>
+            <span class="measurement-range-name">@Label(range)</span>
+        </button>
+    }
+</div>

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementRangeSelector.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementRangeSelector.razor.cs
@@ -1,0 +1,37 @@
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+
+public partial class MeasurementRangeSelector : ComponentBase
+{
+    [Parameter, EditorRequired]
+    public IReadOnlyList<MeasurementScaleRangeModel> Ranges { get; set; } = [];
+
+    [Parameter, EditorRequired]
+    public MeasurementScaleRangeModel Selected { get; set; } = default!;
+
+    [Parameter]
+    public decimal? CanonicalValue { get; set; }
+
+    [Parameter]
+    public EventCallback<MeasurementScaleRangeModel> SelectedChanged { get; set; }
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private IEnumerable<MeasurementScaleRangeModel> LargestFirst => Ranges.Reverse();
+
+    private string Label(MeasurementScaleRangeModel range) => Loc[range.LabelKey];
+
+    private static string ElementId(MeasurementScaleRangeModel range) =>
+        $"measurement-range-{range.Range}";
+
+    private Task SelectAsync(MeasurementScaleRangeModel range)
+    {
+        return range.CanDisplay(CanonicalValue)
+            ? SelectedChanged.InvokeAsync(range)
+            : Task.CompletedTask;
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementRangeSelector.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementRangeSelector.razor.css
@@ -1,0 +1,74 @@
+.measurement-ranges {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-self: stretch;
+    gap: 0.15rem;
+    flex: 0 0 auto;
+}
+
+.measurement-range {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.4rem;
+    flex: 1 1 0;
+    min-height: 2.25rem;
+    min-width: 2.75rem;
+    padding: 0.1rem 0.35rem;
+    border: 1px solid transparent;
+    border-radius: var(--mud-default-borderradius);
+    background: transparent;
+    color: var(--mud-palette-primary);
+    cursor: pointer;
+}
+
+.measurement-range:disabled {
+    opacity: 0.32;
+    cursor: not-allowed;
+}
+
+.measurement-range-selected {
+    border-color: var(--mud-palette-primary);
+    background-color: var(--mud-palette-surface);
+    font-weight: 600;
+}
+
+.measurement-range-fish {
+    display: block;
+    flex: 0 0 auto;
+    fill: var(--mud-palette-primary);
+    transform: scaleX(-1);
+}
+
+.measurement-range-fish-Small {
+    width: 14px;
+}
+
+.measurement-range-fish-Medium {
+    width: 19px;
+}
+
+.measurement-range-fish-Large {
+    width: 25px;
+}
+
+.measurement-range-fish-Monster {
+    width: 32px;
+}
+
+.measurement-range-eye {
+    fill: var(--mud-palette-surface);
+}
+
+.measurement-range-name {
+    font-size: 0.7rem;
+    line-height: 1;
+    white-space: nowrap;
+}
+
+@media (max-width: 420px) {
+    .measurement-range-name {
+        display: none;
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementScaleRangeModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/MeasurementEditor/MeasurementScaleRangeModel.cs
@@ -1,0 +1,58 @@
+using FishingLogBook.Web.Features.Catch.Enums;
+
+namespace FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+
+public sealed record MeasurementScaleRangeModel(
+    MeasurementScaleRangeEnum Range,
+    decimal MaximumCanonical)
+{
+    public static IReadOnlyList<MeasurementScaleRangeModel> Weights { get; } =
+    [
+        new(MeasurementScaleRangeEnum.Small, 5m),
+        new(MeasurementScaleRangeEnum.Medium, 15m),
+        new(MeasurementScaleRangeEnum.Large, 40m),
+        new(MeasurementScaleRangeEnum.Monster, 120m)
+    ];
+
+    public static IReadOnlyList<MeasurementScaleRangeModel> Lengths { get; } =
+    [
+        new(MeasurementScaleRangeEnum.Small, 30m),
+        new(MeasurementScaleRangeEnum.Medium, 60m),
+        new(MeasurementScaleRangeEnum.Large, 120m),
+        new(MeasurementScaleRangeEnum.Monster, 300m)
+    ];
+
+    public string LabelKey
+    {
+        get
+        {
+            return $"Catch_MeasurementRange_{Range}";
+        }
+    }
+
+    public static IReadOnlyList<MeasurementScaleRangeModel> For(bool isWeight)
+    {
+        return isWeight ? Weights : Lengths;
+    }
+
+    public bool CanDisplay(decimal? canonicalValue)
+    {
+        return canonicalValue is null || canonicalValue.Value <= MaximumCanonical;
+    }
+
+    public static MeasurementScaleRangeModel SmallestFor(bool isWeight, decimal? canonicalValue)
+    {
+        var ranges = For(isWeight);
+        return ranges.FirstOrDefault(range => range.CanDisplay(canonicalValue)) ?? ranges[^1];
+    }
+
+    public static MeasurementScaleRangeModel ExpandedFor(
+        bool isWeight,
+        MeasurementScaleRangeModel current,
+        decimal? canonicalValue)
+    {
+        return current.CanDisplay(canonicalValue)
+            ? current
+            : SmallestFor(isWeight, canonicalValue);
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Enums/MeasurementScaleRangeEnum.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Enums/MeasurementScaleRangeEnum.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Web.Features.Catch.Enums;
+
+public enum MeasurementScaleRangeEnum
+{
+    Small = 0,
+    Medium = 1,
+    Large = 2,
+    Monster = 3
+}

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -847,6 +847,21 @@
   <data name="Catch_MeasurementCoarseAdjustment" xml:space="preserve">
     <value>Faites glisser pour ajuster</value>
   </data>
+  <data name="Catch_MeasurementRangeGroup" xml:space="preserve">
+    <value>Plage de l’échelle</value>
+  </data>
+  <data name="Catch_MeasurementRange_Small" xml:space="preserve">
+    <value>Petit</value>
+  </data>
+  <data name="Catch_MeasurementRange_Medium" xml:space="preserve">
+    <value>Moyen</value>
+  </data>
+  <data name="Catch_MeasurementRange_Large" xml:space="preserve">
+    <value>Grand</value>
+  </data>
+  <data name="Catch_MeasurementRange_Monster" xml:space="preserve">
+    <value>Monstre</value>
+  </data>
   <data name="Catch_MeasurementSliderLabel" xml:space="preserve">
     <value>Régler {0}</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -847,6 +847,21 @@
   <data name="Catch_MeasurementCoarseAdjustment" xml:space="preserve">
     <value>Slide to adjust</value>
   </data>
+  <data name="Catch_MeasurementRangeGroup" xml:space="preserve">
+    <value>Scale range</value>
+  </data>
+  <data name="Catch_MeasurementRange_Small" xml:space="preserve">
+    <value>Small</value>
+  </data>
+  <data name="Catch_MeasurementRange_Medium" xml:space="preserve">
+    <value>Medium</value>
+  </data>
+  <data name="Catch_MeasurementRange_Large" xml:space="preserve">
+    <value>Large</value>
+  </data>
+  <data name="Catch_MeasurementRange_Monster" xml:space="preserve">
+    <value>Monster</value>
+  </data>
   <data name="Catch_MeasurementSliderLabel" xml:space="preserve">
     <value>Adjust {0}</value>
   </data>

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/WhenTestingEditing.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/WhenTestingEditing.cs
@@ -7,19 +7,37 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Components.MeasurementEditorTe
 public class WhenTestingEditing : BaseMeasurementEditorTest
 {
     [Fact]
-    public async Task ItShouldNotApplyAnInvalidExactValue()
+    public async Task ItShouldIgnoreNonNumericExactEntryAndKeepTheCapturedValue()
     {
         // Arrange
         await using var context = CreateContext();
         var (cut, dialog) = await ShowAsync(context, Weight(2.5m));
-        cut.Find("#measurement-exact-value").Input("invalid");
 
         // Act
+        cut.Find("#measurement-exact-value").Input("invalid");
         await cut.Find("#measurement-apply").ClickAsync();
 
         // Assert
-        cut.Find("#measurement-validation").Should().NotBeNull();
-        dialog.Result.IsCompleted.Should().BeFalse();
+        cut.FindAll("#measurement-validation").Should().BeEmpty();
+        var result = await dialog.Result;
+        result!.Data.Should().BeOfType<MeasurementEditorResult>().Which.CanonicalValue.Should().Be(2.5m);
+    }
+
+    [Fact]
+    public async Task ItShouldOfferSteppersOnTheExactEntryForWeightAndLength()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        // Act
+        var (weight, _) = await ShowAsync(context, Weight(2.5m));
+        var (length, _) = await ShowAsync(context, Length(64m));
+
+        // Assert
+        weight.FindAll("button[aria-label=Increment]").Should().NotBeEmpty();
+        weight.FindAll("button[aria-label=Decrement]").Should().NotBeEmpty();
+        length.FindAll("button[aria-label=Increment]").Should().NotBeEmpty();
+        length.FindAll("button[aria-label=Decrement]").Should().NotBeEmpty();
     }
 
     [Fact]
@@ -69,7 +87,8 @@ public class WhenTestingEditing : BaseMeasurementEditorTest
 
         // Assert
         cut.Find(".measurement-dial").Should().NotBeNull();
-        cut.Find(".measurement-dial-needle").GetAttribute("transform").Should().Be("rotate(179.5 120 70)");
+        cut.Find("#measurement-range-Monster").GetAttribute("aria-pressed").Should().Be("true");
+        cut.Find(".measurement-dial-needle").GetAttribute("transform").Should().Be("rotate(149.58 120 70)");
         cut.FindAll(".measurement-dial-tick").Should().HaveCount(24);
         cut.Find(".measurement-scale-hook").Should().NotBeNull();
     }
@@ -109,7 +128,7 @@ public class WhenTestingEditing : BaseMeasurementEditorTest
     }
 
     [Fact]
-    public async Task ItShouldClearAnExistingMeasurement()
+    public async Task ItShouldClearInPlaceWithoutClosingTheEditor()
     {
         // Arrange
         await using var context = CreateContext();
@@ -117,12 +136,47 @@ public class WhenTestingEditing : BaseMeasurementEditorTest
 
         // Act
         await cut.Find("#measurement-clear").ClickAsync();
+
+        // Assert
+        cut.Find("#measurement-editor-modal").Should().NotBeNull();
+        dialog.Result.IsCompleted.Should().BeFalse();
+        cut.Find("#measurement-exact-value").GetAttribute("value").Should().BeNullOrEmpty();
+        cut.Find("#measurement-slider").GetAttribute("value").Should().Be("0");
+    }
+
+    [Fact]
+    public async Task ItShouldApplyAClearedMeasurementOnlyWhenTheAnglerConfirms()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Length(64m));
+
+        // Act
+        await cut.Find("#measurement-clear").ClickAsync();
+        await cut.Find("#measurement-apply").ClickAsync();
         var result = await dialog.Result;
 
         // Assert
         result.Should().NotBeNull();
         result!.Canceled.Should().BeFalse();
         result.Data.Should().BeOfType<MeasurementEditorResult>().Which.CanonicalValue.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheStoredMeasurementWhenAClearIsCancelled()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Length(64m));
+
+        // Act
+        await cut.Find("#measurement-clear").ClickAsync();
+        await cut.Find("#measurement-cancel").ClickAsync();
+        var result = await dialog.Result;
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Canceled.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/WhenTestingScaleRanges.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/MeasurementEditorTests/WhenTestingScaleRanges.cs
@@ -1,0 +1,396 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+using FishingLogBook.Web.Features.Catch.Enums;
+using FishingLogBook.Web.Localization;
+using MudBlazor;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Components.MeasurementEditorTests;
+
+public class WhenTestingScaleRanges : BaseMeasurementEditorTest
+{
+    [Fact]
+    public void ItShouldExposeFourRangesWithTheIntendedCanonicalMaxima()
+    {
+        // Arrange
+        var expected = new (MeasurementScaleRangeEnum Range, decimal Maximum)[]
+        {
+            (MeasurementScaleRangeEnum.Small, 5m),
+            (MeasurementScaleRangeEnum.Medium, 15m),
+            (MeasurementScaleRangeEnum.Large, 40m),
+            (MeasurementScaleRangeEnum.Monster, 120m)
+        };
+
+        // Act
+        var ranges = MeasurementScaleRangeModel.Weights;
+
+        // Assert
+        ranges.Should().HaveCount(4);
+        ranges.Select(range => (range.Range, range.MaximumCanonical)).Should().Equal(expected);
+    }
+
+    [Theory]
+    [InlineData(2, nameof(MeasurementScaleRangeEnum.Small))]
+    [InlineData(8, nameof(MeasurementScaleRangeEnum.Medium))]
+    [InlineData(30, nameof(MeasurementScaleRangeEnum.Large))]
+    [InlineData(80, nameof(MeasurementScaleRangeEnum.Monster))]
+    public async Task ItShouldOpenAnExistingWeightInTheSmallestRangeThatContainsIt(
+        int canonicalKilograms,
+        string expectedRange)
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Weight(canonicalKilograms));
+
+        // Assert
+        cut.Find($"#measurement-range-{expectedRange}").GetAttribute("aria-pressed")
+            .Should().Be("true");
+        cut.FindAll("[aria-pressed=true]").Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ItShouldNeverChangeTheCapturedWeightWhileTheRangeChanges()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Weight(2.268m, WeightUnitEnum.Lb));
+        var originalPounds = cut.Find("#measurement-exact-pounds").GetAttribute("value");
+        var originalOunces = cut.Find("#measurement-exact-ounces").GetAttribute("value");
+
+        // Act
+        foreach (var range in new[] { "Medium", "Large", "Monster", "Small" })
+        {
+            await cut.Find($"#measurement-range-{range}").ClickAsync();
+            cut.Find("#measurement-exact-pounds").GetAttribute("value").Should().Be(originalPounds);
+            cut.Find("#measurement-exact-ounces").GetAttribute("value").Should().Be(originalOunces);
+        }
+
+        await cut.Find("#measurement-apply").ClickAsync();
+
+        // Assert
+        var result = await dialog.Result;
+        var applied = (MeasurementEditorResult)result!.Data!;
+        applied.CanonicalValue.Should().Be(2.268m);
+    }
+
+    [Fact]
+    public async Task ItShouldMoveTheNeedleAndSliderMaximumWhenTheRangeChanges()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, _) = await ShowAsync(context, Weight(4m));
+        var smallAngle = cut.Find(".measurement-dial-needle").GetAttribute("transform");
+        var smallMaximum = cut.Find("#measurement-slider-maximum").TextContent;
+
+        // Act
+        await cut.Find("#measurement-range-Large").ClickAsync();
+
+        // Assert
+        var largeAngle = cut.Find(".measurement-dial-needle").GetAttribute("transform");
+        largeAngle.Should().NotBe(smallAngle);
+        smallAngle.Should().Be("rotate(287.2 120 70)");
+        largeAngle.Should().Be("rotate(35.9 120 70)");
+        cut.Find("#measurement-slider-maximum").TextContent.Should().NotBe(smallMaximum);
+        cut.Find("#measurement-exact-value").GetAttribute("value").Should().Be("4");
+    }
+
+    [Fact]
+    public async Task ItShouldLabelTheSliderBoundsInMetricUnits()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Weight(1m));
+
+        // Assert
+        cut.Find("#measurement-slider-minimum").TextContent.Trim().Should().Be("0 kg");
+        cut.Find("#measurement-slider-maximum").TextContent.Trim().Should().Be("5 kg");
+        await cut.Find("#measurement-range-Monster").ClickAsync();
+        cut.Find("#measurement-slider-maximum").TextContent.Trim().Should().Be("120 kg");
+    }
+
+    [Fact]
+    public async Task ItShouldLabelTheSliderBoundsInImperialUnitsForTheSamePhysicalRange()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Weight(1m, WeightUnitEnum.Lb));
+
+        // Assert
+        cut.Find("#measurement-slider-minimum").TextContent.Should().Contain("0 lb");
+        cut.Find("#measurement-slider-maximum").TextContent.Should().Contain("11 lb");
+        cut.Find("#measurement-range-Small").GetAttribute("aria-pressed").Should().Be("true");
+        await cut.Find("#measurement-range-Monster").ClickAsync();
+        cut.Find("#measurement-slider-maximum").TextContent.Should().Contain("264 lb");
+    }
+
+    [Theory]
+    [InlineData("10", nameof(MeasurementScaleRangeEnum.Medium))]
+    [InlineData("35", nameof(MeasurementScaleRangeEnum.Large))]
+    [InlineData("100", nameof(MeasurementScaleRangeEnum.Monster))]
+    public async Task ItShouldExpandToTheSmallestRangeThatCanDisplayAnExactEntry(
+        string exactValue,
+        string expectedRange)
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Weight(1m));
+        cut.Find("#measurement-range-Small").GetAttribute("aria-pressed").Should().Be("true");
+
+        // Act
+        cut.Find("#measurement-exact-value").Input(exactValue);
+
+        // Assert
+        cut.Find($"#measurement-range-{expectedRange}").GetAttribute("aria-pressed")
+            .Should().Be("true");
+        await cut.Find("#measurement-apply").ClickAsync();
+        var result = await dialog.Result;
+        var applied = (MeasurementEditorResult)result!.Data!;
+        applied.CanonicalValue.Should().Be(decimal.Parse(exactValue));
+    }
+
+    [Fact]
+    public async Task ItShouldExpandTheRangeWhenFineAdjustmentCrossesTheMaximum()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Weight(4.95m));
+        cut.Find("#measurement-range-Small").GetAttribute("aria-pressed").Should().Be("true");
+
+        // Act
+        await cut.Find("#measurement-increase").ClickAsync();
+
+        // Assert
+        cut.Find("#measurement-range-Medium").GetAttribute("aria-pressed").Should().Be("true");
+        await cut.Find("#measurement-apply").ClickAsync();
+        var result = await dialog.Result;
+        var applied = (MeasurementEditorResult)result!.Data!;
+        applied.CanonicalValue.Should().Be(5.05m);
+    }
+
+    [Fact]
+    public async Task ItShouldKeepAnExplicitlyChosenLargerRangeWhenTheWeightDecreases()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, _) = await ShowAsync(context, Weight(1m));
+        await cut.Find("#measurement-range-Monster").ClickAsync();
+
+        // Act
+        await cut.Find("#measurement-decrease").ClickAsync();
+
+        // Assert
+        cut.Find("#measurement-range-Monster").GetAttribute("aria-pressed").Should().Be("true");
+        cut.Find("#measurement-range-Small").GetAttribute("aria-pressed").Should().Be("false");
+    }
+
+    [Fact]
+    public async Task ItShouldNotClampTheWeightToTheVisualMaximum()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Weight(1m));
+
+        // Act
+        cut.Find("#measurement-exact-value").Input("300");
+
+        // Assert
+        cut.Find("#measurement-range-Monster").GetAttribute("aria-pressed").Should().Be("true");
+        cut.Find("#measurement-exact-value").GetAttribute("value").Should().Be("300");
+        await cut.Find("#measurement-apply").ClickAsync();
+        var result = await dialog.Result;
+        var applied = (MeasurementEditorResult)result!.Data!;
+        applied.CanonicalValue.Should().Be(300m);
+    }
+
+    [Fact]
+    public async Task ItShouldDisableRangesThatCannotRepresentTheCurrentWeight()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Weight(30m));
+
+        // Assert
+        cut.Find("#measurement-range-Small").HasAttribute("disabled").Should().BeTrue();
+        cut.Find("#measurement-range-Medium").HasAttribute("disabled").Should().BeTrue();
+        cut.Find("#measurement-range-Large").HasAttribute("disabled").Should().BeFalse();
+        cut.Find("#measurement-range-Monster").HasAttribute("disabled").Should().BeFalse();
+        await cut.Find("#measurement-range-Small").ClickAsync();
+        cut.Find("#measurement-range-Large").GetAttribute("aria-pressed").Should().Be("true");
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheSamePhysicalRangeAndWeightAcrossDisplayUnits()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var (metric, _) = await ShowAsync(context, Weight(3m));
+        var (imperial, _) = await ShowAsync(context, Weight(3m, WeightUnitEnum.Lb));
+
+        // Assert
+        metric.Find("#measurement-range-Small").GetAttribute("aria-pressed").Should().Be("true");
+        imperial.FindAll("#measurement-range-Small").Last().GetAttribute("aria-pressed")
+            .Should().Be("true");
+        metric.Find("#measurement-slider-maximum").TextContent.Trim().Should().Be("5 kg");
+        imperial.FindAll("#measurement-slider-maximum").Last().TextContent.Should().Contain("11 lb");
+    }
+
+    [Fact]
+    public async Task ItShouldNotAffectClearOrCancelSemantics()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cleared, clearedDialog) = await ShowAsync(context, Weight(2m));
+        await cleared.Find("#measurement-range-Monster").ClickAsync();
+
+        // Act
+        await cleared.Find("#measurement-clear").ClickAsync();
+        await cleared.Find("#measurement-apply").ClickAsync();
+        var (cancelled, cancelledDialog) = await ShowAsync(context, Weight(2m));
+        await cancelled.FindAll("#measurement-range-Large").Last().ClickAsync();
+        await cancelled.FindAll("#measurement-cancel").Last().ClickAsync();
+
+        // Assert
+        var clearedResult = await clearedDialog.Result;
+        ((MeasurementEditorResult)clearedResult!.Data!).CanonicalValue.Should().BeNull();
+        var cancelledResult = await cancelledDialog.Result;
+        cancelledResult!.Canceled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldExposeAccessibleNamesAndSelectionStateForEveryRange()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Weight(1m));
+
+        // Assert
+        cut.Find("#measurement-ranges").GetAttribute("role").Should().Be("group");
+        foreach (var (range, label) in new[]
+                 {
+                     ("Small", "Small"), ("Medium", "Medium"), ("Large", "Large"), ("Monster", "Monster")
+                 })
+        {
+            var button = cut.Find($"#measurement-range-{range}");
+            button.TagName.Should().Be("BUTTON");
+            button.GetAttribute("type").Should().Be("button");
+            button.GetAttribute("aria-label").Should().Be(label);
+            button.HasAttribute("aria-pressed").Should().BeTrue();
+        }
+
+        cut.Find("#measurement-range-Small").GetAttribute("aria-pressed").Should().Be("true");
+        cut.Find(".measurement-range-selected").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldPlaceTheRangeSelectorBesideTheScaleLargestFirst()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Weight(1m));
+
+        // Assert
+        cut.Find(".measurement-scale-layout").Should().NotBeNull();
+        cut.Find(".measurement-scale-layout .measurement-ranges").Should().NotBeNull();
+        cut.Find(".measurement-scale-layout .measurement-scale").Should().NotBeNull();
+        cut.FindAll(".measurement-range").Select(button => button.Id)
+            .Should().Equal(
+                "measurement-range-Monster",
+                "measurement-range-Large",
+                "measurement-range-Medium",
+                "measurement-range-Small");
+    }
+
+    [Fact]
+    public void ItShouldExposeFourLengthRangesWithTheIntendedCanonicalMaxima()
+    {
+        // Arrange
+        var expected = new (MeasurementScaleRangeEnum Range, decimal Maximum)[]
+        {
+            (MeasurementScaleRangeEnum.Small, 30m),
+            (MeasurementScaleRangeEnum.Medium, 60m),
+            (MeasurementScaleRangeEnum.Large, 120m),
+            (MeasurementScaleRangeEnum.Monster, 300m)
+        };
+
+        // Act
+        var ranges = MeasurementScaleRangeModel.Lengths;
+
+        // Assert
+        ranges.Should().HaveCount(4);
+        ranges.Select(range => (range.Range, range.MaximumCanonical)).Should().Equal(expected);
+    }
+
+    [Fact]
+    public async Task ItShouldOfferTheSameRangeSelectorForLengthBesideTheTape()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Length(50m));
+
+        // Assert
+        cut.Find(".measurement-scale-layout .measurement-tape").Should().NotBeNull();
+        cut.Find("#measurement-range-Medium").GetAttribute("aria-pressed").Should().Be("true");
+        cut.Find("#measurement-slider-minimum").TextContent.Trim().Should().Be("0 cm");
+        cut.Find("#measurement-slider-maximum").TextContent.Trim().Should().Be("60 cm");
+        cut.FindAll(".measurement-range").Should().HaveCount(4);
+        cut.Find("#measurement-range-Small").HasAttribute("disabled").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldExpandTheLengthRangeWithoutChangingTheCapturedLength()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var (cut, dialog) = await ShowAsync(context, Length(20m));
+        cut.Find("#measurement-range-Small").GetAttribute("aria-pressed").Should().Be("true");
+        var tapeAtSmall = cut.Find(".measurement-tape-strip").GetAttribute("width");
+
+        // Act
+        cut.Find("#measurement-exact-value").Input("70");
+
+        // Assert
+        cut.Find("#measurement-range-Large").GetAttribute("aria-pressed").Should().Be("true");
+        cut.Find(".measurement-tape-strip").GetAttribute("width").Should().NotBe(tapeAtSmall);
+        await cut.Find("#measurement-apply").ClickAsync();
+        var result = await dialog.Result;
+        ((MeasurementEditorResult)result!.Data!).CanonicalValue.Should().Be(70m);
+    }
+
+    [Fact]
+    public async Task ItShouldLabelLengthBoundsInImperialUnitsForTheSamePhysicalRange()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowAsync(context, Length(20m, LengthUnitEnum.In));
+
+        // Assert
+        cut.Find("#measurement-range-Small").GetAttribute("aria-pressed").Should().Be("true");
+        cut.Find("#measurement-slider-minimum").TextContent.Trim().Should().Be("0 in");
+        cut.Find("#measurement-slider-maximum").TextContent.Should().Contain("11.81 in");
+    }
+}


### PR DESCRIPTION
Closes #163

## What this does

Adds four visual ranges — Small, Medium, Large, Monster — to the measurement editor so ordinary catches actually move the needle instead of sitting near zero against a fixed maximum.

Ranges are canonical physical mass and length converted for display, so the same range covers the same fish whichever units the angler has saved:

| Range | Weight (canonical) | Length (canonical) |
|---|---|---|
| Small | 5 kg | 30 cm |
| Medium | 15 kg | 60 cm |
| Large | 40 kg | 120 cm |
| Monster | 120 kg | 300 cm |

### The rule that governs all of it

**The captured measurement is the source of truth.** Selecting a range changes only the visual maximum, the needle angle, the tape width and the slider bounds. It never changes, rounds, clamps, resets or otherwise mutates the value. A 300 kg weight stays 300 kg while displayed on a 120 kg dial.

Range selection is editor UI state and is **never persisted** — not to the catch, the database, the profile, IndexedDB or the API. No DTO, schema, storage or validation change is in this PR.

### Behaviour

- The editor opens on the **smallest** range that can display the current value.
- A range that cannot contain the current value is **disabled**; clicking one resolves to the smallest range that can.
- The range **expands automatically** when an exact entry or a +/- adjustment exceeds the current maximum.
- An **explicit larger choice is never shrunk** — if the angler zooms out and then reduces the weight, their choice stands.
- Slider minimum and maximum labels show the bounds in the angler's own units.

## Scope extension beyond the issue

The issue's Out of Scope says *"Do not add: changes to length controls"*. That was correct when written, but manual testing of the weight ranges showed the length tape had the identical problem, and leaving it alone would have shipped two measurement editors behaving differently. The extension was requested after that testing — recorded in [this comment on #163](https://github.com/kingkeamo/fishing-logbook/issues/163#issuecomment-5421914161) so the implementation isn't reviewed against the original wording.

Delivered beyond the original scope:

- Ranges on the **length** tape as well as the weight dial.
- The four range buttons extracted into a reusable `MeasurementRangeSelector` component consumed by both, rather than duplicated.
- Consistency fixes surfaced by the same manual pass:
  - the exact-entry field offers increment/decrement steppers for length as well as weight;
  - slider minimum/maximum labels render on both controls;
  - the selector uses the same palette as the dial and tape rather than a separate grey;
  - non-numeric exact entry no longer wipes the captured measurement;
  - **Clear** clears in place instead of closing the editor, so it can be confirmed or cancelled — clearing is now undoable, where before it was immediate and irreversible.

## Localisation

6 new keys in EN (en-GB) and FR, 404 keys each, parity verified. No hard-coded user-visible English.

## Test coverage

| Suite | Result |
|---|---|
| Measurement editor | 82 (up from 62) |
| `FishingLogBook.Web.Tests` | 937 |
| Full solution | 1,535 |
| vitest | 231 |
| Playwright browser | 39 |

`dotnet format`, `dotnet build` and `git diff --check` clean.

New `WhenTestingScaleRanges` covers: the canonical maxima for both controls; smallest-range-on-open; **weight unchanged across every range switch, verified through Apply** (including imperial 2.268 kg); needle and slider-maximum movement; metric and imperial bound labels; auto-expansion on exact entry and on +/- boundary crossing; explicit larger range retained when the value decreases; 300 kg not clamped; disabled ranges and click resolution; the same physical range across unit systems; Clear/Cancel semantics; and the accessibility contract.

**Browser coverage deliberately omitted.** This behaviour is Blazor render state — needle transform, slider bounds, disabled ranges, ARIA — fully assertable in bUnit and asserted there. Nothing touches IndexedDB, the service worker or the offline shell, which is what `BrowserTests/` exists for, and the measurement editor sits behind Cognito, so covering it would require test-only authentication in production Web. `self-review.md` rules that out for a product ticket, and no follow-up infrastructure ticket is warranted for this feature. Residual risk is visual alignment and icon sizing at phone widths, covered by manual testing.

## Manual post-merge steps

None. No migration, no Terraform, no configuration or secret change. No Terraform was planned or applied.

## Self review

```text
Self review:
- Issue/AC: PASS — all original ACs satisfied and tested; one deliberate scope extension, documented above and on the issue
- Architecture/CQRS: PASS — editor-only UI state; no service, client, API, storage or domain path touched
- Rules: findings 1, 2, 3 (all fixed)
- Security/privacy: PASS — no new data captured, transmitted or persisted; no identity or ownership surface touched
- Database/migrations: N/A — no schema, DTO or storage change
- Tests/coverage: PASS — 82 measurement tests, 937 Web, 1,535 solution
- Browser: N/A — reasoning above
- Web/UI/localisation: PASS — EN + FR, parity verified, stable id selectors, no translated-text selectors
- Code smells: finding 3 (fixed)
- CI/deployment: PASS — no manual steps
```

**Findings discovered during self-review:**

1. **`role="radiogroup"`/`role="radio"` promised keyboard behaviour that was not implemented.** The radio contract obliges arrow-key navigation with roving `tabindex`; the buttons were individually tabbable instead. A screen-reader user would have been told the widget behaves one way while it behaved another — worse than plain buttons.
2. **A CSS rule that could never apply.** `.measurement-scale-layout .measurement-ranges { order: 2 }` sat in the parent's scoped CSS, but the element belongs to the child component, so Blazor stamps the parent's scope id and the selector never matches. It would have needed `::deep`.
3. **The component extraction left its whole ruleset behind.** ~79 lines of `.measurement-weight-range*` CSS stayed in `MeasurementEditorModal.razor.css` after the selector moved out under renamed classes — entirely dead, and invisible to a green test suite.

**Fixes made:**

1. Switched to `role="group"` + `aria-pressed` toggle buttons, which is honest about what the control does and needs no keyboard shim. Tests updated to assert native `<button type="button">` semantics.
2. Deleted the rule rather than reviving it with `::deep` — it was also redundant once the selector followed the visual in DOM order.
3. Deleted the dead block; the child component owns its styling.

**Remaining deliberate gaps:**

- No Playwright coverage, for the architectural reasons above.
- The scope extension to length contradicts the issue's Out of Scope wording. The issue text was **not** edited; the divergence is recorded as a comment instead so the original intent stays visible in the history.
- The first `npm run test:browser` run reported 4 failures in the published offline-shell specs; two consecutive re-runs gave 39/39. No JavaScript changed in this PR, so this reads as a first-run publish-artifact race rather than a defect — flagged rather than reported as a clean sweep, since the cause was not captured.

E2E and manual device testing are being run separately by the author.
