### PR TITLE
FLB#166 | Stop IndexedDB photo reads freezing catch pages

### DIFF
--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
@@ -51,6 +51,8 @@ public static class DiagnosticEventNames
     public const string PhotographDeleteFailed = "PhotographDeleteFailed";
     public const string CatchSyncCompleted = "CatchSyncCompleted";
     public const string CatchSyncFailed = "CatchSyncFailed";
+    public const string CatchServerRecordMissing = "CatchServerRecordMissing";
+
     public const string AuthenticationUnavailable = "AuthenticationUnavailable";
 
     public const string ServiceWorkerError = "ServiceWorkerError";

--- a/src/FishingLogBook.Web/BrowserTests/catch-store-reads.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/catch-store-reads.spec.js
@@ -1,0 +1,224 @@
+import { expect, test } from '@playwright/test';
+
+const catchStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js';
+const databaseName = 'FishingLogBook';
+const ownerUserId = '11111111-1111-1111-1111-111111111111';
+const otherUserId = '22222222-2222-2222-2222-222222222222';
+const photographBytes = 1024 * 1024;
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/src/FishingLogBook.Web/BrowserTests/harness/index.html');
+    await page.evaluate((name) => new Promise((resolve) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+    }), databaseName);
+});
+
+async function seed(page, catches) {
+    await page.evaluate(async ({ catchStoreModule, catches, photographBytes }) => {
+        const { putCatchWithPhotographs } = await import(catchStoreModule);
+        for (const item of catches) {
+            const photographs = item.photographIds.map((photographId, index) => ({
+                id: photographId,
+                catchId: item.catchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array(photographBytes).fill(index + 1)
+            }));
+            await putCatchWithPhotographs(
+                JSON.stringify({
+                    id: item.catchId,
+                    userId: item.userId,
+                    caughtOn: '2026-08-17T08:00:00+00:00',
+                    photographs: photographs.map((photograph) => ({
+                        id: photograph.id,
+                        catchId: item.catchId,
+                        contentType: photograph.contentType,
+                        syncStatus: 'savedLocally'
+                    }))
+                }),
+                photographs);
+        }
+    }, { catchStoreModule, catches, photographBytes });
+}
+
+function catchWithPhotographs(index, userId = ownerUserId, photographCount = 1) {
+    const catchId = `aaaaaaaa-aaaa-aaaa-aaaa-00000000000${index}`;
+    return {
+        catchId,
+        userId,
+        photographIds: Array.from(
+            { length: photographCount },
+            (_, photograph) => `bbbbbbbb-bbbb-bbbb-bbbb-${index}0000000000${photograph}`)
+    };
+}
+
+test('list metadata read transfers no photograph bytes and never opens the photograph store', async ({ page }) => {
+    await seed(page, [
+        catchWithPhotographs(1),
+        catchWithPhotographs(2),
+        catchWithPhotographs(3, ownerUserId, 2),
+        catchWithPhotographs(4),
+        catchWithPhotographs(5),
+        catchWithPhotographs(6),
+        catchWithPhotographs(7),
+        catchWithPhotographs(8)
+    ]);
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId }) => {
+        const { getCatchMetadata, PHOTO_STORE_NAME } = await import(catchStoreModule);
+        const stores = [];
+        const originalGet = IDBObjectStore.prototype.get;
+        const originalOpenCursor = IDBObjectStore.prototype.openCursor;
+        IDBObjectStore.prototype.get = function instrumentedGet(key) {
+            stores.push({ store: this.name, operation: 'get' });
+            return originalGet.call(this, key);
+        };
+        IDBObjectStore.prototype.openCursor = function instrumentedOpenCursor(...args) {
+            stores.push({ store: this.name, operation: 'openCursor' });
+            return originalOpenCursor.apply(this, args);
+        };
+
+        try {
+            const items = await getCatchMetadata(ownerUserId);
+            return {
+                count: items.length,
+                transferredBytes: items.reduce(
+                    (total, item) => total + item.photographs.reduce(
+                        (bytes, photograph) => bytes + photograph.bytesBase64.length,
+                        0),
+                    0),
+                photographStoreAccesses: stores.filter((access) => access.store === PHOTO_STORE_NAME).length
+            };
+        } finally {
+            IDBObjectStore.prototype.get = originalGet;
+            IDBObjectStore.prototype.openCursor = originalOpenCursor;
+        }
+    }, { catchStoreModule, ownerUserId });
+
+    expect(result.count).toBe(8);
+    expect(result.transferredBytes).toBe(0);
+    expect(result.photographStoreAccesses).toBe(0);
+});
+
+test('single Catch read returns only the requested photograph blobs', async ({ page }) => {
+    await seed(page, [
+        catchWithPhotographs(1),
+        catchWithPhotographs(2, ownerUserId, 2),
+        catchWithPhotographs(3)
+    ]);
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId }) => {
+        const { getCatchWithPhotographs, PHOTO_STORE_NAME } = await import(catchStoreModule);
+        const keys = [];
+        const originalGet = IDBObjectStore.prototype.get;
+        IDBObjectStore.prototype.get = function instrumentedGet(key) {
+            keys.push({ store: this.name, key });
+            return originalGet.call(this, key);
+        };
+
+        try {
+            const item = await getCatchWithPhotographs(
+                ownerUserId,
+                'aaaaaaaa-aaaa-aaaa-aaaa-000000000002');
+            return {
+                catchId: JSON.parse(item.json).id,
+                photographIds: item.photographs.map((photograph) => photograph.id),
+                photographKeysRead: keys
+                    .filter((access) => access.store === PHOTO_STORE_NAME)
+                    .map((access) => access.key)
+            };
+        } finally {
+            IDBObjectStore.prototype.get = originalGet;
+        }
+    }, { catchStoreModule, ownerUserId });
+
+    expect(result.catchId).toBe('aaaaaaaa-aaaa-aaaa-aaaa-000000000002');
+    expect(result.photographIds).toEqual([
+        'bbbbbbbb-bbbb-bbbb-bbbb-200000000000',
+        'bbbbbbbb-bbbb-bbbb-bbbb-200000000001'
+    ]);
+    expect(result.photographKeysRead).toEqual([
+        'bbbbbbbb-bbbb-bbbb-bbbb-200000000000',
+        'bbbbbbbb-bbbb-bbbb-bbbb-200000000001'
+    ]);
+});
+
+test('single Catch read does not return another owner Catch or its blobs', async ({ page }) => {
+    await seed(page, [catchWithPhotographs(9, otherUserId)]);
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId }) => {
+        const { getCatchWithPhotographs, PHOTO_STORE_NAME } = await import(catchStoreModule);
+        const keys = [];
+        const originalGet = IDBObjectStore.prototype.get;
+        IDBObjectStore.prototype.get = function instrumentedGet(key) {
+            keys.push({ store: this.name, key });
+            return originalGet.call(this, key);
+        };
+
+        try {
+            const item = await getCatchWithPhotographs(
+                ownerUserId,
+                'aaaaaaaa-aaaa-aaaa-aaaa-000000000009');
+            return {
+                item,
+                photographKeysRead: keys.filter((access) => access.store === PHOTO_STORE_NAME).length
+            };
+        } finally {
+            IDBObjectStore.prototype.get = originalGet;
+        }
+    }, { catchStoreModule, ownerUserId });
+
+    expect(result.item).toBeNull();
+    expect(result.photographKeysRead).toBe(0);
+});
+
+test('offline logbook read still returns cached photograph bytes for every owned Catch', async ({ page }) => {
+    await seed(page, [catchWithPhotographs(1), catchWithPhotographs(2)]);
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId }) => {
+        const { getAllCatchesWithPhotographs } = await import(catchStoreModule);
+        const items = await getAllCatchesWithPhotographs(ownerUserId);
+        return items.map((item) => item.photographs.map((photograph) => photograph.bytesBase64.length));
+    }, { catchStoreModule, ownerUserId });
+
+    expect(result).toHaveLength(2);
+    expect(result.every((lengths) => lengths.every((length) => length > 0))).toBe(true);
+});
+
+test('repeated list reads do not accumulate photograph store work', async ({ page }) => {
+    await seed(page, [
+        catchWithPhotographs(1),
+        catchWithPhotographs(2),
+        catchWithPhotographs(3)
+    ]);
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId }) => {
+        const { getCatchMetadata, PHOTO_STORE_NAME } = await import(catchStoreModule);
+        const accesses = [];
+        const originalGet = IDBObjectStore.prototype.get;
+        const originalOpenCursor = IDBObjectStore.prototype.openCursor;
+        IDBObjectStore.prototype.get = function instrumentedGet(key) {
+            accesses.push(this.name);
+            return originalGet.call(this, key);
+        };
+        IDBObjectStore.prototype.openCursor = function instrumentedOpenCursor(...args) {
+            accesses.push(this.name);
+            return originalOpenCursor.apply(this, args);
+        };
+
+        try {
+            for (let read = 0; read < 5; read++) {
+                await getCatchMetadata(ownerUserId);
+            }
+
+            return accesses.filter((name) => name === PHOTO_STORE_NAME).length;
+        } finally {
+            IDBObjectStore.prototype.get = originalGet;
+            IDBObjectStore.prototype.openCursor = originalOpenCursor;
+        }
+    }, { catchStoreModule, ownerUserId });
+
+    expect(result).toBe(0);
+});

