### PR TITLE
FLB#164 | Final offline reconnect truthfulness, Landing state, and 24h synced-cache retention

### DIFF
--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
@@ -53,6 +53,10 @@ public static class DiagnosticEventNames
     public const string CatchSyncFailed = "CatchSyncFailed";
     public const string CatchServerRecordMissing = "CatchServerRecordMissing";
 
+    public const string CatchCacheCleanupStarted = "CatchCacheCleanupStarted";
+    public const string CatchCacheCleanupCompleted = "CatchCacheCleanupCompleted";
+    public const string CatchCacheCleanupFailed = "CatchCacheCleanupFailed";
+
     public const string AuthenticationUnavailable = "AuthenticationUnavailable";
 
     public const string ServiceWorkerError = "ServiceWorkerError";

--- a/src/FishingLogBook.Web/BrowserTests/catch-store-cleanup.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/catch-store-cleanup.spec.js
@@ -1,0 +1,182 @@
+import { expect, test } from '@playwright/test';
+
+const catchStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js';
+const databaseName = 'FishingLogBook';
+const ownerUserId = '11111111-1111-1111-1111-111111111111';
+const otherUserId = '22222222-2222-2222-2222-222222222222';
+const now = new Date('2026-08-26T12:00:00Z');
+const cutoffIso = new Date(now.getTime() - (24 * 60 * 60 * 1000)).toISOString();
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/src/FishingLogBook.Web/BrowserTests/harness/index.html');
+    await page.evaluate((name) => new Promise((resolve) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+    }), databaseName);
+});
+
+async function seedCatch(page, {
+    catchId,
+    userId,
+    syncStatus,
+    metadataSyncStatus,
+    syncedAt,
+    photographSyncStatus = 'synchronised'
+}) {
+    await page.evaluate(async ({ catchStoreModule, catchId, userId, syncStatus, metadataSyncStatus, syncedAt, photographSyncStatus }) => {
+        const { putCatchWithPhotographs, updateCatchMetadata } = await import(catchStoreModule);
+        const photographId = `${catchId.slice(0, 8)}-cccc-cccc-cccc-cccccccccccc`;
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId,
+                caughtOn: '2020-01-01T08:00:00+00:00',
+                syncStatus: 'savedLocally',
+                metadataSyncStatus: 'savedLocally',
+                photographs: [
+                    { id: photographId, catchId, contentType: 'image/jpeg', syncStatus: 'savedLocally' }
+                ]
+            }),
+            [{ id: photographId, catchId, contentType: 'image/jpeg', bytes: new Uint8Array(64).fill(7) }]);
+
+        await updateCatchMetadata(JSON.stringify({
+            id: catchId,
+            userId,
+            syncStatus,
+            metadataSyncStatus,
+            syncedAt,
+            photographs: [{ id: photographId, catchId, syncStatus: photographSyncStatus }]
+        }));
+
+        return photographId;
+    }, { catchStoreModule, catchId, userId, syncStatus, metadataSyncStatus, syncedAt, photographSyncStatus });
+}
+
+test('cleanup removes an eligible synced catch and its photograph without reading photograph bytes', async ({ page }) => {
+    await seedCatch(page, {
+        catchId: 'aaaaaaaa-aaaa-aaaa-aaaa-000000000001',
+        userId: ownerUserId,
+        syncStatus: 'synchronised',
+        metadataSyncStatus: 'synchronised',
+        syncedAt: new Date(now.getTime() - (25 * 60 * 60 * 1000)).toISOString()
+    });
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId, cutoffIso }) => {
+        const module = await import(catchStoreModule);
+        const gets = [];
+        const originalGet = IDBObjectStore.prototype.get;
+        IDBObjectStore.prototype.get = function instrumentedGet(key) {
+            gets.push({ store: this.name, key });
+            return originalGet.call(this, key);
+        };
+
+        try {
+            const removed = await module.cleanupSyncedCatches(ownerUserId, cutoffIso);
+            const remaining = await module.getCatchMetadata(ownerUserId);
+            return {
+                removed,
+                remainingCount: remaining.length,
+                photographGets: gets.filter((access) => access.store === module.PHOTO_STORE_NAME).length
+            };
+        } finally {
+            IDBObjectStore.prototype.get = originalGet;
+        }
+    }, { catchStoreModule, ownerUserId, cutoffIso });
+
+    expect(result.removed).toBe(1);
+    expect(result.remainingCount).toBe(0);
+    expect(result.photographGets).toBe(0);
+});
+
+test('cleanup retains a synced catch newer than the retention cutoff', async ({ page }) => {
+    await seedCatch(page, {
+        catchId: 'aaaaaaaa-aaaa-aaaa-aaaa-000000000002',
+        userId: ownerUserId,
+        syncStatus: 'synchronised',
+        metadataSyncStatus: 'synchronised',
+        syncedAt: new Date(now.getTime() - (1 * 60 * 60 * 1000)).toISOString()
+    });
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId, cutoffIso }) => {
+        const module = await import(catchStoreModule);
+        const removed = await module.cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await module.getCatchMetadata(ownerUserId);
+        return { removed, remainingCount: remaining.length };
+    }, { catchStoreModule, ownerUserId, cutoffIso });
+
+    expect(result.removed).toBe(0);
+    expect(result.remainingCount).toBe(1);
+});
+
+test('cleanup retains a pending catch even when older than the retention cutoff', async ({ page }) => {
+    await seedCatch(page, {
+        catchId: 'aaaaaaaa-aaaa-aaaa-aaaa-000000000003',
+        userId: ownerUserId,
+        syncStatus: 'waitingToSynchronise',
+        metadataSyncStatus: 'synchronised',
+        syncedAt: new Date(now.getTime() - (48 * 60 * 60 * 1000)).toISOString(),
+        photographSyncStatus: 'waitingToSynchronise'
+    });
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId, cutoffIso }) => {
+        const module = await import(catchStoreModule);
+        const removed = await module.cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await module.getCatchMetadata(ownerUserId);
+        return { removed, remainingCount: remaining.length };
+    }, { catchStoreModule, ownerUserId, cutoffIso });
+
+    expect(result.removed).toBe(0);
+    expect(result.remainingCount).toBe(1);
+});
+
+test('cleanup never removes another owners eligible catch', async ({ page }) => {
+    await seedCatch(page, {
+        catchId: 'aaaaaaaa-aaaa-aaaa-aaaa-000000000004',
+        userId: ownerUserId,
+        syncStatus: 'synchronised',
+        metadataSyncStatus: 'synchronised',
+        syncedAt: new Date(now.getTime() - (48 * 60 * 60 * 1000)).toISOString()
+    });
+    await seedCatch(page, {
+        catchId: 'aaaaaaaa-aaaa-aaaa-aaaa-000000000005',
+        userId: otherUserId,
+        syncStatus: 'synchronised',
+        metadataSyncStatus: 'synchronised',
+        syncedAt: new Date(now.getTime() - (48 * 60 * 60 * 1000)).toISOString()
+    });
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId, otherUserId, cutoffIso }) => {
+        const module = await import(catchStoreModule);
+        const removed = await module.cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const ownerRemaining = await module.getCatchMetadata(ownerUserId);
+        const otherRemaining = await module.getCatchMetadata(otherUserId);
+        return { removed, ownerRemaining: ownerRemaining.length, otherRemaining: otherRemaining.length };
+    }, { catchStoreModule, ownerUserId, otherUserId, cutoffIso });
+
+    expect(result.removed).toBe(1);
+    expect(result.ownerRemaining).toBe(0);
+    expect(result.otherRemaining).toBe(1);
+});
+
+test('cleanup does not disturb a photograph that is still awaiting upload', async ({ page }) => {
+    await seedCatch(page, {
+        catchId: 'aaaaaaaa-aaaa-aaaa-aaaa-000000000006',
+        userId: ownerUserId,
+        syncStatus: 'synchronised',
+        metadataSyncStatus: 'synchronised',
+        syncedAt: new Date(now.getTime() - (48 * 60 * 60 * 1000)).toISOString(),
+        photographSyncStatus: 'waitingToSynchronise'
+    });
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId, cutoffIso }) => {
+        const module = await import(catchStoreModule);
+        const removed = await module.cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await module.getCatchMetadata(ownerUserId);
+        return { removed, remainingCount: remaining.length };
+    }, { catchStoreModule, ownerUserId, cutoffIso });
+
+    expect(result.removed).toBe(0);
+    expect(result.remainingCount).toBe(1);
+});

--- a/src/FishingLogBook.Web/BrowserTests/catch-store-cleanup.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/catch-store-cleanup.spec.js
@@ -54,6 +54,68 @@ async function seedCatch(page, {
     }, { catchStoreModule, catchId, userId, syncStatus, metadataSyncStatus, syncedAt, photographSyncStatus });
 }
 
