### PR TITLE
FLB#164 | Fix photo-metadata-conflict warning persistence and offline app-bar auth visibility

### DIFF
--- a/src/FishingLogBook.Web/Features/Authentication/Components/UserMenu/UserMenu.razor
+++ b/src/FishingLogBook.Web/Features/Authentication/Components/UserMenu/UserMenu.razor
@@ -38,17 +38,20 @@
         </MudMenu>
     </Authorized>
     <NotAuthorized>
-        <MudButton Variant="Variant.Text"
-                   Color="Color.Inherit"
-                   OnClick="BeginSignIn"
-                   id="auth-sign-in-button">
-            @Loc["Auth_SignIn"]
-        </MudButton>
-        <MudButton Variant="Variant.Text"
-                   Color="Color.Inherit"
-                   OnClick="BeginSignIn"
-                   id="auth-create-account-button">
-            @Loc["Auth_CreateAccount"]
-        </MudButton>
+        @if (_isOnline != false)
+        {
+            <MudButton Variant="Variant.Text"
+                       Color="Color.Inherit"
+                       OnClick="BeginSignIn"
+                       id="auth-sign-in-button">
+                @Loc["Auth_SignIn"]
+            </MudButton>
+            <MudButton Variant="Variant.Text"
+                       Color="Color.Inherit"
+                       OnClick="BeginSignIn"
+                       id="auth-create-account-button">
+                @Loc["Auth_CreateAccount"]
+            </MudButton>
+        }
     </NotAuthorized>
 </AuthorizeView>

--- a/src/FishingLogBook.Web/Features/Authentication/Components/UserMenu/UserMenu.razor.cs
+++ b/src/FishingLogBook.Web/Features/Authentication/Components/UserMenu/UserMenu.razor.cs
@@ -1,6 +1,8 @@
 using System.Security.Claims;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Providers;
 using FishingLogBook.Web.Localization;
@@ -16,6 +18,7 @@ public partial class UserMenu : ComponentBase, IDisposable
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private ProfileSummaryModel _summary = ProfileSummaryModel.Empty;
+    private bool? _isOnline;
 
     [Inject]
     private NavigationManager Navigation { get; set; } = default!;
@@ -35,12 +38,20 @@ public partial class UserMenu : ComponentBase, IDisposable
     [Inject]
     private IJSRuntime JsRuntime { get; set; } = default!;
 
+    [Inject]
+    private INetworkService Network { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
     [CascadingParameter]
     private Task<AuthenticationState>? AuthenticationStateTask { get; set; }
 
     protected override void OnInitialized()
     {
         ProfileSummary.Changed += OnSummaryChanged;
+        Network.ConnectivityChanged += OnConnectivityChanged;
+        _ = LoadConnectivityAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -51,6 +62,47 @@ public partial class UserMenu : ComponentBase, IDisposable
         }
 
         await LoadSummaryAsync();
+    }
+
+    private async Task LoadConnectivityAsync()
+    {
+        var cancellationToken = _cancellationTokenSource.Token;
+        try
+        {
+            await Network.StartMonitoringAsync(cancellationToken);
+            var isOnline = await Network.IsOnlineAsync(cancellationToken);
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                await UpdateConnectivityAsync(isOnline);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("user menu connectivity", exception, CancellationToken.None);
+        }
+    }
+
+    private void OnConnectivityChanged(bool isOnline)
+    {
+        _ = UpdateConnectivityAsync(isOnline);
+    }
+
+    private async Task UpdateConnectivityAsync(bool isOnline)
+    {
+        if (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
+        await InvokeAsync(() =>
+        {
+            _isOnline = isOnline;
+            StateHasChanged();
+        });
     }
 
     private void OnSummaryChanged()
@@ -125,6 +177,7 @@ public partial class UserMenu : ComponentBase, IDisposable
     public void Dispose()
     {
         ProfileSummary.Changed -= OnSummaryChanged;
+        Network.ConnectivityChanged -= OnConnectivityChanged;
         _cancellationTokenSource.Cancel();
         _cancellationTokenSource.Dispose();
     }

--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor
@@ -92,12 +92,9 @@
                                       id="catch-caught-on" />
                         @if (ShowPhotographChooser && !_isSaved)
                         {
-                            @if (MetadataConflict)
-                            {
-                                <MudAlert Severity="Severity.Warning" id="catch-photo-metadata-conflict">
-                                    @Loc["Catch_PhotoMetadataConflict"]
-                                </MudAlert>
-                            }
+                            <MudAlert Severity="Severity.Warning" id="catch-photo-metadata-conflict">
+                                @Loc["Catch_PhotoMetadataConflict"]
+                            </MudAlert>
                             <PhotographDetails IdPrefix="catch"
                                                PhotographId="CurrentPhotograph?.Id"
                                                Metadata="CurrentPhotograph?.Metadata"

--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.cs
@@ -216,6 +216,9 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
         }
     }
 
