### PR TITLE
FLB#164 | Stop a camera photograph from suppressing other photographs' metadata

### DIFF
--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.cs
@@ -299,17 +299,14 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
             return;
         }
 
-        var hasCameraPhotograph = _photographs.Any(photograph => photograph.FromCamera);
-        if (hasCameraPhotograph || RepresentativePhotograph is null)
+        if (RepresentativePhotograph is null)
         {
             _representativePhotographId = null;
         }
 
-        _proposal = hasCameraPhotograph
-            ? CatchPhotographProposalModel.Empty
-            : PhotographProposal.Propose(
-                [.. _photographs.Select(photograph => photograph.Metadata)],
-                DateTimeOffset.UtcNow);
+        _proposal = PhotographProposal.Propose(
+            [.. _photographs.Select(photograph => photograph.Metadata)],
+            DateTimeOffset.UtcNow);
         await ApplyCaughtOnAsync();
         ApplyLocation();
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingMixedPhotoSources.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingMixedPhotoSources.cs
@@ -1,0 +1,165 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Pages.RecordCatch;
+using FishingLogBook.Web.Features.Photographs.Models;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components.Forms;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.RecordCatchTests;
+
+public class WhenTestingMixedPhotoSources : BaseRecordCatchTest
+{
+    private const byte CameraPhotograph = 0x0A;
+    private const byte JunePhotograph = 0x0B;
+    private const byte MayPhotograph = 0x0C;
+
+    private static readonly DateTimeOffset JuneCapture = DateTimeOffset.Parse("2025-06-14T06:32:10Z");
+    private static readonly DateTimeOffset MayCapture = DateTimeOffset.Parse("2025-05-02T14:10:00Z");
+
+    private const double CorribLatitude = 53.2707;
+    private const double CorribLongitude = -9.0568;
+    private const double LeeLatitude = 51.8985;
+    private const double LeeLongitude = -8.4756;
+
+    [Fact]
+    public async Task ItShouldBlockSaveUntilTheAnglerResolvesAConflictBetweenTwoGalleryPhotographsWhileACameraPhotographIsPresent()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var photoMetadata = PhotoMetadataFor(
+            (CameraPhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)),
+            (JunePhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)),
+            (MayPhotograph, new PhotographMetadataModel(MayCapture, LeeLatitude, LeeLongitude)));
+        await using var context = CreateContext(store, photoMetadata: photoMetadata);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("now.jpg", CameraPhotograph));
+
+        // Act
+        cut.FindComponents<InputFile>()[1].UploadFiles(
+            JpegFile("june.jpg", JunePhotograph),
+            JpegFile("may.jpg", MayPhotograph));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull());
+        cut.Find("#save-catch-button").HasAttribute("disabled").Should().BeTrue();
+        await cut.Find("#save-catch-button").ClickAsync();
+        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+
+        await cut.Find("#catch-photo-use-details").ClickAsync();
+        cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull();
+        cut.Find("#save-catch-button").HasAttribute("disabled").Should().BeFalse();
+        await cut.Find("#save-catch-button").ClickAsync();
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Photographs.Count == 3
+                && catchRecord.CaughtOn == MayCapture
+                && catchRecord.Location!.Latitude == LeeLatitude
+                && catchRecord.Location.Longitude == LeeLongitude),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldProposeTheGalleryPhotographsDetailsWhenOnlyOneGalleryPhotographHasMetadata()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var photoMetadata = PhotoMetadataFor(
+            (CameraPhotograph, new PhotographMetadataModel(MayCapture, LeeLatitude, LeeLongitude)),
+            (JunePhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)));
+        await using var context = CreateContext(store, photoMetadata: photoMetadata);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("now.jpg", CameraPhotograph));
+
+        // Act
+        cut.FindComponents<InputFile>()[1].UploadFiles(JpegFile("june.jpg", JunePhotograph));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-06-14T06:32"));
+        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.Find("#catch-location-from-photo").Should().NotBeNull();
+        await cut.Find("#save-catch-button").ClickAsync();
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Photographs.Count == 2
+                && catchRecord.CaughtOn == JuneCapture
+                && catchRecord.Location!.Latitude == CorribLatitude
+                && catchRecord.Location.Longitude == CorribLongitude
+                && catchRecord.Location.Source == LocationDefaults.PhotoMetadata),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotFabricateADateOrLocationWhenNeitherPhotographHasMetadata()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        await using var context = CreateContext(store);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("now.jpg", CameraPhotograph));
+
+        // Act
+        cut.FindComponents<InputFile>()[1].UploadFiles(JpegFile("plain.jpg", JunePhotograph));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-carousel").Should().NotBeNull());
+        cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty();
+        cut.FindAll("#catch-location-from-photo").Should().BeEmpty();
+        await cut.Find("#save-catch-button").ClickAsync();
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Photographs.Count == 2
+                && catchRecord.CaughtOn > DateTimeOffset.UtcNow.AddMinutes(-5)
+                && catchRecord.Location == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRecomputeAfterTheConflictingGalleryPhotographIsRemovedWhileACameraPhotographRemains()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var photoMetadata = PhotoMetadataFor(
+            (JunePhotograph, new PhotographMetadataModel(JuneCapture, CorribLatitude, CorribLongitude)),
+            (MayPhotograph, new PhotographMetadataModel(MayCapture, LeeLatitude, LeeLongitude)));
+        await using var context = CreateContext(store, photoMetadata: photoMetadata);
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("now.jpg", CameraPhotograph));
+        cut.FindComponents<InputFile>()[1].UploadFiles(
+            JpegFile("june.jpg", JunePhotograph),
+            JpegFile("may.jpg", MayPhotograph));
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#catch-photo-remove").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-photo-metadata-conflict").Should().BeEmpty());
+        cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-06-14T06:32");
+        cut.Find("#catch-location-from-photo").Should().NotBeNull();
+        await cut.Find("#save-catch-button").ClickAsync();
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Photographs.Count == 2
+                && catchRecord.CaughtOn == JuneCapture
+                && catchRecord.Location!.Latitude == CorribLatitude
+                && catchRecord.Location.Source == LocationDefaults.PhotoMetadata),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotoMetadata.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotoMetadata.cs
@@ -357,7 +357,7 @@ public class WhenTestingPhotoMetadata : BaseRecordCatchTest
     }
 
     [Fact]