--- a/src/FishingLogBook.Web/Features/Catch/Modals/LocationPrivacy/LocationPrivacyModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Modals/LocationPrivacy/LocationPrivacyModal.razor.cs
@@ -61,8 +61,7 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
         try
         {
             var ownerUserId = await LocalCatchOwner.GetUserIdAsync(_cancellationTokenSource.Token);
-            var saved = await CatchStore.GetAllAsync(ownerUserId, _cancellationTokenSource.Token);
-            _catch = saved.FirstOrDefault(catchRecord => catchRecord.Id == CatchId);
+            _catch = await CatchStore.GetAsync(ownerUserId, CatchId, _cancellationTokenSource.Token);
             if (_catch is null)
             {
                 _loadFailed = true;

--- a/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
@@ -46,10 +46,17 @@ internal static class CatchJson
     {
         var metadata = JsonSerializer.Deserialize<CatchMetadata>(json, Options)
             ?? throw new InvalidOperationException("Catch metadata could not be read.");
+        return ToModel(metadata, OrderPhotographs(metadata.Photographs, photographs));
+    }
+
+    private static CatchModel ToModel(
+        CatchMetadata metadata,
+        IReadOnlyList<CatchPhotographModel> photographs)
+    {
         return new CatchModel(
             metadata.Id,
             metadata.CaughtOn,
-            OrderPhotographs(metadata.Photographs, photographs),
+            photographs,
             metadata.SpeciesName,
             metadata.Location,
             metadata.UserId,
@@ -62,6 +69,22 @@ internal static class CatchJson
             metadata.Method,
             metadata.BaitOrLure,
             metadata.Notes);
+    }
+
+    public static CatchModel DeserializeMetadata(string json)
+    {
+        var metadata = JsonSerializer.Deserialize<CatchMetadata>(json, Options)
+            ?? throw new InvalidOperationException("Catch metadata could not be read.");
+        var photographs = metadata.Photographs
+            .Select(photograph => new CatchPhotographModel(
+                photograph.Id,
+                photograph.CatchId,
+                photograph.ContentType,
+                Bytes: null,
+                photograph.SyncStatus,
+                photograph.ObjectKey))
+            .ToArray();
+        return ToModel(metadata, photographs);
     }
 
     private static IReadOnlyList<CatchPhotographModel> OrderPhotographs(

--- a/src/FishingLogBook.Web/Features/Catch/Offline/Stores/ICatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Stores/ICatchStore.cs
@@ -8,6 +8,13 @@ public interface ICatchStore
 
     Task<IReadOnlyList<CatchModel>> GetAllAsync(Guid ownerUserId, CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<CatchModel>> GetMetadataAsync(Guid ownerUserId, CancellationToken cancellationToken);
+
+    Task<CatchModel?> GetMetadataAsync(
+        Guid ownerUserId,
+        Guid catchId,
+        CancellationToken cancellationToken);
+
     Task<CatchModel?> GetAsync(
         Guid ownerUserId,
         Guid catchId,

--- a/src/FishingLogBook.Web/Features/Catch/Offline/Stores/IndexedDbCatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Stores/IndexedDbCatchStore.cs
@@ -77,13 +77,38 @@ public sealed class IndexedDbCatchStore : ICatchStore
         Guid ownerUserId,
         CancellationToken cancellationToken)
     {
+        return await ReadCatchesAsync(
+            ownerUserId,
+            "getAllCatchesWithPhotographs",
+            "read",
+            ToModel,
+            cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<CatchModel>> GetMetadataAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        return await ReadCatchesAsync(
+            ownerUserId,
+            "getCatchMetadata",
+            "metadata-read",
+            static record => CatchJson.DeserializeMetadata(record.Json),
+            cancellationToken);
+    }
+
+    public async Task<CatchModel?> GetMetadataAsync(
+        Guid ownerUserId,
+        Guid catchId,
+        CancellationToken cancellationToken)
+    {
         if (ownerUserId == Guid.Empty)
         {
             throw new InvalidOperationException("A catch owner is required.");
         }
 
         var loaded = await OfflineOperation.ExecuteAsync(
-            "read",
+            "single-metadata-read",
             StoreName,
             DiagnosticEventNames.OfflineDbReadStarted,
             DiagnosticEventNames.OfflineDbReadCompleted,
@@ -94,15 +119,16 @@ public sealed class IndexedDbCatchStore : ICatchStore
             async token =>
             {
                 var module = await GetModuleAsync(token);
-                var records = await module.InvokeAsync<StoredCatchRecord[]>(
-                    "getAllCatchesWithPhotographs",
+                var record = await module.InvokeAsync<StoredCatchRecord?>(
+                    "getCatchMetadataById",
                     token,
-                    ownerUserId.ToString("D"));
-                return (IReadOnlyList<CatchModel>)(records ?? []).Select(ToModel).ToArray();
+                    ownerUserId.ToString("D"),
+                    catchId.ToString("D"));
+                return record is null ? null : CatchJson.DeserializeMetadata(record.Json);
             },
             cancellationToken,
             _logging);
-        return LocalCatchVisibility.ForOwner(loaded, ownerUserId);
+        return loaded is not null && loaded.UserId == ownerUserId ? loaded : null;
     }
 
     public async Task<CatchModel?> GetAsync(
@@ -110,8 +136,33 @@ public sealed class IndexedDbCatchStore : ICatchStore
         Guid catchId,
         CancellationToken cancellationToken)
     {
-        var catches = await GetAllAsync(ownerUserId, cancellationToken);
-        return catches.SingleOrDefault(catchRecord => catchRecord.Id == catchId);
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
+        var loaded = await OfflineOperation.ExecuteAsync(
+            "single-read",
+            StoreName,
+            DiagnosticEventNames.OfflineDbReadStarted,
+            DiagnosticEventNames.OfflineDbReadCompleted,
+            DiagnosticEventNames.OfflineDbReadFailed,
+            DiagnosticEventNames.OfflineDbReadTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                var record = await module.InvokeAsync<StoredCatchRecord?>(
+                    "getCatchWithPhotographs",
+                    token,
+                    ownerUserId.ToString("D"),
+                    catchId.ToString("D"));
+                return record is null ? null : ToModel(record);
+            },
+            cancellationToken,
+            _logging);
+        return loaded is not null && loaded.UserId == ownerUserId ? loaded : null;
     }
 
     public async Task UpdateSyncStateAsync(
@@ -140,6 +191,41 @@ public sealed class IndexedDbCatchStore : ICatchStore
             },
             cancellationToken,
             _logging);
+    }
+
+    private async Task<IReadOnlyList<CatchModel>> ReadCatchesAsync(
+        Guid ownerUserId,
+        string jsFunction,
+        string operation,
+        Func<StoredCatchRecord, CatchModel> toModel,
+        CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
+        var loaded = await OfflineOperation.ExecuteAsync(
+            operation,
+            StoreName,
+            DiagnosticEventNames.OfflineDbReadStarted,
+            DiagnosticEventNames.OfflineDbReadCompleted,
+            DiagnosticEventNames.OfflineDbReadFailed,
+            DiagnosticEventNames.OfflineDbReadTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                var records = await module.InvokeAsync<StoredCatchRecord[]>(
+                    jsFunction,
+                    token,
+                    ownerUserId.ToString("D"));
+                return (IReadOnlyList<CatchModel>)(records ?? []).Select(toModel).ToArray();
+            },
+            cancellationToken,
+            _logging);
+        return LocalCatchVisibility.ForOwner(loaded, ownerUserId);
     }
 
     private static CatchModel ToModel(StoredCatchRecord record)

--- a/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/CatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/CatchSynchroniser.cs
@@ -15,6 +15,7 @@ namespace FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
 public sealed class CatchSynchroniser : ICatchSynchroniser
 {
     private readonly ConcurrentDictionary<Guid, byte> _inFlight = new();
+    private readonly ConcurrentDictionary<Guid, byte> _rerunRequested = new();
     private readonly ICatchStore _store;
     private readonly ICatchClient _client;
     private readonly INetworkService _networkService;
@@ -89,9 +90,9 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
         Guid ownerUserId,
         CancellationToken cancellationToken)
     {
-        var catches = await _store.GetAllAsync(ownerUserId, cancellationToken);
+        var catches = await _store.GetMetadataAsync(ownerUserId, cancellationToken);
         catches = await RecoverInterruptedAsync(catches, cancellationToken);
-        var pending = catches.Where(NeedsSynchronisation).ToArray();
+        var pending = catches.Where(NeedsAutomaticSynchronisation).ToArray();
         if (!await _networkService.IsOnlineAsync(cancellationToken))
         {
             foreach (var catchRecord in pending)
@@ -153,6 +154,7 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
     {
         if (!_inFlight.TryAdd(catchId, 0))
         {
+            _rerunRequested.TryAdd(catchId, 0);
             return;
         }
 
@@ -163,6 +165,11 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
         finally
         {
             _inFlight.TryRemove(catchId, out _);
+            if (_rerunRequested.TryRemove(catchId, out _)
+                && !cancellationToken.IsCancellationRequested)
+            {
+                await SynchroniseGuardedAsync(ownerUserId, catchId, cancellationToken);
+            }
         }
     }
 
@@ -173,6 +180,11 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
     {
         var catchRecord = await _store.GetAsync(ownerUserId, catchId, cancellationToken);
         if (catchRecord is null)
+        {
+            return;
+        }
+
+        if (!NeedsSynchronisation(catchRecord))
         {
             return;
         }
@@ -210,7 +222,11 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
         {
             catchRecord = photograph.SyncStatus == SyncStatus.PendingDeletion
                 ? await DeletePhotographAsync(catchRecord, photograph.Id, cancellationToken)
-                : await SynchronisePhotographAsync(catchRecord, photograph.Id, cancellationToken);
+                : await SynchronisePhotographAsync(
+                    catchRecord,
+                    photograph.Id,
+                    allowServerCatchRecovery: true,
+                    cancellationToken);
         }
 
         catchRecord = catchRecord with { SyncStatus = DeriveOverallStatus(catchRecord) };
@@ -246,27 +262,29 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
         {
             var sent = ToDto(catchRecord);
             await _client.UpsertAsync(sent, cancellationToken);
-            var current = await _store.GetAsync(
+            var stored = await _store.GetMetadataAsync(
                 catchRecord.UserId,
                 catchRecord.Id,
                 cancellationToken);
-            if (current is null)
+            if (stored is null)
             {
                 return catchRecord;
             }
 
-            if (!HasSameMetadata(current, sent))
+            var refreshed = WithPhotographBytesFrom(stored, catchRecord);
+
+            if (!HasSameMetadata(refreshed, sent))
             {
-                current = current with
+                refreshed = refreshed with
                 {
                     SyncStatus = SyncStatus.WaitingToSynchronise,
                     MetadataSyncStatus = SyncStatus.WaitingToSynchronise
                 };
-                await _store.UpdateSyncStateAsync(current, cancellationToken);
-                return current;
+                await _store.UpdateSyncStateAsync(refreshed, cancellationToken);
+                return refreshed;
             }
 
-            catchRecord = current with { MetadataSyncStatus = SyncStatus.Synchronised };
+            catchRecord = refreshed with { MetadataSyncStatus = SyncStatus.Synchronised };
             await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
             await SafeLogAsync(
                 DiagnosticLevel.Information,
@@ -313,6 +331,7 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
     private async Task<CatchModel> SynchronisePhotographAsync(
         CatchModel catchRecord,
         Guid photographId,
+        bool allowServerCatchRecovery,
         CancellationToken cancellationToken)
     {
         catchRecord = WithPhotographStatus(
@@ -372,6 +391,15 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
         }
         catch (Exception exception) when (IsSynchronisationFailure(exception, cancellationToken))
         {
+            if (allowServerCatchRecovery && IsMissingServerCatch(exception))
+            {
+                return await RecoverMissingServerCatchAsync(
+                    catchRecord,
+                    photographId,
+                    exception,
+                    cancellationToken);
+            }
+
             catchRecord = WithPhotographStatus(
                 catchRecord,
                 photographId,
@@ -400,6 +428,70 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
 
             return catchRecord;
         }
+    }
+
+    private async Task<CatchModel> RecoverMissingServerCatchAsync(
+        CatchModel catchRecord,
+        Guid photographId,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        await SafeLogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchServerRecordMissing,
+            "The server catch was missing for a pending photograph upload.",
+            catchRecord.Id,
+            photographId,
+            exception,
+            cancellationToken);
+
+        catchRecord = catchRecord with { MetadataSyncStatus = SyncStatus.WaitingToSynchronise };
+        await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
+        catchRecord = await SynchroniseMetadataAsync(catchRecord, cancellationToken);
+        if (catchRecord.MetadataSyncStatus != SyncStatus.Synchronised)
+        {
+            return WithFailedPhotograph(catchRecord, photographId);
+        }
+
+        return await SynchronisePhotographAsync(
+            catchRecord,
+            photographId,
+            allowServerCatchRecovery: false,
+            cancellationToken);
+    }
+
+    private CatchModel WithFailedPhotograph(CatchModel catchRecord, Guid photographId)
+    {
+        return WithPhotographStatus(
+            catchRecord,
+            photographId,
+            SyncStatus.FailedToSynchronise,
+            objectKey: null);
+    }
+
+    private static CatchModel WithPhotographBytesFrom(CatchModel target, CatchModel source)
+    {
+        var bytesById = source.Photographs
+            .Where(photograph => photograph.Bytes is { Length: > 0 })
+            .ToDictionary(photograph => photograph.Id, photograph => photograph.Bytes!);
+        return target with
+        {
+            Photographs = target.Photographs
+                .Select(photograph => photograph.Bytes is { Length: > 0 }
+                    ? photograph
+                    : bytesById.TryGetValue(photograph.Id, out var bytes)
+                        ? photograph with { Bytes = bytes }
+                        : photograph)
+                .ToArray()
+        };
+    }
+
+    private static bool IsMissingServerCatch(Exception exception)
+    {
+        return exception is HttpRequestException
+        {
+            StatusCode: System.Net.HttpStatusCode.NotFound
+        };
     }
 
     private async Task<CatchModel> DeletePhotographAsync(
@@ -740,6 +832,15 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
     private static bool NeedsSynchronisation(CatchModel catchRecord)
     {
         return catchRecord.SyncStatus != SyncStatus.Synchronised;
+    }
+
+    private static bool NeedsAutomaticSynchronisation(CatchModel catchRecord)
+    {
+        return NeedsSynchronisation(catchRecord)
+            && catchRecord.SyncStatus != SyncStatus.FailedToSynchronise
+            && catchRecord.MetadataSyncStatus != SyncStatus.FailedToSynchronise
+            && catchRecord.Photographs.All(
+                photograph => photograph.SyncStatus != SyncStatus.FailedToSynchronise);
     }
 
     private static bool NeedsPhotographSynchronisation(CatchPhotographModel photograph)

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.Loading.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.Loading.cs
@@ -17,7 +17,7 @@ public partial class CatchEdit
         {
             await LoadPreferencesAsync();
             var ownerUserId = await LocalCatchOwner.GetUserIdAsync(_cancellationTokenSource.Token);
-            _catch = await CatchStore.GetAsync(ownerUserId, CatchId, _cancellationTokenSource.Token)
+            _catch = await TryLoadLocallyAsync(ownerUserId, _cancellationTokenSource.Token)
                 ?? await TryLocalizeFromServerAsync(ownerUserId, _cancellationTokenSource.Token);
             if (_catch is null)
             {
@@ -35,6 +35,25 @@ public partial class CatchEdit
         finally
         {
             _isLoading = false;
+        }
+    }
+
+    private async Task<CatchModel?> TryLoadLocallyAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await CatchStore.GetAsync(ownerUserId, CatchId, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("reading a local catch for editing", exception, CancellationToken.None);
+            return null;
         }
     }
 
@@ -112,7 +131,6 @@ public partial class CatchEdit
         {
             await Logging.LogErrorAsync("saving a server catch for local editing", exception, CancellationToken.None);
             _offlineUnavailable = true;
-            return null;
         }
 
         return localized;

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor
@@ -13,7 +13,12 @@
         @if (_loadFailed)
         {
             <MudAlert Severity="Severity.Error" id="catch-edit-load-failed">
-                @(_offlineUnavailable ? Loc["Catch_EditLoadOfflineFailed"] : Loc["Catch_EditLoadFailed"])
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Justify="Justify.SpaceBetween">
+                    <span>@(_offlineUnavailable ? Loc["Catch_EditLoadOfflineFailed"] : Loc["Catch_EditLoadFailed"])</span>
+                    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Small"
+                               OnClick="RetryLoadAsync" Disabled="_isLoading"
+                               id="catch-edit-load-retry">@Loc["Catch_LoadRetry"]</MudButton>
+                </MudStack>
             </MudAlert>
         }
         else if (_isLoading)

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.razor.cs
@@ -101,6 +101,16 @@ public partial class CatchEdit : ComponentBase, IDisposable
         await LoadAsync();
     }
 
+    private async Task RetryLoadAsync()
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        await LoadAsync();
+    }
+
     private Task OnDetailsSavedAsync(CatchEditSavedModel saved)
     {
         _catch = saved.Catch;

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
@@ -22,7 +22,14 @@
 
         @if (_loadFailed)
         {
-            <MudAlert Severity="Severity.Error" id="catch-list-load-failed">@Loc["Catch_LoadFailed"]</MudAlert>
+            <MudAlert Severity="Severity.Error" id="catch-list-load-failed">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Justify="Justify.SpaceBetween">
+                    <span>@Loc["Catch_LoadFailed"]</span>
+                    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Small"
+                               OnClick="RetryLoadAsync" Disabled="_isLoadInFlight"
+                               id="catch-list-load-retry">@Loc["Catch_LoadRetry"]</MudButton>
+                </MudStack>
+            </MudAlert>
         }
         else if (_isLoading)
         {

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
@@ -13,6 +13,7 @@ using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
 using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Providers;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
@@ -29,6 +30,7 @@ public partial class CatchList : ComponentBase, IDisposable
     private readonly Dictionary<Guid, DateTime> _localCaughtOn = [];
 
     private IReadOnlyList<CatchModel> _allCatches = [];
+    private IReadOnlyList<CatchModel> _remoteCatches = [];
     private IReadOnlyList<CatchGroup> _filteredGroups = [];
     private IReadOnlyList<string> _methodOptions = [];
     private IReadOnlyList<string> _speciesOptions = [];
@@ -39,6 +41,10 @@ public partial class CatchList : ComponentBase, IDisposable
     private LengthUnitEnum _lengthUnit = LengthUnitEnum.Cm;
     private bool _isLoading = true;
     private bool _loadFailed;
+    private bool _isLoadInFlight;
+    private bool _reloadRequested;
+    private bool _localRefreshRequested;
+    private AnglerPreferencesModel? _preferences;
 
     [Inject]
     private ICatchStore CatchStore { get; set; } = default!;
@@ -81,6 +87,35 @@ public partial class CatchList : ComponentBase, IDisposable
 
     private async Task LoadAsync()
     {
+        if (_isLoadInFlight)
+        {
+            _reloadRequested = true;
+            return;
+        }
+
+        _isLoadInFlight = true;
+        try
+        {
+            do
+            {
+                _reloadRequested = false;
+                await LoadOnceAsync();
+            }
+            while (_reloadRequested && !_cancellationTokenSource.IsCancellationRequested);
+        }
+        finally
+        {
+            _isLoadInFlight = false;
+        }
+
+        if (_localRefreshRequested && !_cancellationTokenSource.IsCancellationRequested)
+        {
+            await RefreshLocalAfterSynchronisationAsync();
+        }
+    }
+
+    private async Task LoadOnceAsync()
+    {
         _isLoading = true;
         _loadFailed = false;
         var cancellationToken = _cancellationTokenSource.Token;
@@ -89,19 +124,44 @@ public partial class CatchList : ComponentBase, IDisposable
             var preferencesTask = AnglerPreferences.GetAsync(cancellationToken);
             var ownerUserId = await LocalCatchOwner.GetUserIdAsync(cancellationToken);
             _currentUserId = ownerUserId;
-            var saved = await CatchStore.GetAllAsync(ownerUserId, cancellationToken);
-            var serverOnly = await LoadServerOnlyCatchesAsync(saved, cancellationToken);
-            _allCatches = saved
-                .Concat(serverOnly)
-                .OrderByDescending(catchRecord => catchRecord.CaughtOn)
-                .ToArray();
-            var preferences = await preferencesTask;
-            _weightUnit = preferences.WeightUnit;
-            _lengthUnit = preferences.LengthUnit;
 
-            await ComputeLocalTimesAsync(cancellationToken);
-            ComputeFilterOptions();
-            RebuildFilteredGroups();
+            var localTask = LoadLocalCatchesAsync(ownerUserId, cancellationToken);
+            var remoteTask = LoadRemoteCatchesAsync(cancellationToken);
+            var firstCompleted = await Task.WhenAny(localTask, remoteTask);
+            if (firstCompleted == remoteTask)
+            {
+                var earlyRemote = await remoteTask;
+                if (!earlyRemote.Failed)
+                {
+                    await DisplayAsync(
+                        ownerUserId,
+                        [],
+                        earlyRemote.Catches,
+                        await preferencesTask,
+                        cancellationToken);
+                    _isLoading = false;
+                    await InvokeAsync(StateHasChanged);
+                }
+            }
+
+            var local = await localTask;
+            var remote = await remoteTask;
+            _remoteCatches = remote.Failed ? [] : remote.Catches;
+            _preferences = await preferencesTask;
+            if (local.Failed && remote.Failed)
+            {
+                _loadFailed = true;
+                _allCatches = [];
+                _filteredGroups = [];
+                return;
+            }
+
+            await DisplayAsync(
+                ownerUserId,
+                local.Catches,
+                _remoteCatches,
+                _preferences,
+                cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -120,19 +180,53 @@ public partial class CatchList : ComponentBase, IDisposable
         }
     }
 
-    private async Task<IReadOnlyList<CatchModel>> LoadServerOnlyCatchesAsync(
+    private async Task DisplayAsync(
+        Guid ownerUserId,
         IReadOnlyList<CatchModel> local,
+        IReadOnlyList<CatchModel> remote,
+        AnglerPreferencesModel preferences,
         CancellationToken cancellationToken)
     {
-        IReadOnlyList<CatchViewDto> remote;
+        _allCatches = await MergeAsync(ownerUserId, local, remote, cancellationToken);
+        _weightUnit = preferences.WeightUnit;
+        _lengthUnit = preferences.LengthUnit;
+        await ComputeLocalTimesAsync(cancellationToken);
+        ComputeFilterOptions();
+        RebuildFilteredGroups();
+    }
+
+    private async Task<CatchLoadResult> LoadLocalCatchesAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return new CatchLoadResult(
+                await CatchStore.GetMetadataAsync(ownerUserId, cancellationToken),
+                Failed: false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("catch logbook local read", exception, CancellationToken.None);
+            return new CatchLoadResult([], Failed: true);
+        }
+    }
+
+    private async Task<CatchLoadResult> LoadRemoteCatchesAsync(CancellationToken cancellationToken)
+    {
         try
         {
             if (!await Network.IsOnlineAsync(cancellationToken))
             {
-                return [];
+                return new CatchLoadResult([], Failed: true);
             }
 
-            remote = await CatchClient.GetAllAsync(cancellationToken);
+            var remote = await CatchClient.GetAllAsync(cancellationToken);
+            return new CatchLoadResult([.. remote.Select(ToCatchModel)], Failed: false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -141,13 +235,89 @@ public partial class CatchList : ComponentBase, IDisposable
         catch (Exception exception)
         {
             await Logging.LogErrorAsync("catch logbook server fetch", exception, CancellationToken.None);
-            return [];
+            return new CatchLoadResult([], Failed: true);
+        }
+    }
+
+    private async Task<IReadOnlyList<CatchModel>> MergeAsync(
+        Guid ownerUserId,
+        IReadOnlyList<CatchModel> local,
+        IReadOnlyList<CatchModel> remote,
+        CancellationToken cancellationToken)
+    {
+        var remoteById = remote.ToDictionary(catchRecord => catchRecord.Id);
+        var merged = new List<CatchModel>(local.Count + remote.Count);
+        foreach (var catchRecord in local)
+        {
+            var remoteCatch = remoteById.GetValueOrDefault(catchRecord.Id);
+            if (remoteCatch is not null && IsFullySynchronised(catchRecord))
+            {
+                merged.Add(remoteCatch);
+                continue;
+            }
+
+            merged.Add(await WithDisplayablePhotographsAsync(
+                ownerUserId,
+                catchRecord,
+                remoteCatch,
+                cancellationToken));
         }
 
         var localIds = local.Select(catchRecord => catchRecord.Id).ToHashSet();
-        return [.. remote
-            .Where(catchRecord => !localIds.Contains(catchRecord.Id))
-            .Select(ToCatchModel)];
+        merged.AddRange(remote.Where(catchRecord => !localIds.Contains(catchRecord.Id)));
+        return [.. merged.OrderByDescending(catchRecord => catchRecord.CaughtOn)];
+    }
+
+    private static bool IsFullySynchronised(CatchModel catchRecord)
+    {
+        return catchRecord.SyncStatus == SyncStatus.Synchronised
+            && catchRecord.MetadataSyncStatus == SyncStatus.Synchronised
+            && catchRecord.Photographs.All(
+                photograph => photograph.SyncStatus == SyncStatus.Synchronised);
+    }
+
+    private async Task<CatchModel> WithDisplayablePhotographsAsync(
+        Guid ownerUserId,
+        CatchModel local,
+        CatchModel? remote,
+        CancellationToken cancellationToken)
+    {
+        var remoteUrls = remote?.Photographs
+            .Where(photograph => !string.IsNullOrWhiteSpace(photograph.RemoteUrl))
+            .ToDictionary(photograph => photograph.Id, photograph => photograph.RemoteUrl!)
+            ?? [];
+        var withRemoteUrls = local.Photographs
+            .Select(photograph => photograph.SyncStatus == SyncStatus.Synchronised
+                && remoteUrls.TryGetValue(photograph.Id, out var url)
+                ? photograph with { RemoteUrl = url }
+                : photograph)
+            .ToArray();
+        if (withRemoteUrls.All(photograph => !string.IsNullOrWhiteSpace(photograph.RemoteUrl)))
+        {
+            return local with { Photographs = withRemoteUrls };
+        }
+
+        try
+        {
+            var stored = await CatchStore.GetAsync(ownerUserId, local.Id, cancellationToken);
+            if (stored is not null)
+            {
+                return stored;
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "catch logbook local photograph read",
+                exception,
+                CancellationToken.None);
+        }
+
+        return local with { Photographs = withRemoteUrls };
     }
 
     private static CatchModel ToCatchModel(CatchViewDto dto)
@@ -340,6 +510,16 @@ public partial class CatchList : ComponentBase, IDisposable
         }
     }
 
+    private async Task RetryLoadAsync()
+    {
+        if (_isLoadInFlight)
+        {
+            return;
+        }
+
+        await LoadAsync();
+    }
+
     private void OnSyncStateChanged(object? sender, EventArgs args)
     {
         if (_cancellationTokenSource.IsCancellationRequested)
@@ -349,22 +529,46 @@ public partial class CatchList : ComponentBase, IDisposable
 
         try
         {
-            _ = InvokeAsync(RefreshAfterSynchronisationAsync);
+            _ = InvokeAsync(RefreshLocalAfterSynchronisationAsync);
         }
         catch (ObjectDisposedException)
         {
         }
     }
 
-    private async Task RefreshAfterSynchronisationAsync()
+    private async Task RefreshLocalAfterSynchronisationAsync()
     {
-        await LoadAsync();
-        if (_cancellationTokenSource.IsCancellationRequested)
+        if (_isLoadInFlight)
         {
+            _localRefreshRequested = true;
             return;
         }
 
-        StateHasChanged();
+        _isLoadInFlight = true;
+        try
+        {
+            do
+            {
+                _localRefreshRequested = false;
+                var cancellationToken = _cancellationTokenSource.Token;
+                var local = await LoadLocalCatchesAsync(_currentUserId, cancellationToken);
+                if (!local.Failed && _preferences is not null)
+                {
+                    await DisplayAsync(
+                        _currentUserId,
+                        local.Catches,
+                        _remoteCatches,
+                        _preferences,
+                        cancellationToken);
+                    StateHasChanged();
+                }
+            }
+            while (_localRefreshRequested && !_cancellationTokenSource.IsCancellationRequested);
+        }
+        finally
+        {
+            _isLoadInFlight = false;
+        }
     }
 
     public void Dispose()
@@ -375,4 +579,6 @@ public partial class CatchList : ComponentBase, IDisposable
     }
 
     private sealed record CatchGroup(string Header, IReadOnlyList<CatchModel> Catches);
+
+    private sealed record CatchLoadResult(IReadOnlyList<CatchModel> Catches, bool Failed);
 }

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -294,6 +294,9 @@
   <data name="Catch_RecordFirstCatch" xml:space="preserve">
     <value>Enregistrez votre première prise</value>
   </data>
+  <data name="Catch_LoadRetry" xml:space="preserve">
+    <value>Réessayer</value>
+  </data>
   <data name="Catch_LoadFailed" xml:space="preserve">
     <value>Les prises n'ont pas pu être chargées.</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -294,6 +294,9 @@
   <data name="Catch_RecordFirstCatch" xml:space="preserve">
     <value>Record your first catch</value>
   </data>
+  <data name="Catch_LoadRetry" xml:space="preserve">
+    <value>Try again</value>
+  </data>
   <data name="Catch_LoadFailed" xml:space="preserve">
     <value>Catches could not be loaded.</value>
   </data>

--- a/src/FishingLogBook.Web/wwwroot/js/browser/timeout.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/timeout.js
@@ -1,6 +1,15 @@
+export class TimeoutError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'TimeoutError';
+    }
+}
+
 export function withTimeout(promise, milliseconds, operationName) {
     return new Promise((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error(`${operationName} timed out`)), milliseconds);
+        const timer = setTimeout(
+            () => reject(new TimeoutError(`${operationName} timed out`)),
+            milliseconds);
         promise.then(
             (value) => {
                 clearTimeout(timer);

--- a/src/FishingLogBook.Web/wwwroot/js/browser/timeout.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/timeout.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { withTimeout } from './timeout.js';
+import { TimeoutError, withTimeout } from './timeout.js';
 
 describe('withTimeout', () => {
     afterEach(() => {
@@ -18,7 +18,8 @@ describe('withTimeout', () => {
     it('rejects with a timeout error when the promise never settles', async () => {
         vi.useFakeTimers();
         const assertion = expect(withTimeout(new Promise(() => { }), 40, 'work'))
-            .rejects.toThrow('work timed out');
+            .rejects.toSatisfy((error) =>
+                error instanceof TimeoutError && error.message === 'work timed out');
         await vi.advanceTimersByTimeAsync(40);
         await assertion;
     });

--- a/src/FishingLogBook.Web/wwwroot/js/offline-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/offline-store.js
@@ -1,6 +1,9 @@
 export {
     putCatchWithPhotographs,
     getAllCatchesWithPhotographs,
+    getCatchMetadata,
+    getCatchMetadataById,
+    getCatchWithPhotographs,
     updateCatchMetadata
 } from './storage/catch-store.js';
 export { getStorageEstimate } from './storage/indexed-db.js';

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
@@ -184,9 +184,27 @@ export async function putCatchWithPhotographs(json, photographs) {
         const catchStore = transaction.objectStore(CATCH_STORE_NAME);
         const photoStore = transaction.objectStore(PHOTO_STORE_NAME);
         const incomingIds = new Set(photos.map((photograph) => photograph.id));
-        const catchRequest = catchStore.put(catchRecord);
-        catchRequest.onerror = () => fail(catchRequest.error);
-        catchRequest.onsuccess = () => {
+        const existingRequest = catchStore.get(catchRecord.id);
+        existingRequest.onerror = () => fail(existingRequest.error);
+        existingRequest.onsuccess = () => {
+            const existingPhotographs = existingRequest.result?.photographs;
+            const catchRequest = catchStore.put(catchRecord);
+            catchRequest.onerror = () => fail(catchRequest.error);
+
+            if (!existingRequest.result || Array.isArray(existingPhotographs)) {
+                for (const photograph of existingPhotographs ?? []) {
+                    if (!incomingIds.has(photograph.id)) {
+                        const deleteRequest = photoStore.delete(photograph.id);
+                        deleteRequest.onerror = () => fail(deleteRequest.error);
+                    }
+                }
+
+                writePhotographs(photoStore, photos, succeed, fail);
+                return;
+            }
+
+            // Records written before photograph metadata was embedded in the Catch
+            // require one compatibility scan. Current writes use direct photograph keys.
             const cursorRequest = photoStore.openCursor();
             cursorRequest.onerror = () => fail(cursorRequest.error);
             cursorRequest.onsuccess = () => {
@@ -244,6 +262,7 @@ export async function updateCatchMetadata(json) {
             const incomingPhotographs = new Map(
                 (catchRecord.photographs || []).map((photograph) => [photograph.id, photograph])
             );
+            const metadataChangedWhileSynchronising = hasMetadataDifference(existing, catchRecord);
             const photographs = (existing.photographs || []).map((photograph) => {
                 const incoming = incomingPhotographs.get(photograph.id);
                 if (!incoming) {
@@ -264,8 +283,12 @@ export async function updateCatchMetadata(json) {
 
             const updateRequest = store.put({
                 ...existing,
-                syncStatus: catchRecord.syncStatus,
-                metadataSyncStatus: catchRecord.metadataSyncStatus,
+                syncStatus: metadataChangedWhileSynchronising
+                    ? existing.syncStatus
+                    : catchRecord.syncStatus,
+                metadataSyncStatus: metadataChangedWhileSynchronising
+                    ? existing.metadataSyncStatus
+                    : catchRecord.metadataSyncStatus,
                 location,
                 photographs
             });
@@ -275,7 +298,29 @@ export async function updateCatchMetadata(json) {
     });
 }
 
+function hasMetadataDifference(existing, incoming) {
+    const metadataFields = [
+        'caughtOn',
+        'speciesName',
+        'anglerUserId',
+        'recordedByUserId',
+        'weight',
+        'length',
+        'method',
+        'baitOrLure',
+        'notes'
+    ];
+    return metadataFields.some((field) =>
+        Object.hasOwn(incoming, field)
+        && JSON.stringify(existing[field] ?? null) !== JSON.stringify(incoming[field] ?? null));
+}
+
 export async function getAllCatchesWithPhotographs(ownerUserId) {
+    const owner = normalisedUserId(ownerUserId);
+    if (!owner) {
+        return [];
+    }
+
     return runCatchWithPhotographsTransaction('readonly', 'read', (transaction, succeed, fail) => {
         const catchStore = transaction.objectStore(CATCH_STORE_NAME);
         const photoStore = transaction.objectStore(PHOTO_STORE_NAME);
@@ -285,13 +330,15 @@ export async function getAllCatchesWithPhotographs(ownerUserId) {
         catchRequest.onsuccess = () => {
             const cursor = catchRequest.result;
             if (cursor) {
-                catches.push(cursor.value);
+                if (normalisedUserId(cursor.value?.userId) === owner) {
+                    catches.push(cursor.value);
+                }
+
                 cursor.continue();
                 return;
             }
 
-            const visible = visibleCatchesForOwner(catches, ownerUserId);
-            const visibleIds = new Set(visible.map((item) => item.id));
+            const visibleIds = new Set(catches.map((item) => item.id));
             const photographs = [];
             const photoRequest = photoStore.openCursor();
             photoRequest.onerror = () => fail(photoRequest.error);
@@ -301,32 +348,140 @@ export async function getAllCatchesWithPhotographs(ownerUserId) {
                     if (visibleIds.has(photoCursor.value.catchId)) {
                         photographs.push(photoCursor.value);
                     }
+
                     photoCursor.continue();
                     return;
                 }
 
-                succeed(visible.map((item) => ({
-                    json: JSON.stringify(item),
-                    photographs: orderPhotographs(item, photographs)
-                        .map((photograph) => ({
-                            id: photograph.id,
-                            catchId: photograph.catchId,
-                            contentType: photograph.contentType,
-                            bytesBase64: uint8ToBase64(toUint8Array(photograph.bytes))
-                        }))
-                })));
+                succeed(catches.map((item) => toStoredResult(item, photographs)));
             };
         };
     });
 }
 
-function visibleCatchesForOwner(catches, ownerUserId) {
+export async function getCatchMetadata(ownerUserId) {
     const owner = normalisedUserId(ownerUserId);
     if (!owner) {
         return [];
     }
 
-    return catches.filter((item) => normalisedUserId(item?.userId) === owner);
+    return runCatchTransaction(CATCH_STORE_NAME, 'readonly', 'metadata-read', (store, succeed, fail) => {
+        const catches = [];
+        const request = store.openCursor();
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor) {
+                if (normalisedUserId(cursor.value?.userId) === owner) {
+                    catches.push({ json: JSON.stringify(cursor.value), photographs: [] });
+                }
+
+                cursor.continue();
+                return;
+            }
+
+            succeed(catches);
+        };
+    });
+}
+
+export async function getCatchMetadataById(ownerUserId, catchId) {
+    const owner = normalisedUserId(ownerUserId);
+    if (!owner || typeof catchId !== 'string' || !catchId) {
+        return null;
+    }
+
+    return runCatchTransaction(CATCH_STORE_NAME, 'readonly', 'single-metadata-read', (store, succeed, fail) => {
+        const request = store.get(catchId);
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            const record = request.result;
+            succeed(record && normalisedUserId(record.userId) === owner
+                ? { json: JSON.stringify(record), photographs: [] }
+                : null);
+        };
+    });
+}
+
+export async function getCatchWithPhotographs(ownerUserId, catchId) {
+    const owner = normalisedUserId(ownerUserId);
+    if (!owner || typeof catchId !== 'string' || !catchId) {
+        return null;
+    }
+
+    return runCatchWithPhotographsTransaction('readonly', 'single-read', (transaction, succeed, fail) => {
+        const catchStore = transaction.objectStore(CATCH_STORE_NAME);
+        const photoStore = transaction.objectStore(PHOTO_STORE_NAME);
+        const catchRequest = catchStore.get(catchId);
+        catchRequest.onerror = () => fail(catchRequest.error);
+        catchRequest.onsuccess = () => {
+            const record = catchRequest.result;
+            if (!record || normalisedUserId(record.userId) !== owner) {
+                succeed(null);
+                return;
+            }
+
+            const photographIds = (Array.isArray(record.photographs) ? record.photographs : [])
+                .map((photograph) => photograph?.id)
+                .filter((id) => typeof id === 'string' && id.length > 0);
+            if (photographIds.length === 0) {
+                readPhotographsByCatchId(photoStore, record, succeed, fail);
+                return;
+            }
+
+            readPhotographsByIds(photoStore, record, photographIds, succeed, fail);
+        };
+    });
+}
+
+function readPhotographsByIds(photoStore, record, photographIds, succeed, fail) {
+    const photographs = [];
+    let remaining = photographIds.length;
+    for (const photographId of photographIds) {
+        const request = photoStore.get(photographId);
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            if (request.result && request.result.catchId === record.id) {
+                photographs.push(request.result);
+            }
+
+            remaining -= 1;
+            if (remaining === 0) {
+                succeed(toStoredResult(record, photographs));
+            }
+        };
+    }
+}
+
+function readPhotographsByCatchId(photoStore, record, succeed, fail) {
+    const photographs = [];
+    const request = photoStore.openCursor();
+    request.onerror = () => fail(request.error);
+    request.onsuccess = () => {
+        const cursor = request.result;
+        if (cursor) {
+            if (cursor.value?.catchId === record.id) {
+                photographs.push(cursor.value);
+            }
+
+            cursor.continue();
+            return;
+        }
+
+        succeed(toStoredResult(record, photographs));
+    };
+}
+
+function toStoredResult(record, photographs) {
+    return {
+        json: JSON.stringify(record),
+        photographs: orderPhotographs(record, photographs).map((photograph) => ({
+            id: photograph.id,
+            catchId: photograph.catchId,
+            contentType: photograph.contentType,
+            bytesBase64: uint8ToBase64(toUint8Array(photograph.bytes))
+        }))
+    };
 }
 
 function normalisedUserId(value) {
@@ -388,4 +543,3 @@ function uint8ToBase64(bytes) {
 
     return btoa(binary);
 }
-

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
     CATCH_STORE_NAME,
+    PHOTO_STORE_NAME,
     getAllCatchesWithPhotographs,
+    getCatchMetadata,
+    getCatchMetadataById,
+    getCatchWithPhotographs,
     openCatchDatabase,
     putCatchWithPhotographs,
     updateCatchMetadata
@@ -316,6 +320,49 @@ describe('Catch store', () => {
         expect(stored.photographs[0].syncStatus).toBe(3);
     });
 
+    it('does not let a stale sync completion clear a newer metadata edit', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const photographId = '11111111-1111-1111-1111-111111111111';
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId: ownerUserId,
+                caughtOn: '2026-08-20T08:15:00Z',
+                syncStatus: 2,
+                metadataSyncStatus: 2,
+                photographs: [{ id: photographId, catchId, contentType: 'image/jpeg', syncStatus: 2 }]
+            }),
+            [{ id: photographId, catchId, contentType: 'image/jpeg', bytes: new Uint8Array([1]) }]
+        );
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId: ownerUserId,
+                caughtOn: '2025-06-14T06:32:10Z',
+                syncStatus: 1,
+                metadataSyncStatus: 1,
+                photographs: [{ id: photographId, catchId, contentType: 'image/jpeg', syncStatus: 2 }]
+            }),
+            [{ id: photographId, catchId, contentType: 'image/jpeg', bytes: new Uint8Array([1]) }]
+        );
+
+        await updateCatchMetadata(JSON.stringify({
+            id: catchId,
+            userId: ownerUserId,
+            caughtOn: '2026-08-20T08:15:00Z',
+            syncStatus: 3,
+            metadataSyncStatus: 3,
+            photographs: [{ id: photographId, catchId, contentType: 'image/jpeg', syncStatus: 3 }]
+        }));
+
+        const ownerView = await getAllCatchesWithPhotographs(ownerUserId);
+        const stored = JSON.parse(ownerView[0].json);
+        expect(stored.caughtOn).toBe('2025-06-14T06:32:10Z');
+        expect(stored.syncStatus).toBe(1);
+        expect(stored.metadataSyncStatus).toBe(1);
+        expect(stored.photographs[0].syncStatus).toBe(3);
+    });
+
     it('keeps two separately saved catches on distinct ids', async () => {
         await putCatchWithPhotographs(
             JSON.stringify({ id: 'catch-a', userId: ownerUserId, caughtOn: '2026-08-17T08:00:00+00:00' }),
@@ -602,3 +649,222 @@ function readRawCatch(id) {
         transaction.oncomplete = () => db.close();
     }));
 }
+
+describe('Catch store read granularity', () => {
+    const ownerUserId = '11111111-1111-1111-1111-111111111111';
+    const otherUserId = '22222222-2222-2222-2222-222222222222';
+
+    function recordStoreAccess() {
+        const accesses = { get: [], openCursor: [] };
+        const originalGet = IDBObjectStore.prototype.get;
+        const originalOpenCursor = IDBObjectStore.prototype.openCursor;
+        IDBObjectStore.prototype.get = function instrumentedGet(key) {
+            accesses.get.push({ store: this.name, key });
+            return originalGet.call(this, key);
+        };
+        IDBObjectStore.prototype.openCursor = function instrumentedOpenCursor(...args) {
+            accesses.openCursor.push({ store: this.name });
+            return originalOpenCursor.apply(this, args);
+        };
+        accesses.restore = () => {
+            IDBObjectStore.prototype.get = originalGet;
+            IDBObjectStore.prototype.openCursor = originalOpenCursor;
+        };
+        return accesses;
+    }
+
+    function largePhotograph(id, catchId, seed) {
+        return {
+            id,
+            catchId,
+            contentType: 'image/jpeg',
+            bytes: new Uint8Array(256 * 1024).fill(seed)
+        };
+    }
+
+    async function seedCatch(catchId, photographs, userId = ownerUserId) {
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId,
+                caughtOn: '2026-08-17T08:00:00+00:00',
+                photographs: photographs.map((photograph) => ({
+                    id: photograph.id,
+                    catchId,
+                    contentType: photograph.contentType,
+                    syncStatus: 'savedLocally'
+                }))
+            }),
+            photographs);
+    }
+
+    it('reads list metadata without touching the photograph store', async () => {
+        const first = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const second = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        await seedCatch(first, [largePhotograph('photo-a', first, 1)]);
+        await seedCatch(second, [largePhotograph('photo-b', second, 2)]);
+        const accesses = recordStoreAccess();
+
+        try {
+            const items = await getCatchMetadata(ownerUserId);
+
+            expect(items).toHaveLength(2);
+            expect(items.every((item) => item.photographs.length === 0)).toBe(true);
+            expect(items.some((item) => JSON.parse(item.json).id === first)).toBe(true);
+            expect(accesses.openCursor.map((access) => access.store)).toEqual([CATCH_STORE_NAME]);
+            expect(accesses.get.filter((access) => access.store === PHOTO_STORE_NAME)).toHaveLength(0);
+        } finally {
+            accesses.restore();
+        }
+    });
+
+    it('updates a current Catch without scanning unrelated photographs', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        await seedCatch(catchId, [largePhotograph('old-photo', catchId, 1)]);
+        const accesses = recordStoreAccess();
+
+        try {
+            await seedCatch(catchId, [largePhotograph('new-photo', catchId, 2)]);
+
+            expect(accesses.get).toContainEqual({ store: CATCH_STORE_NAME, key: catchId });
+            expect(accesses.openCursor).toHaveLength(0);
+        } finally {
+            accesses.restore();
+        }
+
+        const item = await getCatchWithPhotographs(ownerUserId, catchId);
+        expect(item.photographs.map((photograph) => photograph.id)).toEqual(['new-photo']);
+    });
+
+    it('writes a new Catch without scanning existing photographs', async () => {
+        const existingId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const newId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        await seedCatch(existingId, [largePhotograph('existing-photo', existingId, 1)]);
+        const accesses = recordStoreAccess();
+
+        try {
+            await seedCatch(newId, [largePhotograph('new-photo', newId, 2)]);
+
+            expect(accesses.get).toContainEqual({ store: CATCH_STORE_NAME, key: newId });
+            expect(accesses.openCursor).toHaveLength(0);
+        } finally {
+            accesses.restore();
+        }
+    });
+
+    it('does not return metadata belonging to another owner', async () => {
+        const owned = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const foreign = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        await seedCatch(owned, [largePhotograph('photo-a', owned, 1)]);
+        await seedCatch(foreign, [largePhotograph('photo-c', foreign, 3)], otherUserId);
+
+        const items = await getCatchMetadata(ownerUserId);
+
+        expect(items).toHaveLength(1);
+        expect(JSON.parse(items[0].json).id).toBe(owned);
+    });
+
+    it('reads one Catch metadata record by key without touching photograph blobs', async () => {
+        const wanted = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const unrelated = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        await seedCatch(wanted, [largePhotograph('photo-a', wanted, 1)]);
+        await seedCatch(unrelated, [largePhotograph('photo-b', unrelated, 2)]);
+        const accesses = recordStoreAccess();
+
+        try {
+            const item = await getCatchMetadataById(ownerUserId, wanted);
+
+            expect(JSON.parse(item.json).id).toBe(wanted);
+            expect(item.photographs).toEqual([]);
+            expect(accesses.get).toEqual([{ store: CATCH_STORE_NAME, key: wanted }]);
+            expect(accesses.openCursor).toHaveLength(0);
+        } finally {
+            accesses.restore();
+        }
+    });
+
+    it('treats an empty owner as no owner for metadata', async () => {
+        const owned = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        await seedCatch(owned, [largePhotograph('photo-a', owned, 1)]);
+
+        const items = await getCatchMetadata('00000000-0000-0000-0000-000000000000');
+
+        expect(items).toEqual([]);
+    });
+
+    it('reads one Catch by key and only its own photograph blobs', async () => {
+        const wanted = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const unrelated = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        await seedCatch(wanted, [largePhotograph('photo-a', wanted, 1)]);
+        await seedCatch(unrelated, [
+            largePhotograph('photo-b', unrelated, 2),
+            largePhotograph('photo-c', unrelated, 3)
+        ]);
+        const accesses = recordStoreAccess();
+
+        try {
+            const item = await getCatchWithPhotographs(ownerUserId, wanted);
+
+            expect(JSON.parse(item.json).id).toBe(wanted);
+            expect(item.photographs).toHaveLength(1);
+            expect(item.photographs[0].id).toBe('photo-a');
+            expect(accesses.get).toEqual([
+                { store: CATCH_STORE_NAME, key: wanted },
+                { store: PHOTO_STORE_NAME, key: 'photo-a' }
+            ]);
+            expect(accesses.openCursor).toHaveLength(0);
+        } finally {
+            accesses.restore();
+        }
+    });
+
+    it('reads every photograph belonging to the requested Catch in metadata order', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        await seedCatch(catchId, [
+            largePhotograph('photo-1', catchId, 1),
+            largePhotograph('photo-2', catchId, 2),
+            largePhotograph('photo-3', catchId, 3)
+        ]);
+
+        const item = await getCatchWithPhotographs(ownerUserId, catchId);
+
+        expect(item.photographs.map((photograph) => photograph.id))
+            .toEqual(['photo-1', 'photo-2', 'photo-3']);
+        expect(item.photographs.every((photograph) => photograph.bytesBase64.length > 0)).toBe(true);
+    });
+
+    it('does not read a Catch belonging to another owner by id', async () => {
+        const foreign = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        await seedCatch(foreign, [largePhotograph('photo-c', foreign, 3)], otherUserId);
+        const accesses = recordStoreAccess();
+
+        try {
+            const item = await getCatchWithPhotographs(ownerUserId, foreign);
+
+            expect(item).toBeNull();
+            expect(accesses.get.filter((access) => access.store === PHOTO_STORE_NAME)).toHaveLength(0);
+        } finally {
+            accesses.restore();
+        }
+    });
+
+    it('returns null for a Catch that is not stored', async () => {
+        const item = await getCatchWithPhotographs(ownerUserId, 'dddddddd-dddd-dddd-dddd-dddddddddddd');
+
+        expect(item).toBeNull();
+    });
+
+    it('falls back to a filtered scan for a legacy Catch with no photograph metadata', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const unrelated = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        await putCatchWithPhotographs(
+            JSON.stringify({ id: catchId, userId: ownerUserId, caughtOn: '2026-08-17T08:00:00+00:00' }),
+            [largePhotograph('legacy-photo', catchId, 1)]);
+        await seedCatch(unrelated, [largePhotograph('photo-b', unrelated, 2)]);
+
+        const item = await getCatchWithPhotographs(ownerUserId, catchId);
+
+        expect(item.photographs).toHaveLength(1);
+        expect(item.photographs[0].id).toBe('legacy-photo');
+    });
+});

--- a/src/FishingLogBook.Web/wwwroot/js/storage/indexed-db.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/indexed-db.js
@@ -1,4 +1,4 @@
-import { withTimeout } from '../browser/timeout.js';
+import { TimeoutError, withTimeout } from '../browser/timeout.js';
 
 export { withTimeout };
 
@@ -49,7 +49,7 @@ export function openDatabase({
             reject(request.error);
         };
     }), timeoutMs, timeoutLabel).catch((error) => {
-        if (String(error?.message || '').includes('timed out')) {
+        if (error instanceof TimeoutError) {
             onTimedOut?.(error);
         }
 
@@ -143,7 +143,7 @@ export function runTransaction(db, options) {
         options.timeoutMs,
         options.timeoutLabel
     ).catch((error) => {
-        if (String(error?.message || '').includes('timed out')) {
+        if (error instanceof TimeoutError) {
             options.onTimedOut?.(error);
             try {
                 transaction?.abort();
@@ -245,7 +245,7 @@ export function runMultiStoreTransaction(db, options) {
         options.timeoutMs,
         options.timeoutLabel
     ).catch((error) => {
-        if (String(error?.message || '').includes('timed out')) {
+        if (error instanceof TimeoutError) {
             options.onTimedOut?.(error);
             try {
                 transaction?.abort();

--- a/src/FishingLogBook.Web/wwwroot/js/storage/indexed-db.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/indexed-db.js
@@ -68,10 +68,12 @@ export function executeTransaction(db, {
     onAborted,
     onError,
     onRequestSucceeded,
-    onClosed
+    onClosed,
+    onTransactionCreated
 }) {
     return new Promise((resolve, reject) => {
         const transaction = db.transaction(storeName, mode);
+        onTransactionCreated?.(transaction);
         onStarted?.();
 
         let result;
@@ -129,12 +131,26 @@ export function executeTransaction(db, {
 }
 
 export function runTransaction(db, options) {
+    let transaction;
     return withTimeout(
-        executeTransaction(db, options),
+        executeTransaction(db, {
+            ...options,
+            onTransactionCreated: (created) => {
+                transaction = created;
+                options.onTransactionCreated?.(created);
+            }
+        }),
         options.timeoutMs,
         options.timeoutLabel
     ).catch((error) => {
-        options.onTimedOut?.(error);
+        if (String(error?.message || '').includes('timed out')) {
+            options.onTimedOut?.(error);
+            try {
+                transaction?.abort();
+            } catch {
+                // The transaction already completed or aborted.
+            }
+        }
         if (options.closeWhenDone !== false) {
             closeDatabase(db);
         }
@@ -154,10 +170,12 @@ export function executeMultiStoreTransaction(db, {
     onAborted,
     onError,
     onRequestSucceeded,
-    onClosed
+    onClosed,
+    onTransactionCreated
 }) {
     return new Promise((resolve, reject) => {
         const transaction = db.transaction(storeNames, mode);
+        onTransactionCreated?.(transaction);
         onStarted?.();
 
         let result;
@@ -215,12 +233,26 @@ export function executeMultiStoreTransaction(db, {
 }
 
 export function runMultiStoreTransaction(db, options) {
+    let transaction;
     return withTimeout(
-        executeMultiStoreTransaction(db, options),
+        executeMultiStoreTransaction(db, {
+            ...options,
+            onTransactionCreated: (created) => {
+                transaction = created;
+                options.onTransactionCreated?.(created);
+            }
+        }),
         options.timeoutMs,
         options.timeoutLabel
     ).catch((error) => {
-        options.onTimedOut?.(error);
+        if (String(error?.message || '').includes('timed out')) {
+            options.onTimedOut?.(error);
+            try {
+                transaction?.abort();
+            } catch {
+                // The transaction already completed or aborted.
+            }
+        }
         if (options.closeWhenDone !== false) {
             closeDatabase(db);
         }

--- a/src/FishingLogBook.Web/wwwroot/js/storage/indexed-db.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/indexed-db.test.js
@@ -4,8 +4,10 @@ import {
     executeTransaction,
     getStorageEstimate,
     openDatabase,
+    runMultiStoreTransaction,
     runTransaction
 } from './indexed-db.js';
+import { TimeoutError } from '../browser/timeout.js';
 
 function createMockDb() {
     let transaction;
@@ -160,11 +162,76 @@ describe('IndexedDB helper', () => {
             timeoutLabel: 'IndexedDB write',
             execute: () => { }
         });
-        const assertion = expect(promise).rejects.toThrow('IndexedDB write timed out');
+        const assertion = expect(promise).rejects.toBeInstanceOf(TimeoutError);
         const abort = vi.spyOn(getTransaction(), 'abort');
         await vi.advanceTimersByTimeAsync(40);
         await assertion;
         vi.useRealTimers();
+        expect(abort).toHaveBeenCalledOnce();
+        expect(db.closed).toBe(true);
+    });
+
+    it('calls the timeout callback only for an explicit timeout error', async () => {
+        vi.useFakeTimers();
+        const { db } = createMockDb();
+        const onTimedOut = vi.fn();
+        const promise = runTransaction(db, {
+            storeName: 'items',
+            mode: 'readonly',
+            timeoutMs: 40,
+            timeoutLabel: 'IndexedDB read',
+            onTimedOut,
+            execute: () => { }
+        });
+        const assertion = expect(promise).rejects.toBeInstanceOf(TimeoutError);
+
+        await vi.advanceTimersByTimeAsync(40);
+        await assertion;
+
+        expect(onTimedOut).toHaveBeenCalledOnce();
+    });
+
+    it('does not treat an ordinary error message as a timeout', async () => {
+        const { db, getTransaction } = createMockDb();
+        const onTimedOut = vi.fn();
+        const promise = runTransaction(db, {
+            storeName: 'items',
+            mode: 'readonly',
+            timeoutMs: 1000,
+            timeoutLabel: 'IndexedDB read',
+            onTimedOut,
+            execute: () => { }
+        });
+        const abort = vi.spyOn(getTransaction(), 'abort');
+
+        getTransaction().error = new Error('request timed out upstream');
+        getTransaction().onerror();
+
+        await expect(promise).rejects.toThrow('request timed out upstream');
+        expect(onTimedOut).not.toHaveBeenCalled();
+        expect(abort).not.toHaveBeenCalled();
+        expect(db.closed).toBe(true);
+    });
+
+    it('aborts a multi-store transaction and reports an explicit timeout', async () => {
+        vi.useFakeTimers();
+        const { db, getTransaction } = createMockDb();
+        const onTimedOut = vi.fn();
+        const promise = runMultiStoreTransaction(db, {
+            storeNames: ['items', 'photographs'],
+            mode: 'readwrite',
+            timeoutMs: 40,
+            timeoutLabel: 'IndexedDB multi-store write',
+            onTimedOut,
+            execute: () => { }
+        });
+        const assertion = expect(promise).rejects.toBeInstanceOf(TimeoutError);
+        const abort = vi.spyOn(getTransaction(), 'abort');
+
+        await vi.advanceTimersByTimeAsync(40);
+        await assertion;
+
+        expect(onTimedOut).toHaveBeenCalledOnce();
         expect(abort).toHaveBeenCalledOnce();
         expect(db.closed).toBe(true);
     });

--- a/src/FishingLogBook.Web/wwwroot/js/storage/indexed-db.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/indexed-db.test.js
@@ -152,7 +152,7 @@ describe('IndexedDB helper', () => {
 
     it('rejects when the transaction times out', async () => {
         vi.useFakeTimers();
-        const { db } = createMockDb();
+        const { db, getTransaction } = createMockDb();
         const promise = runTransaction(db, {
             storeName: 'items',
             mode: 'readwrite',
@@ -161,9 +161,11 @@ describe('IndexedDB helper', () => {
             execute: () => { }
         });
         const assertion = expect(promise).rejects.toThrow('IndexedDB write timed out');
+        const abort = vi.spyOn(getTransaction(), 'abort');
         await vi.advanceTimersByTimeAsync(40);
         await assertion;
         vi.useRealTimers();
+        expect(abort).toHaveBeenCalledOnce();
         expect(db.closed).toBe(true);
     });
 

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingRender.cs
@@ -22,8 +22,8 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId, location: null)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId, location: null));
         var client = Substitute.For<ICatchClient>();
         await using var context = CreateContext(store, client);
 
@@ -37,7 +37,7 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
                 .Contain("This catch has no saved location"));
         cut.FindAll("#catch-location-privacy-options").Should().BeEmpty();
         cut.Find("#catch-location-privacy-cancel").TextContent.Should().Contain("Cancel");
-        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
         await client.DidNotReceive().UpdateLocationVisibilityAsync(
             Arg.Any<Guid>(),
             Arg.Any<string>(),
@@ -52,8 +52,8 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         await using var context = CreateContext(store);
 
         // Act
@@ -81,7 +81,7 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
         cut.Find("#catch-location-privacy-cancel").TextContent.Should().Contain("Cancel");
         cut.Markup.Should().NotContain("53.2707");
         cut.Markup.Should().NotContain("-9.0568");
-        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -91,8 +91,8 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.French);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         await using var context = CreateContext(store);
 
         // Act
@@ -115,7 +115,7 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
             options.Should().Contain("L'emplacement précis peut être visible publiquement.");
             cut.Find("#catch-location-privacy-cancel").TextContent.Should().Contain("Annuler");
         });
-        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -123,20 +123,21 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
         await using var context = CreateContext(store);
 
         // Act
-        var (cut, dialog) = await ShowModalAsync(context, Guid.NewGuid());
+        var (cut, dialog) = await ShowModalAsync(context, catchId);
 
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#catch-location-privacy-load-failed").TextContent
                 .Should()
                 .Contain("This catch could not be loaded"));
-        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
         dialog.Result.IsCompleted.Should().BeFalse();
     }
 
@@ -147,10 +148,10 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OtherUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([]));
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OtherUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns((CatchModel?)null);
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         var owner = Substitute.For<ILocalCatchOwnerService>();
         owner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(OtherUserId);
         var client = Substitute.For<ICatchClient>();
@@ -169,8 +170,8 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
         cut.Markup.Should().NotContain("53.2707");
         cut.Markup.Should().NotContain("-9.0568");
         await owner.Received(1).GetUserIdAsync(Arg.Any<CancellationToken>());
-        await store.Received(1).GetAllAsync(OtherUserId, Arg.Any<CancellationToken>());
-        await store.DidNotReceive().GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetAsync(OtherUserId, catchId, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
         await client.DidNotReceive().UpdateLocationVisibilityAsync(
             Arg.Any<Guid>(),
             Arg.Any<string>(),
@@ -184,8 +185,8 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId, LocationDefaults.Public)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId, LocationDefaults.Public));
         await using var context = CreateContext(store);
 
         // Act
@@ -196,7 +197,7 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
             cut.Find("#catch-location-privacy-public-warning").TextContent
                 .Should()
                 .Contain("Anyone who can view this catch may see the exact fishing spot"));
-        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
         dialog.Result.IsCompleted.Should().BeFalse();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingSave.cs
@@ -26,9 +26,8 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
-                [LocatedCatch(catchId, location: null)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId, location: null));
         var client = Substitute.For<ICatchClient>();
         await using var context = CreateContext(store, client);
         var (cut, dialog) = await ShowModalAsync(context, catchId);
@@ -53,8 +52,8 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         var client = Substitute.For<ICatchClient>();
         await using var context = CreateContext(store, client);
         var (cut, dialog) = await ShowModalAsync(context, catchId);
@@ -84,8 +83,8 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var original = LocatedCatch(catchId);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([original]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(original);
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
         var client = Substitute.For<ICatchClient>();
@@ -125,8 +124,8 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var client = Substitute.For<ICatchClient>();
@@ -168,8 +167,8 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var apiHandler = new UnsynchronisedCatchHandler();
@@ -209,21 +208,18 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var capturedOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
-                [
-                    LocatedCatch(catchId, LocationDefaults.Public) with
-                    {
-                        SyncStatus = SyncStatus.Synchronised,
-                        MetadataSyncStatus = SyncStatus.Synchronised,
-                        Photographs = LocatedCatch(catchId).Photographs
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId, LocationDefaults.Public) with
+            {
+                SyncStatus = SyncStatus.Synchronised,
+                MetadataSyncStatus = SyncStatus.Synchronised,
+                Photographs = LocatedCatch(catchId).Photographs
                             .Select(photograph => photograph with
                             {
                                 SyncStatus = SyncStatus.Synchronised
                             })
                             .ToArray()
-                    }
-                ]));
+            });
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var client = Substitute.For<ICatchClient>();
@@ -271,8 +267,8 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         var client = Substitute.For<ICatchClient>();
         await using var context = CreateContext(store, client);
         var (cut, dialog) = await ShowModalAsync(context, catchId);
@@ -301,8 +297,8 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var client = Substitute.For<ICatchClient>();
@@ -350,8 +346,8 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([LocatedCatch(catchId)]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var client = Substitute.For<ICatchClient>();
@@ -390,15 +386,12 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
-                [
-                    LocatedCatch(catchId, LocationDefaults.Private) with
-                    {
-                        SyncStatus = SyncStatus.Synchronised,
-                        MetadataSyncStatus = SyncStatus.Synchronised
-                    }
-                ]));
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId, LocationDefaults.Private) with
+            {
+                SyncStatus = SyncStatus.Synchronised,
+                MetadataSyncStatus = SyncStatus.Synchronised
+            });
         store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         var client = Substitute.For<ICatchClient>();

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/MemoryCatchStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/MemoryCatchStore.cs
@@ -8,8 +8,19 @@ public sealed class MemoryCatchStore : ICatchStore
 {
     private readonly Dictionary<Guid, CatchModel> _catches;
     private readonly Dictionary<Guid, byte[]> _photographBytes;
+    private readonly HashSet<Guid> _photographReads = [];
 
     public bool FailPhotographWrite { get; set; }
+
+    public Func<Guid, Task>? BeforeSingleRead { get; set; }
+
+    public int GetAllCalls { get; private set; }
+
+    public int GetMetadataCalls { get; private set; }
+
+    public int GetCalls { get; private set; }
+
+    public IReadOnlyCollection<Guid> PhotographBytesReadFor => _photographReads;
 
     public MemoryCatchStore()
         : this([], [])
@@ -60,6 +71,23 @@ public sealed class MemoryCatchStore : ICatchStore
         Guid ownerUserId,
         CancellationToken cancellationToken)
     {
+        GetAllCalls += 1;
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
+        IReadOnlyList<CatchModel> items = _catches.Values
+            .Select(catchRecord => WithPhotographBytes(catchRecord))
+            .ToArray();
+        return Task.FromResult(LocalCatchVisibility.ForOwner(items, ownerUserId));
+    }
+
+    public Task<IReadOnlyList<CatchModel>> GetMetadataAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        GetMetadataCalls += 1;
         if (ownerUserId == Guid.Empty)
         {
             throw new InvalidOperationException("A catch owner is required.");
@@ -69,14 +97,33 @@ public sealed class MemoryCatchStore : ICatchStore
             .Select(catchRecord => catchRecord with
             {
                 Photographs = catchRecord.Photographs
-                    .Select(photograph => photograph with
-                    {
-                        Bytes = _photographBytes.GetValueOrDefault(photograph.Id)
-                    })
+                    .Select(photograph => photograph with { Bytes = null })
                     .ToArray()
             })
             .ToArray();
         return Task.FromResult(LocalCatchVisibility.ForOwner(items, ownerUserId));
+    }
+
+    public Task<CatchModel?> GetMetadataAsync(
+        Guid ownerUserId,
+        Guid catchId,
+        CancellationToken cancellationToken)
+    {
+        GetMetadataCalls += 1;
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
+        var item = _catches.GetValueOrDefault(catchId);
+        return Task.FromResult(item is not null && item.UserId == ownerUserId
+            ? item with
+            {
+                Photographs = item.Photographs
+                    .Select(photograph => photograph with { Bytes = null })
+                    .ToArray()
+            }
+            : null);
     }
 
     public async Task<CatchModel?> GetAsync(
@@ -84,8 +131,23 @@ public sealed class MemoryCatchStore : ICatchStore
         Guid catchId,
         CancellationToken cancellationToken)
     {
-        var catches = await GetAllAsync(ownerUserId, cancellationToken);
-        return catches.SingleOrDefault(catchRecord => catchRecord.Id == catchId);
+        GetCalls += 1;
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
+        if (BeforeSingleRead is not null)
+        {
+            await BeforeSingleRead(catchId);
+        }
+
+        if (!_catches.TryGetValue(catchId, out var stored) || stored.UserId != ownerUserId)
+        {
+            return null;
+        }
+
+        return WithPhotographBytes(stored);
     }
 
     public Task UpdateSyncStateAsync(
@@ -117,5 +179,24 @@ public sealed class MemoryCatchStore : ICatchStore
                 .ToArray()
         };
         return Task.CompletedTask;
+    }
+
+    private CatchModel WithPhotographBytes(CatchModel catchRecord)
+    {
+        return catchRecord with
+        {
+            Photographs = catchRecord.Photographs
+                .Select(photograph =>
+                {
+                    var bytes = _photographBytes.GetValueOrDefault(photograph.Id);
+                    if (bytes is { Length: > 0 })
+                    {
+                        _photographReads.Add(photograph.Id);
+                    }
+
+                    return photograph with { Bytes = bytes };
+                })
+                .ToArray()
+        };
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/WhenTestingIndexedDbReads.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/WhenTestingIndexedDbReads.cs
@@ -1,0 +1,253 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using Microsoft.JSInterop;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.Stores.CatchStoreTests;
+
+public class WhenTestingIndexedDbReads
+{
+    private static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid CatchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid PhotographId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    [Fact]
+    public async Task ItShouldRejectAnEmptyOwnerForASingleCatchRead()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime();
+        var sut = CreateStore(js);
+
+        // Act
+        var act = () => sut.GetAsync(Guid.Empty, CatchId, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        js.Invocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnEmptyOwnerForAMetadataRead()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime();
+        var sut = CreateStore(js);
+
+        // Act
+        var act = () => sut.GetMetadataAsync(Guid.Empty, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        js.Invocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldReadASingleCatchWithoutReadingEveryCatch()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime
+        {
+            SingleRecord = StoredRecord(OwnerUserId, withBytes: true)
+        };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().NotBeNull();
+        loaded!.Id.Should().Be(CatchId);
+        loaded.Photographs.Should().HaveCount(1);
+        loaded.Photographs[0].Bytes.Should().Equal([1, 2, 3]);
+        js.Invocations.Should().ContainSingle();
+        js.Invocations[0].Identifier.Should().Be("getCatchWithPhotographs");
+        js.Invocations[0].Arguments.Should().Equal(
+            OwnerUserId.ToString("D"),
+            CatchId.ToString("D"));
+        js.Identifiers.Should().NotContain("getAllCatchesWithPhotographs");
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnASingleCatchOwnedByAnotherAngler()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime
+        {
+            SingleRecord = StoredRecord(OtherUserId, withBytes: true)
+        };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().BeNull();
+        js.Identifiers.Should().Equal("getCatchWithPhotographs");
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNullWhenTheSingleCatchIsNotStored()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime { SingleRecord = null };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().BeNull();
+        js.Identifiers.Should().Equal("getCatchWithPhotographs");
+    }
+
+    [Fact]
+    public async Task ItShouldReadMetadataWithoutPhotographBytesButKeepPhotographReferences()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime
+        {
+            ListRecords = [StoredRecord(OwnerUserId, withBytes: false)]
+        };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetMetadataAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().ContainSingle();
+        loaded[0].Photographs.Should().ContainSingle();
+        loaded[0].Photographs[0].Id.Should().Be(PhotographId);
+        loaded[0].Photographs[0].ContentType.Should().Be(PhotographContentTypeConstants.Jpeg);
+        loaded[0].Photographs[0].Bytes.Should().BeNull();
+        js.Identifiers.Should().Equal("getCatchMetadata");
+        js.Identifiers.Should().NotContain("getAllCatchesWithPhotographs");
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnAnotherAnglersCatchFromAMetadataRead()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime
+        {
+            ListRecords = [StoredRecord(OtherUserId, withBytes: false)]
+        };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetMetadataAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().BeEmpty();
+        js.Identifiers.Should().Equal("getCatchMetadata");
+    }
+
+    [Fact]
+    public async Task ItShouldStillReadEveryCatchWithBytesForTheOfflineLogbook()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime
+        {
+            ListRecords = [StoredRecord(OwnerUserId, withBytes: true)]
+        };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetAllAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().ContainSingle();
+        loaded[0].Photographs[0].Bytes.Should().Equal([1, 2, 3]);
+        js.Identifiers.Should().Equal("getAllCatchesWithPhotographs");
+    }
+
+    private static IndexedDbCatchStore CreateStore(IJSRuntime js)
+    {
+        return new IndexedDbCatchStore(
+            js,
+            Substitute.For<IDiagnosticLogger>(),
+            Substitute.For<ILoggingService>(),
+            new DiagnosticsClientConfig { OperationTimeoutMilliseconds = 5000 });
+    }
+
+    private static StoredCatchRecord StoredRecord(Guid ownerUserId, bool withBytes)
+    {
+        var model = new CatchModel(
+            CatchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(
+                PhotographId,
+                CatchId,
+                PhotographContentTypeConstants.Jpeg,
+                withBytes ? [1, 2, 3] : null)],
+            UserId: ownerUserId);
+        return new StoredCatchRecord
+        {
+            Json = CatchJson.SerializeMetadata(model),
+            Photographs = withBytes
+                ?
+                [
+                    new StoredCatchPhotographRecord
+                    {
+                        Id = PhotographId.ToString("D"),
+                        CatchId = CatchId.ToString("D"),
+                        ContentType = PhotographContentTypeConstants.Jpeg,
+                        BytesBase64 = Convert.ToBase64String([1, 2, 3])
+                    }
+                ]
+                : []
+        };
+    }
+
+    private sealed record JsInvocation(string Identifier, IReadOnlyList<object?> Arguments);
+
+    private sealed class RecordingJsRuntime : IJSRuntime, IJSObjectReference
+    {
+        private readonly List<JsInvocation> _invocations = [];
+
+        public StoredCatchRecord? SingleRecord { get; set; }
+
+        public StoredCatchRecord[] ListRecords { get; set; } = [];
+
+        public IReadOnlyList<JsInvocation> Invocations => _invocations;
+
+        public IReadOnlyList<string> Identifiers =>
+            [.. _invocations.Select(invocation => invocation.Identifier)];
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier,
+            CancellationToken cancellationToken,
+            object?[]? args)
+        {
+            if (identifier == "import")
+            {
+                return new ValueTask<TValue>((TValue)(object)this);
+            }
+
+            _invocations.Add(new JsInvocation(identifier, args ?? []));
+            object? result = identifier switch
+            {
+                "getCatchWithPhotographs" => SingleRecord,
+                "getCatchMetadata" => ListRecords,
+                "getAllCatchesWithPhotographs" => ListRecords,
+                _ => null
+            };
+            return new ValueTask<TValue>((TValue)result!);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingMissingServerCatch.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingMissingServerCatch.cs
@@ -1,0 +1,202 @@
+using System.Net;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.Synchronisers.CatchSynchroniserTests;
+
+public class WhenTestingMissingServerCatch : BaseCatchSynchroniserTest
+{
+    [Fact]
+    public async Task ItShouldRecreateTheServerCatchWhenTheUploadUrlReportsItIsMissing()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(SinglePhotographCatchAlreadyMarkedSynchronised());
+        var attempts = 0;
+        MockCatchClient.CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                attempts += 1;
+                if (attempts == 1)
+                {
+                    throw new HttpRequestException(
+                        "Catch not found.",
+                        null,
+                        HttpStatusCode.NotFound);
+                }
+
+                var request = call.ArgAt<PhotographUploadRequestDto>(1);
+                return new PhotographUploadDto(
+                    $"catches/{OwnerUserId:D}/{CatchId:D}/{request.PhotographId:D}",
+                    $"https://storage.test/{request.PhotographId:D}");
+            });
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        attempts.Should().Be(2);
+        await MockCatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(dto => dto.Id == CatchId),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.Received(1).RecordPhotographAsync(
+            CatchId,
+            Arg.Is<RecordPhotographDto>(dto => dto.PhotographId == PhotographAId),
+            Arg.Any<CancellationToken>());
+        var stored = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        stored!.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        stored.MetadataSyncStatus.Should().Be(SyncStatus.Synchronised);
+        stored.Photographs.Should().ContainSingle();
+        stored.Photographs[0].SyncStatus.Should().Be(SyncStatus.Synchronised);
+    }
+
+    [Fact]
+    public async Task ItShouldStopAfterOneRecoveryAttemptWhenTheServerKeepsReportingItIsMissing()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(SinglePhotographCatchAlreadyMarkedSynchronised());
+        MockCatchClient.CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Catch not found.", null, HttpStatusCode.NotFound));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockCatchClient.Received(2).CreatePhotographUploadAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<PhotographUploadRequestDto>(),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive().RecordPhotographAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordPhotographDto>(),
+            Arg.Any<CancellationToken>());
+        var stored = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        stored!.SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        stored.Photographs.Should().ContainSingle();
+        stored.Photographs[0].SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+    }
+
+    [Fact]
+    public async Task ItShouldNotAutomaticallyRetryAStaleUploadAfterTheRecoveryAttemptFails()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(SinglePhotographCatchAlreadyMarkedSynchronised());
+        MockCatchClient.CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Catch not found.", null, HttpStatusCode.NotFound));
+        var sut = CreateSut(store);
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockCatchClient.Received(2).CreatePhotographUploadAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<PhotographUploadRequestDto>(),
+            Arg.Any<CancellationToken>());
+        var stored = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        stored!.Photographs[0].SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+        stored.Photographs[0].Bytes.Should().Equal([1, 2, 3]);
+    }
+
+    [Fact]
+    public async Task ItShouldKeepThePhotographBytesWhenTheServerCatchIsMissing()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(SinglePhotographCatchAlreadyMarkedSynchronised());
+        MockCatchClient.CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Catch not found.", null, HttpStatusCode.NotFound));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        var stored = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        stored!.Photographs.Should().ContainSingle();
+        stored.Photographs[0].Bytes.Should().Equal([1, 2, 3]);
+    }
+
+    [Fact]
+    public async Task ItShouldRecordThatTheServerCatchWasMissing()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(SinglePhotographCatchAlreadyMarkedSynchronised());
+        MockCatchClient.CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Catch not found.", null, HttpStatusCode.NotFound));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockDiagnostics.Received(1).LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchServerRecordMissing,
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(metadata =>
+                metadata[DiagnosticMetadata.CatchId] == CatchId.ToString("D")
+                && metadata[DiagnosticMetadata.PhotographId] == PhotographAId.ToString("D")),
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotAttemptRecoveryForAnOrdinaryUploadFailure()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(SinglePhotographCatchAlreadyMarkedSynchronised());
+        MockCatchClient.CreatePhotographUploadAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<PhotographUploadRequestDto>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException(
+                "The service is unavailable.",
+                null,
+                HttpStatusCode.ServiceUnavailable));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockCatchClient.Received(1).CreatePhotographUploadAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<PhotographUploadRequestDto>(),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.DidNotReceive().UpsertAsync(
+            Arg.Any<CatchDto>(),
+            Arg.Any<CancellationToken>());
+        var stored = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        stored!.Photographs[0].SyncStatus.Should().Be(SyncStatus.FailedToSynchronise);
+    }
+
+    private static FishingLogBook.Web.Features.Catch.Models.CatchModel
+        SinglePhotographCatchAlreadyMarkedSynchronised()
+    {
+        return CreateCatch(
+            catchStatus: SyncStatus.WaitingToSynchronise,
+            metadataStatus: SyncStatus.Synchronised,
+            photographs: [CreatePhotograph(PhotographAId, CatchId)]);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingReadGranularity.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingReadGranularity.cs
@@ -1,0 +1,89 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Common;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.Synchronisers.CatchSynchroniserTests;
+
+public class WhenTestingReadGranularity : BaseCatchSynchroniserTest
+{
+    [Fact]
+    public async Task ItShouldScanForPendingWorkWithoutReadingEveryPhotograph()
+    {
+        // Arrange
+        var pending = CreateCatch();
+        var settled = CreateCatch(
+            catchId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            catchStatus: SyncStatus.Synchronised,
+            metadataStatus: SyncStatus.Synchronised,
+            photographs:
+            [
+                CreatePhotograph(
+                    Guid.Parse("dddddddd-4444-4444-4444-444444444444"),
+                    Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                    SyncStatus.Synchronised)
+            ]);
+        var store = await CreateStoreAsync(pending, settled);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        store.GetAllCalls.Should().Be(0);
+        store.GetMetadataCalls.Should().BeGreaterThan(0);
+        store.PhotographBytesReadFor.Should().BeEquivalentTo(
+            new[] { PhotographAId, PhotographBId, PhotographCId });
+        store.PhotographBytesReadFor.Should().NotContain(
+            Guid.Parse("dddddddd-4444-4444-4444-444444444444"));
+    }
+
+    [Fact]
+    public async Task ItShouldReadTheRequestedCatchOnlyOnceForItsPhotographBytes()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateCatch());
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        store.GetAllCalls.Should().Be(0);
+        store.GetCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldRaiseStateChangedOnceForASynchronisationPass()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateCatch());
+        var sut = CreateSut(store);
+        var raised = 0;
+        sut.StateChanged += (_, _) => raised += 1;
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        raised.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldRaiseStateChangedOnceWhenSynchronisationFails()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateCatch());
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<bool>(new InvalidOperationException("Network probe failed.")));
+        var sut = CreateSut(store);
+        var raised = 0;
+        sut.StateChanged += (_, _) => raised += 1;
+
+        // Act
+        var act = () => sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        raised.Should().Be(1);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
@@ -346,6 +346,57 @@ public class WhenTestingSynchronisePending : BaseCatchSynchroniserTest
     }
 
     [Fact]
+    public async Task ItShouldSynchroniseANewerEditRequestedWhileTheCatchIsInFlight()
+    {
+        // Arrange
+        var original = CreateCatch(
+            photographs: [CreatePhotograph(PhotographAId, CatchId)]);
+        var updatedCaughtOn = original.CaughtOn.AddDays(-1);
+        var store = await CreateStoreAsync(original);
+        var metadataStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseMetadata = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var upsertCount = 0;
+        MockCatchClient.UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                upsertCount += 1;
+                if (upsertCount == 1)
+                {
+                    metadataStarted.SetResult();
+                    await releaseMetadata.Task;
+                }
+            });
+        var sut = CreateSut(store);
+
+        // Act
+        var first = sut.SynchronisePendingAsync(CancellationToken.None);
+        await metadataStarted.Task;
+        var current = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        await store.SaveAsync(
+            current! with
+            {
+                CaughtOn = updatedCaughtOn,
+                SyncStatus = SyncStatus.WaitingToSynchronise,
+                MetadataSyncStatus = SyncStatus.WaitingToSynchronise
+            },
+            CancellationToken.None);
+        var second = sut.SynchronisePendingAsync(CancellationToken.None);
+        releaseMetadata.SetResult();
+        await Task.WhenAll(first, second);
+
+        // Assert
+        await MockCatchClient.Received(2).UpsertAsync(
+            Arg.Any<CatchDto>(),
+            Arg.Any<CancellationToken>());
+        await MockCatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(dto => dto.CaughtOn == updatedCaughtOn),
+            Arg.Any<CancellationToken>());
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        saved!.CaughtOn.Should().Be(updatedCaughtOn);
+        saved.SyncStatus.Should().Be(SyncStatus.Synchronised);
+    }
+
+    [Fact]
     public async Task ItShouldNotOverwriteANewerPrivacyChoiceMadeDuringMetadataSync()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingLoadResilience.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingLoadResilience.cs