+    private bool HasPhotoMetadataConflict =>
+        _proposal.HasConflictingDates || _proposal.HasConflictingCoordinates;
+
     private bool DateConflict =>
         _proposal.HasConflictingDates
         && !_caughtOnResolvedByAngler
@@ -224,10 +227,7 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
     private bool CoordinateConflict =>
         _proposal.HasConflictingCoordinates && _representativePhotographId is null;
 
-    private bool MetadataConflict => DateConflict || CoordinateConflict;
-
-    private bool ShowPhotographChooser =>
-        _proposal.HasConflictingDates || _proposal.HasConflictingCoordinates;
+    private bool ShowPhotographChooser => HasPhotoMetadataConflict;
 
     private bool CurrentPhotographIsRepresentative =>
         _representativePhotographId is { } photographId

--- a/tests/FishingLogBook.E2E/specs/photo-metadata-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/photo-metadata-online.spec.mjs
@@ -117,12 +117,13 @@ test('shows each photograph its own capture details while the angler chooses one
     await expect(page.locator('#save-catch-button')).toBeDisabled();
 
     await page.locator('#catch-photo-use-details').click();
-    await expect(page.locator('#catch-photo-metadata-conflict')).toBeHidden();
+    await expect(page.locator('#catch-photo-metadata-conflict')).toBeVisible();
     await expect(page.locator('#save-catch-button')).toBeEnabled();
     await expect(page.locator('#catch-photo-current-metadata')).toBeVisible();
 
     await showPhoto(page, 1, 2);
     await page.locator('#catch-photo-use-details').click();
+    await expect(page.locator('#catch-photo-metadata-conflict')).toBeVisible();
     await expect(page.locator('#catch-caught-on')).toHaveValue('2025-06-14T07:32');
     await expect(page.locator('#catch-location-from-photo')).toBeVisible();
 });

--- a/tests/FishingLogBook.E2E/support/catch-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/catch-journey.mjs
@@ -58,7 +58,7 @@ export async function createCatch(page, waitForServer = false, options = {}) {
         await expect(page.locator('#catch-photo-metadata-conflict')).toBeVisible();
         await showPhoto(page, options.representativePhoto, photoCount);
         await page.locator('#catch-photo-use-details').click();
-        await expect(page.locator('#catch-photo-metadata-conflict')).toBeHidden();
+        await expect(page.locator('#catch-photo-metadata-conflict')).toBeVisible();
     }
     if (options.caughtOn) {
         await page.locator('#catch-caught-on').fill(options.caughtOn);

--- a/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/UserMenuTests/BaseUserMenuTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/UserMenuTests/BaseUserMenuTest.cs
@@ -1,8 +1,10 @@
 using Bunit;
 using Bunit.TestDoubles;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Components.UserMenu;
 using FishingLogBook.Web.Features.Authentication.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Providers;
 using FishingLogBook.Web.Localization;
@@ -19,7 +21,8 @@ public class BaseUserMenuTest
 
     protected static BunitContext CreateContext(
         IProfileSummaryProvider profileSummary,
-        bool isAuthenticated = true)
+        bool isAuthenticated = true,
+        INetworkService? network = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -35,6 +38,8 @@ public class BaseUserMenuTest
             ApiResource = "https://api.test",
             ApiScope = "https://api.test/access"
         });
+        context.Services.AddSingleton(network ?? Network(isOnline: true));
+        context.Services.AddSingleton(Substitute.For<ILoggingService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         var authorization = context.AddAuthorization();
         if (isAuthenticated)
@@ -48,6 +53,13 @@ public class BaseUserMenuTest
         }
 
         return context;
+    }
+
+    protected static INetworkService Network(bool isOnline)
+    {
+        var network = Substitute.For<INetworkService>();
+        network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(isOnline);
+        return network;
     }
 
     protected static IProfileSummaryProvider ProfileSummary(ProfileSummaryModel? summary = null)