+async function writeRawCatch(page, { catchId, userId, syncStatus, metadataSyncStatus, syncedAt }) {
+    await page.evaluate(async ({ catchStoreModule, catchId, userId, syncStatus, metadataSyncStatus, syncedAt }) => {
+        const { openCatchDatabase, CATCH_STORE_NAME } = await import(catchStoreModule);
+        const db = await openCatchDatabase();
+        await new Promise((resolve, reject) => {
+            const transaction = db.transaction(CATCH_STORE_NAME, 'readwrite');
+            const request = transaction.objectStore(CATCH_STORE_NAME).put({
+                id: catchId,
+                userId,
+                caughtOn: '2020-01-01T08:00:00+00:00',
+                syncStatus,
+                metadataSyncStatus,
+                syncedAt,
+                photographs: []
+            });
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+            transaction.oncomplete = () => db.close();
+        });
+    }, { catchStoreModule, catchId, userId, syncStatus, metadataSyncStatus, syncedAt });
+}
+
+test('cleanup removes a fully synced catch with no photographs older than the retention cutoff', async ({ page }) => {
+    await writeRawCatch(page, {
+        catchId: 'aaaaaaaa-1111-1111-1111-111111111111',
+        userId: ownerUserId,
+        syncStatus: 'synchronised',
+        metadataSyncStatus: 'synchronised',
+        syncedAt: new Date(now.getTime() - (25 * 60 * 60 * 1000)).toISOString()
+    });
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId, cutoffIso }) => {
+        const module = await import(catchStoreModule);
+        const removed = await module.cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await module.getCatchMetadata(ownerUserId);
+        return { removed, remainingCount: remaining.length };
+    }, { catchStoreModule, ownerUserId, cutoffIso });
+
+    expect(result.removed).toBe(1);
+    expect(result.remainingCount).toBe(0);
+});
+
+test('cleanup retains a fully synced catch with no photographs newer than the retention cutoff', async ({ page }) => {
+    await writeRawCatch(page, {
+        catchId: 'bbbbbbbb-1111-1111-1111-111111111111',
+        userId: ownerUserId,
+        syncStatus: 'synchronised',
+        metadataSyncStatus: 'synchronised',
+        syncedAt: new Date(now.getTime() - (1 * 60 * 60 * 1000)).toISOString()
+    });
+
+    const result = await page.evaluate(async ({ catchStoreModule, ownerUserId, cutoffIso }) => {
+        const module = await import(catchStoreModule);
+        const removed = await module.cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await module.getCatchMetadata(ownerUserId);
+        return { removed, remainingCount: remaining.length };
+    }, { catchStoreModule, ownerUserId, cutoffIso });
+
+    expect(result.removed).toBe(0);
+    expect(result.remainingCount).toBe(1);
+});
+
 test('cleanup removes an eligible synced catch and its photograph without reading photograph bytes', async ({ page }) => {
     await seedCatch(page, {
         catchId: 'aaaaaaaa-aaaa-aaaa-aaaa-000000000001',

--- a/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
@@ -47,6 +47,19 @@ test.describe('Published offline application shell', () => {
         expect(apiGuard.requests).toEqual([]);
     });
 
+    test('does not offer Open Offline on Landing while genuinely online, even with offline access configured', async ({ page }) => {
+        await addPrfAuthenticator(page);
+        await cachePublishedShell(page);
+        await provisionOfflineOwner(page);
+
+        await page.reload({ waitUntil: 'domcontentloaded' });
+        await expect(page.locator('#public-landing-page')).toBeVisible({ timeout: 15000 });
+
+        await expect(page.locator('#landing-open-offline')).toHaveCount(0);
+        await expect(page.locator('#landing-create-account')).toBeVisible();
+        await expect(page.locator('#landing-sign-in')).toBeVisible();
+    });
+
     test('opens read-only offline diagnostics from the shared header during cold offline startup', async ({ context, page }) => {
         const apiGuard = guardOfflineApiRequests(context);
 
@@ -280,6 +293,12 @@ async function seedOtherOwnersCatch(page) {
 
 async function reopenColdOffline(context, page) {
     await page.goto('about:blank');
+    await context.addInitScript(() => {
+        Object.defineProperty(Navigator.prototype, 'onLine', {
+            configurable: true,
+            get: () => false
+        });
+    });
     await context.setOffline(true);
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('#public-landing-page')).toBeVisible({ timeout: 15000 });

--- a/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Models/CatchModel.cs
@@ -17,4 +17,5 @@ public sealed record CatchModel(
     decimal? Length = null,
     string? Method = null,
     string? BaitOrLure = null,
-    string? Notes = null);
+    string? Notes = null,
+    DateTimeOffset? SyncedAt = null);

--- a/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/CatchJson.cs
@@ -38,7 +38,8 @@ internal static class CatchJson
             catchRecord.Length,
             catchRecord.Method,
             catchRecord.BaitOrLure,
-            catchRecord.Notes);
+            catchRecord.Notes,
+            catchRecord.SyncedAt);
         return JsonSerializer.Serialize(metadata, Options);
     }
 
@@ -68,7 +69,8 @@ internal static class CatchJson
             metadata.Length,
             metadata.Method,
             metadata.BaitOrLure,
-            metadata.Notes);
+            metadata.Notes,
+            metadata.SyncedAt);
     }
 
     public static CatchModel DeserializeMetadata(string json)
@@ -124,7 +126,8 @@ internal static class CatchJson
         decimal? Length = null,
         string? Method = null,
         string? BaitOrLure = null,
-        string? Notes = null);
+        string? Notes = null,
+        DateTimeOffset? SyncedAt = null);
 
     private sealed record CatchPhotographMetadata(
         Guid Id,

--- a/src/FishingLogBook.Web/Features/Catch/Offline/Stores/ICatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Stores/ICatchStore.cs
@@ -21,4 +21,9 @@ public interface ICatchStore
         CancellationToken cancellationToken);
 
     Task UpdateSyncStateAsync(CatchModel catchRecord, CancellationToken cancellationToken);
+
+    Task<int> CleanupSyncedCacheAsync(
+        Guid ownerUserId,
+        DateTimeOffset olderThan,
+        CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Features/Catch/Offline/Stores/IndexedDbCatchStore.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Stores/IndexedDbCatchStore.cs
@@ -193,6 +193,38 @@ public sealed class IndexedDbCatchStore : ICatchStore
             _logging);
     }
 
+    public async Task<int> CleanupSyncedCacheAsync(
+        Guid ownerUserId,
+        DateTimeOffset olderThan,
+        CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
+        return await OfflineOperation.ExecuteAsync(
+            "cleanup",
+            StoreName,
+            DiagnosticEventNames.OfflineDbWriteStarted,
+            DiagnosticEventNames.OfflineDbWriteCompleted,
+            DiagnosticEventNames.OfflineDbWriteFailed,
+            DiagnosticEventNames.OfflineDbWriteTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                return await module.InvokeAsync<int>(
+                    "cleanupSyncedCatches",
+                    token,
+                    ownerUserId.ToString("D"),
+                    olderThan.ToString("O"));
+            },
+            cancellationToken,
+            _logging);
+    }
+
     private async Task<IReadOnlyList<CatchModel>> ReadCatchesAsync(
         Guid ownerUserId,
         string jsFunction,

--- a/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/CatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/CatchSynchroniser.cs
@@ -74,6 +74,71 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
         }
     }
 
+    private static readonly TimeSpan SyncedCacheRetentionWindow = TimeSpan.FromHours(24);
+
+    public async Task CleanupSyncedCacheAsync(CancellationToken cancellationToken)
+    {
+        var ownerUserId = await TryGetOwnerUserIdAsync(cancellationToken);
+        if (ownerUserId is not null)
+        {
+            await CleanupSyncedCacheCoreAsync(ownerUserId.Value, cancellationToken);
+        }
+    }
+
+    public async Task CleanupSyncedCacheAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            return;
+        }
+
+        await CleanupSyncedCacheCoreAsync(ownerUserId, cancellationToken);
+    }
+
+    private async Task CleanupSyncedCacheCoreAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!await _networkService.IsOnlineAsync(cancellationToken))
+            {
+                return;
+            }
+
+            await SafeLogAsync(
+                DiagnosticLevel.Debug,
+                DiagnosticEventNames.CatchCacheCleanupStarted,
+                "Synced local catch cache cleanup started.",
+                catchId: null,
+                photographId: null,
+                exception: null,
+                cancellationToken);
+            var olderThan = DateTimeOffset.UtcNow - SyncedCacheRetentionWindow;
+            await _store.CleanupSyncedCacheAsync(ownerUserId, olderThan, cancellationToken);
+            await SafeLogAsync(
+                DiagnosticLevel.Debug,
+                DiagnosticEventNames.CatchCacheCleanupCompleted,
+                "Synced local catch cache cleanup completed.",
+                catchId: null,
+                photographId: null,
+                exception: null,
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await SafeLogAsync(
+                DiagnosticLevel.Warning,
+                DiagnosticEventNames.CatchCacheCleanupFailed,
+                "Synced local catch cache cleanup failed.",
+                catchId: null,
+                photographId: null,
+                exception,
+                CancellationToken.None);
+        }
+    }
+
     public async Task RetryAsync(Guid catchId, CancellationToken cancellationToken)
     {
         try
@@ -229,7 +294,12 @@ public sealed class CatchSynchroniser : ICatchSynchroniser
                     cancellationToken);
         }
 
-        catchRecord = catchRecord with { SyncStatus = DeriveOverallStatus(catchRecord) };
+        var overallStatus = DeriveOverallStatus(catchRecord);
+        catchRecord = catchRecord with
+        {
+            SyncStatus = overallStatus,
+            SyncedAt = overallStatus == SyncStatus.Synchronised ? DateTimeOffset.UtcNow : catchRecord.SyncedAt
+        };
         await _store.UpdateSyncStateAsync(catchRecord, cancellationToken);
         await SafeLogAsync(
             catchRecord.SyncStatus == SyncStatus.Synchronised

--- a/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/ICatchSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Offline/Synchronisers/ICatchSynchroniser.cs
@@ -9,4 +9,8 @@ public interface ICatchSynchroniser
     Task SynchronisePendingAsync(Guid ownerUserId, CancellationToken cancellationToken);
 
     Task RetryAsync(Guid catchId, CancellationToken cancellationToken);
+
+    Task CleanupSyncedCacheAsync(CancellationToken cancellationToken);
+
+    Task CleanupSyncedCacheAsync(Guid ownerUserId, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Features/OfflineAccess/OfflineReconnectReturnRoute.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/OfflineReconnectReturnRoute.cs
@@ -1,0 +1,24 @@
+namespace FishingLogBook.Web.Features.OfflineAccess;
+
+internal static class OfflineReconnectReturnRoute
+{
+    private const string DefaultRoute = "/catches";
+
+    private static readonly IReadOnlyDictionary<string, string> KnownOfflineRoutes =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["offline/catches"] = "/catches",
+            ["offline/record"] = "/catches/record"
+        };
+
+    public static string Resolve(string? currentRelativePath)
+    {
+        var trimmed = currentRelativePath?.Trim().TrimStart('/');
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return DefaultRoute;
+        }
+
+        return KnownOfflineRoutes.TryGetValue(trimmed, out var route) ? route : DefaultRoute;
+    }
+}