@@ -1,0 +1,202 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Pages.CatchEdit;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchEditTests;
+
+public class WhenTestingLoadResilience : BaseCatchEditTest
+{
+    private static readonly Guid CatchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid PhotographId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    [Fact]
+    public async Task ItShouldFallBackToTheServerWhenTheLocalReadTimesOut()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("single-read timed out after 5000ms."));
+        var catchClient = ServerCatchClient();
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-edit-loading").Should().BeEmpty());
+        cut.FindAll("#catch-edit-load-failed").Should().BeEmpty();
+        cut.Find("#catch-edit-weight").Should().NotBeNull();
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFallBackToTheServerWhenTheLocalReadThrows()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("IndexedDB is unavailable."));
+        var catchClient = ServerCatchClient();
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-edit-loading").Should().BeEmpty());
+        cut.FindAll("#catch-edit-load-failed").Should().BeEmpty();
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStillRenderWhenTheLocalCopyCannotBeWrittenBack()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("single-read timed out after 5000ms."));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("write timed out after 5000ms."));
+        await using var context = CreateContext(store, catchClient: ServerCatchClient());
+
+        // Act
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-edit-loading").Should().BeEmpty());
+        cut.FindAll("#catch-edit-load-failed").Should().BeEmpty();
+        cut.Find("#catch-edit-weight").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheFailureWithRetryWhenBothTheLocalCopyAndTheServerFail()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("single-read timed out after 5000ms."));
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("The API is unreachable."));
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-load-failed").Should().NotBeNull());
+        cut.Find("#catch-edit-load-retry").TextContent.Should().Contain("Try again");
+    }
+
+    [Fact]
+    public async Task ItShouldRenderTheCatchWhenRetrySucceeds()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var attempts = 0;
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                attempts += 1;
+                return attempts == 1
+                    ? throw new TimeoutException("single-read timed out after 5000ms.")
+                    : Task.FromResult<CatchModel?>(StoredCatch(CatchId));
+            });
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("The API is unreachable."));
+        await using var context = CreateContext(store, catchClient: catchClient);
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, CatchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-load-retry").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#catch-edit-load-retry").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-edit-load-failed").Should().BeEmpty());
+        cut.Find("#catch-edit-weight").Should().NotBeNull();
+        await store.Received(2).GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotReplacePendingLocalChangesWithServerState()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var pending = StoredCatch(
+            CatchId,
+            SyncStatus.WaitingToSynchronise,
+            SyncStatus.WaitingToSynchronise,
+            speciesName: "Local Pike",
+            method: "Fly");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>()).Returns(pending);
+        var catchClient = ServerCatchClient("Server Perch");
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-edit-loading").Should().BeEmpty());
+        cut.Markup.Should().Contain("Local Pike");
+        cut.Markup.Should().NotContain("Server Perch");
+        await catchClient.DidNotReceive().GetAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReadOnlyTheRequestedCatchFromLocalStorage()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .Returns(StoredCatch(CatchId));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(p => p.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-weight").Should().NotBeNull());
+        await store.Received(1).GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetAllAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetMetadataAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    private static ICatchClient ServerCatchClient(string speciesName = "Server Perch")
+    {
+        var client = Substitute.For<ICatchClient>();
+        client.GetAsync(CatchId, Arg.Any<CancellationToken>())
+            .Returns(new CatchViewDto(CatchId, OwnerUserId, StoredCaughtOn)
+            {
+                SpeciesName = speciesName,
+                AnglerUserId = OwnerUserId,
+                RecordedByUserId = OwnerUserId,
+                Photographs =
+                [
+                    new CatchPhotographViewDto(
+                        PhotographId,
+                        PhotographContentTypeConstants.Jpeg,
+                        "https://storage.test/photo.jpg")
+                ]
+            });
+        client.DownloadPhotographAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns([1, 2, 3]);
+        return client;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingActions.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingActions.cs
@@ -23,7 +23,7 @@ public class WhenTestingActions : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>([StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"))]);
         await using var context = CreateContext(store);
 
@@ -42,7 +42,7 @@ public class WhenTestingActions : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>([StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"))]);
         await using var context = CreateContext(store);
         var popover = context.Render<MudPopoverProvider>();
@@ -72,7 +72,7 @@ public class WhenTestingActions : BaseCatchListTest
             LocationDefaults.Private,
             LocationDefaults.ConsentVersion);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
                 [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), location: location)]);
         var modalService = Substitute.For<IModalService>();
@@ -94,6 +94,6 @@ public class WhenTestingActions : BaseCatchListTest
         await modalService.Received(1).ShowAsync<LocationPrivacyModal, LocationPrivacyModalModel, LocationPrivacyModalResult>(
             Arg.Is<LocationPrivacyModalModel>(model => model.CatchId == catchId),
             Arg.Any<CancellationToken>());
-        await store.Received(2).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(2).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingDisposal.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingDisposal.cs
@@ -16,7 +16,7 @@ public class WhenTestingDisposal : BaseCatchListTest
     {
         // Arrange
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Array.Empty<CatchModel>());
         var synchroniser = Substitute.For<ICatchSynchroniser>();
         await using var context = CreateContext(store, synchroniser: synchroniser);
@@ -31,6 +31,6 @@ public class WhenTestingDisposal : BaseCatchListTest
 
         // Assert
         act.Should().NotThrow();
-        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingErrorLogging.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingErrorLogging.cs
@@ -15,13 +15,13 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchListTests;
 public class WhenTestingErrorLogging : BaseCatchListTest
 {
     [Fact]
-    public async Task ItShouldLogTheUnexpectedExceptionWhenTheStoreFails()
+    public async Task ItShouldLogTheLocalReadFailureWithoutFailingTheWholeLoad()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
         var thrown = new InvalidOperationException("IndexedDB failed.");
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>()).ThrowsAsync(thrown);
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>()).ThrowsAsync(thrown);
         var logging = Substitute.For<ILoggingService>();
         logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
@@ -31,7 +31,8 @@ public class WhenTestingErrorLogging : BaseCatchListTest
         var cut = context.Render<CatchList>();
 
         // Assert
-        cut.WaitForAssertion(() => cut.Find("#catch-list-load-failed").Should().NotBeNull());
+        cut.WaitForAssertion(() => cut.FindAll("#catch-list-loading").Should().BeEmpty());
+        cut.FindAll("#catch-list-load-failed").Should().BeEmpty();
         await logging.Received(1).LogErrorAsync(
             Arg.Any<string>(),
             thrown,
@@ -61,7 +62,7 @@ public class WhenTestingErrorLogging : BaseCatchListTest
             Arg.Any<string>(),
             thrown,
             Arg.Any<CancellationToken>());
-        await store.DidNotReceive().GetAllAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetMetadataAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingFilters.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingFilters.cs
@@ -18,7 +18,7 @@ public class WhenTestingFilters : BaseCatchListTest
         spinningPerch = Guid.NewGuid();
         flyRoach = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
             [
                 StoredCatch(flyPike, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), speciesName: "Pike", method: "Fly"),

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingLoadResilience.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingLoadResilience.cs
@@ -1,0 +1,436 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
+using FishingLogBook.Web.Features.Catch.Pages.CatchList;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchListTests;
+
+public class WhenTestingLoadResilience : BaseCatchListTest
+{
+    private static readonly Guid ServerCatchId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+    [Fact]
+    public async Task ItShouldRenderServerCatchesWhenTheLocalReadTimesOut()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("read timed out after 5000ms."));
+        var catchClient = ServerCatchClient();
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{ServerCatchId:D}").TextContent.Should().Contain("Perch"));
+        cut.FindAll("#catch-list-load-failed").Should().BeEmpty();
+        await catchClient.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRenderServerCatchesWhenTheLocalReadThrows()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("IndexedDB is unavailable."));
+        var catchClient = ServerCatchClient();
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{ServerCatchId:D}").TextContent.Should().Contain("Perch"));
+        cut.FindAll("#catch-list-load-failed").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRenderServerCatchesBeforeASlowLocalReadCompletes()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var localRead = new TaskCompletionSource<IReadOnlyList<CatchModel>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(localRead.Task);
+        await using var context = CreateContext(store, catchClient: ServerCatchClient());
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{ServerCatchId:D}").TextContent.Should().Contain("Perch"));
+        localRead.Task.IsCompleted.Should().BeFalse();
+
+        localRead.SetResult([]);
+        cut.WaitForAssertion(() => cut.FindAll("#catch-list-loading").Should().BeEmpty());
+    }
+
+    [Fact]
+    public async Task ItShouldRenderLocalCatchesWhenTheServerFetchFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var localId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var local = StoredCatch(localId, DateTimeOffset.UtcNow, speciesName: "Local Pike");
+        var store = LocalStore(local);
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAllAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("The API is unreachable."));
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{localId:D}").TextContent.Should().Contain("Local Pike"));
+        cut.FindAll("#catch-list-load-failed").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepAnUnsynchronisedLocalCatchVisibleWhileOnline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var localId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var local = StoredCatch(
+            localId,
+            DateTimeOffset.UtcNow,
+            SyncStatus.WaitingToSynchronise,
+            speciesName: "Unsent Pike");
+        var store = LocalStore(local);
+        await using var context = CreateContext(store, catchClient: ServerCatchClient());
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{localId:D}").TextContent.Should().Contain("Unsent Pike"));
+        cut.Find($"#catch-card-species-{ServerCatchId:D}").TextContent.Should().Contain("Perch");
+    }
+
+    [Fact]
+    public async Task ItShouldNotReadLocalPhotographBytesWhenTheServerSuppliesTheirUrls()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var sharedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var photographId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var local = new CatchModel(
+            sharedId,
+            DateTimeOffset.UtcNow,
+            [new CatchPhotographModel(
+                photographId,
+                sharedId,
+                PhotographContentTypeConstants.Jpeg,
+                Bytes: null,
+                SyncStatus.Synchronised)],
+            SpeciesName: "Synced Pike",
+            UserId: OwnerUserId,
+            SyncStatus: SyncStatus.Synchronised,
+            MetadataSyncStatus: SyncStatus.Synchronised,
+            AnglerUserId: OwnerUserId,
+            RecordedByUserId: OwnerUserId);
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<CatchModel>)[local]);
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<CatchViewDto>)
+            [
+                new CatchViewDto(sharedId, OwnerUserId, DateTimeOffset.UtcNow)
+                {
+                    SpeciesName = "Synced Pike",
+                    AnglerUserId = OwnerUserId,
+                    RecordedByUserId = OwnerUserId,
+                    Photographs =
+                    [
+                        new CatchPhotographViewDto(
+                            photographId,
+                            PhotographContentTypeConstants.Jpeg,
+                            "https://storage.test/photo.jpg")
+                    ]
+                }
+            ]);
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{sharedId:D}").TextContent.Should().Contain("Synced Pike"));
+        await store.Received(1).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetAllAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPreferNewerServerMetadataOverAFullySynchronisedLocalSnapshot()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var sharedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var local = StoredCatch(sharedId, DateTimeOffset.UtcNow, speciesName: "Old local name") with
+        {
+            SyncStatus = SyncStatus.Synchronised,
+            MetadataSyncStatus = SyncStatus.Synchronised,
+            Photographs = StoredCatch(sharedId, DateTimeOffset.UtcNow).Photographs
+                .Select(photograph => photograph with { SyncStatus = SyncStatus.Synchronised })
+                .ToArray()
+        };
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<CatchModel>)[local]);
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<CatchViewDto>)
+            [
+                new CatchViewDto(sharedId, OwnerUserId, DateTimeOffset.UtcNow)
+                {
+                    SpeciesName = "Fresh server name",
+                    AnglerUserId = OwnerUserId,
+                    RecordedByUserId = OwnerUserId
+                }
+            ]);
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{sharedId:D}").TextContent.Should().Contain("Fresh server name"));
+        await store.DidNotReceive().GetAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReadOnlyTheUnsynchronisedCatchPhotographBytes()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var syncedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var pendingId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var syncedPhotographId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var synced = new CatchModel(
+            syncedId,
+            DateTimeOffset.UtcNow,
+            [new CatchPhotographModel(
+                syncedPhotographId,
+                syncedId,
+                PhotographContentTypeConstants.Jpeg,
+                Bytes: null,
+                SyncStatus.Synchronised)],
+            SpeciesName: "Synced Pike",
+            UserId: OwnerUserId,
+            SyncStatus: SyncStatus.Synchronised,
+            MetadataSyncStatus: SyncStatus.Synchronised,
+            AnglerUserId: OwnerUserId,
+            RecordedByUserId: OwnerUserId);
+        var pending = StoredCatch(
+            pendingId,
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            SyncStatus.WaitingToSynchronise,
+            speciesName: "Unsent Perch");
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<CatchModel>)[synced, pending]);
+        store.GetAsync(OwnerUserId, pendingId, Arg.Any<CancellationToken>()).Returns(pending);
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<CatchViewDto>)
+            [
+                new CatchViewDto(syncedId, OwnerUserId, DateTimeOffset.UtcNow)
+                {
+                    SpeciesName = "Synced Pike",
+                    AnglerUserId = OwnerUserId,
+                    RecordedByUserId = OwnerUserId,
+                    Photographs =
+                    [
+                        new CatchPhotographViewDto(
+                            syncedPhotographId,
+                            PhotographContentTypeConstants.Jpeg,
+                            "https://storage.test/photo.jpg")
+                    ]
+                }
+            ]);
+        await using var context = CreateContext(store, catchClient: catchClient);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{pendingId:D}").TextContent.Should().Contain("Unsent Perch"));
+        await store.Received(1).GetAsync(OwnerUserId, pendingId, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetAsync(OwnerUserId, syncedId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReloadWhenRetryIsPressedAfterBothSourcesFail()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var localId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var recovered = StoredCatch(localId, DateTimeOffset.UtcNow, speciesName: "Recovered Pike");
+        var store = Substitute.For<ICatchStore>();
+        var reads = 0;
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                reads += 1;
+                return reads == 1
+                    ? throw new TimeoutException("read timed out after 5000ms.")
+                    : Task.FromResult<IReadOnlyList<CatchModel>>([recovered]);
+            });
+        store.GetAsync(OwnerUserId, localId, Arg.Any<CancellationToken>()).Returns(recovered);
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAllAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("The API is unreachable."));
+        await using var context = CreateContext(store, catchClient: catchClient);
+        var cut = context.Render<CatchList>();
+        cut.WaitForAssertion(() => cut.Find("#catch-list-load-retry").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#catch-list-load-retry").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{localId:D}").TextContent.Should().Contain("Recovered Pike"));
+        cut.FindAll("#catch-list-load-failed").Should().BeEmpty();
+        await store.Received(2).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotStartOverlappingLoadsWhenRetryIsPressedRepeatedly()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var gate = new TaskCompletionSource();
+        var concurrent = 0;
+        var peak = 0;
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                concurrent += 1;
+                peak = Math.Max(peak, concurrent);
+                await gate.Task;
+                concurrent -= 1;
+                return (IReadOnlyList<CatchModel>)[];
+            });
+        await using var context = CreateContext(store, catchClient: ServerCatchClient());
+
+        // Act
+        var cut = context.Render<CatchList>();
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-card-species-{ServerCatchId:D}").Should().NotBeNull());
+        gate.SetResult();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-list-loading").Should().BeEmpty());
+        peak.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldCoalesceRepeatedSynchronisationStateChangesIntoASingleReload()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var gate = new TaskCompletionSource();
+        var concurrent = 0;
+        var peak = 0;
+        var reads = 0;
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                reads += 1;
+                concurrent += 1;
+                peak = Math.Max(peak, concurrent);
+                if (reads == 1)
+                {
+                    await gate.Task;
+                }
+
+                concurrent -= 1;
+                return (IReadOnlyList<CatchModel>)[];
+            });
+        var synchroniser = Substitute.For<ICatchSynchroniser>();
+        var catchClient = ServerCatchClient();
+        await using var context = CreateContext(
+            store,
+            synchroniser: synchroniser,
+            catchClient: catchClient);
+        var cut = context.Render<CatchList>();
+
+        // Act
+        for (var raise = 0; raise < 5; raise++)
+        {
+            synchroniser.StateChanged += Raise.Event<EventHandler>(synchroniser, EventArgs.Empty);
+        }
+
+        gate.SetResult();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-list-loading").Should().BeEmpty());
+        peak.Should().Be(1);
+        reads.Should().BeLessThan(6);
+        await catchClient.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static ICatchClient ServerCatchClient()
+    {
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<CatchViewDto>)
+            [
+                new CatchViewDto(ServerCatchId, OwnerUserId, DateTimeOffset.UtcNow.AddDays(-1))
+                {
+                    SpeciesName = "Perch",
+                    AnglerUserId = OwnerUserId,
+                    RecordedByUserId = OwnerUserId
+                }
+            ]);
+        return catchClient;
+    }
+
+    private static ICatchStore LocalStore(params CatchModel[] catches)
+    {
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<CatchModel>)[.. catches]);
+        foreach (var catchRecord in catches)
+        {
+            store.GetAsync(OwnerUserId, catchRecord.Id, Arg.Any<CancellationToken>())
+                .Returns(catchRecord);
+        }
+
+        return store;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingProvenance.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingProvenance.cs
@@ -18,7 +18,7 @@ public class WhenTestingProvenance : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
             [
                 StoredCatch(
@@ -44,7 +44,7 @@ public class WhenTestingProvenance : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
             [
                 StoredCatch(

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingRender.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Bunit;
+using FishingLogBook.Web.Features.Catch.Clients;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
@@ -36,7 +37,7 @@ public class WhenTestingRender : BaseCatchListTest
         var yesterdayCatch = Guid.NewGuid();
         var olderCatch = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
             [
                 StoredCatch(olderCatch, DateTimeOffset.Parse("2026-08-10T09:00:00Z"), speciesName: "Roach"),
@@ -68,7 +69,7 @@ public class WhenTestingRender : BaseCatchListTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([]));
         await using var context = CreateContext(store);
 
@@ -82,18 +83,21 @@ public class WhenTestingRender : BaseCatchListTest
             cut.Markup.Should().NotContain("Saved on this device");
             cut.FindAll("a[href='/catches/record']").Should().ContainSingle();
         });
-        await store.Received(1).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ItShouldShowLoadFailedCopyWhenTheStoreFails()
+    public async Task ItShouldShowLoadFailedCopyOnlyWhenBothTheLocalStoreAndTheServerFail()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
-        await using var context = CreateContext(store);
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAllAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("The API is unreachable."));
+        await using var context = CreateContext(store, catchClient: catchClient);
 
         // Act
         var cut = context.Render<CatchList>();
@@ -101,6 +105,9 @@ public class WhenTestingRender : BaseCatchListTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#catch-list-load-failed").TextContent.Should().Contain("could not be loaded"));
+        cut.Find("#catch-list-load-retry").TextContent.Should().Contain("Try again");
+        await store.Received(1).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await catchClient.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -109,7 +116,7 @@ public class WhenTestingRender : BaseCatchListTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.French);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([]));
         await using var context = CreateContext(store);
 