-    public async Task ItShouldReadGalleryMetadataAgainAfterTheCameraPhotographIsRemoved()
+    public async Task ItShouldKeepGalleryMetadataActiveBeforeAndAfterTheCameraPhotographIsRemoved()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
@@ -372,7 +372,8 @@ public class WhenTestingPhotoMetadata : BaseRecordCatchTest
         var cameraPhotographId = VisiblePhotographId(cut);
         cut.FindComponents<InputFile>()[1].UploadFiles(JpegFile("gallery.jpg", SecondPhotograph));
         cut.WaitForAssertion(() =>
-            cut.Find("#catch-caught-on").GetAttribute("value").Should().NotBe("2025-06-14T06:32"));
+            cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-06-14T06:32"));
+        cut.Find("#catch-location-from-photo").Should().NotBeNull();
 
         // Act
         await cut.Find("#catch-photo-previous").ClickAsync();

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotoMetadataConflict.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingPhotoMetadataConflict.cs
@@ -300,7 +300,7 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
     }
 
     [Fact]
-    public async Task ItShouldDropTheChosenPhotographWhenACameraCaptureJoinsTheCatch()
+    public async Task ItShouldKeepTheChosenPhotographWhenACameraCaptureJoinsTheCatch()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
@@ -318,20 +318,23 @@ public class WhenTestingPhotoMetadataConflict : BaseRecordCatchTest
         cut.WaitForAssertion(() => cut.Find("#catch-photo-use-details").Should().NotBeNull());
         await cut.Find("#catch-photo-use-details").ClickAsync();
         cut.Find("#catch-location-from-photo").Should().NotBeNull();
+        cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-05-02T14:10");
 
         // Act
         cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("now.jpg", ThirdPhotograph));
 
         // Assert
-        cut.WaitForAssertion(() => cut.FindAll("#catch-photo-current-metadata").Should().BeEmpty());
-        cut.FindAll("#catch-location-from-photo").Should().BeEmpty();
+        cut.WaitForAssertion(() => cut.Find("#catch-photo-metadata-conflict").Should().NotBeNull());
+        cut.Find("#catch-location-from-photo").Should().NotBeNull();
+        cut.Find("#catch-caught-on").GetAttribute("value").Should().Be("2025-05-02T14:10");
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord =>
                 catchRecord.Photographs.Count == 3
-                && catchRecord.CaughtOn > DateTimeOffset.UtcNow.AddMinutes(-5)
-                && catchRecord.CaughtOn != MayCapture
-                && catchRecord.Location == null),
+                && catchRecord.CaughtOn == MayCapture
+                && catchRecord.Location != null
+                && catchRecord.Location.Latitude == LeeLatitude
+                && catchRecord.Location.Longitude == LeeLongitude),
             Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## Summary