--- a/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineReconnectService.cs
+++ b/src/FishingLogBook.Web/Features/OfflineAccess/Services/OfflineReconnectService.cs
@@ -325,6 +325,7 @@ public sealed class OfflineReconnectService : IOfflineReconnectService
 
             _offlineOwnerContext.Lock();
             SetState(OfflineReconnectStateEnum.Online);
+            _ = _catchSynchroniser.CleanupSyncedCacheAsync(ownerUserId, cancellationToken);
             return true;
         }
     }

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor
@@ -26,7 +26,7 @@
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginCreateAccount" id="landing-create-account">@Loc["Auth_CreateAccount"]</MudButton>
                     <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Large" FullWidth="true" OnClick="BeginSignIn" id="landing-sign-in">@Loc["Auth_SignIn"]</MudButton>
                 }
-                @if (_offlineAvailability == OfflineAvailabilityState.Ready)
+                @if (_isOnline == false && _offlineAvailability == OfflineAvailabilityState.Ready)
                 {
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Secondary"

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Landing/Landing.razor.cs
@@ -37,9 +37,6 @@ public partial class Landing : ComponentBase, IDisposable
     [Inject] private ILoggingService Logging { get; set; } = default!;
     [Inject] private INetworkService Network { get; set; } = default!;
 
-    [SupplyParameterFromQuery(Name = "reconnect")]
-    public string? Reconnect { get; set; }
-
     protected override void OnInitialized()
     {
         AuthenticationStateProvider.AuthenticationStateChanged += OnAuthenticationStateChanged;
@@ -198,11 +195,6 @@ public partial class Landing : ComponentBase, IDisposable
         {
             var authentication = await authenticationState.WaitAsync(cancellationToken);
             if (authentication.User.Identity?.IsAuthenticated != true)
-            {
-                return;
-            }
-
-            if (string.Equals(Reconnect, "offline", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor.cs
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor.cs
@@ -21,6 +21,7 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
 
     private bool _isDarkMode;
     private bool _drawerOpen = true;
+    private bool _cleanupAttempted;
     private DotNetObjectReference<MainLayout>? _dotNetReference;
 
     [Inject]
@@ -100,6 +101,7 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
         try
         {
             await CatchSynchroniser.SynchronisePendingAsync(cancellationToken);
+            TriggerSyncedCacheCleanupOnce(cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -128,6 +130,17 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
                 exception,
                 CancellationToken.None);
         }
+    }
+
+    private void TriggerSyncedCacheCleanupOnce(CancellationToken cancellationToken)
+    {
+        if (_cleanupAttempted)
+        {
+            return;
+        }
+
+        _cleanupAttempted = true;
+        _ = CatchSynchroniser.CleanupSyncedCacheAsync(cancellationToken);
     }
 
     private bool ShouldSynchroniseCurrentRoute()

--- a/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor
@@ -50,10 +50,17 @@
         }
         @if (OfflineReconnect.State == OfflineReconnectStateEnum.AuthenticationRequired)
         {
-            <MudAlert Severity="Severity.Info" Dense="true" Class="offline-reconnect-status" id="offline-reconnect-authentication-required">
-                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+            <MudAlert Severity="Severity.Info" Dense="true" Class="offline-reconnect-status offline-reconnect-sign-in-alert" id="offline-reconnect-authentication-required">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="2">
                     <MudText Typo="Typo.body2">@Loc["OfflineReconnect_AuthenticationRequired"]</MudText>
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SignInToSynchronise" id="offline-reconnect-sign-in">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               Size="Size.Small"
+                               StartIcon="@Icons.Material.Filled.Login"
+                               OnClick="SignInToSynchronise"
+                               Class="offline-reconnect-sign-in-button"
+                               aria-label="@Loc["OfflineReconnect_SignIn"]"
+                               id="offline-reconnect-sign-in">
                         @Loc["OfflineReconnect_SignIn"]
                     </MudButton>
                 </MudStack>

--- a/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.cs
+++ b/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.cs
@@ -1,3 +1,4 @@
+using FishingLogBook.Web.Features.OfflineAccess;
 using FishingLogBook.Web.Features.OfflineAccess.Enums;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Localization;
@@ -68,12 +69,14 @@ public partial class OfflineLayout : LayoutComponentBase, IDisposable
 
     private void SignInToSynchronise()
     {
+        var currentPath = Navigation.ToBaseRelativePath(Navigation.Uri);
+        var returnRoute = OfflineReconnectReturnRoute.Resolve(currentPath);
         Navigation.NavigateToLogin(
             "authentication/login",
             new InteractiveRequestOptions
             {
                 Interaction = InteractionType.SignIn,
-                ReturnUrl = "/?reconnect=offline"
+                ReturnUrl = returnRoute
             });
     }
 

--- a/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.css
+++ b/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.css
@@ -11,3 +11,12 @@
     border-radius: 0;
     margin: 0;
 }
+
+.offline-reconnect-sign-in-alert :deep(.mud-alert-message) {
+    width: 100%;
+}
+
+.offline-reconnect-sign-in-button {
+    flex-shrink: 0;
+    white-space: nowrap;
+}

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -801,9 +801,9 @@
   <data name="OfflineAccess_OpenOffline" xml:space="preserve"><value>Ouvrir hors ligne</value></data>
   <data name="OfflineAccess_UnlockFailed" xml:space="preserve"><value>Impossible d’ouvrir l’accès hors ligne. Réessayez ou connectez-vous lorsque vous avez une connexion.</value></data>
   <data name="OfflineAccess_Mode" xml:space="preserve"><value>Mode hors ligne</value></data>
-  <data name="OfflineReconnect_Reconnecting" xml:space="preserve"><value>Connexion rétablie. Reconnexion en cours…</value></data>
+  <data name="OfflineReconnect_Reconnecting" xml:space="preserve"><value>Vérification de votre connexion…</value></data>
   <data name="OfflineReconnect_Synchronising" xml:space="preserve"><value>Synchronisation de vos prises enregistrées…</value></data>
-  <data name="OfflineReconnect_AuthenticationRequired" xml:space="preserve"><value>Vous êtes de nouveau en ligne. Connectez-vous pour synchroniser vos prises.</value></data>
+  <data name="OfflineReconnect_AuthenticationRequired" xml:space="preserve"><value>Connectez-vous pour synchroniser vos prises enregistrées.</value></data>
   <data name="OfflineReconnect_SignIn" xml:space="preserve"><value>Se connecter pour synchroniser</value></data>
   <data name="OfflineReconnect_OwnerMismatch" xml:space="preserve"><value>Vous avez enregistré ces prises avec un autre compte hors ligne. Connectez-vous avec le compte correspondant pour les synchroniser.</value></data>
   <data name="OfflineReconnect_Failed" xml:space="preserve"><value>Nous n’avons pas encore pu nous reconnecter. Vos prises sont toujours enregistrées sur cet appareil.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -801,9 +801,9 @@
   <data name="OfflineAccess_OpenOffline" xml:space="preserve"><value>Open offline</value></data>
   <data name="OfflineAccess_UnlockFailed" xml:space="preserve"><value>Offline access could not be opened. Try again, or sign in when you have a connection.</value></data>
   <data name="OfflineAccess_Mode" xml:space="preserve"><value>Offline mode</value></data>
-  <data name="OfflineReconnect_Reconnecting" xml:space="preserve"><value>Connection restored. Reconnecting…</value></data>
+  <data name="OfflineReconnect_Reconnecting" xml:space="preserve"><value>Checking your connection…</value></data>
   <data name="OfflineReconnect_Synchronising" xml:space="preserve"><value>Synchronising your saved catches…</value></data>
-  <data name="OfflineReconnect_AuthenticationRequired" xml:space="preserve"><value>You’re back online. Sign in to sync your catches.</value></data>
+  <data name="OfflineReconnect_AuthenticationRequired" xml:space="preserve"><value>Sign in to sync your saved catches.</value></data>
   <data name="OfflineReconnect_SignIn" xml:space="preserve"><value>Sign in to sync</value></data>
   <data name="OfflineReconnect_OwnerMismatch" xml:space="preserve"><value>You recorded these catches using a different offline account. Sign in with the matching account to sync them.</value></data>
   <data name="OfflineReconnect_Failed" xml:space="preserve"><value>We couldn’t reconnect yet. Your catches are still saved on this device.</value></data>

--- a/src/FishingLogBook.Web/wwwroot/js/offline-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/offline-store.js
@@ -4,6 +4,7 @@ export {
     getCatchMetadata,
     getCatchMetadataById,
     getCatchWithPhotographs,
-    updateCatchMetadata
+    updateCatchMetadata,
+    cleanupSyncedCatches
 } from './storage/catch-store.js';
 export { getStorageEstimate } from './storage/indexed-db.js';

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
@@ -528,7 +528,7 @@ function isEligibleForCleanup(record, cutoff) {
     }
 
     const photographs = Array.isArray(record.photographs) ? record.photographs : [];
-    if (photographs.length === 0 || !photographs.every((photograph) => isSynchronisedStatus(photograph.syncStatus))) {
+    if (!photographs.every((photograph) => isSynchronisedStatus(photograph.syncStatus))) {
         return false;
     }
 

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
@@ -289,6 +289,9 @@ export async function updateCatchMetadata(json) {
                 metadataSyncStatus: metadataChangedWhileSynchronising
                     ? existing.metadataSyncStatus
                     : catchRecord.metadataSyncStatus,
+                syncedAt: metadataChangedWhileSynchronising
+                    ? existing.syncedAt
+                    : catchRecord.syncedAt,
                 location,
                 photographs
             });
@@ -482,6 +485,59 @@ function toStoredResult(record, photographs) {
             bytesBase64: uint8ToBase64(toUint8Array(photograph.bytes))
         }))
     };