@@ -128,10 +135,10 @@ public class WhenTestingRender : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var ownerCatchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>(
                 [StoredCatch(ownerCatchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"))]));
-        store.GetAllAsync(OtherUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OtherUserId, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<CatchModel>>([]));
         var owner = SignedInOwner(OtherUserId);
         await using var context = CreateContext(store, owner);
@@ -143,7 +150,7 @@ public class WhenTestingRender : BaseCatchListTest
         cut.WaitForAssertion(() =>
             cut.Find("#catch-list-empty").TextContent.Should().Contain("No catches in your Logbook yet"));
         cut.FindAll($"#catch-card-{ownerCatchId:D}").Should().BeEmpty();
-        await store.Received(1).GetAllAsync(OtherUserId, Arg.Any<CancellationToken>());
-        await store.DidNotReceive().GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(1).GetMetadataAsync(OtherUserId, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingSearch.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingSearch.cs
@@ -17,7 +17,7 @@ public class WhenTestingSearch : BaseCatchListTest
         spinningPerch = Guid.NewGuid();
         wormRoach = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
             [
                 StoredCatch(flyPike, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), speciesName: "Pike", method: "Fly"),

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingServerCatches.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingServerCatches.cs
@@ -22,7 +22,7 @@ public class WhenTestingServerCatches : BaseCatchListTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(Array.Empty<CatchModel>());
         var serverCatchId = Guid.NewGuid();
         var catchClient = Substitute.For<ICatchClient>();
@@ -54,7 +54,7 @@ public class WhenTestingServerCatches : BaseCatchListTest
         var sharedId = Guid.NewGuid();
         var local = StoredCatch(sharedId, DateTimeOffset.UtcNow, speciesName: "Local Pike");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(new[] { local });
         var catchClient = Substitute.For<ICatchClient>();
         catchClient.GetAllAsync(Arg.Any<CancellationToken>())
@@ -86,7 +86,7 @@ public class WhenTestingServerCatches : BaseCatchListTest
         var localId = Guid.NewGuid();
         var local = StoredCatch(localId, DateTimeOffset.UtcNow, speciesName: "Trout");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(new[] { local });
         var catchClient = Substitute.For<ICatchClient>();
         catchClient.GetAllAsync(Arg.Any<CancellationToken>())
@@ -117,7 +117,7 @@ public class WhenTestingServerCatches : BaseCatchListTest
         var localId = Guid.NewGuid();
         var local = StoredCatch(localId, DateTimeOffset.UtcNow, speciesName: "Brown Trout");
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(new[] { local });
         var catchClient = Substitute.For<ICatchClient>();
         var network = OnlineNetwork(isOnline: false);

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingSyncStatus.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingSyncStatus.cs
@@ -20,7 +20,7 @@ public class WhenTestingSyncStatus : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
                 [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), SyncStatus.Synchronised)]);
         await using var context = CreateContext(store);
@@ -44,7 +44,7 @@ public class WhenTestingSyncStatus : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
                 [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), status)]);
         await using var context = CreateContext(store);
