### PR TITLE
FLB#172 | Trip domain, persistence and API foundation

### DIFF
--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -1546,7 +1546,100 @@ The product should be considered commercially validated separately based on actu
 
 ---
 
-# 51. Next Document
+# 51. Fishing Trips
+
+A Fishing Trip records the experience of going fishing. A Catch records a fish caught during it.
+
+A trip with zero catches is a valid and meaningful fishing record. It must never be presented as a failed or incomplete entry.
+
+A trip must not be required in order to record a catch. An angler who catches a fish unexpectedly must still be able to record it immediately.
+
+## Trip ownership
+
+A trip belongs to one owner.
+
+Catches recorded during a trip continue to belong to their own angler and retain their existing ownership and provenance.
+
+## Trip lifecycle
+
+A trip has an explicit status. The supported statuses are:
+
+- Active
+- Completed
+
+An owner may have at most one Active trip at a time.
+
+A trip records:
+
+- start time
+- end time, once finished
+
+Start and end times are stored as absolute instants and displayed in the angler's local time.
+
+A trip may be created retrospectively as Completed, so historical trips can be recorded later.
+
+## Trip identity and title
+
+A trip title is optional.
+
+Where no title is supplied, the application displays a localised date. The generated title is not stored.
+
+A title is a description chosen by the angler, for example "Day with Dad". It is not a substitute for where the trip happened.
+
+## Trip location
+
+Trip location is optional but first-class. A trip without location context is incomplete, particularly a blank trip with no catches.
+
+Three location concepts are distinct and must not be conflated:
+
+- exact coordinates, captured from the device where the angler allows it
+- a display place, describing where the fishing happened, for example "Lough Corrib"
+- a fishing venue or fishery, which is a future concept
+
+Trip coordinates are private by default and follow the same visibility, source and consent rules as catch location.
+
+A catch does not inherit trip coordinates. A catch keeps its own location and provenance.
+
+## Trip content
+
+A trip may own:
+
+- trip photographs that belong to the day rather than to a catch
+- trip notes recorded during or at the end of the trip
+- catches recorded during the trip
+
+Trip photographs and trip notes are separate from catch photographs and catch notes.
+
+Trip notes are timestamped so they can be shown in the order they were written.
+
+## Offline use
+
+A trip must be usable with little or no connectivity.
+
+An angler must be able to start a trip, record catches, add photographs and notes, and finish the trip without live connectivity, and have that data synchronise safely when connectivity returns.
+
+An active trip must remain recoverable after the application is closed and reopened while offline.
+
+## Trip history
+
+A completed trip should be presented as a chronological record of the day, interleaving trip start and finish, photographs, notes and catches by time.
+
+## Out of scope for the first Trip implementation
+
+- participants and invitations
+- guided trip and client workflows
+- video
+- fishing venues and fisheries
+- planned future trips
+- public sharing
+- advanced trip search
+- historical import workflows
+
+These concepts influence the trip model but are not implemented as part of it.
+
+---
+
+# 52. Next Document
 
 The next project document will be:
 

--- a/src/FishingLogBook.Api/Endpoints/TripEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/TripEndpoints.cs
@@ -1,0 +1,146 @@
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.Trips.Commands;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Application.Trips.Queries;
+using FishingLogBook.Shared.Dtos;
+using MediatR;
+
+namespace FishingLogBook.Api.Endpoints;
+
+public static class TripEndpoints
+{
+    public static IEndpointRouteBuilder MapTripEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/api/trips", UpsertAsync)
+            .WithName("UpsertTrip")
+            .WithTags("Trips")
+            .RequireAuthorization()
+            .Produces<TripDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status409Conflict)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        endpoints.MapGet("/api/trips", ListMyAsync)
+            .WithName("ListMyTrips")
+            .WithTags("Trips")
+            .RequireAuthorization()
+            .Produces<IReadOnlyList<TripViewDto>>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        endpoints.MapGet("/api/trips/{tripId:guid}", GetAsync)
+            .WithName("GetTrip")
+            .WithTags("Trips")
+            .RequireAuthorization()
+            .Produces<TripViewDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> UpsertAsync(
+        TripDto tripDto,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new UpsertTripCommand
+            {
+                UserId = currentUser.UserId,
+                Trip = tripDto
+            },
+            cancellationToken);
+        if (response.ValidationErrors is { Count: > 0 })
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.Error is TripAlreadyActiveError)
+        {
+            return Results.Json(response, statusCode: StatusCodes.Status409Conflict);
+        }
+
+        if (response.Error is TripLocationInvalidError
+            or TripLifecycleInvalidError
+            or TripOwnershipConflictError)
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.Ok(response.Trip);
+    }
+
+    private static async Task<IResult> ListMyAsync(
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new GetMyTripsQuery { UserId = currentUser.UserId },
+            cancellationToken);
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.Ok(response.Trips);
+    }
+
+    private static async Task<IResult> GetAsync(
+        Guid tripId,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new GetTripQuery { TripId = tripId },
+            cancellationToken);
+        if (response.Error is CurrentUserUnresolvedError)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (response.Error is TripNotFoundError)
+        {
+            return Results.NotFound();
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.Ok(response.Trip);
+    }
+}

--- a/src/FishingLogBook.Api/Program.cs
+++ b/src/FishingLogBook.Api/Program.cs
@@ -72,6 +72,7 @@ app.MapDiagnosticEndpoints();
 app.MapUserEndpoints();
 app.MapProfileEndpoints();
 app.MapCatchEndpoints();
+app.MapTripEndpoints();
 app.MapFishingPreferenceEndpoints();
 
 app.Run();

--- a/src/FishingLogBook.Application/Args/GetMyTripsArgs.cs
+++ b/src/FishingLogBook.Application/Args/GetMyTripsArgs.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class GetMyTripsArgs
+{
+    public Guid UserId { get; init; }
+}

--- a/src/FishingLogBook.Application/Args/GetTripArgs.cs
+++ b/src/FishingLogBook.Application/Args/GetTripArgs.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class GetTripArgs
+{
+    public Guid TripId { get; init; }
+}

--- a/src/FishingLogBook.Application/Args/UpsertTripArgs.cs
+++ b/src/FishingLogBook.Application/Args/UpsertTripArgs.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Args;
+
+public sealed class UpsertTripArgs
+{
+    public Guid UserId { get; init; }
+
+    public TripDto Trip { get; init; } = new(Guid.Empty, string.Empty, default);
+}

--- a/src/FishingLogBook.Application/Common/Mappings/TripMappingRegistration.cs
+++ b/src/FishingLogBook.Application/Common/Mappings/TripMappingRegistration.cs
@@ -1,0 +1,60 @@
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Dtos;
+using Mapster;
+
+namespace FishingLogBook.Application.Common.Mappings;
+
+public sealed class TripMappingRegistration : IRegister
+{
+    void IRegister.Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<TripDto, TripDto>()
+            .MapWith(source => source);
+
+        config.NewConfig<Trip, TripDto>()
+            .MapWith(source => new TripDto(
+                source.Id,
+                source.Status.ToString(),
+                source.StartedOn,
+                source.EndedOn,
+                source.Location == null
+                    ? null
+                    : new TripLocationDto(
+                        source.Location.Latitude,
+                        source.Location.Longitude,
+                        source.Location.AccuracyMetres,
+                        source.Location.CapturedOn,
+                        source.Location.Source,
+                        source.Location.Visibility,
+                        source.Location.ConsentVersion))
+            {
+                OwnerUserId = source.OwnerUserId,
+                Title = source.Title,
+                PlaceName = source.PlaceName
+            });
+
+        config.NewConfig<Trip, TripViewDto>()
+            .MapWith(source => new TripViewDto(
+                source.Id,
+                source.OwnerUserId,
+                source.Status.ToString(),
+                source.StartedOn,
+                source.EndedOn,
+                source.Location == null
+                    ? null
+                    : new TripLocationDto(
+                        source.Location.Latitude,
+                        source.Location.Longitude,
+                        source.Location.AccuracyMetres,
+                        source.Location.CapturedOn,
+                        source.Location.Source,
+                        source.Location.Visibility,
+                        source.Location.ConsentVersion))
+            {
+                Title = source.Title,
+                PlaceName = source.PlaceName,
+                CreatedOn = source.CreatedOn,
+                UpdatedOn = source.UpdatedOn
+            });
+    }
+}