--- a/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/UserMenuTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Authentication/Components/UserMenuTests/WhenTestingRender.cs
@@ -32,6 +32,77 @@ public class WhenTestingRender : BaseUserMenuTest
     }
 
     [Fact]
+    public async Task ItShouldHideSignInAndCreateAccountWhenGenuinelyOffline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var profileSummary = ProfileSummary();
+        await using var context = CreateContext(profileSummary, isAuthenticated: false, network: Network(isOnline: false));
+
+        // Act
+        var cut = context.Render<UserMenu>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#auth-sign-in-button").Should().BeEmpty());
+        cut.FindAll("#auth-create-account-button").Should().BeEmpty();
+        cut.FindAll("#user-menu-button").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldHideSignInAndCreateAccountWhenConnectivityChangesToOffline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var profileSummary = ProfileSummary();
+        var network = Network(isOnline: true);
+        await using var context = CreateContext(profileSummary, isAuthenticated: false, network: network);
+        var cut = context.Render<UserMenu>();
+        cut.WaitForAssertion(() => cut.Find("#auth-sign-in-button").Should().NotBeNull());
+
+        // Act
+        network.ConnectivityChanged += Raise.Event<Action<bool>>(false);
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#auth-sign-in-button").Should().BeEmpty());
+    }
+
+    [Fact]
+    public async Task ItShouldShowSignInAndCreateAccountAgainWhenConnectivityChangesToOnline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var profileSummary = ProfileSummary();
+        var network = Network(isOnline: false);
+        await using var context = CreateContext(profileSummary, isAuthenticated: false, network: network);
+        var cut = context.Render<UserMenu>();
+        cut.WaitForAssertion(() => cut.FindAll("#auth-sign-in-button").Should().BeEmpty());
+
+        // Act
+        network.ConnectivityChanged += Raise.Event<Action<bool>>(true);
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#auth-sign-in-button").Should().NotBeNull());
+        cut.Find("#auth-create-account-button").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheNormalAuthenticatedMenuRegardlessOfConnectivity()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var profileSummary = ProfileSummary();
+        await using var context = CreateContext(profileSummary, isAuthenticated: true, network: Network(isOnline: false));
+
+        // Act
+        var cut = context.Render<UserMenu>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#user-menu-button").Should().NotBeNull());
+        cut.FindAll("#auth-sign-in-button").Should().BeEmpty();
+        cut.FindAll("#auth-create-account-button").Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ItShouldActivateTheMenuStraightFromTheAvatarButton()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotoMetadata.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotoMetadata.cs
@@ -280,7 +280,7 @@ public class WhenTestingPhotoMetadata : BaseRecordCatchTest
         await cut.Find("#catch-photo-use-details").ClickAsync();
 
         // Assert
-        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
         cut.Find("#save-catch-button").HasAttribute("disabled").Should().BeFalse();
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotoMetadataConflict.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotoMetadataConflict.cs
@@ -18,6 +18,7 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
     private const byte FirstPhotograph = 0x0A;
     private const byte SecondPhotograph = 0x0B;
     private const byte ThirdPhotograph = 0x0C;
+    private const byte FourthPhotograph = 0x0D;
 
     private static readonly DateTimeOffset JuneCapture = DateTimeOffset.Parse("2025-06-14T06:32:10Z");
     private static readonly DateTimeOffset MayCapture = DateTimeOffset.Parse("2025-05-02T14:10:00Z");
@@ -141,7 +142,7 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
         await cut.Find("#catch-photo-use-details").ClickAsync();
 
         // Assert
-        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
         cut.FindAll("#catch-location-from-photo").Should().BeEmpty();
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
@@ -174,7 +175,7 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
         await cut.Find("#catch-photo-use-details").ClickAsync();
 
         // Assert
-        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
         cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-05-02T14:10");
         cut.Find("#catch-location-from-photo").TextContent.Should().Contain("Location from photo");
         await cut.Find("#save-catch-button").ClickAsync();
@@ -249,7 +250,7 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
         await cut.Find("#catch-photo-use-details").ClickAsync();
 
         // Assert
-        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
         cut.Find("#catch-location-from-photo").TextContent.Should().Contain("Location from photo");
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
@@ -286,7 +287,7 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
         await cut.Find("#catch-photo-use-details").ClickAsync();
 
         // Assert