One focused physical-acceptance finding from #170's mobile review, fixed as a narrow follow-up on top of the merged work. Does not redesign the photograph/proposal architecture.

**Root cause**: `RecordCatchEditor.ApplyPhotoMetadataAsync()` computed `hasCameraPhotograph = _photographs.Any(p => p.FromCamera)` and, whenever any camera-captured photograph was present, replaced the *entire* catch proposal with `CatchPhotographProposalModel.Empty` — regardless of how many other gallery photographs carried real, trustworthy metadata. A single camera shot silently suppressed conflict detection and date/location proposals for every other photo in the same catch.

**Investigated first, per instruction, before touching proposal logic**: confirmed the full source-classification path (`PhotographPicker` → `PhotographSourceEnum` → `PhotographPreparationService` → `PreparedPhotographModel.FromCamera`) is already correct and needed no changes:
- Camera vs Gallery is decided purely by which `<input>` fired (`#catch-photo-camera` vs `#catch-photo-gallery`) — never inferred from filename, content, or EXIF.
- Google Photos / any system picker selection goes through the plain gallery `<input>`, so it is always classified as Gallery.
- `PhotographPreparationService` already gives camera photographs empty metadata (`source == Camera ? Empty : ReadMetadataAsync(...)`), so the existing camera-vs-`LastModified` historical-date protection is untouched.

**Fix**: removed the blanket `hasCameraPhotograph` check in `RecordCatchEditor.ApplyPhotoMetadataAsync()`. The proposal is now always computed from the real per-photograph metadata; `CatchPhotographProposalService` already filters out photographs with no metadata, so a camera photo's empty metadata naturally contributes nothing once the blanket suppression is gone. The representative-photo reset no longer needs a camera-specific branch either — a chosen representative that is still present stays chosen regardless of what else joins the catch. No new abstraction or flag was added.

## Tests added/changed

- Rewrote two `RecordCatchEditor` tests that encoded the old (incorrect) suppression behaviour, so they now assert the corrected behaviour (chosen representative and gallery metadata survive a camera photo joining/leaving the catch).
- Added `WhenTestingMixedPhotoSources.cs` (4 new tests): camera + conflicting gallery photos blocks Save until resolved then saves correctly and keeps the warning visible; camera + one metadata-bearing gallery photo is proposed automatically; camera + a gallery photo without metadata fabricates nothing; removing a conflicting gallery photo while a camera photo remains clears the warning and recomputes correctly.
- Confirmed unaffected (re-run, still passing unmodified): all camera-only tests, `PhotographPickerTests`, `PhotographPreparationServiceTests`, and every existing gallery-only tolerance/EXIF/`LastModified` test.

## Self review

```
Issue/AC:            PASS — the reported suppression bug is fixed; no scope expansion
Architecture/CQRS:   N/A (Web-only; no Application/Infrastructure touched)
Rules:               PASS — no new abstractions; reused the existing per-photograph metadata model
Security/privacy:    N/A — no auth/ownership surface touched
Database/migrations: N/A
Tests/coverage:      PASS — 1031 Web unit tests (+4 net new), 258 vitest (unaffected), 64 Playwright browser, 47/47 credentialed E2E
Web/UI/localisation: N/A — no new copy
Code smells:         PASS — diff is scoped to one production method; nothing else in #170's fixes (auth/app-bar, warning-visibility) touched
CI/deployment:       N/A
```

## Validation

| Check | Result |
|---|---|
| `dotnet build` | 0 warnings, 0 errors |
| `dotnet format --verify-no-changes` | clean |
| `git diff --check` | clean |
| `dotnet test` (full solution) | **1629/1629** |
| `npm test` (vitest) | 258/258 |
| `npm run test:browser` | 64/64, 6 expected WebKit skips |
| Credentialed E2E | **47/47** |

## Scope discipline

Does not touch: `PhotographPicker`, `PhotographPreparationService`, `PhotographSourceEnum`, `CatchPhotographProposalService` (tolerances/EXIF precedence), IndexedDB retention/cleanup, `CatchSynchroniser`, the reconnect coordinator, the offline app-bar/auth-visibility fix or the conflict-warning-persistence fix already merged in #170, measurement controls, Trips, or import.

Related to #164 (already closed; this is a normal follow-up bug fix, not a reopening).