@@ -64,7 +64,7 @@ public class WhenTestingSyncStatus : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
                 [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), SyncStatus.Synchronising)]);
         await using var context = CreateContext(store);
@@ -85,12 +85,16 @@ public class WhenTestingSyncStatus : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(
                 _ => [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), SyncStatus.FailedToSynchronise)],
                 _ => [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), SyncStatus.Synchronised)]);
         var synchroniser = Substitute.For<ICatchSynchroniser>();
-        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var catchClient = EmptyCatchClient();
+        await using var context = CreateContext(
+            store,
+            synchroniser: synchroniser,
+            catchClient: catchClient);
         var cut = context.Render<CatchList>();
         cut.WaitForAssertion(() => cut.Find($"#catch-sync-retry-{catchId:D}").Should().NotBeNull());
 
@@ -101,7 +105,7 @@ public class WhenTestingSyncStatus : BaseCatchListTest
         cut.WaitForAssertion(() =>
             cut.FindAll($"#catch-sync-retry-{catchId:D}").Should().BeEmpty());
         await synchroniser.Received(1).RetryAsync(catchId, Arg.Any<CancellationToken>());
-        await store.Received(2).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(2).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -111,12 +115,16 @@ public class WhenTestingSyncStatus : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.English);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(
                 _ => [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), SyncStatus.SavedLocally)],
                 _ => [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), SyncStatus.Synchronised)]);
         var synchroniser = Substitute.For<ICatchSynchroniser>();