-        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
         cut.FindAll("#catch-location-from-photo").Should().BeEmpty();
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
@@ -352,7 +353,7 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
             JpegFile("may.jpg", SecondPhotograph));
         cut.WaitForAssertion(() => cut.Find("#catch-photo-use-details").Should().NotBeNull());
         await cut.Find("#catch-photo-use-details").ClickAsync();
-        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
         cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-05-02T14:10");
 
         // Act
@@ -360,8 +361,24 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
         await cut.Find("#catch-photo-use-details").ClickAsync();
 
         // Assert
-        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
         cut.Find("#catch-photo-current-metadata").Should().NotBeNull();
+        cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-06-14T06:32");
+
+        // Act
+        await cut.Find("#catch-photo-next").ClickAsync();
+        await cut.Find("#catch-photo-use-details").ClickAsync();
+
+        // Assert
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
+        cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-05-02T14:10");
+
+        // Act
+        await cut.Find("#catch-photo-previous").ClickAsync();
+        await cut.Find("#catch-photo-use-details").ClickAsync();
+
+        // Assert
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
         cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-06-14T06:32");
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
@@ -371,6 +388,148 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
                 && catchRecord.Location.Longitude == CorribLongitude
                 && catchRecord.Location.Source == LocationDefaults.PhotoMetadata),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheChosenRepresentativeWhileSwipingWithoutChoosingAgain()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var photoMetadata = PhotoMetadataFor(
+            (FirstPhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)),
+            (SecondPhotograph, new PhotographMetadataModel(MayCapture, LeeLatitude, LeeLongitude)));
+        await using var context = CreateContext(store, photoMetadata: photoMetadata);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[1].UploadFiles(
+            JpegFile("june.jpg", FirstPhotograph),
+            JpegFile("may.jpg", SecondPhotograph));
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-use-details").Should().NotBeNull());
+        await cut.Find("#catch-photo-previous").ClickAsync();
+        await cut.Find("#catch-photo-use-details").ClickAsync();
+        cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-06-14T06:32");
+
+        // Act
+        await cut.Find("#catch-photo-next").ClickAsync();
+
+        // Assert
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
+        cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-06-14T06:32");
+        cut.Find("#catch-photo-current-date").GetAttribute("data-captured-on").Should().Be("2025-05-02T14:10");
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheWarningVisibleWhileNavigatingFourOrMoreConflictingPhotographs()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var photoMetadata = PhotoMetadataFor(
+            (FirstPhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)),
+            (SecondPhotograph, new PhotographMetadataModel(MayCapture, LeeLatitude, LeeLongitude)),
+            (ThirdPhotograph, new PhotographMetadataModel(MayCapture.AddDays(-20), CorribLatitude, CorribLongitude)),
+            (FourthPhotograph, new PhotographMetadataModel(MayCapture.AddDays(-40), LeeLatitude, LeeLongitude)));
+        await using var context = CreateContext(store, photoMetadata: photoMetadata);
+        var cut = context.Render<RecordCatch>();
+
+        // Act
+        cut.FindComponents<InputFile>()[1].UploadFiles(
+            JpegFile("june.jpg", FirstPhotograph),
+            JpegFile("may.jpg", SecondPhotograph),
+            JpegFile("april.jpg", ThirdPhotograph),
+            JpegFile("march.jpg", FourthPhotograph));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull());
+        await cut.Find("#catch-photo-previous").ClickAsync();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
+        await cut.Find("#catch-photo-previous").ClickAsync();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
+        await cut.Find("#catch-photo-previous").ClickAsync();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
+
+        // Act
+        await cut.Find("#catch-photo-use-details").ClickAsync();
+
+        // Assert
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotShowAWarningWhenDatesAreWithinTheSameCatchTolerance()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var photoMetadata = PhotoMetadataFor(
+            (FirstPhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)),
+            (SecondPhotograph, new PhotographMetadataModel(JuneCapture.AddMinutes(20), CorribLatitude, CorribLongitude)));
+        await using var context = CreateContext(store, photoMetadata: photoMetadata);
+        var cut = context.Render<RecordCatch>();
+
+        // Act
+        cut.FindComponents<InputFile>()[1].UploadFiles(
+            JpegFile("first.jpg", FirstPhotograph),
+            JpegFile("second.jpg", SecondPhotograph));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-carousel").Should().NotBeNull());
+        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.FindAll("#catch-photo-use-details").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotShowAWarningWhenCoordinatesAreWithinTheSameLocationTolerance()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        var photoMetadata = PhotoMetadataFor(
+            (FirstPhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)),
+            (SecondPhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude + 0.0016, CorribLongitude)));
+        await using var context = CreateContext(store, photoMetadata: photoMetadata);
+        var cut = context.Render<RecordCatch>();
+
+        // Act
+        cut.FindComponents<InputFile>()[1].UploadFiles(
+            JpegFile("first.jpg", FirstPhotograph),
+            JpegFile("second.jpg", SecondPhotograph));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-carousel").Should().NotBeNull());
+        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.FindAll("#catch-photo-use-details").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldHideTheChooserAndWarningAfterASuccessfulSave()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var photoMetadata = PhotoMetadataFor(
+            (FirstPhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)),
+            (SecondPhotograph, new PhotographMetadataModel(MayCapture, LeeLatitude, LeeLongitude)));
+        await using var context = CreateContext(store, photoMetadata: photoMetadata);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[1].UploadFiles(
+            JpegFile("june.jpg", FirstPhotograph),
+            JpegFile("may.jpg", SecondPhotograph));
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-use-details").Should().NotBeNull());
+        await cut.Find("#catch-photo-use-details").ClickAsync();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
+
+        // Act
+        await cut.Find("#save-catch-button").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-saved").Should().NotBeNull());
+        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.FindAll("#catch-photo-use-details").Should().BeEmpty();
+        await store.Received(1).SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
@@ -1,5 +1,6 @@
 using Bunit;
 using Bunit.TestDoubles;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Browser.Update;
 using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