--- a/src/FishingLogBook.Application/Contracts/Repositories/ITripRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/Repositories/ITripRepository.cs
@@ -1,0 +1,17 @@
+using FishingLogBook.Domain.Trips;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Repositories;
+
+public interface ITripRepository
+{
+    Task<Result<Trip?>> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<Result<IReadOnlyList<Trip>>> GetByOwnerUserIdAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken);
+
+    Task<Result<Trip?>> GetActiveAsync(Guid ownerUserId, CancellationToken cancellationToken);
+
+    Task<Result<Trip>> UpsertAsync(Trip trip, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Contracts/Services/ITripService.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/ITripService.cs
@@ -1,0 +1,16 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Services;
+
+public interface ITripService
+{
+    Task<Result<TripDto>> UpsertAsync(UpsertTripArgs args, CancellationToken cancellationToken);
+
+    Task<Result<TripViewDto>> GetViewAsync(GetTripArgs args, CancellationToken cancellationToken);
+
+    Task<Result<IReadOnlyList<TripViewDto>>> GetMyAsync(
+        GetMyTripsArgs args,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Trips/Commands/UpsertTripCommand.cs
+++ b/src/FishingLogBook.Application/Trips/Commands/UpsertTripCommand.cs
@@ -1,0 +1,96 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using MapsterMapper;
+using MediatR;
+
+namespace FishingLogBook.Application.Trips.Commands;
+
+public sealed class UpsertTripCommand : IRequest<UpsertTripResponse>
+{
+    public Guid UserId { get; init; }
+
+    public TripDto Trip { get; init; } = new(Guid.Empty, string.Empty, default);
+}
+
+public sealed class UpsertTripResponse : ValidatedResponse
+{
+    public TripDto? Trip { get; init; }
+}
+
+public sealed class UpsertTripHandler : IRequestHandler<UpsertTripCommand, UpsertTripResponse>
+{
+    private readonly ITripService _tripService;
+    private readonly IMapper _mapper;
+
+    public UpsertTripHandler(ITripService tripService, IMapper mapper)
+    {
+        _tripService = tripService;
+        _mapper = mapper;
+    }
+
+    public async Task<UpsertTripResponse> Handle(
+        UpsertTripCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _tripService.UpsertAsync(
+            _mapper.Map<UpsertTripArgs>(command),
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<UpsertTripResponse>(result.Errors[0]);
+        }
+
+        return new UpsertTripResponse
+        {
+            Trip = result.Value
+        };
+    }
+}
+
+public sealed class UpsertTripCommandValidator : AbstractValidator<UpsertTripCommand>
+{
+    public UpsertTripCommandValidator()
+    {
+        RuleFor(command => command.UserId)
+            .NotEmpty();
+        RuleFor(command => command.Trip.Id)
+            .NotEmpty();
+        RuleFor(command => command.Trip.Status)
+            .Must(TripConstants.IsKnownStatus)
+            .WithMessage("Trip status is not supported.");
+        RuleFor(command => command.Trip.StartedOn)
+            .NotEqual(default(DateTimeOffset))
+            .Must(startedOn => TripConstants.IsStartedOnValid(startedOn, DateTimeOffset.UtcNow))
+            .WithMessage("Trip start time cannot be in the future.");
+        RuleFor(command => command.Trip)
+            .Must(trip => TripConstants.IsEndedOnValid(trip.StartedOn, trip.EndedOn, DateTimeOffset.UtcNow))
+            .WithMessage("Trip end time must not be before the start or in the future.");
+        RuleFor(command => command.Trip)
+            .Must(trip => trip.Status != TripConstants.Active || trip.EndedOn is null)
+            .WithMessage("An active trip cannot have an end time.");
+        RuleFor(command => command.Trip.Title)
+            .MaximumLength(TripConstants.MaxTitleLength);
+        RuleFor(command => command.Trip.PlaceName)
+            .MaximumLength(TripConstants.MaxPlaceNameLength);
+        When(command => command.Trip.Location is not null, () =>
+        {
+            RuleFor(command => command.Trip.Location!.Latitude)
+                .InclusiveBetween(CatchLocationConstants.MinLatitude, CatchLocationConstants.MaxLatitude);
+            RuleFor(command => command.Trip.Location!.Longitude)
+                .InclusiveBetween(CatchLocationConstants.MinLongitude, CatchLocationConstants.MaxLongitude);
+            RuleFor(command => command.Trip.Location!.CapturedOn)
+                .NotEqual(default(DateTimeOffset));
+            RuleFor(command => command.Trip.Location!.Source)
+                .NotEmpty();
+            RuleFor(command => command.Trip.Location!.Visibility)
+                .Must(LocationDefaults.IsKnownVisibility)
+                .WithMessage("Location visibility is not supported.");
+            RuleFor(command => command.Trip.Location!.ConsentVersion)
+                .NotEmpty();
+        });
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Errors/TripAlreadyActiveError.cs
+++ b/src/FishingLogBook.Application/Trips/Errors/TripAlreadyActiveError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Errors;
+
+public sealed class TripAlreadyActiveError : Error
+{
+    public TripAlreadyActiveError()
+        : base("An active trip already exists.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Errors/TripLifecycleInvalidError.cs
+++ b/src/FishingLogBook.Application/Trips/Errors/TripLifecycleInvalidError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Errors;
+
+public sealed class TripLifecycleInvalidError : Error
+{
+    public TripLifecycleInvalidError()
+        : base("The trip start and end times are not valid.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Errors/TripLocationInvalidError.cs
+++ b/src/FishingLogBook.Application/Trips/Errors/TripLocationInvalidError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Errors;
+
+public sealed class TripLocationInvalidError : Error
+{
+    public TripLocationInvalidError()
+        : base("The trip location is not valid.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Errors/TripNotFoundError.cs
+++ b/src/FishingLogBook.Application/Trips/Errors/TripNotFoundError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Errors;
+
+public sealed class TripNotFoundError : Error
+{
+    public TripNotFoundError()
+        : base("The trip was not found.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Errors/TripOwnershipConflictError.cs
+++ b/src/FishingLogBook.Application/Trips/Errors/TripOwnershipConflictError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Errors;
+
+public sealed class TripOwnershipConflictError : Error
+{
+    public TripOwnershipConflictError()
+        : base("Trip ownership cannot be changed.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Queries/GetMyTripsQuery.cs
+++ b/src/FishingLogBook.Application/Trips/Queries/GetMyTripsQuery.cs
@@ -1,0 +1,56 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using MapsterMapper;
+using MediatR;
+
+namespace FishingLogBook.Application.Trips.Queries;
+
+public sealed class GetMyTripsQuery : IRequest<GetMyTripsResponse>
+{
+    public Guid UserId { get; init; }
+}
+
+public sealed class GetMyTripsResponse : ValidatedResponse
+{
+    public IReadOnlyList<TripViewDto> Trips { get; init; } = [];
+}
+
+public sealed class GetMyTripsHandler : IRequestHandler<GetMyTripsQuery, GetMyTripsResponse>
+{
+    private readonly ITripService _tripService;
+    private readonly IMapper _mapper;
+
+    public GetMyTripsHandler(ITripService tripService, IMapper mapper)
+    {
+        _tripService = tripService;
+        _mapper = mapper;
+    }
+
+    public async Task<GetMyTripsResponse> Handle(GetMyTripsQuery query, CancellationToken cancellationToken)
+    {
+        var result = await _tripService.GetMyAsync(
+            _mapper.Map<GetMyTripsArgs>(query),
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<GetMyTripsResponse>(result.Errors[0]);
+        }
+
+        return new GetMyTripsResponse
+        {
+            Trips = result.Value
+        };
+    }
+}
+
+public sealed class GetMyTripsQueryValidator : AbstractValidator<GetMyTripsQuery>
+{
+    public GetMyTripsQueryValidator()
+    {
+        RuleFor(query => query.UserId)
+            .NotEmpty();
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Queries/GetTripQuery.cs
+++ b/src/FishingLogBook.Application/Trips/Queries/GetTripQuery.cs
@@ -1,0 +1,56 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using MapsterMapper;
+using MediatR;
+
+namespace FishingLogBook.Application.Trips.Queries;
+
+public sealed class GetTripQuery : IRequest<GetTripResponse>
+{
+    public Guid TripId { get; init; }
+}
+
+public sealed class GetTripResponse : ValidatedResponse
+{
+    public TripViewDto? Trip { get; init; }
+}
+
+public sealed class GetTripHandler : IRequestHandler<GetTripQuery, GetTripResponse>
+{
+    private readonly ITripService _tripService;
+    private readonly IMapper _mapper;
+
+    public GetTripHandler(ITripService tripService, IMapper mapper)
+    {
+        _tripService = tripService;
+        _mapper = mapper;
+    }
+
+    public async Task<GetTripResponse> Handle(GetTripQuery query, CancellationToken cancellationToken)
+    {
+        var result = await _tripService.GetViewAsync(
+            _mapper.Map<GetTripArgs>(query),
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<GetTripResponse>(result.Errors[0]);
+        }
+
+        return new GetTripResponse
+        {
+            Trip = result.Value
+        };
+    }
+}
+
+public sealed class GetTripQueryValidator : AbstractValidator<GetTripQuery>
+{
+    public GetTripQueryValidator()
+    {
+        RuleFor(query => query.TripId)
+            .NotEmpty();
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Services/TripService.cs
+++ b/src/FishingLogBook.Application/Trips/Services/TripService.cs
@@ -1,0 +1,141 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using MapsterMapper;
+
+namespace FishingLogBook.Application.Trips.Services;
+
+public sealed class TripService : ITripService
+{
+    private readonly ITripRepository _tripRepository;
+    private readonly ICurrentUser _currentUser;
+    private readonly IMapper _mapper;
+
+    public TripService(
+        ITripRepository tripRepository,
+        ICurrentUser currentUser,
+        IMapper mapper)
+    {
+        _tripRepository = tripRepository;
+        _currentUser = currentUser;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<TripDto>> UpsertAsync(UpsertTripArgs args, CancellationToken cancellationToken)
+    {
+        if (!Enum.TryParse<TripStatusEnum>(args.Trip.Status, ignoreCase: false, out var status))
+        {
+            return Result.Fail<TripDto>(new TripLifecycleInvalidError());
+        }
+
+        var location = ToLocation(args.Trip.Location);
+        if (args.Trip.Location is not null && location is null)
+        {
+            return Result.Fail<TripDto>(new TripLocationInvalidError());
+        }
+
+        var trip = new Trip
+        {
+            Id = args.Trip.Id,
+            OwnerUserId = args.UserId,
+            Title = TrimToNull(args.Trip.Title),
+            PlaceName = TrimToNull(args.Trip.PlaceName),
+            Status = status,
+            StartedOn = args.Trip.StartedOn,
+            EndedOn = args.Trip.EndedOn,
+            Location = location
+        };
+
+        if (!trip.HasCoherentLifecycle())
+        {
+            return Result.Fail<TripDto>(new TripLifecycleInvalidError());
+        }
+
+        if (trip.IsActive)
+        {
+            var active = await _tripRepository.GetActiveAsync(trip.OwnerUserId, cancellationToken);
+            if (active.IsFailed)
+            {
+                return Result.Fail<TripDto>(active.Errors);
+            }
+
+            if (active.Value is not null && active.Value.Id != trip.Id)
+            {
+                return Result.Fail<TripDto>(new TripAlreadyActiveError());
+            }
+        }
+
+        var saved = await _tripRepository.UpsertAsync(trip, cancellationToken);
+        if (saved.IsFailed)
+        {
+            return Result.Fail<TripDto>(saved.Errors);
+        }
+
+        return Result.Ok(_mapper.Map<TripDto>(saved.Value));
+    }
+
+    public async Task<Result<TripViewDto>> GetViewAsync(GetTripArgs args, CancellationToken cancellationToken)
+    {
+        if (!_currentUser.IsResolved)
+        {
+            return Result.Fail<TripViewDto>(new CurrentUserUnresolvedError());
+        }
+
+        var loaded = await _tripRepository.GetByIdAsync(args.TripId, cancellationToken);
+        if (loaded.IsFailed)
+        {
+            return Result.Fail<TripViewDto>(loaded.Errors);
+        }
+
+        if (loaded.Value is null || loaded.Value.OwnerUserId != _currentUser.UserId)
+        {
+            return Result.Fail<TripViewDto>(new TripNotFoundError());
+        }
+
+        return Result.Ok(_mapper.Map<TripViewDto>(loaded.Value));
+    }
+
+    public async Task<Result<IReadOnlyList<TripViewDto>>> GetMyAsync(
+        GetMyTripsArgs args,
+        CancellationToken cancellationToken)
+    {
+        var loaded = await _tripRepository.GetByOwnerUserIdAsync(args.UserId, cancellationToken);
+        if (loaded.IsFailed)
+        {
+            return Result.Fail<IReadOnlyList<TripViewDto>>(loaded.Errors);
+        }
+
+        IReadOnlyList<TripViewDto> views = [.. loaded.Value.Select(_mapper.Map<TripViewDto>)];
+        return Result.Ok(views);
+    }
+
+    private static TripLocation? ToLocation(TripLocationDto? location)
+    {
+        if (location is null)
+        {
+            return null;
+        }
+
+        return TripLocation.TryCreate(
+            location.Latitude,
+            location.Longitude,
+            location.AccuracyMetres,
+            location.CapturedOn,
+            location.Source,
+            location.Visibility,
+            location.ConsentVersion);
+    }
+
+    private static string? TrimToNull(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+}

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608261200_172_CreateTrip.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608261200_172_CreateTrip.sql
@@ -1,0 +1,87 @@
+CREATE TABLE IF NOT EXISTS "Trip"
+(
+    "Id"                     uuid             NOT NULL,
+    "OwnerUserId"            uuid             NOT NULL,
+    "Title"                  text             NULL,
+    "PlaceName"              text             NULL,
+    "Status"                 text             NOT NULL,
+    "StartedOn"              timestamptz      NOT NULL,
+    "EndedOn"                timestamptz      NULL,
+    "Latitude"               double precision NULL,
+    "Longitude"              double precision NULL,
+    "LocationAccuracyMetres" double precision NULL,
+    "LocationCapturedOn"     timestamptz      NULL,
+    "LocationSource"         text             NULL,
+    "LocationVisibility"     text             NULL,
+    "LocationConsentVersion" text             NULL,
+    "CreatedOn"              timestamptz      NOT NULL DEFAULT now(),
+    "UpdatedOn"              timestamptz      NOT NULL DEFAULT now(),
+    CONSTRAINT "PkTrip" PRIMARY KEY ("Id"),
+    CONSTRAINT "FkTripOwnerUser" FOREIGN KEY ("OwnerUserId") REFERENCES "User" ("Id")
+);
+
+CREATE INDEX IF NOT EXISTS "IxTripOwnerUserId" ON "Trip" ("OwnerUserId");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "UxTripOwnerActive"
+    ON "Trip" ("OwnerUserId")
+    WHERE "Status" = 'Active';
+
+ALTER TABLE "Trip"
+    DROP CONSTRAINT IF EXISTS "Trip_Status_Allowed";
+
+ALTER TABLE "Trip"
+    ADD CONSTRAINT "Trip_Status_Allowed" CHECK (
+        "Status" IN ('Active', 'Completed')
+    );
+
+ALTER TABLE "Trip"
+    DROP CONSTRAINT IF EXISTS "Trip_Ended_After_Started";
+
+ALTER TABLE "Trip"
+    ADD CONSTRAINT "Trip_Ended_After_Started" CHECK (
+        "EndedOn" IS NULL OR "EndedOn" >= "StartedOn"
+    );
+
+ALTER TABLE "Trip"
+    DROP CONSTRAINT IF EXISTS "Trip_Active_Has_No_End";
+
+ALTER TABLE "Trip"
+    ADD CONSTRAINT "Trip_Active_Has_No_End" CHECK (
+        "Status" <> 'Active' OR "EndedOn" IS NULL
+    );
+
+ALTER TABLE "Trip"
+    DROP CONSTRAINT IF EXISTS "Trip_Location_Coherent";
+
+ALTER TABLE "Trip"
+    ADD CONSTRAINT "Trip_Location_Coherent" CHECK (
+        (
+            "Latitude" IS NULL
+            AND "Longitude" IS NULL
+            AND "LocationAccuracyMetres" IS NULL
+            AND "LocationCapturedOn" IS NULL
+            AND "LocationSource" IS NULL
+            AND "LocationVisibility" IS NULL
+            AND "LocationConsentVersion" IS NULL
+        )
+        OR
+        (
+            "Latitude" IS NOT NULL
+            AND "Longitude" IS NOT NULL
+            AND "Latitude" BETWEEN -90 AND 90
+            AND "Longitude" BETWEEN -180 AND 180
+            AND "LocationCapturedOn" IS NOT NULL
+            AND "LocationSource" IS NOT NULL
+            AND "LocationVisibility" IS NOT NULL
+            AND "LocationConsentVersion" IS NOT NULL
+        )
+    );
+
+ALTER TABLE "Trip"
+    DROP CONSTRAINT IF EXISTS "Trip_LocationVisibility_Allowed";
+
+ALTER TABLE "Trip"
+    ADD CONSTRAINT "Trip_LocationVisibility_Allowed" CHECK (
+        "LocationVisibility" IS NULL
+        OR "LocationVisibility" IN ('Private', 'Approximate', 'FishingVenueOnly', 'Public')
+    );

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using FishingLogBook.Application.FishingPreferences.Services;
 using FishingLogBook.Application.OfflineAccess.Services;
 using FishingLogBook.Application.Profiles.Services;
 using FishingLogBook.Application.SystemStatus;
+using FishingLogBook.Application.Trips.Services;
 using FishingLogBook.Application.Users;
 using FishingLogBook.Application.Users.Commands;
 using FishingLogBook.Application.Users.Services;
@@ -52,6 +53,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserIdentityService, UserIdentityService>();
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<ICatchService, CatchService>();
+        services.AddScoped<ITripService, TripService>();
         services.AddScoped<ICatchPhotographService, CatchPhotographService>();
         services.AddScoped<ICatchLocationPrivacyService, CatchLocationPrivacyService>();
         services.AddScoped<IPlatformCapabilityService, PlatformCapabilityService>();
@@ -81,6 +83,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserIdentityRepository, UserIdentityRepository>();
         services.AddScoped<IProfileRepository, ProfileRepository>();
         services.AddScoped<ICatchRepository, CatchRepository>();
+        services.AddScoped<ITripRepository, TripRepository>();
         services.AddScoped<IUserPlatformCapabilityRepository, UserPlatformCapabilityRepository>();
         services.AddScoped<IFishingCatalogueRepository, FishingCatalogueRepository>();
         services.AddScoped<IFishingPreferenceRepository, FishingPreferenceRepository>();

--- a/src/FishingLogBook.Domain/Enums/TripStatusEnum.cs
+++ b/src/FishingLogBook.Domain/Enums/TripStatusEnum.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Domain.Enums;
+
+public enum TripStatusEnum
+{
+    Active = 0,
+    Completed = 1
+}

--- a/src/FishingLogBook.Domain/Trips/Trip.cs
+++ b/src/FishingLogBook.Domain/Trips/Trip.cs
@@ -1,0 +1,49 @@
+using FishingLogBook.Domain.Enums;
+
+namespace FishingLogBook.Domain.Trips;
+
+public sealed class Trip
+{
+    public Guid Id { get; init; }
+
+    public Guid OwnerUserId { get; init; }
+
+    public string? Title { get; init; }
+
+    public string? PlaceName { get; init; }
+
+    public TripStatusEnum Status { get; init; }
+
+    public DateTimeOffset StartedOn { get; init; }
+
+    public DateTimeOffset? EndedOn { get; init; }
+
+    public TripLocation? Location { get; init; }
+
+    public DateTimeOffset CreatedOn { get; init; }
+
+    public DateTimeOffset UpdatedOn { get; init; }
+
+    public bool IsActive
+    {
+        get
+        {
+            return Status == TripStatusEnum.Active;
+        }
+    }
+
+    public bool HasCoherentLifecycle()
+    {
+        if (StartedOn == default)
+        {
+            return false;
+        }
+
+        if (EndedOn is not null && EndedOn.Value < StartedOn)
+        {
+            return false;
+        }
+
+        return !IsActive || EndedOn is null;
+    }
+}

--- a/src/FishingLogBook.Domain/Trips/TripLocation.cs
+++ b/src/FishingLogBook.Domain/Trips/TripLocation.cs
@@ -1,0 +1,57 @@
+using FishingLogBook.Domain.Enums;
+
+namespace FishingLogBook.Domain.Trips;
+
+public sealed class TripLocation
+{
+    public double Latitude { get; init; }
+
+    public double Longitude { get; init; }
+
+    public double? AccuracyMetres { get; init; }
+
+    public DateTimeOffset CapturedOn { get; init; }
+
+    public string Source { get; init; } = string.Empty;
+
+    public string Visibility { get; init; } = string.Empty;
+
+    public string ConsentVersion { get; init; } = string.Empty;
+
+    public static TripLocation? TryCreate(
+        double latitude,
+        double longitude,
+        double? accuracyMetres,
+        DateTimeOffset capturedOn,
+        string? source,
+        string? visibility,
+        string? consentVersion)
+    {
+        var trimmedVisibility = visibility?.Trim();
+        if (!AreCoordinatesValid(latitude, longitude)
+            || capturedOn == default
+            || string.IsNullOrWhiteSpace(source)
+            || string.IsNullOrWhiteSpace(trimmedVisibility)
+            || !Enum.TryParse<LocationVisibilityEnum>(trimmedVisibility, ignoreCase: false, out _)
+            || string.IsNullOrWhiteSpace(consentVersion))
+        {
+            return null;
+        }
+
+        return new TripLocation
+        {
+            Latitude = latitude,
+            Longitude = longitude,
+            AccuracyMetres = accuracyMetres,
+            CapturedOn = capturedOn,
+            Source = source.Trim(),
+            Visibility = trimmedVisibility!,
+            ConsentVersion = consentVersion.Trim()
+        };
+    }
+
+    public static bool AreCoordinatesValid(double latitude, double longitude)
+    {
+        return latitude is >= -90 and <= 90 && longitude is >= -180 and <= 180;
+    }
+}

--- a/src/FishingLogBook.Infrastructure/Persistence/Mappings/TripMappingRegistration.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/Mappings/TripMappingRegistration.cs
@@ -1,0 +1,40 @@
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Infrastructure.Persistence.Repositories;
+using Mapster;
+
+namespace FishingLogBook.Infrastructure.Persistence.Mappings;
+
+public sealed class TripMappingRegistration : IRegister
+{
+    void IRegister.Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<TripRepository.TripPersistenceRow, Trip>()
+            .Map(destination => destination.Status, source => ToStatus(source.Status))
+            .Map(destination => destination.Location, source => ToLocation(source));
+    }
+
+    private static TripStatusEnum ToStatus(string? status)
+    {
+        return Enum.TryParse<TripStatusEnum>(status, ignoreCase: false, out var parsed)
+            ? parsed
+            : TripStatusEnum.Completed;
+    }
+
+    private static TripLocation? ToLocation(TripRepository.TripPersistenceRow row)
+    {
+        if (row.Latitude is null || row.Longitude is null)
+        {
+            return null;
+        }
+
+        return TripLocation.TryCreate(
+            row.Latitude.Value,
+            row.Longitude.Value,
+            row.LocationAccuracyMetres,
+            row.LocationCapturedOn ?? default,
+            row.LocationSource,
+            row.LocationVisibility,
+            row.LocationConsentVersion);
+    }
+}

--- a/src/FishingLogBook.Infrastructure/Persistence/Repositories/TripRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/Repositories/TripRepository.cs
@@ -1,0 +1,326 @@
+using Dapper;
+using FishingLogBook.Application.Contracts;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Trips;
+using FluentResults;
+using MapsterMapper;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace FishingLogBook.Infrastructure.Persistence.Repositories;
+
+public sealed class TripRepository : ITripRepository
+{
+    private const string FailedMessage = "Failed to save the trip.";
+
+    private const string SelectSql = """
+        SELECT
+            "Id",
+            "OwnerUserId",
+            "Title",
+            "PlaceName",
+            "Status",
+            "StartedOn",
+            "EndedOn",
+            "Latitude",
+            "Longitude",
+            "LocationAccuracyMetres",
+            "LocationCapturedOn",
+            "LocationSource",
+            "LocationVisibility",
+            "LocationConsentVersion",
+            "CreatedOn",
+            "UpdatedOn"
+        FROM "Trip"
+        """;
+
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly ILogger<TripRepository> _logger;
+    private readonly IMapper _mapper;
+
+    public TripRepository(
+        IDbConnectionFactory connectionFactory,
+        ILogger<TripRepository> logger,
+        IMapper mapper)
+    {
+        _connectionFactory = connectionFactory;
+        _logger = logger;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<Trip?>> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            return Result.Ok(await LoadAsync(connection, transaction: null, id, cancellationToken));
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to load the trip {TripId}.", id);
+            return Result.Fail<Trip?>(FailedMessage);
+        }
+    }
+
+    public async Task<Result<IReadOnlyList<Trip>>> GetByOwnerUserIdAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = $"""
+                {SelectSql}
+                WHERE "OwnerUserId" = @OwnerUserId
+                ORDER BY "StartedOn" DESC;
+                """;
+            var rows = await connection.QueryAsync<TripPersistenceRow>(new CommandDefinition(
+                sql,
+                new { OwnerUserId = ownerUserId },
+                cancellationToken: cancellationToken));
+            IReadOnlyList<Trip> trips = [.. rows.Select(_mapper.Map<Trip>)];
+            return Result.Ok(trips);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to load trips for user {UserId}.", ownerUserId);
+            return Result.Fail<IReadOnlyList<Trip>>(FailedMessage);
+        }
+    }
+
+    public async Task<Result<Trip?>> GetActiveAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = $"""
+                {SelectSql}
+                WHERE "OwnerUserId" = @OwnerUserId
+                  AND "Status" = 'Active'
+                LIMIT 1;
+                """;
+            var row = await connection.QuerySingleOrDefaultAsync<TripPersistenceRow>(new CommandDefinition(
+                sql,
+                new { OwnerUserId = ownerUserId },
+                cancellationToken: cancellationToken));
+            return Result.Ok(row is null ? null : _mapper.Map<Trip>(row));
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to load the active trip for user {UserId}.", ownerUserId);
+            return Result.Fail<Trip?>(FailedMessage);
+        }
+    }
+
+    public async Task<Result<Trip>> UpsertAsync(Trip trip, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+            try
+            {
+                var existing = await LoadAsync(connection, transaction, trip.Id, cancellationToken);
+                if (existing is not null && existing.OwnerUserId != trip.OwnerUserId)
+                {
+                    await transaction.RollbackAsync(cancellationToken);
+                    return Result.Fail<Trip>(new TripOwnershipConflictError());
+                }
+
+                await UpsertRowAsync(connection, transaction, trip, cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+                var saved = await LoadAsync(connection, transaction: null, trip.Id, cancellationToken);
+                return saved is null
+                    ? Result.Fail<Trip>(FailedMessage)
+                    : Result.Ok(saved);
+            }
+            catch
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+        catch (PostgresException exception) when (exception.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            _logger.LogWarning(
+                exception,
+                "An active trip already exists for the owner of trip {TripId}.",
+                trip.Id);
+            return Result.Fail<Trip>(new TripAlreadyActiveError());
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to save the trip {TripId}.", trip.Id);
+            return Result.Fail<Trip>(FailedMessage);
+        }
+    }
+
+    private static async Task UpsertRowAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Trip trip,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            INSERT INTO "Trip" (
+                "Id",
+                "OwnerUserId",
+                "Title",
+                "PlaceName",
+                "Status",
+                "StartedOn",
+                "EndedOn",
+                "Latitude",
+                "Longitude",
+                "LocationAccuracyMetres",
+                "LocationCapturedOn",
+                "LocationSource",
+                "LocationVisibility",
+                "LocationConsentVersion",
+                "UpdatedOn"
+            )
+            VALUES (
+                @Id,
+                @OwnerUserId,
+                @Title,
+                @PlaceName,
+                @Status,
+                @StartedOn,
+                @EndedOn,
+                @Latitude,
+                @Longitude,
+                @LocationAccuracyMetres,
+                @LocationCapturedOn,
+                @LocationSource,
+                @LocationVisibility,
+                @LocationConsentVersion,
+                now()
+            )
+            ON CONFLICT ("Id") DO UPDATE SET
+                "Title" = EXCLUDED."Title",
+                "PlaceName" = EXCLUDED."PlaceName",
+                "Status" = EXCLUDED."Status",
+                "StartedOn" = EXCLUDED."StartedOn",
+                "EndedOn" = EXCLUDED."EndedOn",
+                "Latitude" = EXCLUDED."Latitude",
+                "Longitude" = EXCLUDED."Longitude",
+                "LocationAccuracyMetres" = EXCLUDED."LocationAccuracyMetres",
+                "LocationCapturedOn" = EXCLUDED."LocationCapturedOn",
+                "LocationSource" = EXCLUDED."LocationSource",
+                "LocationVisibility" = EXCLUDED."LocationVisibility",
+                "LocationConsentVersion" = EXCLUDED."LocationConsentVersion",
+                "UpdatedOn" = now();
+            """;
+        await connection.ExecuteAsync(new CommandDefinition(
+            sql,
+            ToParameters(trip),
+            transaction,
+            cancellationToken: cancellationToken));
+    }
+
+    private static TripPersistenceParameters ToParameters(Trip trip)
+    {
+        return new TripPersistenceParameters
+        {
+            Id = trip.Id,
+            OwnerUserId = trip.OwnerUserId,
+            Title = trip.Title,
+            PlaceName = trip.PlaceName,
+            Status = trip.Status.ToString(),
+            StartedOn = trip.StartedOn.ToUniversalTime(),
+            EndedOn = trip.EndedOn?.ToUniversalTime(),
+            Latitude = trip.Location?.Latitude,
+            Longitude = trip.Location?.Longitude,
+            LocationAccuracyMetres = trip.Location?.AccuracyMetres,
+            LocationCapturedOn = trip.Location?.CapturedOn.ToUniversalTime(),
+            LocationSource = trip.Location?.Source,
+            LocationVisibility = trip.Location?.Visibility,
+            LocationConsentVersion = trip.Location?.ConsentVersion
+        };
+    }
+
+    private async Task<Trip?> LoadAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        const string sql = $"""
+            {SelectSql}
+            WHERE "Id" = @Id;
+            """;
+        var row = await connection.QuerySingleOrDefaultAsync<TripPersistenceRow>(new CommandDefinition(
+            sql,
+            new { Id = id },
+            transaction,
+            cancellationToken: cancellationToken));
+        return row is null ? null : _mapper.Map<Trip>(row);
+    }
+
+    public sealed class TripPersistenceRow
+    {
+        public Guid Id { get; init; }
+
+        public Guid OwnerUserId { get; init; }
+
+        public string? Title { get; init; }
+
+        public string? PlaceName { get; init; }
+
+        public string Status { get; init; } = string.Empty;
+
+        public DateTimeOffset StartedOn { get; init; }
+
+        public DateTimeOffset? EndedOn { get; init; }
+
+        public double? Latitude { get; init; }
+
+        public double? Longitude { get; init; }
+
+        public double? LocationAccuracyMetres { get; init; }
+
+        public DateTimeOffset? LocationCapturedOn { get; init; }
+
+        public string? LocationSource { get; init; }
+
+        public string? LocationVisibility { get; init; }
+
+        public string? LocationConsentVersion { get; init; }
+
+        public DateTimeOffset CreatedOn { get; init; }
+
+        public DateTimeOffset UpdatedOn { get; init; }
+    }
+
+    private sealed class TripPersistenceParameters
+    {
+        public Guid Id { get; init; }
+
+        public Guid OwnerUserId { get; init; }
+
+        public string? Title { get; init; }
+
+        public string? PlaceName { get; init; }
+
+        public string Status { get; init; } = string.Empty;
+
+        public DateTimeOffset StartedOn { get; init; }
+
+        public DateTimeOffset? EndedOn { get; init; }
+
+        public double? Latitude { get; init; }
+
+        public double? Longitude { get; init; }
+
+        public double? LocationAccuracyMetres { get; init; }
+
+        public DateTimeOffset? LocationCapturedOn { get; init; }
+
+        public string? LocationSource { get; init; }
+
+        public string? LocationVisibility { get; init; }
+
+        public string? LocationConsentVersion { get; init; }
+    }
+}

--- a/src/FishingLogBook.Shared/Constants/TripConstants.cs
+++ b/src/FishingLogBook.Shared/Constants/TripConstants.cs
@@ -1,0 +1,32 @@
+namespace FishingLogBook.Shared.Constants;
+
+public static class TripConstants
+{
+    public const int MaxTitleLength = 120;
+
+    public const int MaxPlaceNameLength = 160;
+
+    public const string Active = "Active";
+
+    public const string Completed = "Completed";
+
+    public static bool IsKnownStatus(string? status)
+    {
+        return status is Active or Completed;
+    }
+
+    public static bool IsStartedOnValid(DateTimeOffset startedOn, DateTimeOffset now)
+    {
+        return startedOn != default && startedOn <= now;
+    }
+
+    public static bool IsEndedOnValid(DateTimeOffset startedOn, DateTimeOffset? endedOn, DateTimeOffset now)
+    {
+        if (endedOn is null)
+        {
+            return true;
+        }
+
+        return endedOn.Value >= startedOn && endedOn.Value <= now;
+    }
+}

--- a/src/FishingLogBook.Shared/Dtos/TripDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/TripDto.cs
@@ -1,0 +1,15 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record TripDto(
+    Guid Id,
+    string Status,
+    DateTimeOffset StartedOn,
+    DateTimeOffset? EndedOn = null,
+    TripLocationDto? Location = null)
+{
+    public Guid OwnerUserId { get; init; }
+
+    public string? Title { get; init; }
+
+    public string? PlaceName { get; init; }
+}

--- a/src/FishingLogBook.Shared/Dtos/TripLocationDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/TripLocationDto.cs
@@ -1,0 +1,10 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record TripLocationDto(
+    double Latitude,
+    double Longitude,
+    double? AccuracyMetres,
+    DateTimeOffset CapturedOn,
+    string Source,
+    string Visibility,
+    string ConsentVersion);

--- a/src/FishingLogBook.Shared/Dtos/TripViewDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/TripViewDto.cs
@@ -1,0 +1,18 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record TripViewDto(
+    Guid Id,
+    Guid OwnerUserId,
+    string Status,
+    DateTimeOffset StartedOn,
+    DateTimeOffset? EndedOn = null,
+    TripLocationDto? Location = null)
+{
+    public string? Title { get; init; }
+
+    public string? PlaceName { get; init; }
+
+    public DateTimeOffset CreatedOn { get; init; }
+
+    public DateTimeOffset UpdatedOn { get; init; }
+}

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -9,6 +9,7 @@ using FishingLogBook.Domain.Catalogue;
 using FishingLogBook.Domain.Catches;
 using FishingLogBook.Domain.Enums;
 using FishingLogBook.Domain.Profiles;
+using FishingLogBook.Domain.Trips;
 using FishingLogBook.Domain.Users;
 using FishingLogBook.Tests.Common.TestSupport;
 using FluentResults;
@@ -38,6 +39,8 @@ public class SystemApiFactory : WebApplicationFactory<Program>
     public IProfileRepository ProfileRepository { get; } = Substitute.For<IProfileRepository>();
 
     public ICatchRepository CatchRepository { get; } = Substitute.For<ICatchRepository>();
+
+    public ITripRepository TripRepository { get; } = Substitute.For<ITripRepository>();
 
     public IUserPlatformCapabilityRepository UserPlatformCapabilityRepository { get; } =
         Substitute.For<IUserPlatformCapabilityRepository>();
@@ -102,6 +105,18 @@ public class SystemApiFactory : WebApplicationFactory<Program>
         CatchRepository
             .UpdateLocationVisibilityAsync(Arg.Any<PersistCatchLocationVisibilityArgs>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok());
+        TripRepository
+            .UpsertAsync(Arg.Any<Trip>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(call.ArgAt<Trip>(0)));
+        TripRepository
+            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+        TripRepository
+            .GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+        TripRepository
+            .GetByOwnerUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<Trip>>([]));
         UserPlatformCapabilityRepository
             .HasAsync(Arg.Any<FindUserPlatformCapabilityArgs>(), Arg.Any<CancellationToken>())
             .Returns(Result.Ok(false));
@@ -212,6 +227,8 @@ public class SystemApiFactory : WebApplicationFactory<Program>
             services.AddSingleton(ProfileRepository);
             services.RemoveAll<ICatchRepository>();
             services.AddSingleton(CatchRepository);
+            services.RemoveAll<ITripRepository>();
+            services.AddSingleton(TripRepository);
             services.RemoveAll<IFishingCatalogueRepository>();
             services.AddSingleton(FishingCatalogueRepository);
             services.RemoveAll<IFishingPreferenceRepository>();

--- a/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingGet.cs
+++ b/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingGet.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.TripEndpointsTests;
+
+public class WhenTestingGet : IClassFixture<SystemApiFactory>
+{
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingGet(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequestWhenAuthorizationIsMissing()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/trips/{Guid.NewGuid():D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.TripRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNotFoundWhenTheTripIsMissing()
+    {
+        // Arrange
+        var tripId = Guid.NewGuid();
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/trips/{tripId:D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await _factory.TripRepository.Received(1).GetByIdAsync(tripId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNotFoundForAnotherAnglersTrip()
+    {
+        // Arrange
+        var tripId = Guid.NewGuid();
+        ResetRepositories();
+        _factory.TripRepository
+            .GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(new Trip
+            {
+                Id = tripId,
+                OwnerUserId = Guid.NewGuid(),
+                Status = TripStatusEnum.Active,
+                StartedOn = StartedOn
+            }));
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/trips/{tripId:D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await _factory.TripRepository.Received(1).GetByIdAsync(tripId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportServiceUnavailableWhenTheReadFails()
+    {
+        // Arrange
+        var tripId = Guid.NewGuid();
+        ResetRepositories();
+        _factory.TripRepository
+            .GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<Trip?>("Failed to save the trip."));
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/trips/{tripId:D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnABlankTripWithNoTitlePlaceOrLocation()
+    {
+        // Arrange
+        var tripId = Guid.NewGuid();
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: "trip-get-blank"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        _factory.TripRepository
+            .GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(new Trip
+            {
+                Id = tripId,
+                OwnerUserId = current!.UserId,
+                Status = TripStatusEnum.Active,
+                StartedOn = StartedOn
+            }));
+
+        // Act
+        var response = await client.GetAsync($"/api/trips/{tripId:D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var trip = await response.Content.ReadFromJsonAsync<TripViewDto>();
+        trip.Should().NotBeNull();
+        trip!.Id.Should().Be(tripId);
+        trip.OwnerUserId.Should().Be(current.UserId);
+        trip.Status.Should().Be(TripConstants.Active);
+        trip.Title.Should().BeNull();
+        trip.PlaceName.Should().BeNull();
+        trip.Location.Should().BeNull();
+        trip.EndedOn.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnACompletedTripWithItsPlaceAndLocation()
+    {
+        // Arrange
+        var tripId = Guid.NewGuid();
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: "trip-get-located"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        _factory.TripRepository
+            .GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(new Trip
+            {
+                Id = tripId,
+                OwnerUserId = current!.UserId,
+                Title = "Day with Dad",
+                PlaceName = "Lough Corrib",
+                Status = TripStatusEnum.Completed,
+                StartedOn = StartedOn,
+                EndedOn = StartedOn.AddHours(6),
+                Location = TripLocation.TryCreate(
+                    53.4419,
+                    -9.2531,
+                    8,
+                    StartedOn,
+                    LocationDefaults.DeviceGps,
+                    LocationDefaults.Private,
+                    LocationDefaults.ConsentVersion)
+            }));
+
+        // Act
+        var response = await client.GetAsync($"/api/trips/{tripId:D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var trip = await response.Content.ReadFromJsonAsync<TripViewDto>();
+        trip!.Status.Should().Be(TripConstants.Completed);
+        trip.Title.Should().Be("Day with Dad");
+        trip.PlaceName.Should().Be("Lough Corrib");
+        trip.EndedOn.Should().Be(StartedOn.AddHours(6));
+        trip.Location!.Latitude.Should().Be(53.4419);
+        trip.Location.Visibility.Should().Be(LocationDefaults.Private);
+        await _factory.TripRepository.Received(1).GetByIdAsync(tripId, Arg.Any<CancellationToken>());
+    }
+
+    private void ResetRepositories()
+    {
+        _factory.TripRepository.ClearReceivedCalls();
+        _factory.TripRepository
+            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingList.cs
+++ b/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingList.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.TripEndpointsTests;
+
+public class WhenTestingList : IClassFixture<SystemApiFactory>
+{
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingList(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequestWhenAuthorizationIsMissing()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/api/trips");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.TripRepository.DidNotReceive().GetByOwnerUserIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportServiceUnavailableWhenTheReadFails()
+    {
+        // Arrange
+        ResetRepositories();
+        _factory.TripRepository
+            .GetByOwnerUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<IReadOnlyList<Trip>>("Failed to save the trip."));
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.GetAsync("/api/trips");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnAnEmptyListWhenTheAnglerHasNoTrips()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: "trip-list-empty"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+
+        // Act
+        var response = await client.GetAsync("/api/trips");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var trips = await response.Content.ReadFromJsonAsync<IReadOnlyList<TripViewDto>>();
+        trips.Should().BeEmpty();
+        await _factory.TripRepository.Received(1).GetByOwnerUserIdAsync(
+            current!.UserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheAnglersOwnTrips()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: "trip-list-owned"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        var activeId = Guid.NewGuid();
+        var completedId = Guid.NewGuid();
+        _factory.TripRepository
+            .GetByOwnerUserIdAsync(current!.UserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<Trip>>(
+            [
+                new Trip
+                {
+                    Id = activeId,
+                    OwnerUserId = current.UserId,
+                    Status = TripStatusEnum.Active,
+                    StartedOn = StartedOn
+                },
+                new Trip
+                {
+                    Id = completedId,
+                    OwnerUserId = current.UserId,
+                    PlaceName = "Lough Corrib",
+                    Status = TripStatusEnum.Completed,
+                    StartedOn = StartedOn.AddDays(-1),
+                    EndedOn = StartedOn.AddDays(-1).AddHours(5)
+                }
+            ]));
+
+        // Act
+        var response = await client.GetAsync("/api/trips");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var trips = await response.Content.ReadFromJsonAsync<IReadOnlyList<TripViewDto>>();
+        trips.Should().HaveCount(2);
+        trips!.Single(trip => trip.Id == activeId).Status.Should().Be(TripConstants.Active);
+        var completed = trips.Single(trip => trip.Id == completedId);
+        completed.Status.Should().Be(TripConstants.Completed);
+        completed.PlaceName.Should().Be("Lough Corrib");
+        await _factory.TripRepository.Received(1).GetByOwnerUserIdAsync(
+            current.UserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    private void ResetRepositories()
+    {
+        _factory.TripRepository.ClearReceivedCalls();
+        _factory.TripRepository
+            .GetByOwnerUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<Trip>>([]));
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingUpsert.cs
@@ -1,0 +1,303 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.TripEndpointsTests;
+
+public class WhenTestingUpsert : IClassFixture<SystemApiFactory>
+{
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingUpsert(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectTheRequestWhenAuthorizationIsMissing()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/trips", NewTrip());
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.TripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnEmptyTripId()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/trips", NewTrip(tripId: Guid.Empty));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnsupportedStatus()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/trips", NewTrip(status: "Planned"));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAStartInTheFuture()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            "/api/trips",
+            NewTrip(startedOn: DateTimeOffset.UtcNow.AddDays(1)));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnInvalidLocation()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            "/api/trips",
+            NewTrip(location: Location(latitude: 200)));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportAConflictWhenAnotherTripIsAlreadyActive()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: "trip-conflict"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        _factory.TripRepository
+            .GetActiveAsync(current!.UserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(new Trip
+            {
+                Id = Guid.NewGuid(),
+                OwnerUserId = current.UserId,
+                Status = TripStatusEnum.Active,
+                StartedOn = StartedOn
+            }));
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/trips", NewTrip());
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        await _factory.TripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportServiceUnavailableWhenPersistenceFails()
+    {
+        // Arrange
+        ResetRepositories();
+        _factory.TripRepository
+            .UpsertAsync(Arg.Any<Trip>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<Trip>("Failed to save the trip."));
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/trips", NewTrip());
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task ItShouldPersistABlankActiveTrip()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: "trip-blank"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        var trip = NewTrip();
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/trips", trip);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var saved = await response.Content.ReadFromJsonAsync<TripDto>();
+        saved.Should().NotBeNull();
+        saved!.Id.Should().Be(trip.Id);
+        saved.Status.Should().Be(TripConstants.Active);
+        saved.Title.Should().BeNull();
+        saved.PlaceName.Should().BeNull();
+        saved.Location.Should().BeNull();
+        await _factory.TripRepository.Received(1).UpsertAsync(
+            Arg.Is<Trip>(item =>
+                item.Id == trip.Id
+                && item.OwnerUserId == current!.UserId
+                && item.Status == TripStatusEnum.Active
+                && item.Title == null
+                && item.PlaceName == null
+                && item.Location == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistATripWithATitlePlaceAndPrivateLocation()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: "trip-located"));
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        current.Should().NotBeNull();
+        var trip = NewTrip(
+            title: "Day with Dad",
+            placeName: "Lough Corrib",
+            location: Location());
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/trips", trip);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var saved = await response.Content.ReadFromJsonAsync<TripDto>();
+        saved!.Title.Should().Be("Day with Dad");
+        saved.PlaceName.Should().Be("Lough Corrib");
+        saved.Location!.Visibility.Should().Be(LocationDefaults.Private);
+        await _factory.TripRepository.Received(1).UpsertAsync(
+            Arg.Is<Trip>(item =>
+                item.OwnerUserId == current!.UserId
+                && item.Title == "Day with Dad"
+                && item.PlaceName == "Lough Corrib"
+                && item.Location != null
+                && item.Location.Visibility == LocationDefaults.Private
+                && item.Location.Source == LocationDefaults.DeviceGps),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFinishATrip()
+    {
+        // Arrange
+        ResetRepositories();
+        var client = _factory.CreateAuthenticatedClient(
+            TestJwt.CreateAccessToken(subject: "trip-finish"));
+        var trip = NewTrip(
+            status: TripConstants.Completed,
+            endedOn: StartedOn.AddHours(6));
+
+        // Act
+        var response = await client.PostAsJsonAsync("/api/trips", trip);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var saved = await response.Content.ReadFromJsonAsync<TripDto>();
+        saved!.Status.Should().Be(TripConstants.Completed);
+        saved.EndedOn.Should().Be(StartedOn.AddHours(6));
+        await _factory.TripRepository.DidNotReceive().GetActiveAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await _factory.TripRepository.Received(1).UpsertAsync(
+            Arg.Is<Trip>(item =>
+                item.Status == TripStatusEnum.Completed
+                && item.EndedOn == StartedOn.AddHours(6)),
+            Arg.Any<CancellationToken>());
+    }
+
+    private void ResetRepositories()
+    {
+        _factory.TripRepository.ClearReceivedCalls();
+        _factory.TripRepository
+            .GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+        _factory.TripRepository
+            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+        _factory.TripRepository
+            .UpsertAsync(Arg.Any<Trip>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(call.ArgAt<Trip>(0)));
+    }
+
+    private static TripDto NewTrip(
+        Guid? tripId = null,
+        string status = TripConstants.Active,
+        DateTimeOffset? startedOn = null,
+        DateTimeOffset? endedOn = null,
+        string? title = null,
+        string? placeName = null,
+        TripLocationDto? location = null)
+    {
+        return new TripDto(
+            tripId ?? Guid.NewGuid(),
+            status,
+            startedOn ?? StartedOn,
+            endedOn,
+            location)
+        {
+            Title = title,
+            PlaceName = placeName
+        };
+    }
+
+    private static TripLocationDto Location(double latitude = 53.4419, double longitude = -9.2531)
+    {
+        return new TripLocationDto(
+            latitude,
+            longitude,
+            8,
+            StartedOn,
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Commands/UpsertTripCommandValidatorTests/BaseUpsertTripCommandValidatorTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Commands/UpsertTripCommandValidatorTests/BaseUpsertTripCommandValidatorTest.cs
@@ -1,0 +1,57 @@
+using FishingLogBook.Application.Trips.Commands;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Application.Tests.Trips.Commands.UpsertTripCommandValidatorTests;
+
+public class BaseUpsertTripCommandValidatorTest
+{
+    protected static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    protected readonly UpsertTripCommandValidator Sut = new();
+
+    protected static UpsertTripCommand Command(
+        Guid? userId = null,
+        Guid? tripId = null,
+        string status = TripConstants.Active,
+        DateTimeOffset? startedOn = null,
+        DateTimeOffset? endedOn = null,
+        string? title = null,
+        string? placeName = null,
+        TripLocationDto? location = null)
+    {
+        return new UpsertTripCommand
+        {
+            UserId = userId ?? UserId,
+            Trip = new TripDto(
+                tripId ?? TripId,
+                status,
+                startedOn ?? StartedOn,
+                endedOn,
+                location)
+            {
+                Title = title,
+                PlaceName = placeName
+            }
+        };
+    }
+
+    protected static TripLocationDto Location(
+        double latitude = 53.4419,
+        double longitude = -9.2531,
+        string? visibility = null,
+        string? source = null,
+        string? consentVersion = null)
+    {
+        return new TripLocationDto(
+            latitude,
+            longitude,
+            8,
+            StartedOn,
+            source ?? LocationDefaults.DeviceGps,
+            visibility ?? LocationDefaults.Private,
+            consentVersion ?? LocationDefaults.ConsentVersion);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Commands/UpsertTripCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Commands/UpsertTripCommandValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,299 @@
+using FishingLogBook.Shared.Constants;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Trips.Commands.UpsertTripCommandValidatorTests;
+
+public class WhenTestingValidate : BaseUpsertTripCommandValidatorTest
+{
+    [Fact]
+    public void ItShouldRejectAnEmptyOwner()
+    {
+        // Arrange
+        var command = Command(userId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.UserId);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnEmptyTripId()
+    {
+        // Arrange
+        var command = Command(tripId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.Id);
+    }
+
+    [Theory]
+    [InlineData("Planned")]
+    [InlineData("Cancelled")]
+    [InlineData("active")]
+    [InlineData("")]
+    public void ItShouldRejectAnUnsupportedStatus(string status)
+    {
+        // Arrange
+        var command = Command(status: status);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.Status);
+    }
+
+    [Fact]
+    public void ItShouldRejectAMissingStart()
+    {
+        // Arrange
+        var command = Command(startedOn: default(DateTimeOffset));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.StartedOn);
+    }
+
+    [Fact]
+    public void ItShouldRejectAStartInTheFuture()
+    {
+        // Arrange
+        var command = Command(startedOn: DateTimeOffset.UtcNow.AddDays(1));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.StartedOn);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnActiveTripWithAnEnd()
+    {
+        // Arrange
+        var command = Command(endedOn: StartedOn.AddHours(2));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnEndBeforeTheStart()
+    {
+        // Arrange
+        var command = Command(
+            status: TripConstants.Completed,
+            endedOn: StartedOn.AddSeconds(-1));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnEndInTheFuture()
+    {
+        // Arrange
+        var command = Command(
+            status: TripConstants.Completed,
+            endedOn: DateTimeOffset.UtcNow.AddDays(1));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip);
+    }
+
+    [Fact]
+    public void ItShouldRejectATitleOverTheLimit()
+    {
+        // Arrange
+        var command = Command(title: new string('a', TripConstants.MaxTitleLength + 1));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.Title);
+    }
+
+    [Fact]
+    public void ItShouldRejectAPlaceNameOverTheLimit()
+    {
+        // Arrange
+        var command = Command(placeName: new string('a', TripConstants.MaxPlaceNameLength + 1));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.PlaceName);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnUnsupportedLocationVisibility()
+    {
+        // Arrange
+        var command = Command(location: Location(visibility: "Everyone"));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.Location!.Visibility);
+    }
+
+    [Theory]
+    [InlineData(91, 0)]
+    [InlineData(-91, 0)]
+    public void ItShouldRejectALatitudeOutsideTheAllowedRange(double latitude, double longitude)
+    {
+        // Arrange
+        var command = Command(location: Location(latitude, longitude));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.Location!.Latitude);
+    }
+
+    [Theory]
+    [InlineData(0, 181)]
+    [InlineData(0, -181)]
+    public void ItShouldRejectALongitudeOutsideTheAllowedRange(double latitude, double longitude)
+    {
+        // Arrange
+        var command = Command(location: Location(latitude, longitude));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.Location!.Longitude);
+    }
+
+    [Fact]
+    public void ItShouldRejectALocationWithNoSource()
+    {
+        // Arrange
+        var command = Command(location: Location(source: string.Empty));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.Location!.Source);
+    }
+
+    [Fact]
+    public void ItShouldRejectALocationWithNoConsentVersion()
+    {
+        // Arrange
+        var command = Command(location: Location(consentVersion: string.Empty));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Trip.Location!.ConsentVersion);
+    }
+
+    [Fact]
+    public void ItShouldAcceptATitleAtTheLimit()
+    {
+        // Arrange
+        var command = Command(title: new string('a', TripConstants.MaxTitleLength));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ItShouldAcceptAPlaceNameAtTheLimit()
+    {
+        // Arrange
+        var command = Command(placeName: new string('a', TripConstants.MaxPlaceNameLength));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData("Private")]
+    [InlineData("Approximate")]
+    [InlineData("FishingVenueOnly")]
+    [InlineData("Public")]
+    public void ItShouldAcceptEverySupportedLocationVisibility(string visibility)
+    {
+        // Arrange
+        var command = Command(location: Location(visibility: visibility));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ItShouldAcceptAHistoricalCompletedTrip()
+    {
+        // Arrange
+        var command = Command(
+            status: TripConstants.Completed,
+            startedOn: DateTimeOffset.Parse("2019-06-14T05:32:00Z"),
+            endedOn: DateTimeOffset.Parse("2019-06-14T16:22:00Z"));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ItShouldAcceptACompletedTripWithNoEnd()
+    {
+        // Arrange
+        var command = Command(status: TripConstants.Completed);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ItShouldAcceptABlankActiveTrip()
+    {
+        // Arrange
+        var command = Command();
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripServiceTests/BaseTripServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripServiceTests/BaseTripServiceTest.cs
@@ -1,0 +1,117 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.Trips.Services;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripServiceTests;
+
+public class BaseTripServiceTest
+{
+    protected static readonly Guid CurrentUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    protected readonly ITripRepository MockTripRepository = Substitute.For<ITripRepository>();
+    protected readonly ICurrentUser MockCurrentUser = Substitute.For<ICurrentUser>();
+    protected readonly TripService Sut;
+
+    protected BaseTripServiceTest()
+    {
+        MockCurrentUser.IsResolved.Returns(true);
+        MockCurrentUser.UserId.Returns(CurrentUserId);
+        MockTripRepository.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+        MockTripRepository.UpsertAsync(Arg.Any<Trip>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(Persisted(call.ArgAt<Trip>(0))));
+        Sut = new TripService(MockTripRepository, MockCurrentUser, TestMapper.Create());
+    }
+
+    protected static UpsertTripArgs UpsertArgs(
+        Guid? userId = null,
+        Guid? tripId = null,
+        string status = TripConstants.Active,
+        DateTimeOffset? startedOn = null,
+        DateTimeOffset? endedOn = null,
+        string? title = null,
+        string? placeName = null,
+        TripLocationDto? location = null)
+    {
+        return new UpsertTripArgs
+        {
+            UserId = userId ?? CurrentUserId,
+            Trip = new TripDto(
+                tripId ?? TripId,
+                status,
+                startedOn ?? StartedOn,
+                endedOn,
+                location)
+            {
+                Title = title,
+                PlaceName = placeName
+            }
+        };
+    }
+
+    protected static TripLocationDto PrivateLocation(
+        double latitude = 53.4419,
+        double longitude = -9.2531,
+        string? visibility = null)
+    {
+        return new TripLocationDto(
+            latitude,
+            longitude,
+            8,
+            StartedOn,
+            LocationDefaults.DeviceGps,
+            visibility ?? LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+    }
+
+    protected static Trip StoredTrip(
+        Guid? ownerUserId = null,
+        Guid? tripId = null,
+        TripStatusEnum status = TripStatusEnum.Active,
+        DateTimeOffset? endedOn = null,
+        string? title = null,
+        string? placeName = null,
+        TripLocation? location = null)
+    {
+        return new Trip
+        {
+            Id = tripId ?? TripId,
+            OwnerUserId = ownerUserId ?? CurrentUserId,
+            Title = title,
+            PlaceName = placeName,
+            Status = status,
+            StartedOn = StartedOn,
+            EndedOn = endedOn,
+            Location = location,
+            CreatedOn = StartedOn,
+            UpdatedOn = StartedOn
+        };
+    }
+
+    private static Trip Persisted(Trip trip)
+    {
+        return new Trip
+        {
+            Id = trip.Id,
+            OwnerUserId = trip.OwnerUserId,
+            Title = trip.Title,
+            PlaceName = trip.PlaceName,
+            Status = trip.Status,
+            StartedOn = trip.StartedOn,
+            EndedOn = trip.EndedOn,
+            Location = trip.Location,
+            CreatedOn = StartedOn,
+            UpdatedOn = StartedOn
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripServiceTests/WhenTestingGetMy.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripServiceTests/WhenTestingGetMy.cs
@@ -1,0 +1,93 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripServiceTests;
+
+public class WhenTestingGetMy : BaseTripServiceTest
+{
+    [Fact]
+    public async Task ItShouldReturnAnEmptyListWhenTheAnglerHasNoTrips()
+    {
+        // Arrange
+        MockTripRepository.GetByOwnerUserIdAsync(CurrentUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<Trip>>([]));
+
+        // Act
+        var result = await Sut.GetMyAsync(
+            new GetMyTripsArgs { UserId = CurrentUserId },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRequestOnlyTheGivenOwnersTrips()
+    {
+        // Arrange
+        MockTripRepository.GetByOwnerUserIdAsync(CurrentUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<Trip>>([StoredTrip()]));
+
+        // Act
+        var result = await Sut.GetMyAsync(
+            new GetMyTripsArgs { UserId = CurrentUserId },
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle();
+        result.Value[0].OwnerUserId.Should().Be(CurrentUserId);
+        await MockTripRepository.Received(1).GetByOwnerUserIdAsync(
+            CurrentUserId,
+            Arg.Any<CancellationToken>());
+        await MockTripRepository.DidNotReceive().GetByOwnerUserIdAsync(
+            OtherUserId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldMapEveryTripIncludingCompletedOnes()
+    {
+        // Arrange
+        var completedId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        MockTripRepository.GetByOwnerUserIdAsync(CurrentUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<Trip>>(
+            [
+                StoredTrip(),
+                StoredTrip(
+                    tripId: completedId,
+                    status: TripStatusEnum.Completed,
+                    endedOn: StartedOn.AddHours(4))
+            ]));
+
+        // Act
+        var result = await Sut.GetMyAsync(
+            new GetMyTripsArgs { UserId = CurrentUserId },
+            CancellationToken.None);
+
+        // Assert
+        result.Value.Should().HaveCount(2);
+        result.Value.Select(trip => trip.Id).Should().Contain([TripId, completedId]);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheRepositoryFailure()
+    {
+        // Arrange
+        MockTripRepository.GetByOwnerUserIdAsync(CurrentUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<IReadOnlyList<Trip>>("Failed to save the trip."));
+
+        // Act
+        var result = await Sut.GetMyAsync(
+            new GetMyTripsArgs { UserId = CurrentUserId },
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripServiceTests/WhenTestingGetView.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripServiceTests/WhenTestingGetView.cs
@@ -1,0 +1,117 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Capabilities.Errors;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripServiceTests;
+
+public class WhenTestingGetView : BaseTripServiceTest
+{
+    [Fact]
+    public async Task ItShouldRejectAnUnresolvedCaller()
+    {
+        // Arrange
+        MockCurrentUser.IsResolved.Returns(false);
+
+        // Act
+        var result = await Sut.GetViewAsync(new GetTripArgs { TripId = TripId }, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<CurrentUserUnresolvedError>();
+        await MockTripRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportNotFoundWhenTheTripDoesNotExist()
+    {
+        // Arrange
+        MockTripRepository.GetByIdAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+
+        // Act
+        var result = await Sut.GetViewAsync(new GetTripArgs { TripId = TripId }, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNotFoundError>();
+    }
+
+    [Fact]
+    public async Task ItShouldReportNotFoundForAnotherAnglersTrip()
+    {
+        // Arrange
+        MockTripRepository.GetByIdAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(StoredTrip(ownerUserId: OtherUserId)));
+
+        // Act
+        var result = await Sut.GetViewAsync(new GetTripArgs { TripId = TripId }, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNotFoundError>();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheOwnersTripWithItsLocation()
+    {
+        // Arrange
+        var location = TripLocation.TryCreate(
+            53.4419,
+            -9.2531,
+            8,
+            StartedOn,
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+        MockTripRepository.GetByIdAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(StoredTrip(
+                status: TripStatusEnum.Completed,
+                endedOn: StartedOn.AddHours(6),
+                title: "Day with Dad",
+                placeName: "Lough Corrib",
+                location: location)));
+
+        // Act
+        var result = await Sut.GetViewAsync(new GetTripArgs { TripId = TripId }, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(TripId);
+        result.Value.OwnerUserId.Should().Be(CurrentUserId);
+        result.Value.Status.Should().Be(TripConstants.Completed);
+        result.Value.Title.Should().Be("Day with Dad");
+        result.Value.PlaceName.Should().Be("Lough Corrib");
+        result.Value.EndedOn.Should().Be(StartedOn.AddHours(6));
+        result.Value.Location!.Latitude.Should().Be(53.4419);
+        result.Value.Location.Visibility.Should().Be(LocationDefaults.Private);
+        await MockTripRepository.Received(1).GetByIdAsync(TripId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnABlankTripWithNoTitlePlaceOrLocation()
+    {
+        // Arrange
+        MockTripRepository.GetByIdAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(StoredTrip()));
+
+        // Act
+        var result = await Sut.GetViewAsync(new GetTripArgs { TripId = TripId }, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().BeNull();
+        result.Value.PlaceName.Should().BeNull();
+        result.Value.Location.Should().BeNull();
+        result.Value.EndedOn.Should().BeNull();
+        result.Value.Status.Should().Be(TripConstants.Active);
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripServiceTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripServiceTests/WhenTestingUpsert.cs
@@ -1,0 +1,261 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripServiceTests;
+
+public class WhenTestingUpsert : BaseTripServiceTest
+{
+    [Fact]
+    public async Task ItShouldRejectAnUnknownStatus()
+    {
+        // Arrange
+        var args = UpsertArgs(status: "Abandoned");
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripLifecycleInvalidError>();
+        await MockTripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnActiveTripThatAlreadyEnded()
+    {
+        // Arrange
+        var args = UpsertArgs(endedOn: StartedOn.AddHours(3));
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripLifecycleInvalidError>();
+        await MockTripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnEndBeforeTheStart()
+    {
+        // Arrange
+        var args = UpsertArgs(
+            status: TripConstants.Completed,
+            endedOn: StartedOn.AddHours(-1));
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripLifecycleInvalidError>();
+        await MockTripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnInvalidLocation()
+    {
+        // Arrange
+        var args = UpsertArgs(location: PrivateLocation(latitude: 200));
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripLocationInvalidError>();
+        await MockTripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnsupportedLocationVisibility()
+    {
+        // Arrange
+        var args = UpsertArgs(location: PrivateLocation(visibility: "Everyone"));
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripLocationInvalidError>();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectASecondActiveTripForTheSameOwner()
+    {
+        // Arrange
+        MockTripRepository.GetActiveAsync(CurrentUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(StoredTrip(
+                tripId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))));
+        var args = UpsertArgs();
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripAlreadyActiveError>();
+        await MockTripRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Trip>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAllowReplayingTheSameActiveTrip()
+    {
+        // Arrange
+        MockTripRepository.GetActiveAsync(CurrentUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(StoredTrip()));
+        var args = UpsertArgs();
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(TripId);
+        await MockTripRepository.Received(1).UpsertAsync(
+            Arg.Is<Trip>(trip => trip.Id == TripId && trip.Status == TripStatusEnum.Active),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotCheckForAnActiveTripWhenCompletingOne()
+    {
+        // Arrange
+        var args = UpsertArgs(
+            status: TripConstants.Completed,
+            endedOn: StartedOn.AddHours(6));
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockTripRepository.DidNotReceive().GetActiveAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistATripWithNoTitleOrPlaceOrLocation()
+    {
+        // Arrange
+        var args = UpsertArgs();
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().BeNull();
+        result.Value.PlaceName.Should().BeNull();
+        result.Value.Location.Should().BeNull();
+        await MockTripRepository.Received(1).UpsertAsync(
+            Arg.Is<Trip>(trip =>
+                trip.Title == null
+                && trip.PlaceName == null
+                && trip.Location == null
+                && trip.OwnerUserId == CurrentUserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldTrimTitleAndPlaceToNullWhenBlank()
+    {
+        // Arrange
+        var args = UpsertArgs(title: "   ", placeName: "\t");
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockTripRepository.Received(1).UpsertAsync(
+            Arg.Is<Trip>(trip => trip.Title == null && trip.PlaceName == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistAPlaceNameWithoutCoordinates()
+    {
+        // Arrange
+        var args = UpsertArgs(placeName: "  Lough Corrib  ");
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PlaceName.Should().Be("Lough Corrib");
+        result.Value.Location.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldPersistAPrivateLocationWithItsProvenance()
+    {
+        // Arrange
+        var args = UpsertArgs(title: "Day with Dad", location: PrivateLocation());
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().Be("Day with Dad");
+        result.Value.Location.Should().NotBeNull();
+        result.Value.Location!.Latitude.Should().Be(53.4419);
+        result.Value.Location.Longitude.Should().Be(-9.2531);
+        result.Value.Location.AccuracyMetres.Should().Be(8);
+        result.Value.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        result.Value.Location.Visibility.Should().Be(LocationDefaults.Private);
+        result.Value.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+    }
+
+    [Fact]
+    public async Task ItShouldTakeOwnershipFromTheAuthenticatedCallerRatherThanThePayload()
+    {
+        // Arrange
+        var args = UpsertArgs(userId: OtherUserId);
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockTripRepository.Received(1).UpsertAsync(
+            Arg.Is<Trip>(trip => trip.OwnerUserId == OtherUserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheRepositoryFailure()
+    {
+        // Arrange
+        MockTripRepository.UpsertAsync(Arg.Any<Trip>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<Trip>(new TripAlreadyActiveError()));
+        var args = UpsertArgs();
+
+        // Act
+        var result = await Sut.UpsertAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripAlreadyActiveError>();
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripRepositoryTests/BaseTripRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripRepositoryTests/BaseTripRepositoryTest.cs
@@ -1,0 +1,84 @@
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Infrastructure.Persistence;
+using FishingLogBook.Infrastructure.Persistence.Repositories;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Tests.Common.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Repositories.TripRepositoryTests;
+
+[Collection(PostgresCollection.Name)]
+public abstract class BaseTripRepositoryTest
+{
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    protected readonly TripRepository Sut;
+    protected readonly RecordingLogger<TripRepository> Logger = new();
+    protected readonly UserIdentityRepository Users;
+    protected readonly NpgsqlConnectionFactory ConnectionFactory;
+
+    protected BaseTripRepositoryTest(PostgresFixture fixture)
+    {
+        ConnectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
+        Sut = new TripRepository(ConnectionFactory, Logger, TestMapper.Create());
+        Users = new UserIdentityRepository(ConnectionFactory, NullLogger<UserIdentityRepository>.Instance);
+    }
+
+    protected async Task<Guid> CreateUserAsync()
+    {
+        var user = new UserBuilder()
+            .WithEmail($"{Guid.NewGuid():N}@example.test")
+            .Build();
+        var identity = new UserIdentityBuilder()
+            .ForUser(user)
+            .Build();
+        var created = await Users.CreateAsync(user, identity, CancellationToken.None);
+        if (created.IsFailed)
+        {
+            throw new InvalidOperationException(created.Errors[0].Message);
+        }
+
+        return created.Value;
+    }
+
+    protected static Trip NewTrip(
+        Guid ownerUserId,
+        Guid? tripId = null,
+        TripStatusEnum status = TripStatusEnum.Active,
+        DateTimeOffset? startedOn = null,
+        DateTimeOffset? endedOn = null,
+        string? title = null,
+        string? placeName = null,
+        TripLocation? location = null)
+    {
+        return new Trip
+        {
+            Id = tripId ?? Guid.NewGuid(),
+            OwnerUserId = ownerUserId,
+            Title = title,
+            PlaceName = placeName,
+            Status = status,
+            StartedOn = startedOn ?? StartedOn,
+            EndedOn = endedOn,
+            Location = location
+        };
+    }
+
+    protected static TripLocation PrivateLocation(
+        double latitude = 53.4419,
+        double longitude = -9.2531,
+        double? accuracyMetres = 8)
+    {
+        return TripLocation.TryCreate(
+            latitude,
+            longitude,
+            accuracyMetres,
+            StartedOn,
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion)
+            ?? throw new InvalidOperationException("The test location was not valid.");
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripRepositoryTests/WhenTestingGetActive.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripRepositoryTests/WhenTestingGetActive.cs
@@ -1,0 +1,103 @@
+using AwesomeAssertions;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Repositories.TripRepositoryTests;
+
+public class WhenTestingGetActive : BaseTripRepositoryTest
+{
+    public WhenTestingGetActive(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNothingWhenTheAnglerHasNoTrips()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+
+        // Act
+        var result = await Sut.GetActiveAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNothingWhenEveryTripIsCompleted()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        await Sut.UpsertAsync(
+            NewTrip(
+                ownerUserId,
+                status: TripStatusEnum.Completed,
+                endedOn: StartedOn.AddHours(3)),
+            CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetActiveAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnAnotherAnglersActiveTrip()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        await Sut.UpsertAsync(NewTrip(otherUserId), CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetActiveAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheActiveTripWithItsLocation()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(ownerUserId, placeName: "Lough Corrib", location: PrivateLocation());
+        await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetActiveAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Id.Should().Be(trip.Id);
+        result.Value.Status.Should().Be(TripStatusEnum.Active);
+        result.Value.PlaceName.Should().Be("Lough Corrib");
+        result.Value.Location!.Latitude.Should().Be(53.4419);
+    }
+
+    [Fact]
+    public async Task ItShouldIgnoreCompletedTripsWhenAnActiveOneExists()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var completed = NewTrip(
+            ownerUserId,
+            status: TripStatusEnum.Completed,
+            endedOn: StartedOn.AddHours(2));
+        await Sut.UpsertAsync(completed, CancellationToken.None);
+        var active = NewTrip(ownerUserId, startedOn: StartedOn.AddDays(1));
+        await Sut.UpsertAsync(active, CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetActiveAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.Value!.Id.Should().Be(active.Id);
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripRepositoryTests/WhenTestingGetByOwnerUserId.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripRepositoryTests/WhenTestingGetByOwnerUserId.cs
@@ -1,0 +1,97 @@
+using AwesomeAssertions;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Repositories.TripRepositoryTests;
+
+public class WhenTestingGetByOwnerUserId : BaseTripRepositoryTest
+{
+    public WhenTestingGetByOwnerUserId(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldReturnAnEmptyListWhenTheAnglerHasNoTrips()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+
+        // Act
+        var result = await Sut.GetByOwnerUserIdAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnAnotherAnglersTrip()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        var owned = NewTrip(ownerUserId, placeName: "Lough Corrib");
+        var foreign = NewTrip(otherUserId, placeName: "Lough Mask");
+        await Sut.UpsertAsync(owned, CancellationToken.None);
+        await Sut.UpsertAsync(foreign, CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetByOwnerUserIdAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.Value.Should().ContainSingle();
+        result.Value[0].Id.Should().Be(owned.Id);
+        result.Value[0].PlaceName.Should().Be("Lough Corrib");
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNewestTripsFirst()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var older = NewTrip(
+            ownerUserId,
+            status: TripStatusEnum.Completed,
+            startedOn: StartedOn.AddDays(-2),
+            endedOn: StartedOn.AddDays(-2).AddHours(4));
+        var newer = NewTrip(
+            ownerUserId,
+            status: TripStatusEnum.Completed,
+            startedOn: StartedOn,
+            endedOn: StartedOn.AddHours(4));
+        await Sut.UpsertAsync(older, CancellationToken.None);
+        await Sut.UpsertAsync(newer, CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetByOwnerUserIdAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.Value.Should().HaveCount(2);
+        result.Value[0].Id.Should().Be(newer.Id);
+        result.Value[1].Id.Should().Be(older.Id);
+    }
+
+    [Fact]
+    public async Task ItShouldReturnActiveAndCompletedTrips()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var completed = NewTrip(
+            ownerUserId,
+            status: TripStatusEnum.Completed,
+            startedOn: StartedOn.AddDays(-1),
+            endedOn: StartedOn.AddDays(-1).AddHours(3));
+        var active = NewTrip(ownerUserId);
+        await Sut.UpsertAsync(completed, CancellationToken.None);
+        await Sut.UpsertAsync(active, CancellationToken.None);
+
+        // Act
+        var result = await Sut.GetByOwnerUserIdAsync(ownerUserId, CancellationToken.None);
+
+        // Assert
+        result.Value.Select(trip => trip.Status)
+            .Should()
+            .Contain([TripStatusEnum.Active, TripStatusEnum.Completed]);
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripRepositoryTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripRepositoryTests/WhenTestingUpsert.cs
@@ -1,0 +1,288 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Repositories.TripRepositoryTests;
+
+public class WhenTestingUpsert : BaseTripRepositoryTest
+{
+    public WhenTestingUpsert(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldRejectATripWhoseOwnerDoesNotExist()
+    {
+        // Arrange
+        var trip = NewTrip(Guid.NewGuid());
+
+        // Act
+        var result = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        Logger.Records.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectASecondActiveTripForTheSameOwner()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var first = await Sut.UpsertAsync(NewTrip(ownerUserId), CancellationToken.None);
+        first.IsSuccess.Should().BeTrue();
+
+        // Act
+        var second = await Sut.UpsertAsync(NewTrip(ownerUserId), CancellationToken.None);
+
+        // Assert
+        second.IsFailed.Should().BeTrue();
+        second.Errors[0].Should().BeOfType<TripAlreadyActiveError>();
+    }
+
+    [Fact]
+    public async Task ItShouldAllowAnActiveTripForEachOwner()
+    {
+        // Arrange
+        var firstOwner = await CreateUserAsync();
+        var secondOwner = await CreateUserAsync();
+
+        // Act
+        var first = await Sut.UpsertAsync(NewTrip(firstOwner), CancellationToken.None);
+        var second = await Sut.UpsertAsync(NewTrip(secondOwner), CancellationToken.None);
+
+        // Assert
+        first.IsSuccess.Should().BeTrue();
+        second.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldAllowANewActiveTripOnceTheEarlierOneIsCompleted()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var active = NewTrip(ownerUserId);
+        await Sut.UpsertAsync(active, CancellationToken.None);
+        var completed = NewTrip(
+            ownerUserId,
+            tripId: active.Id,
+            status: TripStatusEnum.Completed,
+            endedOn: StartedOn.AddHours(6));
+        await Sut.UpsertAsync(completed, CancellationToken.None);
+
+        // Act
+        var next = await Sut.UpsertAsync(NewTrip(ownerUserId), CancellationToken.None);
+
+        // Assert
+        next.IsSuccess.Should().BeTrue();
+        next.Value.Status.Should().Be(TripStatusEnum.Active);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAChangeOfOwner()
+    {
+        // Arrange
+        var firstOwner = await CreateUserAsync();
+        var secondOwner = await CreateUserAsync();
+        var trip = NewTrip(firstOwner);
+        await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Act
+        var result = await Sut.UpsertAsync(
+            NewTrip(secondOwner, tripId: trip.Id),
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripOwnershipConflictError>();
+        var stored = await Sut.GetByIdAsync(trip.Id, CancellationToken.None);
+        stored.Value!.OwnerUserId.Should().Be(firstOwner);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnEndBeforeTheStart()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(
+            ownerUserId,
+            status: TripStatusEnum.Completed,
+            endedOn: StartedOn.AddHours(-1));
+
+        // Act
+        var result = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        Logger.Records.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldPersistABlankTripWithNoTitlePlaceOrLocation()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(ownerUserId);
+
+        // Act
+        var result = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Title.Should().BeNull();
+        result.Value.PlaceName.Should().BeNull();
+        result.Value.Location.Should().BeNull();
+        result.Value.EndedOn.Should().BeNull();
+        result.Value.Status.Should().Be(TripStatusEnum.Active);
+        result.Value.CreatedOn.Should().NotBe(default);
+        result.Value.UpdatedOn.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task ItShouldPersistAPlaceNameWithoutCoordinates()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(ownerUserId, placeName: "Lough Corrib");
+
+        // Act
+        var result = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PlaceName.Should().Be("Lough Corrib");
+        result.Value.Location.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldPersistTheLocationAndItsProvenance()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(
+            ownerUserId,
+            title: "Day with Dad",
+            placeName: "Lough Corrib",
+            location: PrivateLocation());
+
+        // Act
+        var result = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Location.Should().NotBeNull();
+        result.Value.Location!.Latitude.Should().Be(53.4419);
+        result.Value.Location.Longitude.Should().Be(-9.2531);
+        result.Value.Location.AccuracyMetres.Should().Be(8);
+        result.Value.Location.CapturedOn.Should().Be(StartedOn);
+        result.Value.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        result.Value.Location.Visibility.Should().Be(LocationDefaults.Private);
+        result.Value.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+    }
+
+    [Fact]
+    public async Task ItShouldClearTheLocationWhenUpsertedWithoutOne()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(ownerUserId, location: PrivateLocation());
+        await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Act
+        var result = await Sut.UpsertAsync(
+            NewTrip(ownerUserId, tripId: trip.Id),
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Location.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldFinishATripWithoutCreatingAnother()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(ownerUserId);
+        await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Act
+        var result = await Sut.UpsertAsync(
+            NewTrip(
+                ownerUserId,
+                tripId: trip.Id,
+                status: TripStatusEnum.Completed,
+                endedOn: StartedOn.AddHours(6)),
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(trip.Id);
+        result.Value.Status.Should().Be(TripStatusEnum.Completed);
+        result.Value.EndedOn.Should().Be(StartedOn.AddHours(6));
+        var all = await Sut.GetByOwnerUserIdAsync(ownerUserId, CancellationToken.None);
+        all.Value.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ItShouldBeIdempotentWhenTheSamePayloadIsReplayed()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(ownerUserId, title: "Day with Dad", location: PrivateLocation());
+        var first = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Act
+        var second = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Assert
+        second.IsSuccess.Should().BeTrue();
+        second.Value.Id.Should().Be(first.Value.Id);
+        second.Value.Title.Should().Be(first.Value.Title);
+        second.Value.StartedOn.Should().Be(first.Value.StartedOn);
+        second.Value.Location!.Latitude.Should().Be(first.Value.Location!.Latitude);
+        second.Value.CreatedOn.Should().Be(first.Value.CreatedOn);
+        var all = await Sut.GetByOwnerUserIdAsync(ownerUserId, CancellationToken.None);
+        all.Value.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ItShouldPersistAHistoricalCompletedTrip()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var startedOn = DateTimeOffset.Parse("2019-06-14T05:32:00Z");
+        var trip = NewTrip(
+            ownerUserId,
+            status: TripStatusEnum.Completed,
+            startedOn: startedOn,
+            endedOn: startedOn.AddHours(10));
+
+        // Act
+        var result = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.StartedOn.Should().Be(startedOn);
+        result.Value.EndedOn.Should().Be(startedOn.AddHours(10));
+    }
+
+    [Fact]
+    public async Task ItShouldPersistACompletedTripWithNoEnd()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var trip = NewTrip(ownerUserId, status: TripStatusEnum.Completed);
+
+        // Act
+        var result = await Sut.UpsertAsync(trip, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(TripStatusEnum.Completed);
+        result.Value.EndedOn.Should().BeNull();
+    }
+}


### PR DESCRIPTION
Closes #172
Part of #108

First Trips slice. Architecture/product baseline: [#108 — Agreed V1 implementation baseline](https://github.com/kingkeamo/fishing-logbook/issues/108#issuecomment-5428632438).

Deliberately server-only — no UI, no IndexedDB, no synchroniser — so it can be reviewed purely as the domain and schema decision, which is the part that is expensive to change later.

## Domain

```
Trip                          TripLocation (value object)
  Id            Guid            Latitude        double
  OwnerUserId   Guid            Longitude       double
  Title         string?         AccuracyMetres  double?
  PlaceName     string?         CapturedOn      DateTimeOffset
  Status        TripStatusEnum  Source          string
  StartedOn     DateTimeOffset  Visibility      string
  EndedOn       DateTimeOffset? ConsentVersion  string
  Location      TripLocation?
  CreatedOn     DateTimeOffset  + TryCreate(...) validating factory
  UpdatedOn     DateTimeOffset
```

`TripStatusEnum { Active, Completed }`. `Trip.HasCoherentLifecycle()` holds the invariants: a start is required, an end cannot precede it, and an Active trip cannot carry an end.

## Location shape, and why

Location is V1 per #108, with **three concepts kept separate so a searchable named place can arrive later without replacing this schema**:

| Concept | V1 | Later |
|---|---|---|
| Exact coordinates | `TripLocation`, optional, **private by default**, with accuracy, capture time, source and consent version | unchanged |
| Display place | `PlaceName`, a distinct nullable column — "Lough Corrib" | populated from place search |
| Venue / Fishery | not implemented | nullable `VenueId` beside `PlaceName` |

A **title describes the day** ("Day with Dad") and is never a substitute for where it happened.

`TripLocation` is its own type rather than a reuse of `CatchLocation`, because that class belongs to the Catch aggregate and relocating it would mean editing Catch mapping, SQL and tests inside a slice that must leave Catch alone. Only the *shape* is duplicated — the privacy rules stay single-sourced through `LocationDefaults.IsKnownVisibility` and `CatchLocationConstants`, so the visibility allow-list has one definition.

**A catch does not inherit trip coordinates.** Nothing here touches catch location or provenance.

## Schema

One additive script, `01_Tables/202608261200_172_CreateTrip.sql`:

- `PkTrip`, `FkTripOwnerUser → "User"`, `IxTripOwnerUserId`
- **`UxTripOwnerActive`** — partial unique index on `("OwnerUserId") WHERE "Status" = 'Active'`
- `Trip_Status_Allowed`, `Trip_Ended_After_Started`, `Trip_Active_Has_No_End`
- `Trip_Location_Coherent` and `Trip_LocationVisibility_Allowed`, mirroring the Catch constraints

Location columns reuse the `"Catch"` column names so the convention is obvious. Nothing altered, nothing dropped, no backfill.

## API

`POST /api/trips` (upsert) · `GET /api/trips` · `GET /api/trips/{tripId:guid}`

Mirrors `CatchEndpoints`, including the POST-as-upsert convention — the repository has no PUT/PATCH idiom for aggregates, so inventing one would have been inconsistent. Errors map to 400 / 401 / 404 / **409** / 503.

## One active trip per owner

Enforced in three places, each doing a different job:

1. the partial unique index — cannot be bypassed;
2. the service, before it writes, returning `TripAlreadyActiveError`;
3. the endpoint, mapping that to **409**.

The repository also classifies a unique violation into the same typed error, so a race that slips past the service check surfaces as a conflict rather than a 503.

## Idempotency

`INSERT … ON CONFLICT ("Id") DO UPDATE` inside a transaction, keyed on the client-supplied GUID. Replaying an identical payload returns the same trip, preserves `CreatedOn`, and creates no second row. Re-upserting the *same* active trip is allowed; a *different* one is rejected — which is what makes a replayed synchronisation safe in T4.

A trip may also be created **directly as Completed with historical timestamps**, so retrospective trips stay possible for #150.

## Blank trips

A trip with no catches, photographs or notes is valid. The Catch rule requiring at least one photograph is **deliberately not inherited** — it is enforced in three places for catches and none of them apply here.

## Requirements

`docs/Requirements.md` gained **§51 Fishing Trips** — the solo-trip section the investigation found missing (the word "Trip" previously appeared only inside §25–27 on *guided* trips). §23–§28 were **not** renumbered because #38/#39 reference those numbers; only the trailing "Next Document" moved to §52, and nothing references it.

## Out of scope

`Catch.TripId` (T5 — the foundational migration did not need it) · local store and IndexedDB v5 (T2) · synchroniser (T4) · UI and active-trip banner (T3) · photographs (T6) · notes (T7) · timeline (T8) · Plan Trip, place search, reverse geocoding, participants, video.

## Tests

76 new:

| Layer | Count | Proves |
|---|---|---|
| Application service | 20 | lifecycle rejections, active-trip rejection, replay of the same active trip, owner from caller not payload, trimming, blank trip, owner isolation |
| Validator | 33 | every status, both length limits at limit and limit+1, all four visibilities, coordinate bounds, historical and no-end acceptance |
| Repository (**real PostgreSQL**) | 23 | the partial unique index actually rejecting a second active trip, both check constraints, ownership conflict, location round-trip including clearing it, idempotent replay creating no duplicate, newest-first ordering, owner isolation |
| API (real mediator chain) | 20 | unauthenticated, validation failure, not found, another angler's trip as 404, **409** conflict, 503, success bodies with `Arg.Is<Trip>` on what crossed the boundary |

Full validation after self-review fixes: `dotnet format` clean · `dotnet build` clean · **1,724 .NET tests pass** · vitest 256 · browser 64 · `git diff --check` clean.

## Self review

```text
Self review:
- Issue/AC: PASS — every acceptance criterion implemented and tested
- Architecture/CQRS: PASS — Endpoint → IMediator → Handler → ITripService → ITripRepository, no SQL above Infrastructure
- Rules: findings 1, 2 (fixed)
- Security/privacy: PASS — owner from server identity; another angler's trip returns 404, not 403
- Database/migrations: PASS — additive only, no destructive change, no rename
- Tests/coverage: PASS — 76 new, real PostgreSQL for every meaningful SQL path
- Browser: N/A — no Web code in this slice
- Web/UI/localisation: N/A — no user-visible text
- Code smells: findings 3, 4 (fixed)
- CI/deployment: PASS — one migration apply, no Terraform
```

**Findings discovered during self-review:**

1. **`TripRepository` hand-mapped persistence rows onto the domain.** `database.md` and `cqrs.md` require injecting `IMapper` with the row conversion in an `Infrastructure/Persistence/Mappings/` `IRegister`, and `CatchRepository` already does exactly that. Mine bypassed the convention.
2. **A 14-field inline anonymous Dapper parameter object.** The convention is a named `*PersistenceParameters` type. Fixing it surfaced a second, more substantive miss: I was **not normalising timestamps with `.ToUniversalTime()`** at the persistence boundary, which `CatchRepository` does.
3. **`TripNotOwnedError` was dead code.** `GetView` deliberately returns *not found* for another angler's trip rather than leaking its existence, so the error had no caller.
4. **A test that did not test what it claimed.** `ItShouldRejectAMissingStart` passed `startedOn: default`, which for a `DateTimeOffset?` parameter is `null` — the helper's `??` then substituted a valid time, so the test passed without ever exercising the rule.

**Fixes made:**

1. `TripRepository` now injects `IMapper`; row → domain lives in `Infrastructure/Persistence/Mappings/TripMappingRegistration.cs`, with `TripLocation.TryCreate` referenced from the registration so the invariant stays explicit.
2. Added `TripPersistenceParameters` + `ToParameters(Trip)`, including the missing UTC normalisation.
3. Deleted the unused error.
4. Changed to `default(DateTimeOffset)`; the test now genuinely exercises the rule.

**Remaining deliberate gaps:**

- No location **exposure projection** (the `CatchLocationExposureDto` equivalent). Both trip reads are owner-scoped and a non-owner gets 404, so the 404 *is* the privacy boundary in V1 and a single-branch projection would be dead code. The sharing slice introduces it, exactly as the Catch feature gained its exposure model when sharing arrived — flagged so it is a conscious decision rather than an omission.
- `Trip_Status_Allowed` will need one additive line when `Planned` arrives. Explicit and cheap, and preferable to leaving status unconstrained at the DB level while visibility is constrained.
- **Existing Catch ownership boundary untouched.** `CatchService.UpsertAsync` still forces `AnglerUserId`/`RecordedByUserId` to the caller. Lifting that is deliberate future work for #38/#39 and must not be done incidentally.

## Manual post-merge steps

**One migration apply.** No Terraform, no configuration, no secrets — trips add no infrastructure.