+}
+
+export async function cleanupSyncedCatches(ownerUserId, olderThanIso) {
+    const owner = normalisedUserId(ownerUserId);
+    const cutoff = Date.parse(olderThanIso);
+    if (!owner || Number.isNaN(cutoff)) {
+        return 0;
+    }
+
+    return runCatchWithPhotographsTransaction('readwrite', 'cleanup', (transaction, succeed, fail) => {
+        const catchStore = transaction.objectStore(CATCH_STORE_NAME);
+        const photoStore = transaction.objectStore(PHOTO_STORE_NAME);
+        let removed = 0;
+        const request = catchStore.openCursor();
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) {
+                succeed(removed);
+                return;
+            }
+
+            const record = cursor.value;
+            if (normalisedUserId(record?.userId) === owner && isEligibleForCleanup(record, cutoff)) {
+                for (const photograph of record.photographs || []) {
+                    photoStore.delete(photograph.id);
+                }
+
+                cursor.delete();
+                removed += 1;
+            }
+
+            cursor.continue();
+        };
+    });
+}
+
+function isEligibleForCleanup(record, cutoff) {
+    if (!isSynchronisedStatus(record.syncStatus) || !isSynchronisedStatus(record.metadataSyncStatus)) {
+        return false;
+    }
+
+    const photographs = Array.isArray(record.photographs) ? record.photographs : [];
+    if (photographs.length === 0 || !photographs.every((photograph) => isSynchronisedStatus(photograph.syncStatus))) {
+        return false;
+    }
+
+    const syncedAt = Date.parse(record.syncedAt);
+    return !Number.isNaN(syncedAt) && syncedAt <= cutoff;
+}
+
+function isSynchronisedStatus(status) {
+    return status === 'synchronised' || status === 3;
 }
 
 function normalisedUserId(value) {

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
     CATCH_STORE_NAME,
     PHOTO_STORE_NAME,
+    cleanupSyncedCatches,
     getAllCatchesWithPhotographs,
     getCatchMetadata,
     getCatchMetadataById,
@@ -867,4 +868,194 @@ describe('Catch store read granularity', () => {
         expect(item.photographs).toHaveLength(1);
         expect(item.photographs[0].id).toBe('legacy-photo');
     });
+});
+
+describe('Catch store cleanup', () => {
+    const ownerUserId = '11111111-1111-1111-1111-111111111111';
+    const otherUserId = '22222222-2222-2222-2222-222222222222';
+    const now = Date.parse('2026-08-26T12:00:00Z');
+    const cutoffIso = new Date(now - (24 * 60 * 60 * 1000)).toISOString();
+
+    async function seedSyncedCatch(catchId, {
+        userId = ownerUserId,
+        syncStatus = 'synchronised',
+        metadataSyncStatus = 'synchronised',
+        photographSyncStatus = 'synchronised',
+        syncedAt
+    } = {}) {
+        const photographId = `${catchId.slice(0, 8)}-cccc-cccc-cccc-cccccccccccc`;
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId,
+                caughtOn: '2020-01-01T08:00:00+00:00',
+                syncStatus: 'savedLocally',
+                metadataSyncStatus: 'savedLocally',
+                photographs: [{ id: photographId, catchId, contentType: 'image/jpeg', syncStatus: 'savedLocally' }]
+            }),
+            [{ id: photographId, catchId, contentType: 'image/jpeg', bytes: new Uint8Array([1, 2, 3]) }]);
+        await updateCatchMetadata(JSON.stringify({
+            id: catchId,
+            userId,
+            syncStatus,
+            metadataSyncStatus,
+            syncedAt,
+            photographs: [{ id: photographId, catchId, syncStatus: photographSyncStatus }]
+        }));
+        return photographId;
+    }
+
+    it('removes an eligible synced Catch and its photograph without reading photograph bytes', async () => {
+        const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        await seedSyncedCatch(catchId, {
+            syncedAt: new Date(now - (25 * 60 * 60 * 1000)).toISOString()
+        });
+        const accesses = recordCleanupStoreAccess();
+
+        try {
+            const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+            const remaining = await getCatchMetadata(ownerUserId);
+
+            expect(removed).toBe(1);
+            expect(remaining).toHaveLength(0);
+            expect(accesses.get.filter((access) => access.store === PHOTO_STORE_NAME)).toHaveLength(0);
+            expect(accesses.get.filter((access) => access.store === CATCH_STORE_NAME)).toHaveLength(0);
+        } finally {
+            accesses.restore();
+        }
+    });
+
+    it('retains a synced Catch newer than the retention cutoff', async () => {
+        const catchId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        await seedSyncedCatch(catchId, { syncedAt: new Date(now - (1 * 60 * 60 * 1000)).toISOString() });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await getCatchMetadata(ownerUserId);
+
+        expect(removed).toBe(0);
+        expect(remaining).toHaveLength(1);
+    });
+
+    it('treats the exact retention boundary as eligible', async () => {
+        const catchId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        await seedSyncedCatch(catchId, { syncedAt: cutoffIso });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+
+        expect(removed).toBe(1);
+    });
+
+    it('never cleans up while offline-derived pending state is current, regardless of syncedAt age', async () => {
+        const catchId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+        await seedSyncedCatch(catchId, {
+            syncStatus: 'waitingToSynchronise',
+            metadataSyncStatus: 'waitingToSynchronise',
+            photographSyncStatus: 'waitingToSynchronise',
+            syncedAt: new Date(now - (240 * 60 * 60 * 1000)).toISOString()
+        });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await getCatchMetadata(ownerUserId);
+
+        expect(removed).toBe(0);
+        expect(remaining).toHaveLength(1);
+    });
+
+    it('retains a failed/recoverable Catch regardless of age', async () => {
+        const catchId = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+        await seedSyncedCatch(catchId, {
+            syncStatus: 'failedToSynchronise',
+            metadataSyncStatus: 'failedToSynchronise',
+            photographSyncStatus: 'failedToSynchronise',
+            syncedAt: new Date(now - (240 * 60 * 60 * 1000)).toISOString()
+        });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+
+        expect(removed).toBe(0);
+    });
+
+    it('retains a Catch whose photograph is still awaiting upload', async () => {
+        const catchId = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+        await seedSyncedCatch(catchId, {
+            photographSyncStatus: 'waitingToSynchronise',
+            syncedAt: new Date(now - (48 * 60 * 60 * 1000)).toISOString()
+        });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+
+        expect(removed).toBe(0);
+    });
+
+    it('never removes another owner Catch, even when eligible', async () => {
+        const ownerCatchId = '11111111-2222-3333-4444-555555555555';
+        const otherCatchId = '99999999-8888-7777-6666-555555555555';
+        await seedSyncedCatch(ownerCatchId, { syncedAt: new Date(now - (48 * 60 * 60 * 1000)).toISOString() });
+        await seedSyncedCatch(otherCatchId, {
+            userId: otherUserId,
+            syncedAt: new Date(now - (48 * 60 * 60 * 1000)).toISOString()
+        });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const ownerRemaining = await getCatchMetadata(ownerUserId);
+        const otherRemaining = await getCatchMetadata(otherUserId);
+
+        expect(removed).toBe(1);
+        expect(ownerRemaining).toHaveLength(0);
+        expect(otherRemaining).toHaveLength(1);
+    });
+
+    it('ignores an old CaughtOn when the Catch synced recently', async () => {
+        const catchId = '22222222-3333-4444-5555-666666666666';
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: catchId,
+                userId: ownerUserId,
+                caughtOn: '2015-01-01T08:00:00+00:00',
+                syncStatus: 'savedLocally',
+                metadataSyncStatus: 'savedLocally',
+                photographs: [{ id: 'old-catch-photo', catchId, contentType: 'image/jpeg', syncStatus: 'savedLocally' }]
+            }),
+            [{ id: 'old-catch-photo', catchId, contentType: 'image/jpeg', bytes: new Uint8Array([1]) }]);
+        await updateCatchMetadata(JSON.stringify({
+            id: catchId,
+            userId: ownerUserId,
+            syncStatus: 'synchronised',
+            metadataSyncStatus: 'synchronised',
+            syncedAt: new Date(now - (1 * 60 * 60 * 1000)).toISOString(),
+            photographs: [{ id: 'old-catch-photo', catchId, syncStatus: 'synchronised' }]
+        }));
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+
+        expect(removed).toBe(0);
+    });
+
+    it('does not treat a Catch with no recorded syncedAt as eligible', async () => {
+        const catchId = '33333333-4444-5555-6666-777777777777';
+        await seedSyncedCatch(catchId, { syncedAt: undefined });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+
+        expect(removed).toBe(0);
+    });
+
+    it('returns zero for an unknown owner without throwing', async () => {
+        const removed = await cleanupSyncedCatches('', cutoffIso);
+
+        expect(removed).toBe(0);
+    });
+
+    function recordCleanupStoreAccess() {
+        const accesses = { get: [] };
+        const originalGet = IDBObjectStore.prototype.get;
+        IDBObjectStore.prototype.get = function instrumentedGet(key) {
+            accesses.get.push({ store: this.name, key });
+            return originalGet.call(this, key);
+        };
+        accesses.restore = () => {
+            IDBObjectStore.prototype.get = originalGet;
+        };
+        return accesses;
+    }
 });

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.test.js
@@ -905,6 +905,52 @@ describe('Catch store cleanup', () => {
         return photographId;
     }
 
+    function writeRawCatch(catchId, {
+        userId = ownerUserId,
+        syncStatus = 'synchronised',
+        metadataSyncStatus = 'synchronised',
+        photographs = [],
+        syncedAt
+    } = {}) {
+        return openCatchDatabase().then((db) => new Promise((resolve, reject) => {
+            const transaction = db.transaction(CATCH_STORE_NAME, 'readwrite');
+            const request = transaction.objectStore(CATCH_STORE_NAME).put({
+                id: catchId,
+                userId,
+                caughtOn: '2020-01-01T08:00:00+00:00',
+                syncStatus,
+                metadataSyncStatus,
+                syncedAt,
+                photographs
+            });
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+            transaction.oncomplete = () => db.close();
+        }));
+    }
+
+    it('removes a fully synced Catch with no photographs older than the retention cutoff', async () => {
+        const catchId = 'aaaaaaaa-1111-1111-1111-111111111111';
+        await writeRawCatch(catchId, { syncedAt: new Date(now - (25 * 60 * 60 * 1000)).toISOString() });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await getCatchMetadata(ownerUserId);
+
+        expect(removed).toBe(1);
+        expect(remaining).toHaveLength(0);
+    });
+
+    it('retains a fully synced Catch with no photographs newer than the retention cutoff', async () => {
+        const catchId = 'bbbbbbbb-1111-1111-1111-111111111111';
+        await writeRawCatch(catchId, { syncedAt: new Date(now - (1 * 60 * 60 * 1000)).toISOString() });
+
+        const removed = await cleanupSyncedCatches(ownerUserId, cutoffIso);
+        const remaining = await getCatchMetadata(ownerUserId);
+
+        expect(removed).toBe(0);
+        expect(remaining).toHaveLength(1);
+    });
+
     it('removes an eligible synced Catch and its photograph without reading photograph bytes', async () => {
         const catchId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
         await seedSyncedCatch(catchId, {

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/CatchJsonTests/WhenTestingDeserialize.cs
@@ -9,6 +9,39 @@ namespace FishingLogBook.Web.Tests.Features.Catch.Offline.CatchJsonTests;
 public class WhenTestingDeserialize : BaseCatchJsonTest
 {
     [Fact]
+    public void ItShouldRoundTripSyncedAt()
+    {
+        // Arrange
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var syncedAt = DateTimeOffset.Parse("2026-08-25T10:15:30Z");
+        var model = new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            [new CatchPhotographModel(catchId, catchId, PhotographContentTypeConstants.Jpeg, [1])],
+            SyncedAt: syncedAt);
+
+        // Act
+        var json = CatchJson.SerializeMetadata(model);
+        var restored = CatchJson.DeserializeMetadata(json);
+
+        // Assert
+        restored.SyncedAt.Should().Be(syncedAt);
+    }
+
+    [Fact]
+    public void ItShouldDefaultSyncedAtToNullWhenMissingFromStoredJson()
+    {
+        // Arrange
+        const string json = """{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","caughtOn":"2026-08-17T08:00:00Z","photographs":[]}""";
+
+        // Act
+        var restored = CatchJson.DeserializeMetadata(json);
+
+        // Assert
+        restored.SyncedAt.Should().BeNull();
+    }
+
+    [Fact]
     public void ItShouldOrderPhotographsByMetadataRatherThanInputOrder()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/MemoryCatchStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/MemoryCatchStore.cs
@@ -1,3 +1,4 @@
+using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
@@ -166,6 +167,7 @@ public sealed class MemoryCatchStore : ICatchStore
         {
             SyncStatus = catchRecord.SyncStatus,
             MetadataSyncStatus = catchRecord.MetadataSyncStatus,
+            SyncedAt = catchRecord.SyncedAt,
             Photographs = existing.Photographs
                 .Select(photograph => incomingPhotographs.TryGetValue(
                     photograph.Id,
@@ -179,6 +181,43 @@ public sealed class MemoryCatchStore : ICatchStore
                 .ToArray()
         };
         return Task.CompletedTask;
+    }
+
+    public int CleanupCalls { get; private set; }
+
+    public Task<int> CleanupSyncedCacheAsync(
+        Guid ownerUserId,
+        DateTimeOffset olderThan,
+        CancellationToken cancellationToken)
+    {
+        CleanupCalls += 1;
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A catch owner is required.");
+        }
+
+        var eligible = _catches.Values
+            .Where(catchRecord => catchRecord.UserId == ownerUserId)
+            .Where(catchRecord => catchRecord.SyncStatus == SyncStatus.Synchronised
+                && catchRecord.MetadataSyncStatus == SyncStatus.Synchronised
+                && catchRecord.Photographs.Count > 0
+                && catchRecord.Photographs.All(
+                    photograph => photograph.SyncStatus == SyncStatus.Synchronised)
+                && catchRecord.SyncedAt is not null
+                && catchRecord.SyncedAt <= olderThan)
+            .ToArray();
+
+        foreach (var catchRecord in eligible)
+        {
+            foreach (var photograph in catchRecord.Photographs)
+            {
+                _photographBytes.Remove(photograph.Id);
+            }
+
+            _catches.Remove(catchRecord.Id);
+        }
+
+        return Task.FromResult(eligible.Length);
     }
 
     private CatchModel WithPhotographBytes(CatchModel catchRecord)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/MemoryCatchStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/MemoryCatchStore.cs
@@ -200,7 +200,6 @@ public sealed class MemoryCatchStore : ICatchStore
             .Where(catchRecord => catchRecord.UserId == ownerUserId)
             .Where(catchRecord => catchRecord.SyncStatus == SyncStatus.Synchronised
                 && catchRecord.MetadataSyncStatus == SyncStatus.Synchronised
-                && catchRecord.Photographs.Count > 0
                 && catchRecord.Photographs.All(
                     photograph => photograph.SyncStatus == SyncStatus.Synchronised)
                 && catchRecord.SyncedAt is not null

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/WhenTestingCleanup.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/WhenTestingCleanup.cs
@@ -1,0 +1,217 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.Stores.CatchStoreTests;
+
+public class WhenTestingCleanup : BaseCatchStoreTest
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-08-26T12:00:00Z");
+
+    [Fact]
+    public async Task ItShouldRemoveASyncedCatchOlderThanTheCutoff()
+    {
+        // Arrange
+        await SaveSyncedCatchAsync(Guid.NewGuid(), OwnerUserId, syncedAt: Now.AddHours(-25));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(1);
+        BackingCatches.Should().BeEmpty();
+        BackingPhotographs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRetainASyncedCatchNewerThanTheCutoff()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        await SaveSyncedCatchAsync(catchId, OwnerUserId, syncedAt: Now.AddHours(-23));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(0);
+        BackingCatches.Should().ContainKey(catchId);
+    }
+
+    [Fact]
+    public async Task ItShouldTreatTheExactBoundaryAsEligible()
+    {
+        // Arrange
+        var cutoff = Now.AddHours(-24);
+        await SaveSyncedCatchAsync(Guid.NewGuid(), OwnerUserId, syncedAt: cutoff);
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, cutoff, CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldRetainAPendingCatchRegardlessOfAge()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        await SaveCatchAsync(
+            catchId,
+            OwnerUserId,
+            SyncStatus.WaitingToSynchronise,
+            SyncStatus.WaitingToSynchronise,
+            photographStatus: SyncStatus.WaitingToSynchronise,
+            syncedAt: Now.AddDays(-10));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(0);
+        BackingCatches.Should().ContainKey(catchId);
+    }
+
+    [Fact]
+    public async Task ItShouldRetainAFailedCatchRegardlessOfAge()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        await SaveCatchAsync(
+            catchId,
+            OwnerUserId,
+            SyncStatus.FailedToSynchronise,
+            SyncStatus.FailedToSynchronise,
+            photographStatus: SyncStatus.FailedToSynchronise,
+            syncedAt: Now.AddDays(-10));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(0);
+        BackingCatches.Should().ContainKey(catchId);
+    }
+
+    [Fact]
+    public async Task ItShouldRetainACatchWithAPhotographStillAwaitingUpload()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        await SaveCatchAsync(
+            catchId,
+            OwnerUserId,
+            SyncStatus.Synchronised,
+            SyncStatus.Synchronised,
+            photographStatus: SyncStatus.WaitingToSynchronise,
+            syncedAt: Now.AddDays(-2));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(0);
+        BackingCatches.Should().ContainKey(catchId);
+    }
+
+    [Fact]
+    public async Task ItShouldRetainACatchWhoseCurrentStateIsPendingEvenWithAnOldSyncedAtTimestamp()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        await SaveSyncedCatchAsync(catchId, OwnerUserId, syncedAt: Now.AddDays(-5));
+        var resynced = BackingCatches[catchId] with
+        {
+            SyncStatus = SyncStatus.WaitingToSynchronise,
+            MetadataSyncStatus = SyncStatus.WaitingToSynchronise
+        };
+        await Sut.UpdateSyncStateAsync(resynced, CancellationToken.None);
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(0);
+        BackingCatches.Should().ContainKey(catchId);
+    }
+
+    [Fact]
+    public async Task ItShouldNotRemoveAnotherOwnersEligibleCatch()
+    {
+        // Arrange
+        var ownerCatchId = Guid.NewGuid();
+        var otherCatchId = Guid.NewGuid();
+        await SaveSyncedCatchAsync(ownerCatchId, OwnerUserId, syncedAt: Now.AddHours(-25));
+        await SaveSyncedCatchAsync(otherCatchId, OtherUserId, syncedAt: Now.AddHours(-25));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(1);
+        BackingCatches.Should().NotContainKey(ownerCatchId);
+        BackingCatches.Should().ContainKey(otherCatchId);
+    }
+
+    [Fact]
+    public async Task ItShouldIgnoreCaughtOnWhenDecidingEligibility()
+    {
+        // Arrange
+        var oldCatchDateRecentSync = Guid.NewGuid();
+        await SaveCatchAsync(
+            oldCatchDateRecentSync,
+            OwnerUserId,
+            SyncStatus.Synchronised,
+            SyncStatus.Synchronised,
+            photographStatus: SyncStatus.Synchronised,
+            syncedAt: Now.AddHours(-1),
+            caughtOn: Now.AddYears(-2));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(0);
+        BackingCatches.Should().ContainKey(oldCatchDateRecentSync);
+    }
+
+    private Task SaveSyncedCatchAsync(Guid catchId, Guid ownerUserId, DateTimeOffset syncedAt)
+    {
+        return SaveCatchAsync(
+            catchId,
+            ownerUserId,
+            SyncStatus.Synchronised,
+            SyncStatus.Synchronised,
+            photographStatus: SyncStatus.Synchronised,
+            syncedAt: syncedAt);
+    }
+
+    private async Task SaveCatchAsync(
+        Guid catchId,
+        Guid ownerUserId,
+        SyncStatus syncStatus,
+        SyncStatus metadataSyncStatus,
+        SyncStatus photographStatus,
+        DateTimeOffset syncedAt,
+        DateTimeOffset? caughtOn = null)
+    {
+        var photographId = Guid.NewGuid();
+        var catchRecord = new CatchModel(
+            catchId,
+            caughtOn ?? Now,
+            [new CatchPhotographModel(photographId, catchId, PhotographContentTypeConstants.Jpeg, [1, 2, 3], photographStatus)],
+            UserId: ownerUserId,
+            SyncStatus: SyncStatus.SavedLocally,
+            MetadataSyncStatus: SyncStatus.SavedLocally);
+        await Sut.SaveAsync(catchRecord, CancellationToken.None);
+        var withState = catchRecord with
+        {
+            SyncStatus = syncStatus,
+            MetadataSyncStatus = metadataSyncStatus,
+            SyncedAt = syncedAt
+        };
+        await Sut.UpdateSyncStateAsync(withState, CancellationToken.None);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/WhenTestingCleanup.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/WhenTestingCleanup.cs
@@ -156,6 +156,48 @@ public class WhenTestingCleanup : BaseCatchStoreTest
     }
 
     [Fact]
+    public async Task ItShouldRemoveAFullySyncedCatchWithNoPhotographsOlderThanTheCutoff()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        SaveRawCatch(
+            catchId,
+            OwnerUserId,
+            SyncStatus.Synchronised,
+            SyncStatus.Synchronised,
+            photographs: [],
+            syncedAt: Now.AddHours(-25));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(1);
+        BackingCatches.Should().NotContainKey(catchId);
+    }
+
+    [Fact]
+    public async Task ItShouldRetainAFullySyncedCatchWithNoPhotographsNewerThanTheCutoff()
+    {
+        // Arrange
+        var catchId = Guid.NewGuid();
+        SaveRawCatch(
+            catchId,
+            OwnerUserId,
+            SyncStatus.Synchronised,
+            SyncStatus.Synchronised,
+            photographs: [],
+            syncedAt: Now.AddHours(-23));
+
+        // Act
+        var removed = await Sut.CleanupSyncedCacheAsync(OwnerUserId, Now.AddHours(-24), CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(0);
+        BackingCatches.Should().ContainKey(catchId);
+    }
+
+    [Fact]
     public async Task ItShouldIgnoreCaughtOnWhenDecidingEligibility()
     {
         // Arrange
@@ -175,6 +217,24 @@ public class WhenTestingCleanup : BaseCatchStoreTest
         // Assert
         removed.Should().Be(0);
         BackingCatches.Should().ContainKey(oldCatchDateRecentSync);
+    }
+
+    private void SaveRawCatch(
+        Guid catchId,
+        Guid ownerUserId,
+        SyncStatus syncStatus,
+        SyncStatus metadataSyncStatus,
+        IReadOnlyList<CatchPhotographModel> photographs,
+        DateTimeOffset syncedAt)
+    {
+        BackingCatches[catchId] = new CatchModel(
+            catchId,
+            Now,
+            photographs,
+            UserId: ownerUserId,
+            SyncStatus: syncStatus,
+            MetadataSyncStatus: metadataSyncStatus,
+            SyncedAt: syncedAt);
     }
 
     private Task SaveSyncedCatchAsync(Guid catchId, Guid ownerUserId, DateTimeOffset syncedAt)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/WhenTestingIndexedDbReads.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Stores/CatchStoreTests/WhenTestingIndexedDbReads.cs
@@ -166,6 +166,40 @@ public class WhenTestingIndexedDbReads
         js.Identifiers.Should().Equal("getAllCatchesWithPhotographs");
     }
 
+    [Fact]
+    public async Task ItShouldRejectAnEmptyOwnerForCleanup()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime();
+        var sut = CreateStore(js);
+
+        // Act
+        var act = () => sut.CleanupSyncedCacheAsync(Guid.Empty, DateTimeOffset.UtcNow, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        js.Invocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldInvokeCleanupWithTheOwnerAndAnIsoCutoff()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime { CleanupResult = 2 };
+        var sut = CreateStore(js);
+        var cutoff = DateTimeOffset.Parse("2026-08-25T10:00:00Z");
+
+        // Act
+        var removed = await sut.CleanupSyncedCacheAsync(OwnerUserId, cutoff, CancellationToken.None);
+
+        // Assert
+        removed.Should().Be(2);
+        js.Invocations.Should().ContainSingle();
+        js.Invocations[0].Identifier.Should().Be("cleanupSyncedCatches");
+        js.Invocations[0].Arguments[0].Should().Be(OwnerUserId.ToString("D"));
+        js.Invocations[0].Arguments[1].Should().Be(cutoff.ToString("O"));
+    }
+
     private static IndexedDbCatchStore CreateStore(IJSRuntime js)
     {
         return new IndexedDbCatchStore(
@@ -214,6 +248,8 @@ public class WhenTestingIndexedDbReads
 
         public StoredCatchRecord[] ListRecords { get; set; } = [];
 
+        public int CleanupResult { get; set; }
+
         public IReadOnlyList<JsInvocation> Invocations => _invocations;
 
         public IReadOnlyList<string> Identifiers =>
@@ -240,6 +276,7 @@ public class WhenTestingIndexedDbReads
                 "getCatchWithPhotographs" => SingleRecord,
                 "getCatchMetadata" => ListRecords,
                 "getAllCatchesWithPhotographs" => ListRecords,
+                "cleanupSyncedCatches" => CleanupResult,
                 _ => null
             };
             return new ValueTask<TValue>((TValue)result!);

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingCleanup.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingCleanup.cs
@@ -1,0 +1,192 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
+using FishingLogBook.Web.Tests.Features.Catch.Offline.Stores.CatchStoreTests;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Offline.Synchronisers.CatchSynchroniserTests;
+
+public class WhenTestingCleanup : BaseCatchSynchroniserTest
+{
+    private CatchSynchroniser CreateSut(ICatchStore store)
+    {
+        return new CatchSynchroniser(
+            store,
+            MockCatchClient,
+            MockNetworkService,
+            MockLocalCatchOwner,
+            MockDiagnostics,
+            MockLogging);
+    }
+
+    [Fact]
+    public async Task ItShouldStampSyncedAtWhenACatchFullySynchronises()
+    {
+        // Arrange
+        var before = DateTimeOffset.UtcNow;
+        var store = await CreateStoreAsync(CreateCatch());
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved.SyncedAt.Should().NotBeNull();
+        saved.SyncedAt.Should().BeOnOrAfter(before);
+        saved.SyncedAt.Should().BeOnOrBefore(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public async Task ItShouldCleanUpTheResolvedOwnersSyncedCacheWhenOnline()
+    {
+        // Arrange
+        var store = new MemoryCatchStore();
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.CleanupSyncedCacheAsync(CancellationToken.None);
+
+        // Assert
+        await MockLocalCatchOwner.Received(1).GetUserIdAsync(Arg.Any<CancellationToken>());
+        store.CleanupCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldCleanUpAnExplicitOwnersSyncedCacheWhenOnline()
+    {
+        // Arrange
+        var store = new MemoryCatchStore();
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.CleanupSyncedCacheAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockLocalCatchOwner.DidNotReceive().GetUserIdAsync(Arg.Any<CancellationToken>());
+        store.CleanupCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldUseAnApproximatelyTwentyFourHourRetentionWindow()
+    {
+        // Arrange
+        var store = Substitute.For<ICatchStore>();
+        var sut = CreateSut(store);
+        var before = DateTimeOffset.UtcNow;
+
+        // Act
+        await sut.CleanupSyncedCacheAsync(OwnerUserId, CancellationToken.None);
+        var after = DateTimeOffset.UtcNow;
+
+        // Assert
+        await store.Received(1).CleanupSyncedCacheAsync(
+            OwnerUserId,
+            Arg.Is<DateTimeOffset>(cutoff =>
+                cutoff >= before.AddHours(-24).AddSeconds(-5)
+                && cutoff <= after.AddHours(-24).AddSeconds(5)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotCleanUpACatchWithANewerPendingEditAfterAnEarlierSuccessfulSync()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateCatch());
+        var sut = CreateSut(store);
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var synced = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        synced!.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        var backdated = synced with { SyncedAt = DateTimeOffset.UtcNow.AddHours(-25) };
+        await store.UpdateSyncStateAsync(backdated, CancellationToken.None);
+        var editedAfterSync = backdated with
+        {
+            SpeciesName = "Perch",
+            SyncStatus = SyncStatus.WaitingToSynchronise,
+            MetadataSyncStatus = SyncStatus.WaitingToSynchronise
+        };
+        await store.UpdateSyncStateAsync(editedAfterSync, CancellationToken.None);
+
+        // Act
+        await sut.CleanupSyncedCacheAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        var stillPresent = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+        stillPresent.Should().NotBeNull();
+        stillPresent!.SyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+    }
+
+    [Fact]
+    public async Task ItShouldNotCleanUpWhileOffline()
+    {
+        // Arrange
+        var store = new MemoryCatchStore();
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.CleanupSyncedCacheAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        store.CleanupCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldDoNothingForAnEmptyOwner()
+    {
+        // Arrange
+        var store = new MemoryCatchStore();
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.CleanupSyncedCacheAsync(Guid.Empty, CancellationToken.None);
+
+        // Assert
+        store.CleanupCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldNotCleanUpWhenTheOwnerCannotBeResolved()
+    {
+        // Arrange
+        var store = new MemoryCatchStore();
+        MockLocalCatchOwner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("no local owner"));
+        var sut = CreateSut(store);
+
+        // Act
+        var act = () => sut.CleanupSyncedCacheAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        store.CleanupCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldNotThrowWhenTheStoreFailsToCleanUp()
+    {
+        // Arrange
+        var store = Substitute.For<ICatchStore>();
+        store.CleanupSyncedCacheAsync(Arg.Any<Guid>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("cleanup failed"));
+        var sut = CreateSut(store);
+
+        // Act
+        var act = () => sut.CleanupSyncedCacheAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        await MockDiagnostics.Received(1).LogAsync(
+            DiagnosticLevel.Warning,
+            DiagnosticEventNames.CatchCacheCleanupFailed,
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(metadata =>
+                metadata[DiagnosticMetadata.ErrorType] == nameof(InvalidOperationException)),
+            null,
+            CancellationToken.None);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/OfflineReconnectReturnRouteTests/WhenTestingResolve.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/OfflineReconnectReturnRouteTests/WhenTestingResolve.cs
@@ -1,0 +1,77 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.OfflineAccess;
+
+namespace FishingLogBook.Web.Tests.Features.OfflineAccess.OfflineReconnectReturnRouteTests;
+
+public class WhenTestingResolve
+{
+    [Fact]
+    public void ItShouldFallBackToCatchesWhenThePathIsNull()
+    {
+        // Arrange
+        string? path = null;
+
+        // Act
+        var resolved = OfflineReconnectReturnRoute.Resolve(path);
+
+        // Assert
+        resolved.Should().Be("/catches");
+    }
+
+    [Fact]
+    public void ItShouldFallBackToCatchesWhenThePathIsEmpty()
+    {
+        // Act
+        var resolved = OfflineReconnectReturnRoute.Resolve(string.Empty);
+
+        // Assert
+        resolved.Should().Be("/catches");
+    }
+
+    [Fact]
+    public void ItShouldMapTheOfflineCatchesRouteToCatches()
+    {
+        // Act
+        var resolved = OfflineReconnectReturnRoute.Resolve("offline/catches");
+
+        // Assert
+        resolved.Should().Be("/catches");
+    }
+
+    [Fact]
+    public void ItShouldMapTheOfflineRecordRouteToCatchesRecord()
+    {
+        // Act
+        var resolved = OfflineReconnectReturnRoute.Resolve("offline/record");
+
+        // Assert
+        resolved.Should().Be("/catches/record");
+    }
+
+    [Fact]
+    public void ItShouldTolerateALeadingSlashOnTheCapturedPath()
+    {
+        // Act
+        var resolved = OfflineReconnectReturnRoute.Resolve("/offline/catches");
+
+        // Assert
+        resolved.Should().Be("/catches");
+    }
+
+    [Theory]
+    [InlineData("https://evil.example.com")]
+    [InlineData("http://evil.example.com/catches")]
+    [InlineData("//evil.example.com")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("offline/../authentication/login")]
+    [InlineData("offline/catches/../../secret")]
+    [InlineData("unrecognised/route")]
+    public void ItShouldRejectUnsafeOrUnknownValuesAndFallBackToCatches(string unsafeValue)
+    {
+        // Act
+        var resolved = OfflineReconnectReturnRoute.Resolve(unsafeValue);
+
+        // Assert
+        resolved.Should().Be("/catches");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStart.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/Services/OfflineReconnectServiceTests/WhenTestingStart.cs
@@ -155,6 +155,38 @@ public class WhenTestingStart : BaseOfflineReconnectServiceTest
     }
 
     [Fact]
+    public async Task ItShouldTriggerSyncedCacheCleanupOnceReconnectSettlesOnline()
+    {
+        // Arrange
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(true);
+
+        // Act
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Online);
+        await MockCatchSynchroniser.Received(1).CleanupSyncedCacheAsync(
+            OfflineUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotTriggerSyncedCacheCleanupWhenReconnectDoesNotReachOnline()
+    {
+        // Arrange
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+
+        // Act
+        await Sut.StartAsync(CancellationToken.None);
+
+        // Assert
+        Sut.State.Should().Be(OfflineReconnectStateEnum.Offline);
+        await MockCatchSynchroniser.DidNotReceive().CleanupSyncedCacheAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldAttemptAutomaticallyOnlyOnceUntilConnectivityIsLostAgain()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/LandingTests/WhenTestingRouting.cs
@@ -130,24 +130,6 @@ public class WhenTestingRouting : BaseLandingTest
     }
 
     [Fact]
-    public async Task ItShouldRequireExplicitOfflineUnlockAfterReconnectSignInReturns()
-    {
-        // Arrange
-        var onboarding = Onboarding(true);
-        await using var context = CreateContext(onboarding, isAuthenticated: true);
-        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/?reconnect=offline");
-
-        // Act
-        var cut = context.Render<LandingPage>();
-        await Task.Yield();
-
-        // Assert
-        cut.Find("#public-landing-page").Should().NotBeNull();
-        context.Services.GetRequiredService<NavigationManager>().Uri.Should().Be("http://localhost/?reconnect=offline");
-        await onboarding.DidNotReceive().IsCompletedAsync(Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
     public async Task ItShouldOfferOfflineUnlockWithoutWaitingForAuthentication()
     {
         // Arrange
@@ -172,6 +154,49 @@ public class WhenTestingRouting : BaseLandingTest
         await device.DidNotReceive().UnlockAsync(Arg.Any<CancellationToken>());
         await network.Received(1).StartMonitoringAsync(Arg.Any<CancellationToken>());
         await network.Received(1).IsOnlineAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldHideOpenOfflineWhileOnlineEvenWhenConfigured()
+    {
+        // Arrange
+        var device = OfflineAccessDevice(hasReadyEntitlement: true);
+        var network = Network(isOnline: true);
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            offlineAccessDevice: device,
+            network: network);
+
+        // Act
+        var cut = context.Render<LandingPage>();
+
+        // Assert
+        cut.WaitForAssertion(() => device.HasReadyEntitlementAsync(Arg.Any<CancellationToken>()));
+        cut.FindAll("#landing-open-offline").Should().BeEmpty();
+        cut.Find("#landing-create-account").Should().NotBeNull();
+        cut.Find("#landing-sign-in").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldHideOpenOfflineWhenConnectivityIsRestoredEvenIfStillConfigured()
+    {
+        // Arrange
+        var device = OfflineAccessDevice(hasReadyEntitlement: true);
+        var network = Network(isOnline: false);
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            offlineAccessDevice: device,
+            network: network);
+        var cut = context.Render<LandingPage>();
+        cut.WaitForAssertion(() => cut.Find("#landing-open-offline").Should().NotBeNull());
+
+        // Act
+        network.ConnectivityChanged += Raise.Event<Action<bool>>(true);
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#landing-open-offline").Should().BeEmpty());
     }
 
     [Fact]
@@ -327,9 +352,8 @@ public class WhenTestingRouting : BaseLandingTest
             offlineAccessDevice: device,
             network: network);
         var cut = context.Render<LandingPage>();
-        cut.WaitForAssertion(() =>
-            cut.Find("#landing-offline-availability-failed").TextContent
-                .Should().Contain("couldn't check offline access"));
+        cut.WaitForAssertion(() => cut.Find("#landing-offline-availability-failed").TextContent
+            .Should().Contain("couldn't check offline access"));
         cut.FindAll("#landing-offline-not-configured").Should().BeEmpty();
         cut.FindAll("#landing-create-account").Should().BeEmpty();
         cut.FindAll("#landing-sign-in").Should().BeEmpty();
@@ -385,11 +409,13 @@ public class WhenTestingRouting : BaseLandingTest
                 _ => new OfflineAccessAvailabilityModel("future-state", "ignored-detail"),
                 _ => new OfflineAccessAvailabilityModel("ready", "ready-record-found"));
         var logging = Substitute.For<ILoggingService>();
+        var network = Network(isOnline: false);
         await using var context = CreateContext(
             Onboarding(false),
             isAuthenticated: false,
             logging: logging,
-            offlineAccessDevice: device);
+            offlineAccessDevice: device,
+            network: network);
         var cut = context.Render<LandingPage>();
         cut.WaitForAssertion(() => cut.Find("#landing-offline-availability-failed").Should().NotBeNull());
 
@@ -414,7 +440,11 @@ public class WhenTestingRouting : BaseLandingTest
         var device = OfflineAccessDevice(hasReadyEntitlement: true);
         device.UnlockAsync(Arg.Any<CancellationToken>()).Returns(
             new OfflineAccessUnlockResultModel("unlocked", Guid.Parse("11111111-1111-1111-1111-111111111111"), 1));
-        await using var context = CreateContext(Onboarding(false), isAuthenticated: false, offlineAccessDevice: device);
+        await using var context = CreateContext(
+            Onboarding(false),
+            isAuthenticated: false,
+            offlineAccessDevice: device,
+            network: Network(isOnline: false));
         var cut = context.Render<LandingPage>();
         cut.WaitForAssertion(() => cut.Find("#landing-open-offline").Should().NotBeNull());
 

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
@@ -38,6 +38,29 @@ public class WhenTestingSynchronisation : BaseMainLayoutTest
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ItShouldTriggerSyncedCacheCleanupOnlyOnceAcrossNavigationReentry()
+    {
+        // Arrange
+        var catchSynchroniser = Substitute.For<ICatchSynchroniser>();
+        var diagnosticSynchroniser = Substitute.For<IDiagnosticSynchroniser>();
+        await using var context = CreateContext(
+            isAuthenticated: true,
+            catchSynchroniser,
+            diagnosticSynchroniser);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/catches");
+        context.Render<MainLayout>();
+        await Task.Yield();
+
+        // Act
+        context.Services.GetRequiredService<NavigationManager>()
+            .NavigateTo("/profile");
+        await Task.Yield();
+
+        // Assert
+        await catchSynchroniser.Received(1).CleanupSyncedCacheAsync(Arg.Any<CancellationToken>());
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("onboarding")]

--- a/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/WhenTestingRender.cs
@@ -4,6 +4,8 @@ using Bunit.TestDoubles;
 using FishingLogBook.Web.Features.OfflineAccess.Enums;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Layouts.OfflineLayout;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -28,8 +30,13 @@ public class WhenTestingRender : BaseOfflineLayoutTest
         cut.Find("#offline-diagnostics-button").GetAttribute("href").Should().Be("/offline-diagnostics");
         cut.Find("#offline-catches-nav-link").Should().NotBeNull();
         cut.Find("#offline-record-nav-link").Should().NotBeNull();
+        cut.Find("#offline-lock-nav-link").Should().NotBeNull();
         cut.FindAll("#profile-nav-link").Should().BeEmpty();
         cut.FindAll("#app-update-banner").Should().BeEmpty();
+        cut.FindAll("#user-menu-button").Should().BeEmpty();
+        cut.FindAll("#auth-sign-in-button").Should().BeEmpty();
+        cut.FindAll("#auth-create-account-button").Should().BeEmpty();
+        cut.FindAll("#app-menu-button").Should().BeEmpty();
     }
 
     [Fact]
@@ -86,12 +93,13 @@ public class WhenTestingRender : BaseOfflineLayoutTest
     }
 
     [Fact]
-    public async Task ItShouldUseNormalSignInAndReturnForAnExplicitOfflineUnlock()
+    public async Task ItShouldReturnToTheOriginatingCatchesRouteAfterSignInToSync()
     {
         // Arrange
         var reconnect = Substitute.For<IOfflineReconnectService>();
         reconnect.State.Returns(OfflineReconnectStateEnum.AuthenticationRequired);
         await using var context = CreateContext(out _, reconnect);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/offline/catches");
         var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
             layout => layout.Body,
             (RenderFragment)(_ => { })));
@@ -102,9 +110,88 @@ public class WhenTestingRender : BaseOfflineLayoutTest
         // Assert
         var navigation = (BunitNavigationManager)context.Services.GetRequiredService<NavigationManager>();
         navigation.Uri.Should().Contain("authentication/login");
-        navigation.History.Should().ContainSingle();
-        navigation.History.Single().Options.HistoryEntryState.Should().Contain("reconnect=offline");
+        navigation.History.First().Options.HistoryEntryState.Should().Contain("\"returnUrl\":\"/catches\"");
+        navigation.History.First().Options.HistoryEntryState.Should().NotContain("reconnect=offline");
         await reconnect.DidNotReceive().AttemptAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnToTheOriginatingRecordRouteAfterSignInToSync()
+    {
+        // Arrange
+        var reconnect = Substitute.For<IOfflineReconnectService>();
+        reconnect.State.Returns(OfflineReconnectStateEnum.AuthenticationRequired);
+        await using var context = CreateContext(out _, reconnect);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/offline/record");
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Act
+        await cut.Find("#offline-reconnect-sign-in").ClickAsync();
+
+        // Assert
+        var navigation = (BunitNavigationManager)context.Services.GetRequiredService<NavigationManager>();
+        navigation.History.First().Options.HistoryEntryState.Should().Contain("\"returnUrl\":\"/catches/record\"");
+    }
+
+    [Fact]
+    public async Task ItShouldFallBackToCatchesWhenTheCurrentOfflineRouteIsUnrecognised()
+    {
+        // Arrange
+        var reconnect = Substitute.For<IOfflineReconnectService>();
+        reconnect.State.Returns(OfflineReconnectStateEnum.AuthenticationRequired);
+        await using var context = CreateContext(out _, reconnect);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/offline/unexpected");
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Act
+        await cut.Find("#offline-reconnect-sign-in").ClickAsync();
+
+        // Assert
+        var navigation = (BunitNavigationManager)context.Services.GetRequiredService<NavigationManager>();
+        navigation.History.First().Options.HistoryEntryState.Should().Contain("\"returnUrl\":\"/catches\"");
+    }
+
+    [Fact]
+    public async Task ItShouldNotClaimConnectionIsRestoredWhileVerifyingIt()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var reconnect = Substitute.For<IOfflineReconnectService>();
+        reconnect.State.Returns(OfflineReconnectStateEnum.ConnectivityRestored);
+        await using var context = CreateContext(out _, reconnect);
+
+        // Act
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Assert
+        var text = cut.Find("#offline-reconnect-progress").TextContent;
+        text.Should().NotContain("restored");
+        text.Should().NotContain("Restored");
+    }
+
+    [Fact]
+    public async Task ItShouldNotClaimToBeOnlineWhenOnlyAskingForAuthentication()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var reconnect = Substitute.For<IOfflineReconnectService>();
+        reconnect.State.Returns(OfflineReconnectStateEnum.AuthenticationRequired);
+        await using var context = CreateContext(out _, reconnect);
+
+        // Act
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Assert
+        var text = cut.Find("#offline-reconnect-authentication-required").TextContent;
+        text.Should().NotContain("back online");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Final offline MVP UX/state polish on top of #166/#168's stable IndexedDB architecture, plus bounded local-cache retention. No redesign of the reconnect coordinator, OfflineOwnerContext, WebAuthn/PRF, or IndexedDB architecture.

- **Truthful reconnect state**: the reconnect banner previously read "Connection restored. Reconnecting…" based only on `navigator.onLine`, which the code already treats as an unreliable *hint* (see `ItShouldAttemptRecoveryWhenTheCurrentConnectivityHintIsOnline`). Reworded copy so nothing is claimed as fact before a real network round trip succeeds. No state-machine change.
- **Landing**: `OPEN OFFLINE` now only shows while genuinely offline (was previously shown whenever offline access was configured, regardless of connectivity — the "mutually contradictory actions" bug). Sign in/Create account visibility while offline was already correct.
- **Compact Sign in to sync**: restyled from a large filled button to a small outlined action with a login icon, inside the existing reconnect status card.
- **Return to originating route**: after a successful reconnect sign-in, the user now lands back on `/catches` or `/catches/record` instead of public Landing, via a new allow-list resolver (`OfflineReconnectReturnRoute`) that can only ever emit one of those two safe local paths — tested against external/absolute/traversal return values.
- **App-bar audit**: confirmed `OfflineLayout`'s existing drawer/header already correctly expose only offline-safe actions (Catches, Record, Lock, theme, language, diagnostics) with no online-only controls; added explicit test coverage rather than changing production code.
- **24-hour local cache retention**: successfully-synced catch/photograph bytes become eligible for local-only eviction once safely synced for >24h *while confirmed online*. No cleanup while offline, ever. Eligibility is driven by live sync state (not just the timestamp), so a pending edit, in-flight upload, or failed/recoverable catch is never touched regardless of `SyncedAt` age.

## Retention implementation

- Added `CatchModel.SyncedAt`, stamped only when a catch's metadata **and every photograph** report `Synchronised`. Carried through the existing opaque per-record JSON blob already stored in IndexedDB — **no schema/version change** (`CATCH_DATABASE_VERSION` stays at 4).
- New `cleanupSyncedCatches(ownerUserId, cutoffIso)` in `catch-store.js`: one owner-scoped cursor over catch metadata, deletes eligible records by key (`cursor.delete()` / `photoStore.delete(id)`). Never calls `.get()` on the photo store, never reads or Base64-encodes photograph bytes — proven by instrumented vitest and real-browser Playwright tests.
- Triggered from two natural, infrequent lifecycle points: `MainLayout`'s first successful synchronisation per session, and `OfflineReconnectService` settling into `Online`. Both fire-and-forget, both re-check `IsOnlineAsync()` internally, both swallow and diagnostically log failures — never blocks navigation, login, or sync, never surfaces a user-facing error.

## Self review

```
Issue/AC:             PASS — all 9 numbered sections of #164 addressed
Architecture/CQRS:    N/A (Web-only; no Application/Infrastructure touched)
Rules:                PASS — blazor.md folder/suffix conventions followed; no Helpers/Managers added
Security/privacy:     PASS — return-route is an allow-list; owner isolation structural in cleanup
Database/migrations:  N/A — no IndexedDB schema/version change
Tests/coverage:       PASS — 1016 Web unit tests (+43 new), 256 vitest, 64 Playwright browser tests, 47/47 credentialed E2E
Browser:               PASS — new catch-store-cleanup.spec.js proves no-byte-read cleanup in real IndexedDB; offline-shell.spec.js covers online-Landing state in a real published shell
Web/UI/localisation:   PASS — EN+FR updated for both changed strings; no hard-coded copy
Code smells:           PASS — one small justified static class (OfflineReconnectReturnRoute), mirrors existing CatchJson precedent
CI/deployment:         N/A
```

**Findings caught and fixed during self-review:**
1. `catch-store.js`'s `updateCatchMetadata` merge only ever wrote back `syncStatus`/`metadataSyncStatus` — a new `syncedAt` would have been silently dropped on every sync-state write. Fixed by adding it to the same guarded merge that already protects `syncStatus` against a stale completion.
2. The `MemoryCatchStore` test double had the identical gap — fixed so C# tests exercise the real contract.
3. Two pre-existing Playwright tests in `offline-shell.spec.js` were only passing because the old code never checked online state before showing `Open Offline`. Root cause: `context.setOffline(true)` doesn't reliably flip `navigator.onLine` in that harness. Fixed the shared `reopenColdOffline` helper to force it explicitly, matching the pattern the first test in that file already used.

## Validation

| Check | Result |
|---|---|
| `dotnet build` | 0 warnings, 0 errors |
| `dotnet format --verify-no-changes` | clean |
| `git diff --check` | clean |
| `dotnet test` (full solution) | Shared 18/18, Db.Migrations 10/10, Application 300/300, Api 151/151, Infrastructure 119/119, **Web 1016/1016** |
| `npm test` (vitest) | **256/256** |
| `npm run test:browser` (Playwright) | **59 passed, 5 expected WebKit skips** |
| Credentialed E2E (`playwright test`, real Cognito + Docker Postgres + API + Web) | **47/47 passed** — identical count to #168's baseline, no regression |

## Remaining physical-only risk

Automated coverage (bUnit, vitest, real-browser Playwright including WebAuthn/PRF, and the full credentialed E2E suite) is green, but the Samsung/Android and iPhone physical acceptance checklist from #164 still needs a manual run, since no automated harness can prove real OEM WebView/Safari `navigator.onLine` behaviour or biometric hardware.

## #157

No new credentialed E2E journeys were added to `tests/FishingLogBook.E2E` — #157 explicitly excludes offline from its backlog, and the two offline-specific journeys this PR touches (WebAuthn/PRF passkey unlock, sign-in-to-sync return route) are structurally outside that suite's scope (it never exercises WebAuthn). Coverage for this work lives in the lightweight `src/FishingLogBook.Web/BrowserTests/` harness instead, which already supports virtual WebAuthn authenticators.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