@@ -26,7 +27,8 @@ public class BaseMainLayoutTest
         ICatchSynchroniser? catchSynchroniser = null,
         IDiagnosticSynchroniser? diagnosticSynchroniser = null,
         IProfileSummaryProvider? profileSummary = null,
-        IAppUpdateService? appUpdate = null)
+        IAppUpdateService? appUpdate = null,
+        INetworkService? network = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -60,6 +62,7 @@ public class BaseMainLayoutTest
         context.Services.AddSingleton(Substitute.For<ILoggingService>());
         context.Services.AddSingleton(appUpdate ?? Substitute.For<IAppUpdateService>());
         context.Services.AddSingleton(profileSummary ?? QuietProfileSummary());
+        context.Services.AddSingleton(network ?? Network(isOnline: true));
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
     }
@@ -72,4 +75,10 @@ public class BaseMainLayoutTest
         return provider;
     }
 
+    protected static INetworkService Network(bool isOnline)
+    {
+        var network = Substitute.For<INetworkService>();
+        network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(isOnline);
+        return network;
+    }
 }


### PR DESCRIPTION
## Summary

Two focused physical-acceptance findings from #169's mobile review, fixed as narrow follow-ups on top of the merged offline MVP work. Neither redesigns the completed offline/photo architecture.

### 1. Photograph metadata conflict warning must remain visible while the conflict still exists

**Root cause**: the warning banner and Save-blocking/location-application logic were both driven from the same `DateConflict`/`CoordinateConflict` flags, which include `_representativePhotographId is null`. Choosing a representative photo (via "Use this photo's details") cleared those flags to unblock Save — and, as a side effect, silently hid the warning even though the underlying photograph set still genuinely conflicted. The chooser stayed on screen, so the user saw a confusing "conflict resolved but chooser still open" state.

**Fix**: split the concepts. `HasPhotoMetadataConflict` now reflects only `_proposal.HasConflictingDates || _proposal.HasConflictingCoordinates` — the raw, representative-independent conflict — and drives both the warning and the chooser's visibility (which already used this exact expression under a different name). `DateConflict`/`CoordinateConflict`/`CanSave` and all date/coordinate application logic are byte-for-byte unchanged: Save-blocking, the 30-minute/250m tolerances, EXIF/LastModified precedence, and representative-selection semantics are untouched. The warning now only disappears when the underlying conflict genuinely resolves (a conflicting photo is removed, remaining values fall within tolerance) or the catch is saved — never merely because a representative was chosen.

### 2. Offline app bar still showed Sign in / Create account