-        await using var context = CreateContext(store, synchroniser: synchroniser);
+        var catchClient = EmptyCatchClient();
+        await using var context = CreateContext(
+            store,
+            synchroniser: synchroniser,
+            catchClient: catchClient);
         var cut = context.Render<CatchList>();
         cut.WaitForAssertion(() => cut.Find($"#catch-sync-retry-{catchId:D}").Should().NotBeNull());
 
@@ -126,7 +134,8 @@ public class WhenTestingSyncStatus : BaseCatchListTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.FindAll($"#catch-sync-retry-{catchId:D}").Should().BeEmpty());
-        await store.Received(2).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await store.Received(2).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await catchClient.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -136,7 +145,7 @@ public class WhenTestingSyncStatus : BaseCatchListTest
         using var culture = TestCulture.Use(CultureNames.French);
         var catchId = Guid.NewGuid();
         var store = Substitute.For<ICatchStore>();
-        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns<IReadOnlyList<CatchModel>>(
                 [StoredCatch(catchId, DateTimeOffset.Parse("2026-08-17T08:00:00Z"), SyncStatus.FailedToSynchronise)]);
         await using var context = CreateContext(store);

--- a/tests/FishingLogBook.Web.Tests/JavaScript/OfflineStore/WhenTestingDiagnosticEvents.cs
+++ b/tests/FishingLogBook.Web.Tests/JavaScript/OfflineStore/WhenTestingDiagnosticEvents.cs
@@ -12,20 +12,24 @@ public class WhenTestingDiagnosticEvents : BaseOfflineStoreTest
         var script = ReadOfflineStoreScript();
 
         // Act
