### PR TITLE
FLB#173 | Local Trip store and IndexedDB v5

### DIFF
--- a/src/FishingLogBook.Web/BrowserTests/logbook-upgrade.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/logbook-upgrade.spec.js
@@ -1,0 +1,368 @@
+import { expect, test } from '@playwright/test';
+
+const tripStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.js';
+const catchStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js';
+const logbookModule = '/src/FishingLogBook.Web/wwwroot/js/storage/logbook-database.js';
+const databaseName = 'FishingLogBook';
+const entitlementDatabaseName = 'FishingLogBookOfflineAccess';
+const ownerUserId = '11111111-1111-1111-1111-111111111111';
+const otherUserId = '22222222-2222-2222-2222-222222222222';
+const seededCatchId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const seededPhotographId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const tripId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const otherTripId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const startedOn = '2026-08-26T05:32:00+00:00';
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/src/FishingLogBook.Web/BrowserTests/harness/index.html');
+    await page.evaluate(async (names) => {
+        for (const name of names) {
+            await new Promise((resolve) => {
+                const request = indexedDB.deleteDatabase(name);
+                request.onsuccess = () => resolve();
+                request.onerror = () => resolve();
+                request.onblocked = () => resolve();
+            });
+        }
+    }, [databaseName, entitlementDatabaseName]);
+});
+
+async function seedVersionFour(page) {
+    return page.evaluate(async ({ databaseName, seededCatchId, seededPhotographId, ownerUserId }) => {
+        const db = await new Promise((resolve, reject) => {
+            const request = indexedDB.open(databaseName, 4);
+            request.onupgradeneeded = () => {
+                const upgrading = request.result;
+                upgrading.createObjectStore('catches', { keyPath: 'id' });
+                upgrading.createObjectStore('catchPhotographs', { keyPath: 'id' });
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+
+        await new Promise((resolve, reject) => {
+            const transaction = db.transaction(['catches', 'catchPhotographs'], 'readwrite');
+            transaction.objectStore('catches').put({
+                id: seededCatchId,
+                userId: ownerUserId,
+                caughtOn: '2026-06-14T09:48:00+00:00',
+                notes: 'the one from before the upgrade',
+                syncStatus: 'savedLocally',
+                photographs: [{ id: seededPhotographId, catchId: seededCatchId, contentType: 'image/jpeg' }]
+            });
+            transaction.objectStore('catchPhotographs').put({
+                id: seededPhotographId,
+                catchId: seededCatchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array(64 * 1024).fill(7).buffer
+            });
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => reject(transaction.error);
+            transaction.onabort = () => reject(transaction.error);
+        });
+
+        const version = db.version;
+        const stores = [...db.objectStoreNames].sort();
+        db.close();
+        return { version, stores };
+    }, { databaseName, seededCatchId, seededPhotographId, ownerUserId });
+}
+
+async function seedEntitlementDatabase(page) {
+    return page.evaluate(async (name) => {
+        const db = await new Promise((resolve, reject) => {
+            const request = indexedDB.open(name, 1);
+            request.onupgradeneeded = () => {
+                request.result.createObjectStore('deviceEntitlements', { keyPath: 'ownerKey' });
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+
+        await new Promise((resolve, reject) => {
+            const transaction = db.transaction('deviceEntitlements', 'readwrite');
+            transaction.objectStore('deviceEntitlements').put({
+                ownerKey: 'owner-1',
+                state: 'ready',
+                ciphertext: [1, 2, 3, 4]
+            });
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => reject(transaction.error);
+        });
+
+        const version = db.version;
+        db.close();
+        return version;
+    }, entitlementDatabaseName);
+}
+
+function newTrip(overrides = {}) {
+    return {
+        id: tripId,
+        ownerUserId,
+        status: 'Active',
+        startedOn,
+        endedOn: null,
+        title: null,
+        placeName: null,
+        location: null,
+        syncStatus: 'savedLocally',
+        syncedAt: null,
+        ...overrides
+    };
+}
+
+async function saveTrip(page, record) {
+    return page.evaluate(async ({ tripStoreModule, record }) => {
+        const { putTrip } = await import(tripStoreModule);
+        return putTrip(JSON.stringify(record));
+    }, { tripStoreModule, record });
+}
+
+async function readTrip(page, owner, id) {
+    return page.evaluate(async ({ tripStoreModule, owner, id }) => {
+        const { getTrip } = await import(tripStoreModule);
+        const stored = await getTrip(owner, id);
+        return stored === null ? null : JSON.parse(stored.json);
+    }, { tripStoreModule, owner, id });
+}
+
+async function readActiveTrip(page, owner) {
+    return page.evaluate(async ({ tripStoreModule, owner }) => {
+        const { getActiveTrip } = await import(tripStoreModule);
+        const stored = await getActiveTrip(owner);
+        return stored === null ? null : JSON.parse(stored.json);
+    }, { tripStoreModule, owner });
+}
+
+async function inspectDatabase(page) {
+    return page.evaluate(async (name) => {
+        const db = await new Promise((resolve, reject) => {
+            const request = indexedDB.open(name);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+        const result = { version: db.version, stores: [...db.objectStoreNames].sort() };
+        db.close();
+        return result;
+    }, databaseName);
+}
+
+test('an existing version 4 database upgrades to 5 and keeps every Catch record and blob', async ({ page }) => {
+    const seeded = await seedVersionFour(page);
+    expect(seeded.version).toBe(4);
+    expect(seeded.stores).toEqual(['catchPhotographs', 'catches']);
+
+    const survivors = await page.evaluate(async ({ catchStoreModule, ownerUserId }) => {
+        const { getAllCatchesWithPhotographs } = await import(catchStoreModule);
+        const catches = await getAllCatchesWithPhotographs(ownerUserId);
+        return catches.map((item) => ({
+            notes: JSON.parse(item.json).notes,
+            photographCount: item.photographs.length,
+            base64Length: item.photographs[0]?.bytesBase64.length ?? 0
+        }));
+    }, { catchStoreModule, ownerUserId });
+
+    const upgraded = await inspectDatabase(page);
+
+    expect(upgraded.version).toBe(5);
+    expect(upgraded.stores).toEqual(['catchPhotographs', 'catches', 'trips']);
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0].notes).toBe('the one from before the upgrade');
+    expect(survivors[0].photographCount).toBe(1);
+    expect(survivors[0].base64Length).toBeGreaterThan(0);
+});
+
+test('the upgrade adds the Trip store without deleting any Catch data', async ({ page }) => {
+    await seedVersionFour(page);
+
+    await saveTrip(page, newTrip());
+
+    const stored = await page.evaluate(async ({ catchStoreModule, ownerUserId, seededCatchId }) => {
+        const { getCatchMetadataById } = await import(catchStoreModule);
+        const record = await getCatchMetadataById(ownerUserId, seededCatchId);
+        return record === null ? null : JSON.parse(record.json).notes;
+    }, { catchStoreModule, ownerUserId, seededCatchId });
+
+    expect(stored).toBe('the one from before the upgrade');
+    expect((await inspectDatabase(page)).stores).toContain('trips');
+});
+
+test('the upgrade leaves the separate offline entitlement database untouched', async ({ page }) => {
+    const entitlementVersion = await seedEntitlementDatabase(page);
+    await seedVersionFour(page);
+
+    await saveTrip(page, newTrip());
+
+    const entitlements = await page.evaluate(async (name) => {
+        const db = await new Promise((resolve, reject) => {
+            const request = indexedDB.open(name);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+        const records = await new Promise((resolve, reject) => {
+            const request = db.transaction('deviceEntitlements', 'readonly')
+                .objectStore('deviceEntitlements')
+                .getAll();
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+        const result = { version: db.version, stores: [...db.objectStoreNames], records };
+        db.close();
+        return result;
+    }, entitlementDatabaseName);
+
+    expect(entitlements.version).toBe(entitlementVersion);
+    expect(entitlements.stores).toEqual(['deviceEntitlements']);
+    expect(entitlements.records).toHaveLength(1);
+    expect(entitlements.records[0].state).toBe('ready');
+});
+
+test('a blank Trip round-trips through a real upgrade', async ({ page }) => {
+    await seedVersionFour(page);
+
+    await saveTrip(page, newTrip());
+    const stored = await readTrip(page, ownerUserId, tripId);
+
+    expect(stored.status).toBe('Active');
+    expect(stored.startedOn).toBe(startedOn);
+    expect(stored.title).toBeNull();
+    expect(stored.placeName).toBeNull();
+    expect(stored.location).toBeNull();
+    expect(stored.endedOn).toBeNull();
+});
+
+test('a completed Trip with a full location round-trips without losing provenance', async ({ page }) => {
+    const location = {
+        latitude: 53.4419,
+        longitude: -9.2531,
+        accuracyMetres: 8,
+        capturedOn: startedOn,
+        source: 'DeviceGps',
+        visibility: 'Private',
+        consentVersion: '1'
+    };
+
+    await saveTrip(page, newTrip({
+        status: 'Completed',
+        endedOn: '2026-08-26T11:15:00+00:00',
+        title: 'Day with Dad',
+        placeName: 'Lough Corrib',
+        location
+    }));
+
+    const stored = await readTrip(page, ownerUserId, tripId);
+
+    expect(stored.status).toBe('Completed');
+    expect(stored.endedOn).toBe('2026-08-26T11:15:00+00:00');
+    expect(stored.title).toBe('Day with Dad');
+    expect(stored.placeName).toBe('Lough Corrib');
+    expect(stored.location).toEqual(location);
+});
+
+test('a single Trip read touches only the Trip store', async ({ page }) => {
+    await seedVersionFour(page);
+    await saveTrip(page, newTrip());
+
+    const accesses = await page.evaluate(async ({ tripStoreModule, owner, id }) => {
+        const { getTrip } = await import(tripStoreModule);
+        const stores = [];
+        const originalGet = IDBObjectStore.prototype.get;
+        const originalOpenCursor = IDBObjectStore.prototype.openCursor;
+        IDBObjectStore.prototype.get = function instrumentedGet(key) {
+            stores.push({ store: this.name, operation: 'get' });
+            return originalGet.call(this, key);
+        };
+        IDBObjectStore.prototype.openCursor = function instrumentedOpenCursor(...args) {
+            stores.push({ store: this.name, operation: 'openCursor' });
+            return originalOpenCursor.apply(this, args);
+        };
+
+        try {
+            await getTrip(owner, id);
+            return stores;
+        } finally {
+            IDBObjectStore.prototype.get = originalGet;
+            IDBObjectStore.prototype.openCursor = originalOpenCursor;
+        }
+    }, { tripStoreModule, owner: ownerUserId, id: tripId });
+
+    expect(accesses).toEqual([{ store: 'trips', operation: 'get' }]);
+});
+
+test('a Trip list read is owner scoped', async ({ page }) => {
+    await saveTrip(page, newTrip({ placeName: 'Lough Corrib' }));
+    await saveTrip(page, newTrip({ id: otherTripId, ownerUserId: otherUserId, placeName: 'Lough Mask' }));
+
+    const trips = await page.evaluate(async ({ tripStoreModule, owner }) => {
+        const { getTrips } = await import(tripStoreModule);
+        const stored = await getTrips(owner);
+        return stored.map((item) => JSON.parse(item.json).placeName);
+    }, { tripStoreModule, owner: ownerUserId });
+
+    expect(trips).toEqual(['Lough Corrib']);
+});
+
+test('an active Trip read is owner scoped', async ({ page }) => {
+    await saveTrip(page, newTrip({ id: otherTripId, ownerUserId: otherUserId }));
+
+    expect(await readActiveTrip(page, ownerUserId)).toBeNull();
+    expect((await readActiveTrip(page, otherUserId)).id).toBe(otherTripId);
+});
+
+test('a second distinct active Trip is rejected for the same owner', async ({ page }) => {
+    await saveTrip(page, newTrip());
+
+    const outcome = await saveTrip(page, newTrip({ id: otherTripId }));
+
+    expect(outcome).toBe('activeConflict');
+    expect((await readActiveTrip(page, ownerUserId)).id).toBe(tripId);
+    expect(await readTrip(page, ownerUserId, otherTripId)).toBeNull();
+});
+
+test('updating the same active Trip succeeds', async ({ page }) => {
+    await saveTrip(page, newTrip());
+
+    const outcome = await saveTrip(page, newTrip({ placeName: 'Lough Corrib' }));
+
+    expect(outcome).toBe('saved');
+    expect((await readActiveTrip(page, ownerUserId)).placeName).toBe('Lough Corrib');
+});
+
+test('each owner may hold their own active Trip', async ({ page }) => {
+    await saveTrip(page, newTrip());
+
+    const outcome = await saveTrip(page, newTrip({ id: otherTripId, ownerUserId: otherUserId }));
+
+    expect(outcome).toBe('saved');
+    expect((await readActiveTrip(page, ownerUserId)).id).toBe(tripId);
+    expect((await readActiveTrip(page, otherUserId)).id).toBe(otherTripId);
+});
+
+test('the active Trip is still discoverable after a full page reload', async ({ page }) => {
+    await saveTrip(page, newTrip({ placeName: 'Lough Corrib' }));
+
+    await page.reload();
+    await page.waitForFunction(() => document.readyState === 'complete');
+
+    const recovered = await readActiveTrip(page, ownerUserId);
+
+    expect(recovered.id).toBe(tripId);
+    expect(recovered.placeName).toBe('Lough Corrib');
+    expect(recovered.status).toBe('Active');
+});
+
+test('the logbook database reports one owning module for its name and version', async ({ page }) => {
+    const schema = await page.evaluate(async (module) => {
+        const logbook = await import(module);
+        return {
+            name: logbook.LOGBOOK_DATABASE_NAME,
+            version: logbook.LOGBOOK_DATABASE_VERSION,
+            tripStore: logbook.TRIP_STORE_NAME
+        };
+    }, logbookModule);
+
+    expect(schema.name).toBe(databaseName);
+    expect(schema.version).toBe(5);
+    expect(schema.tripStore).toBe('trips');
+});

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripLocationModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripLocationModel.cs
@@ -1,0 +1,10 @@
+namespace FishingLogBook.Web.Features.Trips.Models;
+
+public sealed record TripLocationModel(
+    double Latitude,
+    double Longitude,
+    double? AccuracyMetres,
+    DateTimeOffset CapturedOn,
+    string Source,
+    string Visibility,
+    string ConsentVersion);

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripModel.cs
@@ -1,0 +1,15 @@
+using FishingLogBook.Web.Common;
+
+namespace FishingLogBook.Web.Features.Trips.Models;
+
+public sealed record TripModel(
+    Guid Id,
+    Guid OwnerUserId,
+    string Status,
+    DateTimeOffset StartedOn,
+    DateTimeOffset? EndedOn = null,
+    string? Title = null,
+    string? PlaceName = null,
+    TripLocationModel? Location = null,
+    SyncStatus SyncStatus = SyncStatus.SavedLocally,
+    DateTimeOffset? SyncedAt = null);

--- a/src/FishingLogBook.Web/Features/Trips/Offline/LocalTripVisibility.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/LocalTripVisibility.cs
@@ -1,0 +1,20 @@
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Offline;
+
+internal static class LocalTripVisibility
+{
+    public static IReadOnlyList<TripModel> ForOwner(
+        IReadOnlyList<TripModel> trips,
+        Guid ownerUserId)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            return [];
+        }
+
+        return trips
+            .Where(trip => trip.OwnerUserId == ownerUserId)
+            .ToArray();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/StoredTripRecord.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/StoredTripRecord.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Web.Features.Trips.Offline;
+
+internal sealed class StoredTripRecord
+{
+    public string Json { get; set; } = string.Empty;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/Stores/ITripStore.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/Stores/ITripStore.cs
@@ -1,0 +1,14 @@
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+public interface ITripStore
+{
+    Task SaveAsync(TripModel trip, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TripModel>> GetAllAsync(Guid ownerUserId, CancellationToken cancellationToken);
+
+    Task<TripModel?> GetAsync(Guid ownerUserId, Guid tripId, CancellationToken cancellationToken);
+
+    Task<TripModel?> GetActiveAsync(Guid ownerUserId, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/Stores/IndexedDbTripStore.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/Stores/IndexedDbTripStore.cs
@@ -1,0 +1,178 @@
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Web.Common.Offline;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+public sealed class IndexedDbTripStore : ITripStore
+{
+    private const string ModulePath = "./js/offline-store.js";
+    private const string StoreName = "trips";
+    private const string ActiveConflictOutcome = "activeConflict";
+
+    private readonly IJSRuntime _jsRuntime;
+    private readonly IDiagnosticLogger _diagnostics;
+    private readonly ILoggingService _logging;
+    private readonly DiagnosticsClientConfig _config;
+    private readonly SemaphoreSlim _moduleLock = new(1, 1);
+    private IJSObjectReference? _module;
+
+    public IndexedDbTripStore(
+        IJSRuntime jsRuntime,
+        IDiagnosticLogger diagnostics,
+        ILoggingService logging,
+        DiagnosticsClientConfig config)
+    {
+        _jsRuntime = jsRuntime;
+        _diagnostics = diagnostics;
+        _logging = logging;
+        _config = config;
+    }
+
+    public async Task SaveAsync(TripModel trip, CancellationToken cancellationToken)
+    {
+        if (trip.OwnerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip requires an owner.");
+        }
+
+        if (trip.Id == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip requires an identifier.");
+        }
+
+        var json = TripJson.Serialize(trip);
+        var outcome = await OfflineOperation.ExecuteAsync(
+            "write",
+            StoreName,
+            DiagnosticEventNames.OfflineDbWriteStarted,
+            DiagnosticEventNames.OfflineDbWriteCompleted,
+            DiagnosticEventNames.OfflineDbWriteFailed,
+            DiagnosticEventNames.OfflineDbWriteTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                return await module.InvokeAsync<string>("putTrip", token, json);
+            },
+            cancellationToken,
+            _logging);
+
+        if (string.Equals(outcome, ActiveConflictOutcome, StringComparison.Ordinal))
+        {
+            throw new TripAlreadyActiveException();
+        }
+    }
+
+    public async Task<IReadOnlyList<TripModel>> GetAllAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip owner is required.");
+        }
+
+        var loaded = await OfflineOperation.ExecuteAsync(
+            "metadata-read",
+            StoreName,
+            DiagnosticEventNames.OfflineDbReadStarted,
+            DiagnosticEventNames.OfflineDbReadCompleted,
+            DiagnosticEventNames.OfflineDbReadFailed,
+            DiagnosticEventNames.OfflineDbReadTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                var records = await module.InvokeAsync<StoredTripRecord[]>(
+                    "getTrips",
+                    token,
+                    ownerUserId.ToString("D"));
+                return (IReadOnlyList<TripModel>)(records ?? [])
+                    .Select(record => TripJson.Deserialize(record.Json))
+                    .ToArray();
+            },
+            cancellationToken,
+            _logging);
+        return LocalTripVisibility.ForOwner(loaded, ownerUserId);
+    }
+
+    public async Task<TripModel?> GetAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        CancellationToken cancellationToken)
+    {
+        return await ReadSingleAsync(
+            ownerUserId,
+            "single-read",
+            "getTrip",
+            [ownerUserId.ToString("D"), tripId.ToString("D")],
+            cancellationToken);
+    }
+
+    public async Task<TripModel?> GetActiveAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        return await ReadSingleAsync(
+            ownerUserId,
+            "active-read",
+            "getActiveTrip",
+            [ownerUserId.ToString("D")],
+            cancellationToken);
+    }
+
+    private async Task<TripModel?> ReadSingleAsync(
+        Guid ownerUserId,
+        string operation,
+        string jsFunction,
+        object?[] arguments,
+        CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip owner is required.");
+        }
+
+        var loaded = await OfflineOperation.ExecuteAsync(
+            operation,
+            StoreName,
+            DiagnosticEventNames.OfflineDbReadStarted,
+            DiagnosticEventNames.OfflineDbReadCompleted,
+            DiagnosticEventNames.OfflineDbReadFailed,
+            DiagnosticEventNames.OfflineDbReadTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                var record = await module.InvokeAsync<StoredTripRecord?>(jsFunction, token, arguments);
+                return record is null ? null : TripJson.Deserialize(record.Json);
+            },
+            cancellationToken,
+            _logging);
+        return loaded is not null && loaded.OwnerUserId == ownerUserId ? loaded : null;
+    }
+
+    private async Task<IJSObjectReference> GetModuleAsync(CancellationToken cancellationToken)
+    {
+        if (_module is not null)
+        {
+            return _module;
+        }
+
+        await _moduleLock.WaitAsync(cancellationToken);
+        try
+        {
+            _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+            return _module;
+        }
+        finally
+        {
+            _moduleLock.Release();
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/TripAlreadyActiveException.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/TripAlreadyActiveException.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Web.Features.Trips.Offline;
+
+public sealed class TripAlreadyActiveException : InvalidOperationException
+{
+    public TripAlreadyActiveException()
+        : base("An active trip already exists for this angler.")
+    {
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/TripJson.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/TripJson.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Offline;
+
+internal static class TripJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+
+    public static string Serialize(TripModel trip)
+    {
+        return JsonSerializer.Serialize(ToRecord(trip), Options);
+    }
+
+    public static TripModel Deserialize(string json)
+    {
+        var record = JsonSerializer.Deserialize<StoredTrip>(json, Options)
+            ?? throw new InvalidOperationException("Trip metadata could not be read.");
+        return new TripModel(
+            record.Id,
+            record.OwnerUserId,
+            record.Status,
+            record.StartedOn,
+            record.EndedOn,
+            record.Title,
+            record.PlaceName,
+            ToLocation(record.Location),
+            record.SyncStatus,
+            record.SyncedAt);
+    }
+
+    private static StoredTrip ToRecord(TripModel trip)
+    {
+        return new StoredTrip(
+            trip.Id,
+            trip.OwnerUserId,
+            trip.Status,
+            trip.StartedOn,
+            trip.EndedOn,
+            trip.Title,
+            trip.PlaceName,
+            trip.Location is null
+                ? null
+                : new StoredTripLocation(
+                    trip.Location.Latitude,
+                    trip.Location.Longitude,
+                    trip.Location.AccuracyMetres,
+                    trip.Location.CapturedOn,
+                    trip.Location.Source,
+                    trip.Location.Visibility,
+                    trip.Location.ConsentVersion),
+            trip.SyncStatus,
+            trip.SyncedAt);
+    }
+
+    private static TripLocationModel? ToLocation(StoredTripLocation? location)
+    {
+        if (location is null)
+        {
+            return null;
+        }
+
+        return new TripLocationModel(
+            location.Latitude,
+            location.Longitude,
+            location.AccuracyMetres,
+            location.CapturedOn,
+            location.Source,
+            location.Visibility,
+            location.ConsentVersion);
+    }
+
+    private sealed record StoredTrip(
+        Guid Id,
+        Guid OwnerUserId,
+        string Status,
+        DateTimeOffset StartedOn,
+        DateTimeOffset? EndedOn = null,
+        string? Title = null,
+        string? PlaceName = null,
+        StoredTripLocation? Location = null,
+        SyncStatus SyncStatus = SyncStatus.SavedLocally,
+        DateTimeOffset? SyncedAt = null);
+
+    private sealed record StoredTripLocation(
+        double Latitude,
+        double Longitude,
+        double? AccuracyMetres,
+        DateTimeOffset CapturedOn,
+        string Source,
+        string Visibility,
+        string ConsentVersion);
+}

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ using FishingLogBook.Web.Features.Profile.Offline;
 using FishingLogBook.Web.Features.Profile.Offline.Stores;
 using FishingLogBook.Web.Features.Profile.Providers;
 using FishingLogBook.Web.Features.SystemStatus.Clients;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
 using FishingLogBook.Web.Features.Users.Clients;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
@@ -80,6 +81,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IOfflineReconnectService, OfflineReconnectService>();
         services.AddScoped<ITimeService, TimeService>();
         services.AddScoped<ICatchStore, IndexedDbCatchStore>();
+        services.AddScoped<ITripStore, IndexedDbTripStore>();
         services.AddScoped<ICatchSynchroniser, CatchSynchroniser>();
         services.AddScoped<ICatchClient, CatchClient>();
         services.AddScoped<ICurrentUserClient, CurrentUserClient>();

--- a/src/FishingLogBook.Web/wwwroot/js/offline-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/offline-store.js
@@ -7,4 +7,10 @@ export {
     updateCatchMetadata,
     cleanupSyncedCatches
 } from './storage/catch-store.js';
+export {
+    putTrip,
+    getTrips,
+    getTrip,
+    getActiveTrip
+} from './storage/trip-store.js';
 export { getStorageEstimate } from './storage/indexed-db.js';

--- a/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js
@@ -1,165 +1,33 @@
 import {
-    closeDatabase,
-    elapsedSince,
-    openDatabase,
-    runMultiStoreTransaction,
-    runTransaction
-} from './indexed-db.js';
-import { emit, emitStorageEstimate, emitTimedOut } from './offline-diagnostics.js';
+    CATCH_STORE_NAME as LOGBOOK_CATCH_STORE_NAME,
+    LOGBOOK_DATABASE_NAME,
+    LOGBOOK_DATABASE_VERSION,
+    PHOTO_STORE_NAME as LOGBOOK_PHOTO_STORE_NAME,
+    normalisedOwnerId,
+    openLogbookDatabase,
+    openTimeoutMs as logbookOpenTimeoutMs,
+    runLogbookMultiStoreTransaction,
+    runLogbookTransaction
+} from './logbook-database.js';
 
-export const CATCH_DATABASE_NAME = 'FishingLogBook';
-export const CATCH_STORE_NAME = 'catches';
-export const PHOTO_STORE_NAME = 'catchPhotographs';
-export const CATCH_DATABASE_VERSION = 4;
-export const openTimeoutMs = 8000;
+export const CATCH_DATABASE_NAME = LOGBOOK_DATABASE_NAME;
+export const CATCH_STORE_NAME = LOGBOOK_CATCH_STORE_NAME;
+export const PHOTO_STORE_NAME = LOGBOOK_PHOTO_STORE_NAME;
+export const CATCH_DATABASE_VERSION = LOGBOOK_DATABASE_VERSION;
+export const openTimeoutMs = logbookOpenTimeoutMs;
 
-const LEGACY_TEST_CATCH_STORE_NAME = 'testCatches';
-const LEGACY_TEST_CATCH_PHOTO_STORE_NAME = 'testCatchPhotographs';
-
-const databaseName = CATCH_DATABASE_NAME;
-const storeName = CATCH_STORE_NAME;
-const photographStoreName = PHOTO_STORE_NAME;
-const version = CATCH_DATABASE_VERSION;
-
-export function openCatchDatabase() {
-    const started = performance.now();
-    emit('OfflineDbOpenStarted', { storeName, operation: 'open', elapsedMilliseconds: 0 });
-    return openDatabase({
-        databaseName,
-        version,
-        timeoutMs: openTimeoutMs,
-        timeoutLabel: 'IndexedDB open',
-        onUpgrade: (db) => {
-            if (!db.objectStoreNames.contains(storeName)) {
-                db.createObjectStore(storeName, { keyPath: 'id' });
-            }
-            if (!db.objectStoreNames.contains(photographStoreName)) {
-                db.createObjectStore(photographStoreName, { keyPath: 'id' });
-            }
-            if (db.objectStoreNames.contains(LEGACY_TEST_CATCH_STORE_NAME)) {
-                db.deleteObjectStore(LEGACY_TEST_CATCH_STORE_NAME);
-            }
-            if (db.objectStoreNames.contains(LEGACY_TEST_CATCH_PHOTO_STORE_NAME)) {
-                db.deleteObjectStore(LEGACY_TEST_CATCH_PHOTO_STORE_NAME);
-            }
-        },
-        onOpened: () => {
-            emit('OfflineDbOpenCompleted', {
-                operation: 'open',
-                elapsedMilliseconds: elapsedSince(started)
-            });
-            void emitStorageEstimate();
-        },
-        onFailed: (error) => {
-            emit('OfflineDbOpenFailed', {
-                operation: 'open',
-                elapsedMilliseconds: elapsedSince(started),
-                errorType: error?.name
-            });
-        },
-        onTimedOut: () => {
-            emit('OfflineDbOpenTimedOut', {
-                operation: 'open',
-                elapsedMilliseconds: elapsedSince(started)
-            });
-        },
-        onVersionChange: (db) => {
-            closeDatabase(db);
-            emit('OfflineDbClosed', {
-                operation: 'versionchange',
-                elapsedMilliseconds: elapsedSince(started)
-            });
-        }
-    });
-}
+export const openCatchDatabase = openLogbookDatabase;
 
 export function runCatchTransaction(objectStoreName, mode, operationName, execute) {
-    const started = performance.now();
-    return openCatchDatabase().then((db) => runTransaction(db, {
-        storeName: objectStoreName,
-        mode,
-        timeoutMs: openTimeoutMs,
-        timeoutLabel: `IndexedDB ${operationName}`,
-        execute,
-        closeWhenDone: true,
-        onStarted: () => emit('OfflineDbTransactionStarted', {
-            storeName: objectStoreName,
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started)
-        }),
-        onCompleted: () => emit('OfflineDbTransactionCompleted', {
-            storeName: objectStoreName,
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started)
-        }),
-        onAborted: (error) => emit('OfflineDbTransactionAborted', {
-            storeName: objectStoreName,
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started),
-            errorType: error?.name
-        }),
-        onError: (error) => emit('OfflineDbTransactionError', {
-            storeName: objectStoreName,
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started),
-            errorType: error?.name
-        }),
-        onRequestSucceeded: () => emit('OfflineDbRequestSucceeded', {
-            storeName: objectStoreName,
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started)
-        }),
-        onClosed: () => emit('OfflineDbClosed', {
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started)
-        }),
-        onTimedOut: (error) => emitTimedOut(mode, objectStoreName, started, error)
-    }));
+    return runLogbookTransaction(objectStoreName, mode, operationName, execute);
 }
 
 function runCatchWithPhotographsTransaction(mode, operationName, execute) {
-    const started = performance.now();
-    const storeNames = [CATCH_STORE_NAME, PHOTO_STORE_NAME];
-    return openCatchDatabase().then((db) => runMultiStoreTransaction(db, {
-        storeNames,
+    return runLogbookMultiStoreTransaction(
+        [CATCH_STORE_NAME, PHOTO_STORE_NAME],
         mode,
-        timeoutMs: openTimeoutMs,
-        timeoutLabel: `IndexedDB ${operationName}`,
-        execute,
-        closeWhenDone: true,
-        onStarted: () => emit('OfflineDbTransactionStarted', {
-            storeName: storeNames.join(','),
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started)
-        }),
-        onCompleted: () => emit('OfflineDbTransactionCompleted', {
-            storeName: storeNames.join(','),
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started)
-        }),
-        onAborted: (error) => emit('OfflineDbTransactionAborted', {
-            storeName: storeNames.join(','),
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started),
-            errorType: error?.name
-        }),
-        onError: (error) => emit('OfflineDbTransactionError', {
-            storeName: storeNames.join(','),
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started),
-            errorType: error?.name
-        }),
-        onRequestSucceeded: () => emit('OfflineDbRequestSucceeded', {
-            storeName: storeNames.join(','),
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started)
-        }),
-        onClosed: () => emit('OfflineDbClosed', {
-            operation: operationName,
-            elapsedMilliseconds: elapsedSince(started)
-        }),
-        onTimedOut: (error) => emitTimedOut(mode, storeNames.join(','), started, error)
-    }));
+        operationName,
+        execute);
 }
 
 export async function putCatchWithPhotographs(json, photographs) {
@@ -245,7 +113,7 @@ function writePhotographs(photoStore, photos, succeed, fail) {
 
 export async function updateCatchMetadata(json) {
     const catchRecord = JSON.parse(json);
-    if (!catchRecord?.id || !normalisedUserId(catchRecord.userId)) {
+    if (!catchRecord?.id || !normalisedOwnerId(catchRecord.userId)) {
         throw new Error('Owned Catch id is required');
     }
 
@@ -254,7 +122,7 @@ export async function updateCatchMetadata(json) {
         existingRequest.onerror = () => fail(existingRequest.error);
         existingRequest.onsuccess = () => {
             const existing = existingRequest.result;
-            if (!existing || normalisedUserId(existing.userId) !== normalisedUserId(catchRecord.userId)) {
+            if (!existing || normalisedOwnerId(existing.userId) !== normalisedOwnerId(catchRecord.userId)) {
                 fail(new Error('Owned Catch was not found'));
                 return;
             }
@@ -319,7 +187,7 @@ function hasMetadataDifference(existing, incoming) {
 }
 
 export async function getAllCatchesWithPhotographs(ownerUserId) {
-    const owner = normalisedUserId(ownerUserId);
+    const owner = normalisedOwnerId(ownerUserId);
     if (!owner) {
         return [];
     }
@@ -333,7 +201,7 @@ export async function getAllCatchesWithPhotographs(ownerUserId) {
         catchRequest.onsuccess = () => {
             const cursor = catchRequest.result;
             if (cursor) {
-                if (normalisedUserId(cursor.value?.userId) === owner) {
+                if (normalisedOwnerId(cursor.value?.userId) === owner) {
                     catches.push(cursor.value);
                 }
 
@@ -363,7 +231,7 @@ export async function getAllCatchesWithPhotographs(ownerUserId) {
 }
 
 export async function getCatchMetadata(ownerUserId) {
-    const owner = normalisedUserId(ownerUserId);
+    const owner = normalisedOwnerId(ownerUserId);
     if (!owner) {
         return [];
     }
@@ -375,7 +243,7 @@ export async function getCatchMetadata(ownerUserId) {
         request.onsuccess = () => {
             const cursor = request.result;
             if (cursor) {
-                if (normalisedUserId(cursor.value?.userId) === owner) {
+                if (normalisedOwnerId(cursor.value?.userId) === owner) {
                     catches.push({ json: JSON.stringify(cursor.value), photographs: [] });
                 }
 
@@ -389,7 +257,7 @@ export async function getCatchMetadata(ownerUserId) {
 }
 
 export async function getCatchMetadataById(ownerUserId, catchId) {
-    const owner = normalisedUserId(ownerUserId);
+    const owner = normalisedOwnerId(ownerUserId);
     if (!owner || typeof catchId !== 'string' || !catchId) {
         return null;
     }
@@ -399,7 +267,7 @@ export async function getCatchMetadataById(ownerUserId, catchId) {
         request.onerror = () => fail(request.error);
         request.onsuccess = () => {
             const record = request.result;
-            succeed(record && normalisedUserId(record.userId) === owner
+            succeed(record && normalisedOwnerId(record.userId) === owner
                 ? { json: JSON.stringify(record), photographs: [] }
                 : null);
         };
@@ -407,7 +275,7 @@ export async function getCatchMetadataById(ownerUserId, catchId) {
 }
 
 export async function getCatchWithPhotographs(ownerUserId, catchId) {
-    const owner = normalisedUserId(ownerUserId);
+    const owner = normalisedOwnerId(ownerUserId);
     if (!owner || typeof catchId !== 'string' || !catchId) {
         return null;
     }
@@ -419,7 +287,7 @@ export async function getCatchWithPhotographs(ownerUserId, catchId) {
         catchRequest.onerror = () => fail(catchRequest.error);
         catchRequest.onsuccess = () => {
             const record = catchRequest.result;
-            if (!record || normalisedUserId(record.userId) !== owner) {
+            if (!record || normalisedOwnerId(record.userId) !== owner) {
                 succeed(null);
                 return;
             }
@@ -488,7 +356,7 @@ function toStoredResult(record, photographs) {
 }
 
 export async function cleanupSyncedCatches(ownerUserId, olderThanIso) {
-    const owner = normalisedUserId(ownerUserId);
+    const owner = normalisedOwnerId(ownerUserId);
     const cutoff = Date.parse(olderThanIso);
     if (!owner || Number.isNaN(cutoff)) {
         return 0;
@@ -508,7 +376,7 @@ export async function cleanupSyncedCatches(ownerUserId, olderThanIso) {
             }
 
             const record = cursor.value;
-            if (normalisedUserId(record?.userId) === owner && isEligibleForCleanup(record, cutoff)) {
+            if (normalisedOwnerId(record?.userId) === owner && isEligibleForCleanup(record, cutoff)) {
                 for (const photograph of record.photographs || []) {
                     photoStore.delete(photograph.id);
                 }
@@ -538,19 +406,6 @@ function isEligibleForCleanup(record, cutoff) {
 
 function isSynchronisedStatus(status) {
     return status === 'synchronised' || status === 3;
-}
-
-function normalisedUserId(value) {
-    if (typeof value !== 'string') {
-        return '';
-    }
-
-    const normalised = value.trim().toLowerCase();
-    if (!normalised || normalised === '00000000-0000-0000-0000-000000000000') {
-        return '';
-    }
-
-    return normalised;
 }
 
 function orderPhotographs(catchRecord, photographs) {

--- a/src/FishingLogBook.Web/wwwroot/js/storage/logbook-database.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/logbook-database.js
@@ -1,0 +1,178 @@
+import {
+    closeDatabase,
+    elapsedSince,
+    openDatabase,
+    runMultiStoreTransaction,
+    runTransaction
+} from './indexed-db.js';
+import { emit, emitStorageEstimate, emitTimedOut } from './offline-diagnostics.js';
+
+export const LOGBOOK_DATABASE_NAME = 'FishingLogBook';
+export const LOGBOOK_DATABASE_VERSION = 5;
+export const CATCH_STORE_NAME = 'catches';
+export const PHOTO_STORE_NAME = 'catchPhotographs';
+export const TRIP_STORE_NAME = 'trips';
+export const openTimeoutMs = 8000;
+
+const LEGACY_TEST_CATCH_STORE_NAME = 'testCatches';
+const LEGACY_TEST_CATCH_PHOTO_STORE_NAME = 'testCatchPhotographs';
+
+export function openLogbookDatabase() {
+    const started = performance.now();
+    emit('OfflineDbOpenStarted', {
+        storeName: CATCH_STORE_NAME,
+        operation: 'open',
+        elapsedMilliseconds: 0
+    });
+    return openDatabase({
+        databaseName: LOGBOOK_DATABASE_NAME,
+        version: LOGBOOK_DATABASE_VERSION,
+        timeoutMs: openTimeoutMs,
+        timeoutLabel: 'IndexedDB open',
+        onUpgrade: (db) => {
+            if (!db.objectStoreNames.contains(CATCH_STORE_NAME)) {
+                db.createObjectStore(CATCH_STORE_NAME, { keyPath: 'id' });
+            }
+            if (!db.objectStoreNames.contains(PHOTO_STORE_NAME)) {
+                db.createObjectStore(PHOTO_STORE_NAME, { keyPath: 'id' });
+            }
+            if (!db.objectStoreNames.contains(TRIP_STORE_NAME)) {
+                db.createObjectStore(TRIP_STORE_NAME, { keyPath: 'id' });
+            }
+            if (db.objectStoreNames.contains(LEGACY_TEST_CATCH_STORE_NAME)) {
+                db.deleteObjectStore(LEGACY_TEST_CATCH_STORE_NAME);
+            }
+            if (db.objectStoreNames.contains(LEGACY_TEST_CATCH_PHOTO_STORE_NAME)) {
+                db.deleteObjectStore(LEGACY_TEST_CATCH_PHOTO_STORE_NAME);
+            }
+        },
+        onOpened: () => {
+            emit('OfflineDbOpenCompleted', {
+                operation: 'open',
+                elapsedMilliseconds: elapsedSince(started)
+            });
+            void emitStorageEstimate();
+        },
+        onFailed: (error) => {
+            emit('OfflineDbOpenFailed', {
+                operation: 'open',
+                elapsedMilliseconds: elapsedSince(started),
+                errorType: error?.name
+            });
+        },
+        onTimedOut: () => {
+            emit('OfflineDbOpenTimedOut', {
+                operation: 'open',
+                elapsedMilliseconds: elapsedSince(started)
+            });
+        },
+        onVersionChange: (db) => {
+            closeDatabase(db);
+            emit('OfflineDbClosed', {
+                operation: 'versionchange',
+                elapsedMilliseconds: elapsedSince(started)
+            });
+        }
+    });
+}
+
+export function runLogbookTransaction(objectStoreName, mode, operationName, execute) {
+    const started = performance.now();
+    return openLogbookDatabase().then((db) => runTransaction(db, {
+        storeName: objectStoreName,
+        mode,
+        timeoutMs: openTimeoutMs,
+        timeoutLabel: `IndexedDB ${operationName}`,
+        execute,
+        closeWhenDone: true,
+        onStarted: () => emit('OfflineDbTransactionStarted', {
+            storeName: objectStoreName,
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started)
+        }),
+        onCompleted: () => emit('OfflineDbTransactionCompleted', {
+            storeName: objectStoreName,
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started)
+        }),
+        onAborted: (error) => emit('OfflineDbTransactionAborted', {
+            storeName: objectStoreName,
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started),
+            errorType: error?.name
+        }),
+        onError: (error) => emit('OfflineDbTransactionError', {
+            storeName: objectStoreName,
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started),
+            errorType: error?.name
+        }),
+        onRequestSucceeded: () => emit('OfflineDbRequestSucceeded', {
+            storeName: objectStoreName,
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started)
+        }),
+        onClosed: () => emit('OfflineDbClosed', {
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started)
+        }),
+        onTimedOut: (error) => emitTimedOut(mode, objectStoreName, started, error)
+    }));
+}
+
+export function runLogbookMultiStoreTransaction(storeNames, mode, operationName, execute) {
+    const started = performance.now();
+    return openLogbookDatabase().then((db) => runMultiStoreTransaction(db, {
+        storeNames,
+        mode,
+        timeoutMs: openTimeoutMs,
+        timeoutLabel: `IndexedDB ${operationName}`,
+        execute,
+        closeWhenDone: true,
+        onStarted: () => emit('OfflineDbTransactionStarted', {
+            storeName: storeNames.join(','),
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started)
+        }),
+        onCompleted: () => emit('OfflineDbTransactionCompleted', {
+            storeName: storeNames.join(','),
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started)
+        }),
+        onAborted: (error) => emit('OfflineDbTransactionAborted', {
+            storeName: storeNames.join(','),
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started),
+            errorType: error?.name
+        }),
+        onError: (error) => emit('OfflineDbTransactionError', {
+            storeName: storeNames.join(','),
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started),
+            errorType: error?.name
+        }),
+        onRequestSucceeded: () => emit('OfflineDbRequestSucceeded', {
+            storeName: storeNames.join(','),
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started)
+        }),
+        onClosed: () => emit('OfflineDbClosed', {
+            operation: operationName,
+            elapsedMilliseconds: elapsedSince(started)
+        }),
+        onTimedOut: (error) => emitTimedOut(mode, storeNames.join(','), started, error)
+    }));
+}
+
+export function normalisedOwnerId(value) {
+    if (typeof value !== 'string') {
+        return '';
+    }
+
+    const normalised = value.trim().toLowerCase();
+    if (!normalised || normalised === '00000000-0000-0000-0000-000000000000') {
+        return '';
+    }
+
+    return normalised;
+}

--- a/src/FishingLogBook.Web/wwwroot/js/storage/schema-safety.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/schema-safety.test.js
@@ -10,6 +10,7 @@ import {
     getAllCatchesWithPhotographs,
     putCatchWithPhotographs
 } from './catch-store.js';
+import { TRIP_STORE_NAME } from './trip-store.js';
 import {
     DIAGNOSTIC_DATABASE_NAME,
     DIAGNOSTIC_STORE_NAME,
@@ -62,8 +63,31 @@ describe('schema safety', () => {
         expect(indexedDbSource).not.toContain(PREFERENCE_DATABASE_NAME);
     });
 
-    it('keeps the released Catch database version unchanged', () => {
-        expect(CATCH_DATABASE_VERSION).toBe(4);
+    it('keeps the released logbook database version unchanged', () => {
+        expect(CATCH_DATABASE_VERSION).toBe(5);
+    });
+
+    it('does not mix Trip and other feature schema names across store modules', () => {
+        const tripSource = readJs('trip-store.js');
+        const diagnosticSource = readJs('diagnostic-store.js');
+        const preferenceSource = readJs('preference-store.js');
+
+        expect(tripSource).not.toContain('FishingLogBookDiagnostics');
+        expect(tripSource).not.toContain('FishingLogBookPreferences');
+        expect(tripSource).not.toContain('diagnosticEvents');
+        expect(tripSource).not.toContain('fishingPreferences');
+        expect(diagnosticSource).not.toContain(TRIP_STORE_NAME);
+        expect(preferenceSource).not.toContain(TRIP_STORE_NAME);
+    });
+
+    it('owns the logbook database name in exactly one module', () => {
+        const logbookSource = readJs('logbook-database.js');
+        const catchSource = readJs('catch-store.js');
+        const tripSource = readJs('trip-store.js');
+
+        expect(logbookSource).toContain(`'${CATCH_DATABASE_NAME}'`);
+        expect(catchSource).not.toContain(`'${CATCH_DATABASE_NAME}'`);
+        expect(tripSource).not.toContain(`'${CATCH_DATABASE_NAME}'`);
     });
 
     it('does not let the preference store modify the Catch schema', async () => {
@@ -84,7 +108,8 @@ describe('schema safety', () => {
         });
 
         expect(catchDb.version).toBe(CATCH_DATABASE_VERSION);
-        expect([...catchDb.objectStoreNames].sort()).toEqual([CATCH_STORE_NAME, PHOTO_STORE_NAME].sort());
+        expect([...catchDb.objectStoreNames].sort())
+            .toEqual([CATCH_STORE_NAME, PHOTO_STORE_NAME, TRIP_STORE_NAME].sort());
         expect(catchDb.objectStoreNames.contains(PREFERENCE_STORE_NAME)).toBe(false);
         expect([...preferenceDb.objectStoreNames]).toEqual([PREFERENCE_STORE_NAME]);
         expect(preferenceDb.objectStoreNames.contains(CATCH_STORE_NAME)).toBe(false);
@@ -135,7 +160,8 @@ describe('schema safety', () => {
             request.onerror = () => reject(request.error);
         });
 
-        expect([...db.objectStoreNames].sort()).toEqual([CATCH_STORE_NAME, PHOTO_STORE_NAME].sort());
+        expect([...db.objectStoreNames].sort())
+            .toEqual([CATCH_STORE_NAME, PHOTO_STORE_NAME, TRIP_STORE_NAME].sort());
         db.close();
     });
 
@@ -163,7 +189,8 @@ describe('schema safety', () => {
         });
 
         expect(upgraded.version).toBe(CATCH_DATABASE_VERSION);
-        expect([...upgraded.objectStoreNames].sort()).toEqual([CATCH_STORE_NAME, PHOTO_STORE_NAME].sort());
+        expect([...upgraded.objectStoreNames].sort())
+            .toEqual([CATCH_STORE_NAME, PHOTO_STORE_NAME, TRIP_STORE_NAME].sort());
         expect(upgraded.objectStoreNames.contains('testCatches')).toBe(false);
         expect(upgraded.objectStoreNames.contains('testCatchPhotographs')).toBe(false);
         upgraded.close();

--- a/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.js
@@ -1,0 +1,132 @@
+import {
+    TRIP_STORE_NAME,
+    normalisedOwnerId,
+    runLogbookTransaction
+} from './logbook-database.js';
+
+export const TRIP_ACTIVE_STATUS = 'Active';
+export const TRIP_SAVED_OUTCOME = 'saved';
+export const TRIP_ACTIVE_CONFLICT_OUTCOME = 'activeConflict';
+
+export { TRIP_STORE_NAME };
+
+export async function putTrip(json) {
+    const trip = JSON.parse(json);
+    if (!trip?.id || !normalisedOwnerId(trip.ownerUserId)) {
+        throw new Error('Owned Trip id is required');
+    }
+
+    return runLogbookTransaction(TRIP_STORE_NAME, 'readwrite', 'write', (store, succeed, fail) => {
+        const owner = normalisedOwnerId(trip.ownerUserId);
+        const request = store.openCursor();
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor) {
+                if (conflictsWithActiveTrip(cursor.value, trip, owner)) {
+                    succeed(TRIP_ACTIVE_CONFLICT_OUTCOME);
+                    return;
+                }
+
+                if (isOwnedByAnother(cursor.value, trip, owner)) {
+                    fail(new Error('Trip ownership cannot be changed'));
+                    return;
+                }
+
+                cursor.continue();
+                return;
+            }
+
+            const write = store.put(trip);
+            write.onerror = () => fail(write.error);
+            write.onsuccess = () => succeed(TRIP_SAVED_OUTCOME);
+        };
+    });
+}
+
+export async function getTrips(ownerUserId) {
+    const owner = normalisedOwnerId(ownerUserId);
+    if (!owner) {
+        return [];
+    }
+
+    return runLogbookTransaction(TRIP_STORE_NAME, 'readonly', 'metadata-read', (store, succeed, fail) => {
+        const trips = [];
+        const request = store.openCursor();
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (cursor) {
+                if (normalisedOwnerId(cursor.value?.ownerUserId) === owner) {
+                    trips.push({ json: JSON.stringify(cursor.value) });
+                }
+
+                cursor.continue();
+                return;
+            }
+
+            succeed(trips);
+        };
+    });
+}
+
+export async function getTrip(ownerUserId, tripId) {
+    const owner = normalisedOwnerId(ownerUserId);
+    if (!owner || typeof tripId !== 'string' || !tripId) {
+        return null;
+    }
+
+    return runLogbookTransaction(TRIP_STORE_NAME, 'readonly', 'single-read', (store, succeed, fail) => {
+        const request = store.get(tripId);
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            const trip = request.result;
+            if (!trip || normalisedOwnerId(trip.ownerUserId) !== owner) {
+                succeed(null);
+                return;
+            }
+
+            succeed({ json: JSON.stringify(trip) });
+        };
+    });
+}
+
+export async function getActiveTrip(ownerUserId) {
+    const owner = normalisedOwnerId(ownerUserId);
+    if (!owner) {
+        return null;
+    }
+
+    return runLogbookTransaction(TRIP_STORE_NAME, 'readonly', 'active-read', (store, succeed, fail) => {
+        const request = store.openCursor();
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) {
+                succeed(null);
+                return;
+            }
+
+            if (isActiveForOwner(cursor.value, owner)) {
+                succeed({ json: JSON.stringify(cursor.value) });
+                return;
+            }
+
+            cursor.continue();
+        };
+    });
+}
+
+function isActiveForOwner(trip, owner) {
+    return normalisedOwnerId(trip?.ownerUserId) === owner && trip?.status === TRIP_ACTIVE_STATUS;
+}
+
+function conflictsWithActiveTrip(stored, incoming, owner) {
+    return incoming.status === TRIP_ACTIVE_STATUS
+        && stored?.id !== incoming.id
+        && isActiveForOwner(stored, owner);
+}
+
+function isOwnedByAnother(stored, incoming, owner) {
+    return stored?.id === incoming.id && normalisedOwnerId(stored?.ownerUserId) !== owner;
+}

--- a/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.test.js
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import {
+    TRIP_ACTIVE_CONFLICT_OUTCOME,
+    TRIP_SAVED_OUTCOME,
+    getActiveTrip,
+    getTrip,
+    getTrips,
+    putTrip
+} from './trip-store.js';
+import { getAllCatchesWithPhotographs, putCatchWithPhotographs } from './catch-store.js';
+
+describe('Trip store', () => {
+    const ownerUserId = '11111111-1111-1111-1111-111111111111';
+    const otherUserId = '22222222-2222-2222-2222-222222222222';
+    const startedOn = '2026-08-26T05:32:00+00:00';
+
+    function trip(overrides = {}) {
+        return {
+            id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            ownerUserId,
+            status: 'Active',
+            startedOn,
+            endedOn: null,
+            title: null,
+            placeName: null,
+            location: null,
+            syncStatus: 'savedLocally',
+            syncedAt: null,
+            ...overrides
+        };
+    }
+
+    function fullLocation() {
+        return {
+            latitude: 53.4419,
+            longitude: -9.2531,
+            accuracyMetres: 8,
+            capturedOn: startedOn,
+            source: 'DeviceGps',
+            visibility: 'Private',
+            consentVersion: '1'
+        };
+    }
+
+    async function save(record) {
+        return putTrip(JSON.stringify(record));
+    }
+
+    it('rejects a trip with no id', async () => {
+        await expect(save(trip({ id: '' }))).rejects.toThrow('Owned Trip id is required');
+    });
+
+    it('rejects a trip with no owner', async () => {
+        await expect(save(trip({ ownerUserId: '' }))).rejects.toThrow('Owned Trip id is required');
+    });
+
+    it('rejects a trip whose owner is the empty guid', async () => {
+        await expect(save(trip({ ownerUserId: '00000000-0000-0000-0000-000000000000' })))
+            .rejects.toThrow('Owned Trip id is required');
+    });
+
+    it('round-trips a blank active trip', async () => {
+        await save(trip());
+
+        const stored = await getTrip(ownerUserId, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+        const parsed = JSON.parse(stored.json);
+
+        expect(parsed.status).toBe('Active');
+        expect(parsed.startedOn).toBe(startedOn);
+        expect(parsed.endedOn).toBeNull();
+        expect(parsed.title).toBeNull();
+        expect(parsed.placeName).toBeNull();
+        expect(parsed.location).toBeNull();
+    });
+
+    it('round-trips a completed trip with a title and place', async () => {
+        await save(trip({
+            status: 'Completed',
+            endedOn: '2026-08-26T11:15:00+00:00',
+            title: 'Day with Dad',
+            placeName: 'Lough Corrib'
+        }));
+
+        const parsed = JSON.parse((await getTrip(ownerUserId, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')).json);
+
+        expect(parsed.status).toBe('Completed');
+        expect(parsed.endedOn).toBe('2026-08-26T11:15:00+00:00');
+        expect(parsed.title).toBe('Day with Dad');
+        expect(parsed.placeName).toBe('Lough Corrib');
+    });
+
+    it('round-trips a full location without losing provenance or privacy', async () => {
+        await save(trip({ location: fullLocation() }));
+
+        const parsed = JSON.parse((await getTrip(ownerUserId, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')).json);
+
+        expect(parsed.location).toEqual(fullLocation());
+    });
+
+    it('keeps a null location null rather than inventing a partial one', async () => {
+        await save(trip({ location: null }));
+
+        const parsed = JSON.parse((await getTrip(ownerUserId, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')).json);
+
+        expect(parsed.location).toBeNull();
+    });
+
+    it('does not return another owner trip by id', async () => {
+        await save(trip({ ownerUserId: otherUserId }));
+
+        const stored = await getTrip(ownerUserId, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+
+        expect(stored).toBeNull();
+    });
+
+    it('returns null for a trip that is not stored', async () => {
+        const stored = await getTrip(ownerUserId, 'dddddddd-dddd-dddd-dddd-dddddddddddd');
+
+        expect(stored).toBeNull();
+    });
+
+    it('lists only the requested owner trips', async () => {
+        await save(trip({ placeName: 'Lough Corrib' }));
+        await save(trip({
+            id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+            ownerUserId: otherUserId,
+            placeName: 'Lough Mask'
+        }));
+
+        const trips = await getTrips(ownerUserId);
+
+        expect(trips).toHaveLength(1);
+        expect(JSON.parse(trips[0].json).placeName).toBe('Lough Corrib');
+    });
+
+    it('treats an empty owner as no owner for a list read', async () => {
+        await save(trip());
+
+        const trips = await getTrips('00000000-0000-0000-0000-000000000000');
+
+        expect(trips).toEqual([]);
+    });
+
+    it('finds the active trip for an owner', async () => {
+        await save(trip({
+            id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+            status: 'Completed',
+            endedOn: '2026-08-25T11:00:00+00:00'
+        }));
+        await save(trip());
+
+        const active = await getActiveTrip(ownerUserId);
+
+        expect(JSON.parse(active.json).id).toBe('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+    });
+
+    it('finds no active trip when every trip is completed', async () => {
+        await save(trip({ status: 'Completed', endedOn: '2026-08-26T11:00:00+00:00' }));
+
+        const active = await getActiveTrip(ownerUserId);
+
+        expect(active).toBeNull();
+    });
+
+    it('does not return another owner active trip', async () => {
+        await save(trip({ ownerUserId: otherUserId }));
+
+        const active = await getActiveTrip(ownerUserId);
+
+        expect(active).toBeNull();
+    });
+
+    it('rejects a second distinct active trip for the same owner', async () => {
+        await save(trip());
+
+        const outcome = await save(trip({ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' }));
+
+        expect(outcome).toBe(TRIP_ACTIVE_CONFLICT_OUTCOME);
+        expect(await getTrips(ownerUserId)).toHaveLength(1);
+    });
+
+    it('allows updating the same active trip', async () => {
+        await save(trip());
+
+        const outcome = await save(trip({ placeName: 'Lough Corrib' }));
+
+        expect(outcome).toBe(TRIP_SAVED_OUTCOME);
+        const parsed = JSON.parse((await getActiveTrip(ownerUserId)).json);
+        expect(parsed.placeName).toBe('Lough Corrib');
+    });
+
+    it('allows a new active trip once the earlier one is completed', async () => {
+        await save(trip());
+        await save(trip({ status: 'Completed', endedOn: '2026-08-26T11:00:00+00:00' }));
+
+        const outcome = await save(trip({ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' }));
+
+        expect(outcome).toBe(TRIP_SAVED_OUTCOME);
+        expect(JSON.parse((await getActiveTrip(ownerUserId)).json).id)
+            .toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+    });
+
+    it('allows each owner their own active trip', async () => {
+        await save(trip());
+
+        const outcome = await save(trip({
+            id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+            ownerUserId: otherUserId
+        }));
+
+        expect(outcome).toBe(TRIP_SAVED_OUTCOME);
+        expect(JSON.parse((await getActiveTrip(ownerUserId)).json).ownerUserId).toBe(ownerUserId);
+        expect(JSON.parse((await getActiveTrip(otherUserId)).json).ownerUserId).toBe(otherUserId);
+    });
+
+    it('does not let a write reassign an existing trip to another owner', async () => {
+        await save(trip());
+
+        await expect(save(trip({ ownerUserId: otherUserId, status: 'Completed', endedOn: null })))
+            .rejects.toThrow('Trip ownership cannot be changed');
+        expect(JSON.parse((await getTrip(ownerUserId, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')).json).ownerUserId)
+            .toBe(ownerUserId);
+    });
+
+    it('does not disturb stored catches', async () => {
+        await putCatchWithPhotographs(
+            JSON.stringify({ id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', userId: ownerUserId, notes: 'keep' }),
+            [{
+                id: 'photo-1',
+                catchId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([1, 2, 3])
+            }]);
+
+        await save(trip());
+
+        const catches = await getAllCatchesWithPhotographs(ownerUserId);
+        expect(catches).toHaveLength(1);
+        expect(JSON.parse(catches[0].json).notes).toBe('keep');
+        expect(catches[0].photographs).toHaveLength(1);
+    });
+});

--- a/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingTripRegistration.cs
+++ b/tests/FishingLogBook.Web.Tests/DependencyInjection/WhenTestingTripRegistration.cs
@@ -1,0 +1,39 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FishingLogBook.Web.Tests.DependencyInjection;
+
+public class WhenTestingTripRegistration : BaseDependencyInjectionTest
+{
+    [Fact]
+    public async Task ItShouldResolveTheLocalTripStore()
+    {
+        // Arrange
+        await using var provider = CreateProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        // Act
+        var store = scope.ServiceProvider.GetRequiredService<ITripStore>();
+
+        // Assert
+        store.Should().BeOfType<IndexedDbTripStore>();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheLocalCatchStoreRegisteredAlongsideTrips()
+    {
+        // Arrange
+        await using var provider = CreateProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        // Act
+        var catchStore = scope.ServiceProvider.GetRequiredService<ICatchStore>();
+        var tripStore = scope.ServiceProvider.GetRequiredService<ITripStore>();
+
+        // Assert
+        catchStore.Should().BeOfType<IndexedDbCatchStore>();
+        tripStore.Should().NotBeSameAs(catchStore);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Stores/TripStoreTests/WhenTestingIndexedDbInteraction.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Stores/TripStoreTests/WhenTestingIndexedDbInteraction.cs
@@ -1,0 +1,330 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using Microsoft.JSInterop;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripStoreTests;
+
+public class WhenTestingIndexedDbInteraction
+{
+    private static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    [Fact]
+    public async Task ItShouldRejectATripWithNoOwner()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime();
+        var sut = CreateStore(js);
+
+        // Act
+        var act = () => sut.SaveAsync(NewTrip() with { OwnerUserId = Guid.Empty }, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        js.Invocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectATripWithNoIdentifier()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime();
+        var sut = CreateStore(js);
+
+        // Act
+        var act = () => sut.SaveAsync(NewTrip() with { Id = Guid.Empty }, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        js.Invocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnEmptyOwnerForEveryRead()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime();
+        var sut = CreateStore(js);
+
+        // Act
+        var all = () => sut.GetAllAsync(Guid.Empty, CancellationToken.None);
+        var single = () => sut.GetAsync(Guid.Empty, TripId, CancellationToken.None);
+        var active = () => sut.GetActiveAsync(Guid.Empty, CancellationToken.None);
+
+        // Assert
+        await all.Should().ThrowAsync<InvalidOperationException>();
+        await single.Should().ThrowAsync<InvalidOperationException>();
+        await active.Should().ThrowAsync<InvalidOperationException>();
+        js.Invocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldSurfaceALocalActiveTripConflict()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime { WriteOutcome = "activeConflict" };
+        var sut = CreateStore(js);
+
+        // Act
+        var act = () => sut.SaveAsync(NewTrip(), CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<TripAlreadyActiveException>();
+        js.Identifiers.Should().Equal("putTrip");
+    }
+
+    [Fact]
+    public async Task ItShouldSaveATripAsSerialisedMetadata()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime();
+        var sut = CreateStore(js);
+
+        // Act
+        await sut.SaveAsync(NewTrip() with { PlaceName = "Lough Corrib" }, CancellationToken.None);
+
+        // Assert
+        js.Identifiers.Should().Equal("putTrip");
+        js.Invocations[0].Arguments.Should().ContainSingle();
+        var json = js.Invocations[0].Arguments[0].Should().BeOfType<string>().Subject;
+        json.Should().Contain("\"placeName\":\"Lough Corrib\"");
+        json.Should().Contain("\"status\":\"Active\"");
+        json.Should().Contain(OwnerUserId.ToString("D"));
+    }
+
+    [Fact]
+    public async Task ItShouldReadASingleTripDirectlyWithoutListingEveryTrip()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime { SingleRecord = StoredRecord(OwnerUserId) };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetAsync(OwnerUserId, TripId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().NotBeNull();
+        loaded!.Id.Should().Be(TripId);
+        js.Identifiers.Should().Equal("getTrip");
+        js.Identifiers.Should().NotContain("getTrips");
+        js.Invocations[0].Arguments.Should().Equal(OwnerUserId.ToString("D"), TripId.ToString("D"));
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnASingleTripOwnedByAnotherAngler()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime { SingleRecord = StoredRecord(OtherUserId) };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetAsync(OwnerUserId, TripId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNullWhenTheTripIsNotStored()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime { SingleRecord = null };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetAsync(OwnerUserId, TripId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().BeNull();
+        js.Identifiers.Should().Equal("getTrip");
+    }
+
+    [Fact]
+    public async Task ItShouldReadTheActiveTripDirectly()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime { SingleRecord = StoredRecord(OwnerUserId) };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().NotBeNull();
+        loaded!.Status.Should().Be(TripConstants.Active);
+        js.Identifiers.Should().Equal("getActiveTrip");
+        js.Identifiers.Should().NotContain("getTrips");
+        js.Invocations[0].Arguments.Should().Equal(OwnerUserId.ToString("D"));
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnAnotherAnglersActiveTrip()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime { SingleRecord = StoredRecord(OtherUserId) };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldListOnlyTheOwnersTrips()
+    {
+        // Arrange
+        var js = new RecordingJsRuntime
+        {
+            ListRecords = [StoredRecord(OwnerUserId), StoredRecord(OtherUserId, Guid.NewGuid())]
+        };
+        var sut = CreateStore(js);
+
+        // Act
+        var loaded = await sut.GetAllAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        loaded.Should().ContainSingle();
+        loaded[0].OwnerUserId.Should().Be(OwnerUserId);
+        js.Identifiers.Should().Equal("getTrips");
+    }
+
+    [Fact]
+    public async Task ItShouldTimeOutRatherThanHangWhenTheModuleNeverLoads()
+    {
+        // Arrange
+        var sut = new IndexedDbTripStore(
+            new HangingJsRuntime(),
+            Substitute.For<IDiagnosticLogger>(),
+            Substitute.For<ILoggingService>(),
+            new DiagnosticsClientConfig { OperationTimeoutMilliseconds = 250 });
+
+        // Act
+        var act = () => sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<TimeoutException>();
+    }
+
+    private static IndexedDbTripStore CreateStore(IJSRuntime js)
+    {
+        return new IndexedDbTripStore(
+            js,
+            Substitute.For<IDiagnosticLogger>(),
+            Substitute.For<ILoggingService>(),
+            new DiagnosticsClientConfig { OperationTimeoutMilliseconds = 5000 });
+    }
+
+    private static TripModel NewTrip()
+    {
+        return new TripModel(TripId, OwnerUserId, TripConstants.Active, StartedOn);
+    }
+
+    private static StoredTripRecord StoredRecord(Guid ownerUserId, Guid? tripId = null)
+    {
+        return new StoredTripRecord
+        {
+            Json = TripJson.Serialize(new TripModel(
+                tripId ?? TripId,
+                ownerUserId,
+                TripConstants.Active,
+                StartedOn))
+        };
+    }
+
+    private sealed record JsInvocation(string Identifier, IReadOnlyList<object?> Arguments);
+
+    private sealed class RecordingJsRuntime : IJSRuntime, IJSObjectReference
+    {
+        private readonly List<JsInvocation> _invocations = [];
+
+        public string WriteOutcome { get; set; } = "saved";
+
+        public StoredTripRecord? SingleRecord { get; set; }
+
+        public StoredTripRecord[] ListRecords { get; set; } = [];
+
+        public IReadOnlyList<JsInvocation> Invocations => _invocations;
+
+        public IReadOnlyList<string> Identifiers =>
+            [.. _invocations.Select(invocation => invocation.Identifier)];
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier,
+            CancellationToken cancellationToken,
+            object?[]? args)
+        {
+            if (identifier == "import")
+            {
+                return new ValueTask<TValue>((TValue)(object)this);
+            }
+
+            _invocations.Add(new JsInvocation(identifier, Flatten(args)));
+            object? result = identifier switch
+            {
+                "putTrip" => WriteOutcome,
+                "getTrip" => SingleRecord,
+                "getActiveTrip" => SingleRecord,
+                "getTrips" => ListRecords,
+                _ => null
+            };
+            return new ValueTask<TValue>((TValue)result!);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        private static IReadOnlyList<object?> Flatten(object?[]? args)
+        {
+            if (args is null)
+            {
+                return [];
+            }
+
+            if (args.Length == 1 && args[0] is object?[] nested)
+            {
+                return nested;
+            }
+
+            return args;
+        }
+    }
+
+    private sealed class HangingJsRuntime : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier,
+            CancellationToken cancellationToken,
+            object?[]? args)
+        {
+            return new ValueTask<TValue>(Hang<TValue>(cancellationToken));
+        }
+
+        private static async Task<TValue> Hang<TValue>(CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            return default!;
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/TripJsonTests/WhenTestingRoundTrip.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/TripJsonTests/WhenTestingRoundTrip.cs
@@ -1,0 +1,200 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Offline.TripJsonTests;
+
+public class WhenTestingRoundTrip
+{
+    private static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    [Fact]
+    public void ItShouldRejectUnreadableJson()
+    {
+        // Arrange
+        // Act
+        var act = () => TripJson.Deserialize("null");
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void ItShouldWriteTheTripStatusAsThePascalCaseNameTheStoreCompares()
+    {
+        // Arrange
+        var trip = NewTrip();
+
+        // Act
+        var json = TripJson.Serialize(trip);
+
+        // Assert
+        json.Should().Contain("\"status\":\"Active\"");
+    }
+
+    [Fact]
+    public void ItShouldWriteTheSyncStatusAsACamelCaseNameMatchingTheCatchConvention()
+    {
+        // Arrange
+        var trip = NewTrip() with { SyncStatus = SyncStatus.Synchronised };
+
+        // Act
+        var json = TripJson.Serialize(trip);
+
+        // Assert
+        json.Should().Contain("\"syncStatus\":\"synchronised\"");
+    }
+
+    [Fact]
+    public void ItShouldRoundTripABlankActiveTrip()
+    {
+        // Arrange
+        var trip = NewTrip();
+
+        // Act
+        var restored = TripJson.Deserialize(TripJson.Serialize(trip));
+
+        // Assert
+        restored.Should().Be(trip);
+        restored.Title.Should().BeNull();
+        restored.PlaceName.Should().BeNull();
+        restored.Location.Should().BeNull();
+        restored.EndedOn.Should().BeNull();
+        restored.SyncedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void ItShouldRoundTripACompletedTripWithATitleAndPlace()
+    {
+        // Arrange
+        var trip = NewTrip() with
+        {
+            Status = TripConstants.Completed,
+            EndedOn = StartedOn.AddHours(6),
+            Title = "Day with Dad",
+            PlaceName = "Lough Corrib"
+        };
+
+        // Act
+        var restored = TripJson.Deserialize(TripJson.Serialize(trip));
+
+        // Assert
+        restored.Should().Be(trip);
+        restored.Status.Should().Be(TripConstants.Completed);
+        restored.EndedOn.Should().Be(StartedOn.AddHours(6));
+    }
+
+    [Fact]
+    public void ItShouldRoundTripEveryLocationFieldIncludingProvenanceAndPrivacy()
+    {
+        // Arrange
+        var trip = NewTrip() with
+        {
+            Location = new TripLocationModel(
+                53.4419,
+                -9.2531,
+                8,
+                StartedOn,
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion)
+        };
+
+        // Act
+        var restored = TripJson.Deserialize(TripJson.Serialize(trip));
+
+        // Assert
+        restored.Location.Should().NotBeNull();
+        restored.Location!.Latitude.Should().Be(53.4419);
+        restored.Location.Longitude.Should().Be(-9.2531);
+        restored.Location.AccuracyMetres.Should().Be(8);
+        restored.Location.CapturedOn.Should().Be(StartedOn);
+        restored.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        restored.Location.Visibility.Should().Be(LocationDefaults.Private);
+        restored.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+    }
+
+    [Fact]
+    public void ItShouldRoundTripALocationWithNoAccuracy()
+    {
+        // Arrange
+        var trip = NewTrip() with
+        {
+            Location = new TripLocationModel(
+                53.4419,
+                -9.2531,
+                null,
+                StartedOn,
+                LocationDefaults.DeviceGps,
+                LocationDefaults.Private,
+                LocationDefaults.ConsentVersion)
+        };
+
+        // Act
+        var restored = TripJson.Deserialize(TripJson.Serialize(trip));
+
+        // Assert
+        restored.Location!.AccuracyMetres.Should().BeNull();
+    }
+
+    [Fact]
+    public void ItShouldPreserveTheOffsetOnStoredInstants()
+    {
+        // Arrange
+        var startedOn = DateTimeOffset.Parse("2026-08-26T06:32:00+01:00");
+        var trip = NewTrip() with { StartedOn = startedOn };
+
+        // Act
+        var restored = TripJson.Deserialize(TripJson.Serialize(trip));
+
+        // Assert
+        restored.StartedOn.Should().Be(startedOn);
+        restored.StartedOn.ToUniversalTime().Should().Be(startedOn.ToUniversalTime());
+    }
+
+    [Fact]
+    public void ItShouldNotSubstituteTheCurrentTimeForAMissingEnd()
+    {
+        // Arrange
+        var json = TripJson.Serialize(NewTrip());
+
+        // Act
+        var restored = TripJson.Deserialize(json);
+
+        // Assert
+        restored.EndedOn.Should().BeNull();
+    }
+
+    [Fact]
+    public void ItShouldRoundTripTheSyncState()
+    {
+        // Arrange
+        var syncedAt = StartedOn.AddHours(7);
+        var trip = NewTrip() with
+        {
+            SyncStatus = SyncStatus.Synchronised,
+            SyncedAt = syncedAt
+        };
+
+        // Act
+        var restored = TripJson.Deserialize(TripJson.Serialize(trip));
+
+        // Assert
+        restored.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        restored.SyncedAt.Should().Be(syncedAt);
+    }
+
+    private static TripModel NewTrip()
+    {
+        return new TripModel(
+            TripId,
+            OwnerUserId,
+            TripConstants.Active,
+            StartedOn);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/JavaScript/OfflineStore/BaseOfflineStoreTest.cs
+++ b/tests/FishingLogBook.Web.Tests/JavaScript/OfflineStore/BaseOfflineStoreTest.cs
@@ -8,7 +8,9 @@ public class BaseOfflineStoreTest
             ReadWwwRootJs("browser", "timeout.js"),
             ReadWwwRootJs("storage", "indexed-db.js"),
             ReadWwwRootJs("storage", "offline-diagnostics.js"),
-            ReadWwwRootJs("storage", "catch-store.js"));
+            ReadWwwRootJs("storage", "logbook-database.js"),
+            ReadWwwRootJs("storage", "catch-store.js"),
+            ReadWwwRootJs("storage", "trip-store.js"));
     }
 
     private static string ReadWwwRootJs(params string[] relativeSegments)


### PR DESCRIPTION
Closes #173
Part of #108

Second Trips slice, on top of #172 (now merged). Architecture/product baseline: [#108 — Agreed V1 implementation baseline](https://github.com/kingkeamo/fishing-logbook/issues/108#issuecomment-5428632438).

Trips now persist locally, so an angler can start, continue and finish one without connectivity, and an active trip survives closing and reopening the app. No UI, no synchroniser, no `Catch.TripId` — those are T3, T4 and T5.

## The IndexedDB upgrade

**Version 4 → 5 on the `FishingLogBook` database.** This is the highest-risk change in the whole feature: it touches a database already holding real queued catches and photograph blobs on the test devices.

Purely additive. One `createObjectStore` guarded by an existence check. Nothing renamed, dropped, cleared or rewritten, and the pre-existing legacy `testCatches` cleanup is carried over verbatim rather than reworked.

The other three databases — `FishingLogBookOfflineAccess`, `FishingLogBookPreferences`, `FishingLogBookDiagnostics` — are separate and untouched, which a test asserts rather than assumes.

### One store only

`trips` (`keyPath: 'id'`, no indexes). **`tripPhotographs` and `tripNotes` are deliberately not created.**

The upgrade handler is a series of `if (!contains) create` guards, so T6 and T7 can each add their store in a later additive version, and a v4 user who lands on v7 gets all of them in a single upgrade. There is no safety benefit to creating empty stores now, so doing it would be pure speculation.

### Shared schema ownership

The database name, version, upgrade handler and transaction helpers move out of `catch-store.js` into a new `logbook-database.js` that both stores import. Trips and catches genuinely share one database, and creating a `trips` store inside a function called `openCatchDatabase`, governed by a constant called `CATCH_DATABASE_VERSION`, would have been actively misleading.

`catch-store.js` re-exports its previous names, so **no Catch behaviour changed** — all 41 existing Catch vitest tests pass untouched.

## Local model and store

```csharp
TripModel(Id, OwnerUserId, Status, StartedOn, EndedOn?, Title?, PlaceName?,
          Location?, SyncStatus, SyncedAt?)

ITripStore
  SaveAsync(trip, ct)
  GetAllAsync(ownerUserId, ct)
  GetAsync(ownerUserId, tripId, ct)      // direct key read
  GetActiveAsync(ownerUserId, ct)        // direct owner + status read
```

`Status` is a `string` constrained by `TripConstants.IsKnownStatus`, mirroring how `CatchLocationModel.Visibility` already works — Web references Shared only, so the Domain enum is unavailable and duplicating it would be worse than a constrained string.

**No `CreatedOn`/`UpdatedOn` locally.** They are server-assigned and nothing in T3 or T4 needs them, so adding them now would be inventing fields for later slices.

**Sync state is two fields**: `SyncStatus` so T4 can find pending work, and `SyncedAt` because #108's retention rules key on it. No `MetadataSyncStatus` — trips own no child media in this slice.

### No read is implemented by listing and filtering

`GetAsync` is a direct `store.get(tripId)`; `GetActiveAsync` is a single owner-scoped cursor that stops at the first match. This is the #166 anti-pattern and it is not repeated — a browser test instruments `IDBObjectStore` and asserts a single-trip read performs exactly one `get` against `trips` and nothing else.

## One active trip locally

Enforced **inside the readwrite transaction that writes the trip** — one authoritative local write boundary, not split across layers and not dependent on any component state.

The JS returns a discriminated outcome (`'saved'` / `'activeConflict'`) which the store turns into `TripAlreadyActiveException`. A returned outcome rather than error-message matching, so an expected domain conflict is distinguishable from a genuine failure without parsing strings.

| Scenario | Behaviour |
|---|---|
| Second **distinct** active trip, same owner | rejected, nothing written |
| Re-saving the **same** active trip | succeeds |
| New active trip after the earlier one completed | succeeds |
| Each owner holding their own active trip | succeeds |
| Write moving an existing trip id to another owner | rejected outright |

## Owner isolation

`ownerUserId` is filtered **during** every cursor in JS — never after an expensive read — with a `LocalTripVisibility.ForOwner` pass in .NET as defence in depth. Proven for all three reads plus the ownership-reassignment case.

## Cold reopen

No in-memory current-trip state exists anywhere. The active trip is discovered from owner-scoped stored data, proven by a real `page.reload()` followed by `getActiveTrip`. This is what makes T3's Start Fishing survive a force-quit on the water.

## Cleanup

Verified rather than assumed: `cleanupSyncedCatches` opens a transaction scoped to `[catches, catchPhotographs]` and cursors only the catch store, so it **cannot** reach `trips`. No guard was needed. Actual trip retention belongs to T4, where the #108 rules apply — active and pending trips never evicted.

## Tests

**26 browser tests** (13 specs × Chromium and WebKit) covering all 18 assertions #173 asked for: the v4→v5 upgrade with catch metadata and a 64 KB blob surviving, the entitlement database untouched, blank / active / completed / with-location / without-location round-trips, location provenance preserved, direct-read instrumentation, owner scoping on all three reads, the four active-trip variants, and reload recovery.

**33 .NET tests**: 10 `TripJson` round-trip, 12 store and JS-interaction (including the timeout path), 2 DI resolution, plus 9 updated schema guards.

Full validation: `dotnet format` clean · `dotnet build` clean · **1,748 .NET tests** · vitest **280** · browser **90** · `git diff --check` clean.

No credentialed E2E — this slice touches no user journey. No physical-device acceptance claimed; that is T9.

## Self review

```text
Self review:
- Issue/AC: PASS — every acceptance criterion implemented and tested
- Architecture: PASS — feature-first under Features/Trips, store role in Offline/Stores
- Rules: findings 1, 2 (fixed)
- Security/privacy: PASS — owner scoped during every cursor; location provenance and
  visibility round-trip intact; no coordinates or payloads logged
- Database/migrations: PASS — additive IndexedDB upgrade, no server migration in this slice
- Tests/coverage: PASS — real browser proof, not mocks, for the upgrade
- Browser: PASS — 26 tests across two engines
- Web/UI/localisation: N/A — no user-visible text in this slice
- Code smells: findings 3, 4 (fixed)
- CI/deployment: PASS — no manual steps
```

**Findings discovered during self-review:**

1. **A deliberate tripwire fired, exactly as designed.** `schema-safety.test.js` asserted `CATCH_DATABASE_VERSION === 4` and an exact store set — a guard against casual schema bumps, which #108 explicitly warned about.
2. **Two .NET tests read the JS source** (`JavaScript/OfflineStore`) and broke, because extracting the shared module moved the timeout and diagnostics code they inspect.
3. **Enum casing mismatch, caught before it shipped.** I first used `JsonStringEnumConverter()` with no naming policy, producing `"SavedLocally"`, while the existing JS reads `'synchronised'`. Left alone this would have recreated exactly the class of latent bug found in #166, where JS and .NET disagreed on a persisted enum's shape and the tests did not reflect production.
4. **`ITripStore` had no consumer**, so nothing proved it was registered — a typo would only have surfaced in T3.

**Fixes made:**

1. Updated the guards **deliberately** to v5 and the three-store set, kept as exact-set assertions so a future casual change still trips them, and **added two more**: trip-store must not mention other features' schema names, and the database name must live in exactly one module.
2. Added `logbook-database.js` and `trip-store.js` to the concatenated source, so those assertions now cover the whole offline-storage surface. Strengthened, not weakened.
3. Aligned to `JsonNamingPolicy.CamelCase` and added a test asserting the serialised JSON contains `"syncStatus":"synchronised"` — locking the exact cross-language contract.
4. Added DI resolution tests, which immediately hit the `IAsyncDisposable` container-disposal trap and were fixed with `CreateAsyncScope`.

**Remaining deliberate gaps:**

- Trip retention is not wired into cleanup. Verified impossible for the current cleanup to touch trips, so this is a genuine T4 concern rather than a hole.
- No UI, synchroniser, `Catch.TripId`, photographs, notes or timeline — all later slices, all untouched here.

## Manual post-merge steps

**None.** No database migration, no Terraform, no configuration. The IndexedDB upgrade runs in each browser on next open.