**Root cause**: `MainLayout` is the app's `DefaultLayout` (`App.razor`), so it wraps every unauthenticated-reachable route including Landing. `UserMenu`'s `NotAuthorized` branch (rendered inside `MainLayout`'s app bar) showed Sign in/Create account purely from `AuthorizeView`'s authentication state, with no awareness of genuine connectivity — so while genuinely offline and unauthenticated, the app bar showed a second, contradictory set of auth actions alongside Landing's own (already-correct, #169) offline-aware ones. Confirmed `OfflineLayout` never renders `UserMenu` at all, so the leak was only reachable via `MainLayout`/Landing, not the unlocked offline session itself.

**Fix**: `UserMenu` now tracks connectivity the same way Landing already does — reusing the existing `INetworkService` (no new state/service) — and only renders Sign in/Create account while online or before connectivity is known. ASP.NET authentication semantics are untouched: `AuthorizeView`'s `Authorized`/`NotAuthorized` split still comes purely from real authentication state; this only adds a presentation gate inside `NotAuthorized`. The offline unlock flow is untouched and the user is never marked authenticated. `OfflineLayout`'s reconnect `SIGN IN TO SYNC` action and automatic silent re-authentication on reconnect (#169) are on a completely separate path and are unaffected.

## Self review

```
Issue/AC:            PASS — both physical-acceptance findings addressed narrowly
Architecture/CQRS:   N/A (Web-only; no Application/Infrastructure touched)
Rules:               PASS — no new abstractions; reused existing INetworkService pattern
Security/privacy:    PASS — no auth semantics changed; ASP.NET Authorized/NotAuthorized untouched
Database/migrations: N/A
Tests/coverage:      PASS — 1027 Web unit tests (+9 new), 258 vitest (unaffected), 64 Playwright browser, 47/47 credentialed E2E
Web/UI/localisation: PASS — no new copy
Code smells:         PASS — no duplicated connectivity state; #169's IndexedDB/retention/reconnect architecture untouched
CI/deployment:       N/A
```

**Findings caught and fixed during self-review:**
1. `MainLayoutTests`' `BaseMainLayoutTest` didn't register `INetworkService`, since `UserMenu` (rendered inside `MainLayout`) now depends on it — 28 MainLayout tests failed on DI resolution until fixed.
2. Several existing `RecordCatchEditor` tests (`WhenTestingPhotoMetadataConflict.cs`, `WhenTestingPhotoMetadata.cs`) encoded the old buggy behaviour, asserting the warning disappeared after choosing a representative — corrected to assert it remains visible, since that's exactly the bug being fixed.
3. A shared E2E helper (`tests/FishingLogBook.E2E/support/catch-journey.mjs`) had the identical stale assertion, missed on the first pass — caught by an initial full E2E run showing 2 failures, traced to the shared helper, fixed, and confirmed clean on a second full run (47/47).

## Tests added/changed

- `RecordCatchEditor`: 6 new tests (representative persists while swiping, 4+ photo navigation, date/coordinate tolerance boundaries, warning clears on save) + 6 existing tests corrected to the new intended behaviour.
- `UserMenu`: 4 new tests (hidden while offline, reactive to connectivity changes both directions, authenticated menu unaffected by connectivity).
- E2E: 1 shared-helper assertion + 1 direct spec assertion corrected; no new journeys added (scope was fixing existing coverage, not adding new ones — `#157` unaffected, still excludes offline).

## Validation

| Check | Result |
|---|---|
| `dotnet build` | 0 warnings, 0 errors |
| `dotnet format --verify-no-changes` | clean |
| `git diff --check` | clean |
| `dotnet test` (Web) | **1027/1027** (+9) |
| `npm test` (vitest) | 258/258 (unaffected — no JS changed in this PR) |
| `npm run test:browser` | 64/64, 6 expected WebKit skips (unaffected) |
| Credentialed E2E | **47/47** — first run surfaced 2 failures traced to a stale shared test helper (not production code), fixed, re-run clean |

## Scope discipline

Does not touch: IndexedDB retention/cleanup implementation, #168 storage/performance work, `CatchSynchroniser`, `OfflineOwnerContext`, WebAuthn/PRF, the reconnect coordinator, photograph parsing/sanitisation, measurement controls, Trips, or import. The mobile measurement keyboard `Done` behaviour noticed during testing is explicitly out of scope here.

Contributes to #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