+        var diagnosticScript = script[..script.IndexOf(
+            "export async function putCatchWithPhotographs",
+            StringComparison.Ordinal)];
+
         // Assert
-        script.Should().Contain(DiagnosticEventNames.OfflineDbOpenStarted);
-        script.Should().Contain(DiagnosticEventNames.OfflineDbOpenCompleted);
-        script.Should().Contain(DiagnosticEventNames.OfflineDbOpenFailed);
-        script.Should().Contain(DiagnosticEventNames.OfflineDbTransactionStarted);
-        script.Should().Contain(DiagnosticEventNames.OfflineDbRequestSucceeded);
-        script.Should().Contain(DiagnosticEventNames.OfflineDbTransactionCompleted);
-        script.Should().Contain(DiagnosticEventNames.OfflineDbTransactionAborted);
-        script.Should().Contain(DiagnosticEventNames.OfflineDbTransactionError);
-        script.Should().Contain(DiagnosticEventNames.OfflineDbClosed);
-        script.Should().Contain("navigator.storage.estimate");
-        script.Should().Contain("elapsedMilliseconds");
-        script.Should().NotContain("species");
-        script.Should().NotContain("latitude");
-        script.Should().NotContain("base64,");
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbOpenStarted);
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbOpenCompleted);
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbOpenFailed);
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbTransactionStarted);
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbRequestSucceeded);
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbTransactionCompleted);
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbTransactionAborted);
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbTransactionError);
+        diagnosticScript.Should().Contain(DiagnosticEventNames.OfflineDbClosed);
+        diagnosticScript.Should().Contain("navigator.storage.estimate");
+        diagnosticScript.Should().Contain("elapsedMilliseconds");
+        diagnosticScript.Should().NotContain("species");
+        diagnosticScript.Should().NotContain("latitude");
+        diagnosticScript.Should().NotContain("base64,");
     }
 }


### PR DESCRIPTION
## Summary

- split lightweight IndexedDB catch metadata reads from true owner-scoped single-catch and photograph reads
- keep Catch List and synchronisation paths from loading every photograph through JavaScript/WASM
- make online Catch List API loading and Catch Edit server fallback resilient to local IndexedDB failures, with localised in-place retry
- coalesce synchroniser-driven list refreshes and refresh only local metadata, avoiding duplicate `/api/catches` requests and repeated signed-image downloads
- abort timed-out IndexedDB transactions and recover safely when a server catch disappears during photograph synchronisation
- preserve newer local edits when an older in-flight synchronisation completes

## Root cause

The previous single-catch read was implemented through the full catch-list path. That loaded all catches and photographs from IndexedDB, converted photograph bytes to Base64, crossed the JS/WASM boundary, and only then selected one catch. Catch List also coupled successful API rendering to local storage reads, while synchroniser state changes triggered full API reloads and fresh signed image URLs.

The faster read path exposed a separate synchronisation race: an in-flight completion could overwrite a newer local metadata edit. This PR queues a coalesced follow-up attempt and prevents stale completion data from replacing newer local state.

## Storage and access shape

- catch-list reads cursor over lightweight catch metadata only
- a single-catch read uses the direct owner-scoped catch key and only that catch's photograph keys
- photograph bytes remain in IndexedDB until a requested catch or synchronisation operation needs them
- no IndexedDB schema or version change

## Validation

- full E2E suite: **47/47 passed**
- JavaScript/Vitest: **243/243 passed**
- Catch List tests: **50/50 passed**
- Catch synchroniser tests: **29/29 passed**
- Web suite: **973/973 passed**, with affected focused suites rerun after the final refinements
- Infrastructure suite: **119/119 passed**
- browser suite: **49 passed, 5 expected WebKit skips**
- focused browser storage/read suite: **19/19 passed**
- realistic photograph/blob browser suite: **5/5 passed**
- Release build: succeeded with 0 warnings and 0 errors
- `dotnet format` and `git diff --check`: passed

## Physical validation still required

This PR does not claim physical-device acceptance. Please verify on Samsung and iPhone:

- repeated online Catch List visits do not issue a second `/api/catches` request during background sync or progressively reload all images
- Catch Edit opens and saves normally
- cold-offline cached catches and photographs remain available
- offline record/edit persists locally
- reconnect synchronises queued catch/photograph work without an automatic retry loop

Closes #166
