### PR TITLE
FLB#174 | Start and finish a solo trip, with active-trip recovery

### DIFF
--- a/src/FishingLogBook.Web/BrowserTests/trip-lifecycle.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/trip-lifecycle.spec.js
@@ -1,0 +1,170 @@
+import { expect, test } from '@playwright/test';
+
+const tripStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.js';
+const catchStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js';
+const databaseName = 'FishingLogBook';
+const ownerUserId = '11111111-1111-1111-1111-111111111111';
+const tripId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const seededCatchId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const startedOn = '2026-08-26T05:32:00+00:00';
+const endedOn = '2026-08-26T12:15:00+00:00';
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/src/FishingLogBook.Web/BrowserTests/harness/index.html');
+    await page.evaluate((name) => new Promise((resolve) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+    }), databaseName);
+});
+
+function trip(overrides = {}) {
+    return {
+        id: tripId,
+        ownerUserId,
+        status: 'Active',
+        startedOn,
+        endedOn: null,
+        title: null,
+        placeName: null,
+        location: null,
+        syncStatus: 'savedLocally',
+        syncedAt: null,
+        ...overrides
+    };
+}
+
+async function saveTrip(page, record) {
+    return page.evaluate(async ({ tripStoreModule, record }) => {
+        const { putTrip } = await import(tripStoreModule);
+        return putTrip(JSON.stringify(record));
+    }, { tripStoreModule, record });
+}
+
+async function readActiveTrip(page) {
+    return page.evaluate(async ({ tripStoreModule, ownerUserId }) => {
+        const { getActiveTrip } = await import(tripStoreModule);
+        const stored = await getActiveTrip(ownerUserId);
+        return stored === null ? null : JSON.parse(stored.json);
+    }, { tripStoreModule, ownerUserId });
+}
+
+async function readTrip(page) {
+    return page.evaluate(async ({ tripStoreModule, ownerUserId, tripId }) => {
+        const { getTrip } = await import(tripStoreModule);
+        const stored = await getTrip(ownerUserId, tripId);
+        return stored === null ? null : JSON.parse(stored.json);
+    }, { tripStoreModule, ownerUserId, tripId });
+}
+
+async function seedCatch(page) {
+    await page.evaluate(async ({ catchStoreModule, ownerUserId, seededCatchId }) => {
+        const { putCatchWithPhotographs } = await import(catchStoreModule);
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: seededCatchId,
+                userId: ownerUserId,
+                caughtOn: '2026-06-14T09:48:00+00:00',
+                notes: 'unrelated to any trip',
+                photographs: [{ id: 'photo-1', catchId: seededCatchId, contentType: 'image/jpeg' }]
+            }),
+            [{
+                id: 'photo-1',
+                catchId: seededCatchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array(2048).fill(3)
+            }]);
+    }, { catchStoreModule, ownerUserId, seededCatchId });
+}
+
+test('starting a trip writes an active record to IndexedDB', async ({ page }) => {
+    const outcome = await saveTrip(page, trip());
+
+    expect(outcome).toBe('saved');
+    const active = await readActiveTrip(page);
+    expect(active.id).toBe(tripId);
+    expect(active.status).toBe('Active');
+    expect(active.endedOn).toBeNull();
+});
+
+test('the active trip survives a full reload', async ({ page }) => {
+    await saveTrip(page, trip());
+
+    await page.reload();
+    await page.waitForFunction(() => document.readyState === 'complete');
+
+    const active = await readActiveTrip(page);
+    expect(active.id).toBe(tripId);
+    expect(active.startedOn).toBe(startedOn);
+});
+
+test('finishing marks the same record completed rather than creating another', async ({ page }) => {
+    await saveTrip(page, trip());
+
+    const outcome = await saveTrip(page, trip({ status: 'Completed', endedOn }));
+
+    expect(outcome).toBe('saved');
+    const stored = await readTrip(page);
+    expect(stored.id).toBe(tripId);
+    expect(stored.status).toBe('Completed');
+    expect(stored.endedOn).toBe(endedOn);
+    expect(stored.startedOn).toBe(startedOn);
+});
+
+test('no active trip remains after finishing, including across a reload', async ({ page }) => {
+    await saveTrip(page, trip());
+    await saveTrip(page, trip({ status: 'Completed', endedOn }));
+
+    expect(await readActiveTrip(page)).toBeNull();
+
+    await page.reload();
+    await page.waitForFunction(() => document.readyState === 'complete');
+
+    expect(await readActiveTrip(page)).toBeNull();
+});
+
+test('a new trip may start once the previous one is finished', async ({ page }) => {
+    await saveTrip(page, trip());
+    await saveTrip(page, trip({ status: 'Completed', endedOn }));
+
+    const outcome = await saveTrip(page, trip({ id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' }));
+
+    expect(outcome).toBe('saved');
+    expect((await readActiveTrip(page)).id).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+});
+
+test('the whole start and finish journey leaves stored catches untouched', async ({ page }) => {
+    await seedCatch(page);
+
+    await saveTrip(page, trip());
+    await saveTrip(page, trip({ status: 'Completed', endedOn }));
+
+    const catches = await page.evaluate(async ({ catchStoreModule, ownerUserId }) => {
+        const { getAllCatchesWithPhotographs } = await import(catchStoreModule);
+        const stored = await getAllCatchesWithPhotographs(ownerUserId);
+        return stored.map((item) => ({
+            notes: JSON.parse(item.json).notes,
+            photographs: item.photographs.length
+        }));
+    }, { catchStoreModule, ownerUserId });
+
+    expect(catches).toHaveLength(1);
+    expect(catches[0].notes).toBe('unrelated to any trip');
+    expect(catches[0].photographs).toBe(1);
+});
+
+test('the local start and finish journey issues no network request', async ({ page }) => {
+    const requests = [];
+    page.on('request', (request) => {
+        const url = request.url();
+        if (url.includes('/api/')) {
+            requests.push(url);
+        }
+    });
+
+    await saveTrip(page, trip());
+    await saveTrip(page, trip({ status: 'Completed', endedOn }));
+
+    expect(requests).toEqual([]);
+});

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
@@ -10,14 +10,37 @@
     <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
         <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="flex-wrap" Spacing="2">
             <MudText Typo="Typo.h4" id="catch-list-title">@Loc["Catch_LogbookTitle"]</MudText>
-            <MudButton Variant="Variant.Filled"
-                       Color="Color.Primary"
-                       Href="/catches/record"
-                       StartIcon="@Icons.Material.Filled.AddAPhoto"
-                       Class="catch-record-cta"
-                       id="catch-record-link">
-                @Loc["Catch_RecordNav"]
-            </MudButton>
+            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="flex-wrap">
+                @if (_activeTrip is not null)
+                {
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Secondary"
+                               Href="@ActiveTripHref"
+                               StartIcon="@Icons.Material.Filled.Sailing"
+                               id="trip-continue-link">
+                        @Loc["Trip_Continue"]
+                    </MudButton>
+                }
+                else
+                {
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Secondary"
+                               OnClick="StartFishingAsync"
+                               Disabled="_isStartingTrip"
+                               StartIcon="@Icons.Material.Filled.Sailing"
+                               id="trip-start-link">
+                        @Loc["Trip_StartFishing"]
+                    </MudButton>
+                }
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           Href="/catches/record"
+                           StartIcon="@Icons.Material.Filled.AddAPhoto"
+                           Class="catch-record-cta"
+                           id="catch-record-link">
+                    @Loc["Catch_RecordNav"]
+                </MudButton>
+            </MudStack>
         </MudStack>
 
         @if (_loadFailed)

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
@@ -15,6 +15,9 @@ using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Providers;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -43,6 +46,8 @@ public partial class CatchList : ComponentBase, IDisposable
     private bool _loadFailed;
     private bool _isLoadInFlight;
     private bool _reloadRequested;
+    private TripModel? _activeTrip;
+    private bool _isStartingTrip;
     private bool _localRefreshRequested;
     private AnglerPreferencesModel? _preferences;
 
@@ -78,6 +83,20 @@ public partial class CatchList : ComponentBase, IDisposable
 
     [Inject]
     private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IActiveTripService ActiveTrip { get; set; } = default!;
+
+    [Inject]
+    private NavigationManager Navigation { get; set; } = default!;
+
+    private string ActiveTripHref
+    {
+        get
+        {
+            return _activeTrip is null ? "/catches" : $"/trips/{_activeTrip.Id:D}";
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -124,6 +143,7 @@ public partial class CatchList : ComponentBase, IDisposable
             var preferencesTask = AnglerPreferences.GetAsync(cancellationToken);
             var ownerUserId = await LocalCatchOwner.GetUserIdAsync(cancellationToken);
             _currentUserId = ownerUserId;
+            _activeTrip = await LoadActiveTripAsync(ownerUserId, cancellationToken);
 
             var localTask = LoadLocalCatchesAsync(ownerUserId, cancellationToken);
             var remoteTask = LoadRemoteCatchesAsync(cancellationToken);
@@ -193,6 +213,60 @@ public partial class CatchList : ComponentBase, IDisposable
         await ComputeLocalTimesAsync(cancellationToken);
         ComputeFilterOptions();
         RebuildFilteredGroups();
+    }
+
+    private async Task<TripModel?> LoadActiveTripAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await ActiveTrip.GetActiveAsync(ownerUserId, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("resolving the active trip", exception, CancellationToken.None);
+            return null;
+        }
+    }
+
+    private async Task StartFishingAsync()
+    {
+        if (_isStartingTrip || _activeTrip is not null)
+        {
+            return;
+        }
+
+        _isStartingTrip = true;
+        var cancellationToken = _cancellationTokenSource.Token;
+        try
+        {
+            var started = await ActiveTrip.StartAsync(_currentUserId, cancellationToken);
+            Navigation.NavigateTo($"/trips/{started.Id:D}");
+        }
+        catch (TripAlreadyActiveException)
+        {
+            _activeTrip = await LoadActiveTripAsync(_currentUserId, cancellationToken);
+            if (_activeTrip is not null)
+            {
+                Navigation.NavigateTo($"/trips/{_activeTrip.Id:D}");
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("starting a trip", exception, CancellationToken.None);
+        }
+        finally
+        {
+            _isStartingTrip = false;
+        }
     }
 
     private async Task<CatchLoadResult> LoadLocalCatchesAsync(

--- a/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor
@@ -10,13 +10,36 @@
     <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
         <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="flex-wrap" Spacing="2">
             <MudText Typo="Typo.h4" id="offline-catch-list-title">@Loc["Catch_LogbookTitle"]</MudText>
-            <MudButton Variant="Variant.Filled"
-                       Color="Color.Primary"
-                       Href="/offline/record"
-                       StartIcon="@Icons.Material.Filled.AddAPhoto"
-                       id="offline-catch-record-link">
-                @Loc["Catch_RecordNav"]
-            </MudButton>
+            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="flex-wrap">
+                @if (_activeTrip is not null)
+                {
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Secondary"
+                               Href="@ActiveTripHref"
+                               StartIcon="@Icons.Material.Filled.Sailing"
+                               id="offline-trip-continue-link">
+                        @Loc["Trip_Continue"]
+                    </MudButton>
+                }
+                else
+                {
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Secondary"
+                               OnClick="StartFishingAsync"
+                               Disabled="_isStartingTrip"
+                               StartIcon="@Icons.Material.Filled.Sailing"
+                               id="offline-trip-start-link">
+                        @Loc["Trip_StartFishing"]
+                    </MudButton>
+                }
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           Href="/offline/record"
+                           StartIcon="@Icons.Material.Filled.AddAPhoto"
+                           id="offline-catch-record-link">
+                    @Loc["Catch_RecordNav"]
+                </MudButton>
+            </MudStack>
         </MudStack>
 
         @if (_loadFailed)

--- a/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor.cs
@@ -5,6 +5,9 @@ using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Features.Profile.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -19,12 +22,24 @@ public partial class OfflineCatchList : ComponentBase
     private LengthUnitEnum _lengthUnit = LengthUnitEnum.Cm;
     private bool _isLoading = true;
     private bool _loadFailed;
+    private TripModel? _activeTrip;
+    private bool _isStartingTrip;
 
     [Inject] private ICatchStore CatchStore { get; set; } = default!;
     [Inject] private IOfflineOwnerContextService OfflineOwnerContext { get; set; } = default!;
     [Inject] private IAnglerPreferencesStore AnglerPreferencesStore { get; set; } = default!;
+    [Inject] private IActiveTripService ActiveTrip { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private ILoggingService Logging { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private string ActiveTripHref
+    {
+        get
+        {
+            return _activeTrip is null ? "/offline/catches" : $"/offline/trips/{_activeTrip.Id:D}";
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -36,6 +51,7 @@ public partial class OfflineCatchList : ComponentBase
             _catches = LocalCatchVisibility.ForOwner(
                 await CatchStore.GetAllAsync(owner.UserId, CancellationToken.None),
                 owner.UserId);
+            _activeTrip = await LoadActiveTripAsync(owner.UserId);
             var preferences = await AnglerPreferencesStore.GetAsync(owner.UserId, CancellationToken.None);
             if (preferences is not null)
             {
@@ -51,6 +67,50 @@ public partial class OfflineCatchList : ComponentBase
         finally
         {
             _isLoading = false;
+        }
+    }
+
+    private async Task<TripModel?> LoadActiveTripAsync(Guid ownerUserId)
+    {
+        try
+        {
+            return await ActiveTrip.GetActiveAsync(ownerUserId, CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("resolving the offline active trip", exception, CancellationToken.None);
+            return null;
+        }
+    }
+
+    private async Task StartFishingAsync()
+    {
+        if (_isStartingTrip || _activeTrip is not null || _ownerUserId == Guid.Empty)
+        {
+            return;
+        }
+
+        _isStartingTrip = true;
+        try
+        {
+            var started = await ActiveTrip.StartAsync(_ownerUserId, CancellationToken.None);
+            Navigation.NavigateTo($"/offline/trips/{started.Id:D}");
+        }
+        catch (TripAlreadyActiveException)
+        {
+            _activeTrip = await LoadActiveTripAsync(_ownerUserId);
+            if (_activeTrip is not null)
+            {
+                Navigation.NavigateTo($"/offline/trips/{_activeTrip.Id:D}");
+            }
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("starting an offline trip", exception, CancellationToken.None);
+        }
+        finally
+        {
+            _isStartingTrip = false;
         }
     }
 }

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor
@@ -1,0 +1,15 @@
+@namespace FishingLogBook.Web.Features.Trips.Components.ActiveTripBanner
+
+@if (_trip is not null)
+{
+    <div class="active-trip-banner" role="status" id="active-trip-banner">
+        <MudIcon Icon="@Icons.Material.Filled.Sailing" Size="Size.Small" aria-hidden="true" />
+        <span class="active-trip-banner-text">@Loc["Trip_InProgress"]</span>
+        <MudButton Variant="Variant.Text"
+                   Size="Size.Small"
+                   Href="@ContinueHref"
+                   id="active-trip-banner-continue">
+            @Loc["Trip_Continue"]
+        </MudButton>
+    </div>
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor.cs
@@ -1,0 +1,87 @@
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Trips.Components.ActiveTripBanner;
+
+public partial class ActiveTripBanner : ComponentBase, IDisposable
+{
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    private TripModel? _trip;
+
+    [Inject]
+    private IActiveTripService ActiveTrip { get; set; } = default!;
+
+    [Inject]
+    private ILocalCatchOwnerService LocalOwner { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private string ContinueHref
+    {
+        get
+        {
+            return _trip is null ? "/catches" : $"/trips/{_trip.Id:D}";
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        ActiveTrip.StateChanged += OnActiveTripChanged;
+        await RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        var cancellationToken = _cancellationTokenSource.Token;
+        try
+        {
+            var ownerUserId = await LocalOwner.GetUserIdAsync(cancellationToken);
+            _trip = await ActiveTrip.GetActiveAsync(ownerUserId, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            _trip = null;
+            await Logging.LogErrorAsync("resolving the active trip banner", exception, CancellationToken.None);
+        }
+    }
+
+    private void OnActiveTripChanged(object? sender, EventArgs args)
+    {
+        if (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = InvokeAsync(async () =>
+            {
+                await RefreshAsync();
+                StateHasChanged();
+            });
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        ActiveTrip.StateChanged -= OnActiveTripChanged;
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor.css
@@ -1,0 +1,14 @@
+.active-trip-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 1rem;
+    background: var(--mud-palette-primary-hover);
+    border-bottom: 1px solid var(--mud-palette-lines-default);
+    color: var(--mud-palette-text-primary);
+}
+
+.active-trip-banner-text {
+    flex: 1 1 auto;
+    font-size: 0.9rem;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
@@ -1,0 +1,43 @@
+@namespace FishingLogBook.Web.Features.Trips.Components.ActiveTripView
+
+<MudPaper Elevation="0" Class="active-trip-card" id="active-trip-card">
+    <MudStack Spacing="3">
+        <MudStack Spacing="1">
+            <MudText Typo="Typo.overline" Class="active-trip-eyebrow" id="active-trip-eyebrow">
+                @Loc["Trip_ActiveLabel"]
+            </MudText>
+            <MudText Typo="Typo.h5" id="active-trip-heading">@Heading</MudText>
+            @if (HasPlace)
+            {
+                <MudText Typo="Typo.body2" Class="mud-text-secondary" id="active-trip-place">
+                    @Trip.PlaceName
+                </MudText>
+            }
+        </MudStack>
+
+        <MudStack Row="true" Spacing="6" Class="flex-wrap">
+            <MudStack Spacing="0">
+                <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Trip_StartedLabel"]</MudText>
+                <MudText Typo="Typo.body1" id="active-trip-started">@StartedLabel</MudText>
+            </MudStack>
+            @if (ElapsedLabel is not null)
+            {
+                <MudStack Spacing="0">
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Trip_DurationLabel"]</MudText>
+                    <MudText Typo="Typo.body1" id="active-trip-elapsed">@ElapsedLabel</MudText>
+                </MudStack>
+            }
+        </MudStack>
+
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   Size="Size.Large"
+                   FullWidth="true"
+                   Disabled="IsFinishing"
+                   OnClick="OnFinish"
+                   StartIcon="@Icons.Material.Filled.Flag"
+                   id="active-trip-finish">
+            @Loc["Trip_Finish"]
+        </MudButton>
+    </MudStack>
+</MudPaper>

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
@@ -1,0 +1,54 @@
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Trips.Components.ActiveTripView;
+
+public partial class ActiveTripView : ComponentBase
+{
+    [Parameter]
+    [EditorRequired]
+    public TripModel Trip { get; set; } = default!;
+
+    [Parameter]
+    public string? StartedLabel { get; set; }
+
+    [Parameter]
+    public string? ElapsedLabel { get; set; }
+
+    [Parameter]
+    public string? GeneratedTitle { get; set; }
+
+    [Parameter]
+    public bool IsFinishing { get; set; }
+
+    [Parameter]
+    public EventCallback OnFinish { get; set; }
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool HasPlace
+    {
+        get
+        {
+            return !string.IsNullOrWhiteSpace(Trip.PlaceName);
+        }
+    }
+
+    private string Heading
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(Trip.Title))
+            {
+                return Trip.Title!;
+            }
+
+            return string.IsNullOrWhiteSpace(GeneratedTitle)
+                ? Loc["Trip_ActiveLabel"].Value
+                : GeneratedTitle!;
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.css
@@ -1,0 +1,11 @@
+.active-trip-card {
+    padding: 1.25rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    background: var(--mud-palette-surface);
+}
+
+.active-trip-eyebrow {
+    color: var(--mud-palette-primary);
+    letter-spacing: 0.08em;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor
@@ -1,0 +1,30 @@
+@namespace FishingLogBook.Web.Features.Trips.Components.CompletedTripSummary
+
+<MudPaper Elevation="0" Class="completed-trip-card" id="completed-trip-card">
+    <MudStack Spacing="3" AlignItems="AlignItems.Center">
+        <MudIcon Icon="@Icons.Material.Filled.CheckCircle"
+                 Color="Color.Primary"
+                 Size="Size.Large"
+                 aria-hidden="true" />
+        <MudText Typo="Typo.h5" Align="Align.Center" id="completed-trip-heading">
+            @Loc["Trip_Finished"]
+        </MudText>
+        <MudText Typo="Typo.h6" Align="Align.Center" id="completed-trip-title">@Heading</MudText>
+        @if (DurationLabel is not null)
+        {
+            <MudStack Spacing="0" AlignItems="AlignItems.Center">
+                <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Trip_DurationLabel"]</MudText>
+                <MudText Typo="Typo.body1" id="completed-trip-duration">@DurationLabel</MudText>
+            </MudStack>
+        }
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   Size="Size.Large"
+                   FullWidth="true"
+                   Href="@LogbookHref"
+                   StartIcon="@Icons.Material.Filled.MenuBook"
+                   id="completed-trip-logbook">
+            @Loc["Trip_BackToLogbook"]
+        </MudButton>
+    </MudStack>
+</MudPaper>

--- a/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor.cs
@@ -1,0 +1,38 @@
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Trips.Components.CompletedTripSummary;
+
+public partial class CompletedTripSummary : ComponentBase
+{
+    [Parameter]
+    [EditorRequired]
+    public TripModel Trip { get; set; } = default!;
+
+    [Parameter]
+    public string? DurationLabel { get; set; }
+
+    [Parameter]
+    public string? GeneratedTitle { get; set; }
+
+    [Parameter]
+    public string LogbookHref { get; set; } = "/catches";
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private string Heading
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(Trip.Title))
+            {
+                return Trip.Title!;
+            }
+
+            return GeneratedTitle ?? string.Empty;
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor.css
@@ -1,0 +1,6 @@
+.completed-trip-card {
+    padding: 1.75rem 1.25rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: var(--mud-default-borderradius);
+    background: var(--mud-palette-surface);
+}

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripDisplayModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripDisplayModel.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Web.Features.Trips.Models;
+
+public sealed record TripDisplayModel(
+    string? StartedDate,
+    string? StartedTime,
+    string? EndedTime,
+    TimeSpan? Elapsed);

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
@@ -1,0 +1,46 @@
+@page "/trips/{TripId:guid}"
+@attribute [Authorize]
+@using FishingLogBook.Web.Features.Trips.Components.ActiveTripView
+@using FishingLogBook.Web.Features.Trips.Components.CompletedTripSummary
+
+<PageTitle>@Loc["Trip_ActiveLabel"]</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Gutters="false" Class="trip-page">
+    <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
+        @if (_loadFailed)
+        {
+            <MudAlert Severity="Severity.Error" id="trip-load-failed">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Justify="Justify.SpaceBetween">
+                    <span>@Loc["Trip_LoadFailed"]</span>
+                    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Small"
+                               OnClick="RetryAsync" Disabled="_isLoading"
+                               id="trip-load-retry">@Loc["Action_TryAgain"]</MudButton>
+                </MudStack>
+            </MudAlert>
+        }
+        else if (_isLoading)
+        {
+            <MudProgressCircular Indeterminate="true" Color="Color.Primary" Class="align-self-center" id="trip-loading" />
+        }
+        else if (_trip is null)
+        {
+            <MudAlert Severity="Severity.Info" id="trip-not-found">@Loc["Trip_NotFound"]</MudAlert>
+        }
+        else if (IsCompleted)
+        {
+            <CompletedTripSummary Trip="_trip"
+                                  DurationLabel="@DurationLabel"
+                                  GeneratedTitle="@GeneratedTitle"
+                                  LogbookHref="/catches" />
+        }
+        else
+        {
+            <ActiveTripView Trip="_trip"
+                            StartedLabel="@StartedLabel"
+                            ElapsedLabel="@DurationLabel"
+                            GeneratedTitle="@GeneratedTitle"
+                            IsFinishing="_isFinishing"
+                            OnFinish="FinishAsync" />
+        }
+    </MudStack>
+</MudContainer>

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
@@ -1,0 +1,199 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Trips.Pages.ActiveTrip;
+
+public partial class ActiveTrip : ComponentBase, IDisposable
+{
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    private TripModel? _trip;
+    private TripDisplayModel? _display;
+    private bool _isLoading = true;
+    private bool _loadFailed;
+    private bool _isFinishing;
+    private bool _locationAttempted;
+
+    [Parameter]
+    public Guid TripId { get; set; }
+
+    [Inject]
+    private ITripStore TripStore { get; set; } = default!;
+
+    [Inject]
+    private IActiveTripService ActiveTripService { get; set; } = default!;
+
+    [Inject]
+    private ITripDisplayService TripDisplay { get; set; } = default!;
+
+    [Inject]
+    private ILocalCatchOwnerService LocalOwner { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool IsCompleted
+    {
+        get
+        {
+            return _trip?.Status == TripConstants.Completed;
+        }
+    }
+
+    private string? GeneratedTitle
+    {
+        get
+        {
+            return _display?.StartedDate;
+        }
+    }
+
+    private string? StartedLabel
+    {
+        get
+        {
+            return _display?.StartedTime;
+        }
+    }
+
+    private string? DurationLabel
+    {
+        get
+        {
+            return _display?.Elapsed is null ? null : FormatDuration(_display.Elapsed.Value);
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || _locationAttempted || _trip is null || IsCompleted)
+        {
+            return;
+        }
+
+        _locationAttempted = true;
+        await TryAttachLocationAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _loadFailed = false;
+        var cancellationToken = _cancellationTokenSource.Token;
+        try
+        {
+            var ownerUserId = await LocalOwner.GetUserIdAsync(cancellationToken);
+            _trip = await TripStore.GetAsync(ownerUserId, TripId, cancellationToken);
+            if (_trip is not null)
+            {
+                _display = await TripDisplay.DescribeAsync(_trip, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            _loadFailed = true;
+            _trip = null;
+            await Logging.LogErrorAsync("loading a trip", exception, CancellationToken.None);
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task RetryAsync()
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task FinishAsync()
+    {
+        if (_trip is null || _isFinishing || IsCompleted)
+        {
+            return;
+        }
+
+        _isFinishing = true;
+        var cancellationToken = _cancellationTokenSource.Token;
+        try
+        {
+            _trip = await ActiveTripService.FinishAsync(_trip, cancellationToken);
+            _display = await TripDisplay.DescribeAsync(_trip, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception exception)
+        {
+            _loadFailed = true;
+            await Logging.LogErrorAsync("finishing a trip", exception, CancellationToken.None);
+        }
+        finally
+        {
+            _isFinishing = false;
+        }
+    }
+
+    private async Task TryAttachLocationAsync()
+    {
+        var cancellationToken = _cancellationTokenSource.Token;
+        try
+        {
+            var located = await ActiveTripService.TryAttachLocationAsync(_trip!, cancellationToken);
+            if (located is null)
+            {
+                return;
+            }
+
+            _trip = located;
+            StateHasChanged();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("attaching a trip location", exception, CancellationToken.None);
+        }
+    }
+
+    private string FormatDuration(TimeSpan elapsed)
+    {
+        var hours = (int)elapsed.TotalHours;
+        var minutes = elapsed.Minutes;
+        return hours > 0
+            ? Loc["Trip_DurationHoursMinutes", hours, minutes]
+            : Loc["Trip_DurationMinutes", minutes];
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.css
@@ -1,0 +1,3 @@
+.trip-page {
+    padding-top: 0.5rem;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor
@@ -1,0 +1,48 @@
+@page "/offline/trips/{TripId:guid}"
+@attribute [OfflineRoute]
+@layout OfflineLayout
+@using FishingLogBook.Web.Features.OfflineAccess
+@using FishingLogBook.Web.Features.Trips.Components.ActiveTripView
+@using FishingLogBook.Web.Features.Trips.Components.CompletedTripSummary
+
+<PageTitle>@Loc["Trip_ActiveLabel"]</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Gutters="false" Class="offline-trip-page">
+    <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
+        @if (_loadFailed)
+        {
+            <MudAlert Severity="Severity.Error" id="offline-trip-load-failed">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Justify="Justify.SpaceBetween">
+                    <span>@Loc["Trip_LoadFailed"]</span>
+                    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Small"
+                               OnClick="RetryAsync" Disabled="_isLoading"
+                               id="offline-trip-load-retry">@Loc["Action_TryAgain"]</MudButton>
+                </MudStack>
+            </MudAlert>
+        }
+        else if (_isLoading)
+        {
+            <MudProgressCircular Indeterminate="true" Color="Color.Primary" Class="align-self-center" id="offline-trip-loading" />
+        }
+        else if (_trip is null)
+        {
+            <MudAlert Severity="Severity.Info" id="offline-trip-not-found">@Loc["Trip_NotFound"]</MudAlert>
+        }
+        else if (IsCompleted)
+        {
+            <CompletedTripSummary Trip="_trip"
+                                  DurationLabel="@DurationLabel"
+                                  GeneratedTitle="@GeneratedTitle"
+                                  LogbookHref="/offline/catches" />
+        }
+        else
+        {
+            <ActiveTripView Trip="_trip"
+                            StartedLabel="@StartedLabel"
+                            ElapsedLabel="@DurationLabel"
+                            GeneratedTitle="@GeneratedTitle"
+                            IsFinishing="_isFinishing"
+                            OnFinish="FinishAsync" />
+        }
+    </MudStack>
+</MudContainer>

--- a/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor.cs
@@ -1,0 +1,147 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Trips.Pages.OfflineActiveTrip;
+
+public partial class OfflineActiveTrip : ComponentBase
+{
+    private TripModel? _trip;
+    private TripDisplayModel? _display;
+    private bool _isLoading = true;
+    private bool _loadFailed;
+    private bool _isFinishing;
+
+    [Parameter]
+    public Guid TripId { get; set; }
+
+    [Inject]
+    private ITripStore TripStore { get; set; } = default!;
+
+    [Inject]
+    private IActiveTripService ActiveTrip { get; set; } = default!;
+
+    [Inject]
+    private ITripDisplayService TripDisplay { get; set; } = default!;
+
+    [Inject]
+    private IOfflineOwnerContextService OfflineOwnerContext { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool IsCompleted
+    {
+        get
+        {
+            return _trip?.Status == TripConstants.Completed;
+        }
+    }
+
+    private string? GeneratedTitle
+    {
+        get
+        {
+            return _display?.StartedDate;
+        }
+    }
+
+    private string? StartedLabel
+    {
+        get
+        {
+            return _display?.StartedTime;
+        }
+    }
+
+    private string? DurationLabel
+    {
+        get
+        {
+            return _display?.Elapsed is null ? null : FormatDuration(_display.Elapsed.Value);
+        }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _loadFailed = false;
+        try
+        {
+            var owner = OfflineOwnerContext.Owner
+                ?? throw new InvalidOperationException("Offline access is locked.");
+            _trip = await TripStore.GetAsync(owner.UserId, TripId, CancellationToken.None);
+            if (_trip is not null)
+            {
+                _display = await TripDisplay.DescribeAsync(_trip, CancellationToken.None);
+            }
+        }
+        catch (Exception exception)
+        {
+            _loadFailed = true;
+            _trip = null;
+            await Logging.LogErrorAsync("loading a trip offline", exception, CancellationToken.None);
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task RetryAsync()
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task FinishAsync()
+    {
+        if (_trip is null || _isFinishing || IsCompleted)
+        {
+            return;
+        }
+
+        _isFinishing = true;
+        try
+        {
+            _trip = await ActiveTrip.FinishAsync(_trip, CancellationToken.None);
+            _display = await TripDisplay.DescribeAsync(_trip, CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            _loadFailed = true;
+            await Logging.LogErrorAsync("finishing a trip offline", exception, CancellationToken.None);
+        }
+        finally
+        {
+            _isFinishing = false;
+        }
+    }
+
+    private string FormatDuration(TimeSpan elapsed)
+    {
+        var hours = (int)elapsed.TotalHours;
+        var minutes = elapsed.Minutes;
+        return hours > 0
+            ? Loc["Trip_DurationHoursMinutes", hours, minutes]
+            : Loc["Trip_DurationMinutes", minutes];
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor.css
@@ -1,0 +1,3 @@
+.offline-trip-page {
+    padding-top: 0.5rem;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Services/ActiveTripService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/ActiveTripService.cs
@@ -1,0 +1,155 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Browser.Location;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+namespace FishingLogBook.Web.Features.Trips.Services;
+
+public sealed class ActiveTripService : IActiveTripService
+{
+    private readonly ITripStore _tripStore;
+    private readonly ILocationService _locationService;
+    private readonly ILoggingService _logging;
+
+    private Guid _cachedOwnerUserId;
+    private TripModel? _cachedActiveTrip;
+    private bool _hasCachedActiveTrip;
+
+    public event EventHandler? StateChanged;
+
+    public ActiveTripService(
+        ITripStore tripStore,
+        ILocationService locationService,
+        ILoggingService logging)
+    {
+        _tripStore = tripStore;
+        _locationService = locationService;
+        _logging = logging;
+    }
+
+    public async Task<TripModel?> GetActiveAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            return null;
+        }
+
+        if (_hasCachedActiveTrip && _cachedOwnerUserId == ownerUserId)
+        {
+            return _cachedActiveTrip;
+        }
+
+        var active = await _tripStore.GetActiveAsync(ownerUserId, cancellationToken);
+        Remember(ownerUserId, active);
+        return active;
+    }
+
+    public async Task<TripModel> StartAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip requires an owner.");
+        }
+
+        var trip = new TripModel(
+            Guid.NewGuid(),
+            ownerUserId,
+            TripConstants.Active,
+            DateTimeOffset.UtcNow,
+            SyncStatus: SyncStatus.SavedLocally);
+        await _tripStore.SaveAsync(trip, cancellationToken);
+        Remember(ownerUserId, trip);
+        RaiseStateChanged();
+        return trip;
+    }
+
+    public async Task<TripModel> FinishAsync(TripModel trip, CancellationToken cancellationToken)
+    {
+        var finished = trip with
+        {
+            Status = TripConstants.Completed,
+            EndedOn = DateTimeOffset.UtcNow,
+            SyncStatus = SyncStatus.SavedLocally
+        };
+        await _tripStore.SaveAsync(finished, cancellationToken);
+        Remember(trip.OwnerUserId, null);
+        RaiseStateChanged();
+        return finished;
+    }
+
+    public async Task<TripModel?> TryAttachLocationAsync(TripModel trip, CancellationToken cancellationToken)
+    {
+        if (trip.Location is not null || trip.Status != TripConstants.Active)
+        {
+            return null;
+        }
+
+        var captured = await TryCaptureAsync(cancellationToken);
+        if (captured is null)
+        {
+            return null;
+        }
+
+        var current = await _tripStore.GetAsync(trip.OwnerUserId, trip.Id, cancellationToken);
+        if (current is null || current.Status != TripConstants.Active || current.Location is not null)
+        {
+            return null;
+        }
+
+        var located = current with { Location = captured };
+        await _tripStore.SaveAsync(located, cancellationToken);
+        Remember(trip.OwnerUserId, located);
+        return located;
+    }
+
+    public void Invalidate()
+    {
+        _hasCachedActiveTrip = false;
+        _cachedActiveTrip = null;
+        _cachedOwnerUserId = Guid.Empty;
+    }
+
+    private async Task<TripLocationModel?> TryCaptureAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var captured = await _locationService.TryCaptureAsync(userRequested: false, cancellationToken);
+            if (captured is null)
+            {
+                return null;
+            }
+
+            return new TripLocationModel(
+                captured.Latitude,
+                captured.Longitude,
+                captured.AccuracyMetres,
+                captured.CapturedOn,
+                captured.Source,
+                captured.Visibility,
+                captured.ConsentVersion);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await _logging.LogErrorAsync("capturing a trip location", exception, CancellationToken.None);
+            return null;
+        }
+    }
+
+    private void Remember(Guid ownerUserId, TripModel? trip)
+    {
+        _cachedOwnerUserId = ownerUserId;
+        _cachedActiveTrip = trip;
+        _hasCachedActiveTrip = true;
+    }
+
+    private void RaiseStateChanged()
+    {
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Services/IActiveTripService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/IActiveTripService.cs
@@ -1,0 +1,18 @@
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Services;
+
+public interface IActiveTripService
+{
+    event EventHandler? StateChanged;
+
+    Task<TripModel?> GetActiveAsync(Guid ownerUserId, CancellationToken cancellationToken);
+
+    Task<TripModel> StartAsync(Guid ownerUserId, CancellationToken cancellationToken);
+
+    Task<TripModel> FinishAsync(TripModel trip, CancellationToken cancellationToken);
+
+    Task<TripModel?> TryAttachLocationAsync(TripModel trip, CancellationToken cancellationToken);
+
+    void Invalidate();
+}

--- a/src/FishingLogBook.Web/Features/Trips/Services/ITripDisplayService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/ITripDisplayService.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Services;
+
+public interface ITripDisplayService
+{
+    Task<TripDisplayModel> DescribeAsync(TripModel trip, CancellationToken cancellationToken);
+
+    TimeSpan? Elapsed(TripModel trip);
+}

--- a/src/FishingLogBook.Web/Features/Trips/Services/TripDisplayService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/TripDisplayService.cs
@@ -1,0 +1,48 @@
+using System.Globalization;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Services;
+
+public sealed class TripDisplayService : ITripDisplayService
+{
+    private readonly ITimeService _timeService;
+
+    public TripDisplayService(ITimeService timeService)
+    {
+        _timeService = timeService;
+    }
+
+    public async Task<TripDisplayModel> DescribeAsync(TripModel trip, CancellationToken cancellationToken)
+    {
+        var startedLocal = await ToLocalAsync(trip.StartedOn, cancellationToken);
+        var endedLocal = trip.EndedOn is null
+            ? null
+            : await ToLocalAsync(trip.EndedOn.Value, cancellationToken);
+        return new TripDisplayModel(
+            startedLocal?.ToString("d MMM yyyy", CultureInfo.CurrentCulture),
+            startedLocal?.ToString("t", CultureInfo.CurrentCulture),
+            endedLocal?.ToString("t", CultureInfo.CurrentCulture),
+            Elapsed(trip));
+    }
+
+    public TimeSpan? Elapsed(TripModel trip)
+    {
+        var until = trip.EndedOn ?? DateTimeOffset.UtcNow;
+        var elapsed = until - trip.StartedOn;
+        return elapsed < TimeSpan.Zero ? null : elapsed;
+    }
+
+    private async Task<DateTime?> ToLocalAsync(DateTimeOffset instant, CancellationToken cancellationToken)
+    {
+        var value = await _timeService.ToDateTimeLocalValueAsync(instant, cancellationToken);
+        return DateTime.TryParseExact(
+            value,
+            "yyyy-MM-ddTHH:mm",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed)
+            ? parsed
+            : null;
+    }
+}

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
@@ -1,3 +1,4 @@
+@using FishingLogBook.Web.Features.Trips.Components.ActiveTripBanner
 @inherits LayoutComponentBase
 
 <MudThemeProvider Theme="_theme" IsDarkMode="_isDarkMode" />
@@ -48,6 +49,7 @@
         <AuthorizeView>
             <Authorized>
                 <AppUpdateBanner />
+                <ActiveTripBanner />
             </Authorized>
         </AuthorizeView>
         <div class="app-shell-content" id="app-shell-content">

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -297,6 +297,45 @@
   <data name="Catch_LoadRetry" xml:space="preserve">
     <value>Réessayer</value>
   </data>
+  <data name="Trip_StartFishing" xml:space="preserve">
+    <value>Commencer la pêche</value>
+  </data>
+  <data name="Trip_Continue" xml:space="preserve">
+    <value>Reprendre la sortie</value>
+  </data>
+  <data name="Trip_InProgress" xml:space="preserve">
+    <value>Sortie de pêche en cours</value>
+  </data>
+  <data name="Trip_ActiveLabel" xml:space="preserve">
+    <value>Sortie en cours</value>
+  </data>
+  <data name="Trip_StartedLabel" xml:space="preserve">
+    <value>Commencée</value>
+  </data>
+  <data name="Trip_DurationLabel" xml:space="preserve">
+    <value>Durée</value>
+  </data>
+  <data name="Trip_DurationHoursMinutes" xml:space="preserve">
+    <value>{0} h {1} min</value>
+  </data>
+  <data name="Trip_DurationMinutes" xml:space="preserve">
+    <value>{0} min</value>
+  </data>
+  <data name="Trip_Finish" xml:space="preserve">
+    <value>Terminer la sortie</value>
+  </data>
+  <data name="Trip_Finished" xml:space="preserve">
+    <value>Sortie terminée</value>
+  </data>
+  <data name="Trip_BackToLogbook" xml:space="preserve">
+    <value>Retour au carnet</value>
+  </data>
+  <data name="Trip_LoadFailed" xml:space="preserve">
+    <value>Cette sortie n'a pas pu être chargée.</value>
+  </data>
+  <data name="Trip_NotFound" xml:space="preserve">
+    <value>Cette sortie n'est plus disponible.</value>
+  </data>
   <data name="Catch_LoadFailed" xml:space="preserve">
     <value>Les prises n'ont pas pu être chargées.</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -297,6 +297,45 @@
   <data name="Catch_LoadRetry" xml:space="preserve">
     <value>Try again</value>
   </data>
+  <data name="Trip_StartFishing" xml:space="preserve">
+    <value>Start fishing</value>
+  </data>
+  <data name="Trip_Continue" xml:space="preserve">
+    <value>Continue trip</value>
+  </data>
+  <data name="Trip_InProgress" xml:space="preserve">
+    <value>Fishing trip in progress</value>
+  </data>
+  <data name="Trip_ActiveLabel" xml:space="preserve">
+    <value>Active trip</value>
+  </data>
+  <data name="Trip_StartedLabel" xml:space="preserve">
+    <value>Started</value>
+  </data>
+  <data name="Trip_DurationLabel" xml:space="preserve">
+    <value>Duration</value>
+  </data>
+  <data name="Trip_DurationHoursMinutes" xml:space="preserve">
+    <value>{0}h {1}m</value>
+  </data>
+  <data name="Trip_DurationMinutes" xml:space="preserve">
+    <value>{0}m</value>
+  </data>
+  <data name="Trip_Finish" xml:space="preserve">
+    <value>Finish trip</value>
+  </data>
+  <data name="Trip_Finished" xml:space="preserve">
+    <value>Trip finished</value>
+  </data>
+  <data name="Trip_BackToLogbook" xml:space="preserve">
+    <value>Back to logbook</value>
+  </data>
+  <data name="Trip_LoadFailed" xml:space="preserve">
+    <value>This trip could not be loaded.</value>
+  </data>
+  <data name="Trip_NotFound" xml:space="preserve">
+    <value>This trip is no longer available.</value>
+  </data>
   <data name="Catch_LoadFailed" xml:space="preserve">
     <value>Catches could not be loaded.</value>
   </data>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ using FishingLogBook.Web.Features.Profile.Offline.Stores;
 using FishingLogBook.Web.Features.Profile.Providers;
 using FishingLogBook.Web.Features.SystemStatus.Clients;
 using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Features.Users.Clients;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
@@ -82,6 +83,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITimeService, TimeService>();
         services.AddScoped<ICatchStore, IndexedDbCatchStore>();
         services.AddScoped<ITripStore, IndexedDbTripStore>();
+        services.AddScoped<IActiveTripService, ActiveTripService>();
+        services.AddScoped<ITripDisplayService, TripDisplayService>();
         services.AddScoped<ICatchSynchroniser, CatchSynchroniser>();
         services.AddScoped<ICatchClient, CatchClient>();
         services.AddScoped<ICurrentUserClient, CurrentUserClient>();

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/BaseCatchListTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/BaseCatchListTest.cs
@@ -16,6 +16,8 @@ using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Providers;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Tests.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,6 +55,7 @@ public class BaseCatchListTest
         context.Services.AddSingleton(logging ?? QuietLogging());
         context.Services.AddSingleton(catchClient ?? EmptyCatchClient());
         context.Services.AddSingleton(network ?? OnlineNetwork());
+        context.Services.AddSingleton(QuietActiveTripService());
         context.Services.AddSingleton<IMeasurementService, MeasurementService>();
         context.Services.AddSingleton<ICatchDateGroupingService, CatchDateGroupingService>();
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
@@ -93,6 +96,14 @@ public class BaseCatchListTest
                 weightUnit,
                 lengthUnit));
         return provider;
+    }
+
+    protected static IActiveTripService QuietActiveTripService()
+    {
+        var service = Substitute.For<IActiveTripService>();
+        service.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((TripModel?)null);
+        return service;
     }
 
     protected static ILoggingService QuietLogging()

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingStartFishing.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingStartFishing.cs
@@ -1,0 +1,176 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Pages.CatchList;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchListTests;
+
+public class WhenTestingStartFishing : BaseCatchListTest
+{
+    private static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    [Fact]
+    public async Task ItShouldOfferStartFishingWhenNoTripIsActive()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = EmptyStore();
+        var activeTrip = ActiveTripService(null);
+        await using var context = CreateContext(store);
+        context.Services.AddSingleton(activeTrip);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-start-link").TextContent.Should().Contain("Start fishing"));
+        cut.FindAll("#trip-continue-link").Should().BeEmpty();
+        cut.Find("#catch-record-link").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldOfferContinueWhenATripIsActive()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = EmptyStore();
+        var activeTrip = ActiveTripService(ActiveTrip());
+        await using var context = CreateContext(store);
+        context.Services.AddSingleton(activeTrip);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-continue-link").TextContent.Should().Contain("Continue trip"));
+        cut.FindAll("#trip-start-link").Should().BeEmpty();
+        cut.Find("#trip-continue-link").GetAttribute("href").Should().Be($"/trips/{TripId:D}");
+    }
+
+    [Fact]
+    public async Task ItShouldStartATripAndNavigateToIt()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = EmptyStore();
+        var activeTrip = ActiveTripService(null);
+        activeTrip.StartAsync(OwnerUserId, Arg.Any<CancellationToken>()).Returns(ActiveTrip());
+        await using var context = CreateContext(store);
+        context.Services.AddSingleton(activeTrip);
+        var cut = context.Render<CatchList>();
+        cut.WaitForAssertion(() => cut.Find("#trip-start-link").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#trip-start-link").ClickAsync();
+
+        // Assert
+        await activeTrip.Received(1).StartAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        context.Services.GetRequiredService<NavigationManager>().Uri
+            .Should().EndWith($"/trips/{TripId:D}");
+    }
+
+    [Fact]
+    public async Task ItShouldRecoverToTheExistingTripWhenAnotherIsAlreadyActive()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = EmptyStore();
+        var activeTrip = Substitute.For<IActiveTripService>();
+        var started = false;
+        activeTrip.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<TripModel?>(started ? ActiveTrip() : null));
+        activeTrip.StartAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns<Task<TripModel>>(_ =>
+            {
+                started = true;
+                throw new TripAlreadyActiveException();
+            });
+        await using var context = CreateContext(store);
+        context.Services.AddSingleton(activeTrip);
+        var cut = context.Render<CatchList>();
+        cut.WaitForAssertion(() => cut.Find("#trip-start-link").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#trip-start-link").ClickAsync();
+
+        // Assert
+        context.Services.GetRequiredService<NavigationManager>().Uri
+            .Should().EndWith($"/trips/{TripId:D}");
+        cut.Markup.Should().NotContain("TripAlreadyActiveException");
+    }
+
+    [Fact]
+    public async Task ItShouldStillRenderTheLogbookWhenTheActiveTripLookupFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = EmptyStore();
+        var activeTrip = Substitute.For<IActiveTripService>();
+        activeTrip.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("active-read timed out."));
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, logging: logging);
+        context.Services.AddSingleton(activeTrip);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#trip-start-link").Should().NotBeNull());
+        cut.FindAll("#catch-list-load-failed").Should().BeEmpty();
+        await logging.Received(1).LogErrorAsync(
+            "resolving the active trip",
+            Arg.Any<TimeoutException>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var store = EmptyStore();
+        var activeTrip = ActiveTripService(null);
+        await using var context = CreateContext(store);
+        context.Services.AddSingleton(activeTrip);
+
+        // Act
+        var cut = context.Render<CatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-start-link").TextContent.Should().Contain("Commencer la pêche"));
+    }
+
+    private static ICatchStore EmptyStore()
+    {
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Web.Features.Catch.Models.CatchModel>());
+        return store;
+    }
+
+    private static IActiveTripService ActiveTripService(TripModel? trip)
+    {
+        var service = Substitute.For<IActiveTripService>();
+        service.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(trip);
+        return service;
+    }
+
+    private static TripModel ActiveTrip()
+    {
+        return new TripModel(TripId, OwnerUserId, TripConstants.Active, StartedOn);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchListTests/BaseOfflineCatchListTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchListTests/BaseOfflineCatchListTest.cs
@@ -9,6 +9,8 @@ using FishingLogBook.Web.Features.OfflineAccess.Models;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
@@ -33,6 +35,7 @@ public class BaseOfflineCatchListTest
         context.Services.AddSingleton(store);
         context.Services.AddSingleton(preferences ?? EmptyPreferences());
         context.Services.AddSingleton(logging ?? QuietLogging());
+        context.Services.AddSingleton(QuietActiveTripService());
         context.Services.AddSingleton<IMeasurementService, MeasurementService>();
         context.Services.AddSingleton<ICatchDateGroupingService, CatchDateGroupingService>();
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
@@ -40,6 +43,14 @@ public class BaseOfflineCatchListTest
         owner.Unlock(new OfflineOwnerModel(OwnerUserId, 1));
         context.Services.AddSingleton<IOfflineOwnerContextService>(owner);
         return context;
+    }
+
+    protected static IActiveTripService QuietActiveTripService()
+    {
+        var service = Substitute.For<IActiveTripService>();
+        service.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((TripModel?)null);
+        return service;
     }
 
     protected static ILoggingService QuietLogging()

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchListTests/WhenTestingStartFishing.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchListTests/WhenTestingStartFishing.cs
@@ -1,0 +1,97 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Pages.OfflineCatchList;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.OfflineCatchListTests;
+
+public class WhenTestingStartFishing : BaseOfflineCatchListTest
+{
+    private static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    [Fact]
+    public async Task ItShouldOfferStartFishingWhenNoTripIsActive()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var activeTrip = ActiveTripService(null);
+        await using var context = CreateContext(EmptyCatchStore());
+        context.Services.AddSingleton(activeTrip);
+
+        // Act
+        var cut = context.Render<OfflineCatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#offline-trip-start-link").TextContent.Should().Contain("Start fishing"));
+        cut.FindAll("#offline-trip-continue-link").Should().BeEmpty();
+        await activeTrip.Received(1).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOfferContinueToTheOfflineTripRouteWhenOneIsActive()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var activeTrip = ActiveTripService(ActiveTrip());
+        await using var context = CreateContext(EmptyCatchStore());
+        context.Services.AddSingleton(activeTrip);
+
+        // Act
+        var cut = context.Render<OfflineCatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#offline-trip-continue-link").GetAttribute("href")
+                .Should().Be($"/offline/trips/{TripId:D}"));
+        cut.FindAll("#offline-trip-start-link").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldStartATripAndNavigateToTheOfflineRoute()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var activeTrip = ActiveTripService(null);
+        activeTrip.StartAsync(OwnerUserId, Arg.Any<CancellationToken>()).Returns(ActiveTrip());
+        await using var context = CreateContext(EmptyCatchStore());
+        context.Services.AddSingleton(activeTrip);
+        var cut = context.Render<OfflineCatchList>();
+        cut.WaitForAssertion(() => cut.Find("#offline-trip-start-link").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#offline-trip-start-link").ClickAsync();
+
+        // Assert
+        await activeTrip.Received(1).StartAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        context.Services.GetRequiredService<NavigationManager>().Uri
+            .Should().EndWith($"/offline/trips/{TripId:D}");
+    }
+
+    private static FishingLogBook.Web.Features.Catch.Offline.Stores.ICatchStore EmptyCatchStore()
+    {
+        var store = Substitute.For<FishingLogBook.Web.Features.Catch.Offline.Stores.ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<FishingLogBook.Web.Features.Catch.Models.CatchModel>());
+        return store;
+    }
+
+    private static IActiveTripService ActiveTripService(TripModel? trip)
+    {
+        var service = Substitute.For<IActiveTripService>();
+        service.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(trip);
+        return service;
+    }
+
+    private static TripModel ActiveTrip()
+    {
+        return new TripModel(TripId, OwnerUserId, TripConstants.Active, StartedOn);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/ActiveTripBannerTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/ActiveTripBannerTests/WhenTestingRender.cs
@@ -1,0 +1,164 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Components.ActiveTripBanner;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Components.ActiveTripBannerTests;
+
+public class WhenTestingRender
+{
+    private static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    [Fact]
+    public async Task ItShouldRenderNothingWhenNoTripIsActive()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var activeTrip = ActiveTripService(null);
+        await using var context = CreateContext(activeTrip);
+
+        // Act
+        var cut = context.Render<ActiveTripBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#active-trip-banner").Should().BeEmpty());
+        await activeTrip.Received(1).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRenderNothingWhenTheOwnerCannotBeResolved()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("The current user is not signed in."));
+        var activeTrip = ActiveTripService(ActiveTrip());
+        var logging = QuietLogging();
+        await using var context = CreateContext(activeTrip, owner, logging);
+
+        // Act
+        var cut = context.Render<ActiveTripBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#active-trip-banner").Should().BeEmpty());
+        await activeTrip.DidNotReceive().GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "resolving the active trip banner",
+            Arg.Any<InvalidOperationException>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAnnounceTheTripAndLinkToIt()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var activeTrip = ActiveTripService(ActiveTrip());
+        await using var context = CreateContext(activeTrip);
+
+        // Act
+        var cut = context.Render<ActiveTripBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-banner").TextContent.Should().Contain("Fishing trip in progress"));
+        cut.Find("#active-trip-banner").GetAttribute("role").Should().Be("status");
+        cut.Find("#active-trip-banner-continue").GetAttribute("href")
+            .Should().Be($"/trips/{TripId:D}");
+        cut.Find("#active-trip-banner-continue").TextContent.Should().Contain("Continue trip");
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var activeTrip = ActiveTripService(ActiveTrip());
+        await using var context = CreateContext(activeTrip);
+
+        // Act
+        var cut = context.Render<ActiveTripBanner>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-banner").TextContent.Should().Contain("Sortie de pêche en cours"));
+        cut.Find("#active-trip-banner-continue").TextContent.Should().Contain("Reprendre la sortie");
+    }
+
+    [Fact]
+    public async Task ItShouldDisappearWhenTheTripIsFinished()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var activeTrip = Substitute.For<IActiveTripService>();
+        var finished = false;
+        activeTrip.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<TripModel?>(finished ? null : ActiveTrip()));
+        await using var context = CreateContext(activeTrip);
+        var cut = context.Render<ActiveTripBanner>();
+        cut.WaitForAssertion(() => cut.Find("#active-trip-banner").Should().NotBeNull());
+
+        // Act
+        finished = true;
+        activeTrip.StateChanged += Raise.Event<EventHandler>(activeTrip, EventArgs.Empty);
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#active-trip-banner").Should().BeEmpty());
+        await activeTrip.Received(2).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    private static BunitContext CreateContext(
+        IActiveTripService activeTrip,
+        ILocalCatchOwnerService? owner = null,
+        ILoggingService? logging = null)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(activeTrip);
+        context.Services.AddSingleton(owner ?? SignedInOwner());
+        context.Services.AddSingleton(logging ?? QuietLogging());
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+
+    private static IActiveTripService ActiveTripService(TripModel? trip)
+    {
+        var service = Substitute.For<IActiveTripService>();
+        service.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(trip);
+        return service;
+    }
+
+    private static ILocalCatchOwnerService SignedInOwner()
+    {
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(OwnerUserId);
+        return owner;
+    }
+
+    private static ILoggingService QuietLogging()
+    {
+        var logging = Substitute.For<ILoggingService>();
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return logging;
+    }
+
+    private static TripModel ActiveTrip()
+    {
+        return new TripModel(TripId, OwnerUserId, TripConstants.Active, StartedOn);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/BaseActiveTripTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/BaseActiveTripTest.cs
@@ -1,0 +1,118 @@
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Pages.ActiveTripTests;
+
+public class BaseActiveTripTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    protected static BunitContext CreateContext(
+        ITripStore store,
+        IActiveTripService? activeTrip = null,
+        ILocalCatchOwnerService? owner = null,
+        IOfflineOwnerContextService? offlineOwner = null,
+        ILoggingService? logging = null)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(store);
+        context.Services.AddSingleton(activeTrip ?? QuietActiveTripService());
+        context.Services.AddSingleton(owner ?? SignedInOwner());
+        context.Services.AddSingleton(offlineOwner ?? UnlockedOfflineOwner());
+        context.Services.AddSingleton(logging ?? QuietLogging());
+        context.Services.AddSingleton<ITimeService>(TestTimeService.WithOffset(TimeSpan.Zero));
+        context.Services.AddSingleton<ITripDisplayService>(provider =>
+            new TripDisplayService(provider.GetRequiredService<ITimeService>()));
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+
+    protected static IActiveTripService QuietActiveTripService()
+    {
+        var service = Substitute.For<IActiveTripService>();
+        service.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((TripModel?)null);
+        service.TryAttachLocationAsync(Arg.Any<TripModel>(), Arg.Any<CancellationToken>())
+            .Returns((TripModel?)null);
+        service.FinishAsync(Arg.Any<TripModel>(), Arg.Any<CancellationToken>())
+            .Returns(call => Finished(call.ArgAt<TripModel>(0)));
+        return service;
+    }
+
+    protected static ILocalCatchOwnerService SignedInOwner(Guid? userId = null)
+    {
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>()).Returns(userId ?? OwnerUserId);
+        return owner;
+    }
+
+    protected static IOfflineOwnerContextService UnlockedOfflineOwner(Guid? userId = null)
+    {
+        var offlineOwner = Substitute.For<IOfflineOwnerContextService>();
+        offlineOwner.IsUnlocked.Returns(true);
+        offlineOwner.Owner.Returns(new OfflineOwnerModel(userId ?? OwnerUserId, 1));
+        return offlineOwner;
+    }
+
+    protected static IOfflineOwnerContextService LockedOfflineOwner()
+    {
+        var offlineOwner = Substitute.For<IOfflineOwnerContextService>();
+        offlineOwner.IsUnlocked.Returns(false);
+        offlineOwner.Owner.Returns((OfflineOwnerModel?)null);
+        return offlineOwner;
+    }
+
+    protected static ILoggingService QuietLogging()
+    {
+        var logging = Substitute.For<ILoggingService>();
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return logging;
+    }
+
+    protected static TripModel StoredActiveTrip(
+        string? title = null,
+        string? placeName = null,
+        DateTimeOffset? startedOn = null)
+    {
+        return new TripModel(
+            TripId,
+            OwnerUserId,
+            TripConstants.Active,
+            startedOn ?? StartedOn,
+            Title: title,
+            PlaceName: placeName);
+    }
+
+    protected static TripModel StoredCompletedTrip(DateTimeOffset? endedOn = null)
+    {
+        return Finished(StoredActiveTrip(), endedOn);
+    }
+
+    private static TripModel Finished(TripModel trip, DateTimeOffset? endedOn = null)
+    {
+        return trip with
+        {
+            Status = TripConstants.Completed,
+            EndedOn = endedOn ?? trip.StartedOn.AddHours(6).AddMinutes(43)
+        };
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingFinish.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingFinish.cs
@@ -1,0 +1,151 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using ActiveTripPage = FishingLogBook.Web.Features.Trips.Pages.ActiveTrip.ActiveTrip;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Pages.ActiveTripTests;
+
+public class WhenTestingFinish : BaseActiveTripTest
+{
+    [Fact]
+    public async Task ItShouldFinishTheSameTripAndShowTheAcknowledgement()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        var activeTrip = QuietActiveTripService();
+        await using var context = CreateContext(store, activeTrip);
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+        cut.WaitForAssertion(() => cut.Find("#active-trip-finish").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#active-trip-finish").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#completed-trip-heading").Should().NotBeNull());
+        cut.FindAll("#active-trip-finish").Should().BeEmpty();
+        await activeTrip.Received(1).FinishAsync(
+            Arg.Is<TripModel>(trip => trip.Id == TripId && trip.Status == TripConstants.Active),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotFinishATripThatIsAlreadyCompleted()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredCompletedTrip());
+        var activeTrip = QuietActiveTripService();
+        await using var context = CreateContext(store, activeTrip);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#completed-trip-heading").Should().NotBeNull());
+        await activeTrip.DidNotReceive().FinishAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheFailureWhenFinishingFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        var activeTrip = QuietActiveTripService();
+        activeTrip.FinishAsync(Arg.Any<TripModel>(), Arg.Any<CancellationToken>())
+            .Returns<Task<TripModel>>(_ => throw new TimeoutException("write timed out."));
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, activeTrip, logging: logging);
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+        cut.WaitForAssertion(() => cut.Find("#active-trip-finish").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#active-trip-finish").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#trip-load-failed").Should().NotBeNull());
+        await logging.Received(1).LogErrorAsync(
+            "finishing a trip",
+            Arg.Any<TimeoutException>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAttachAnOpportunisticLocationWithoutBlockingTheTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        var trip = StoredActiveTrip();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(trip);
+        var activeTrip = QuietActiveTripService();
+        activeTrip.TryAttachLocationAsync(Arg.Any<TripModel>(), Arg.Any<CancellationToken>())
+            .Returns(trip with { PlaceName = null });
+        await using var context = CreateContext(store, activeTrip);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-card").Should().NotBeNull());
+        await activeTrip.Received(1).TryAttachLocationAsync(
+            Arg.Is<TripModel>(item => item.Id == TripId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotAttemptLocationForACompletedTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredCompletedTrip());
+        var activeTrip = QuietActiveTripService();
+        await using var context = CreateContext(store, activeTrip);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#completed-trip-heading").Should().NotBeNull());
+        await activeTrip.DidNotReceive().TryAttachLocationAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStillRenderTheTripWhenLocationCaptureFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        var activeTrip = QuietActiveTripService();
+        activeTrip.TryAttachLocationAsync(Arg.Any<TripModel>(), Arg.Any<CancellationToken>())
+            .Returns<Task<TripModel?>>(_ => throw new InvalidOperationException("Geolocation is unavailable."));
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, activeTrip, logging: logging);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-card").Should().NotBeNull());
+        cut.FindAll("#trip-load-failed").Should().BeEmpty();
+        await logging.Received(1).LogErrorAsync(
+            "attaching a trip location",
+            Arg.Any<InvalidOperationException>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingRender.cs
@@ -1,0 +1,173 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using ActiveTripPage = FishingLogBook.Web.Features.Trips.Pages.ActiveTrip.ActiveTrip;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Pages.ActiveTripTests;
+
+public class WhenTestingRender : BaseActiveTripTest
+{
+    [Fact]
+    public async Task ItShouldShowTheFailureWithRetryWhenTheLocalReadThrows()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("single-read timed out."));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-load-failed").TextContent.Should().Contain("could not be loaded"));
+        cut.Find("#trip-load-retry").TextContent.Should().Contain("Try again");
+    }
+
+    [Fact]
+    public async Task ItShouldReloadWhenRetryIsPressed()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        var reads = 0;
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                reads += 1;
+                return reads == 1
+                    ? throw new TimeoutException("single-read timed out.")
+                    : Task.FromResult<TripModel?>(StoredActiveTrip());
+            });
+        await using var context = CreateContext(store);
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+        cut.WaitForAssertion(() => cut.Find("#trip-load-retry").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#trip-load-retry").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-card").Should().NotBeNull());
+        await store.Received(2).GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheUnavailableMessageWhenTheTripIsNotStored()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns((TripModel?)null);
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-not-found").TextContent.Should().Contain("no longer available"));
+        cut.FindAll("#active-trip-card").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRenderTheActiveTripFromThePersistedStore()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-card").Should().NotBeNull());
+        cut.Find("#active-trip-eyebrow").TextContent.Should().Contain("Active trip");
+        cut.Find("#active-trip-started").TextContent.Should().NotBeEmpty();
+        cut.Find("#active-trip-finish").TextContent.Should().Contain("Finish trip");
+        await store.Received(1).GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowAGeneratedDateWhenTheTripHasNoTitle()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-heading").TextContent.Should().Contain("2026"));
+        await store.DidNotReceive().SaveAsync(Arg.Any<TripModel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheTitleAndPlaceWhenTheyAreSet()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .Returns(StoredActiveTrip(title: "Day with Dad", placeName: "Lough Corrib"));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-heading").TextContent.Should().Contain("Day with Dad"));
+        cut.Find("#active-trip-place").TextContent.Should().Contain("Lough Corrib");
+    }
+
+    [Fact]
+    public async Task ItShouldRenderTheCompletedSummaryForAFinishedTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredCompletedTrip());
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#completed-trip-heading").TextContent.Should().Contain("Trip finished"));
+        cut.Find("#completed-trip-duration").TextContent.Should().Contain("6h 43m");
+        cut.Find("#completed-trip-logbook").TextContent.Should().Contain("Back to logbook");
+        cut.FindAll("#active-trip-finish").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-finish").TextContent.Should().Contain("Terminer la sortie"));
+        cut.Find("#active-trip-eyebrow").TextContent.Should().Contain("Sortie en cours");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/OfflineActiveTripTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/OfflineActiveTripTests/WhenTestingRender.cs
@@ -1,0 +1,157 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Features.Trips.Pages.ActiveTripTests;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using OfflineActiveTripPage = FishingLogBook.Web.Features.Trips.Pages.OfflineActiveTrip.OfflineActiveTrip;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Pages.OfflineActiveTripTests;
+
+public class WhenTestingRender : BaseActiveTripTest
+{
+    [Fact]
+    public async Task ItShouldFailClosedWhenTheOfflineOwnerIsMissing()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        await using var context = CreateContext(store, offlineOwner: LockedOfflineOwner());
+
+        // Act
+        var cut = context.Render<OfflineActiveTripPage>(
+            parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#offline-trip-load-failed").Should().NotBeNull());
+        await store.DidNotReceive().GetAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReadOnlyFromTheLocalStoreForTheUnlockedOwner()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        var onlineOwner = SignedInOwner();
+        await using var context = CreateContext(store, owner: onlineOwner);
+
+        // Act
+        var cut = context.Render<OfflineActiveTripPage>(
+            parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-card").Should().NotBeNull());
+        await store.Received(1).GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>());
+        await onlineOwner.DidNotReceive().GetUserIdAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnATripBelongingToAnotherOwner()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns((TripModel?)null);
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<OfflineActiveTripPage>(
+            parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#offline-trip-not-found").Should().NotBeNull());
+        cut.FindAll("#active-trip-card").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheFailureWithRetryWhenTheLocalReadThrows()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("single-read timed out."));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<OfflineActiveTripPage>(
+            parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#offline-trip-load-failed").Should().NotBeNull());
+        cut.Find("#offline-trip-load-retry").TextContent.Should().Contain("Try again");
+    }
+
+    [Fact]
+    public async Task ItShouldFinishATripOfflineWithoutAnyOnlineOwnerLookup()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        var activeTrip = QuietActiveTripService();
+        var onlineOwner = SignedInOwner();
+        await using var context = CreateContext(store, activeTrip, owner: onlineOwner);
+        var cut = context.Render<OfflineActiveTripPage>(
+            parameters => parameters.Add(p => p.TripId, TripId));
+        cut.WaitForAssertion(() => cut.Find("#active-trip-finish").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#active-trip-finish").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#completed-trip-heading").Should().NotBeNull());
+        cut.Find("#completed-trip-logbook").GetAttribute("href").Should().Be("/offline/catches");
+        await activeTrip.Received(1).FinishAsync(
+            Arg.Is<TripModel>(trip => trip.Id == TripId),
+            Arg.Any<CancellationToken>());
+        await onlineOwner.DidNotReceive().GetUserIdAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotAttemptLocationCaptureOnTheOfflineRoute()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        var activeTrip = QuietActiveTripService();
+        await using var context = CreateContext(store, activeTrip);
+
+        // Act
+        var cut = context.Render<OfflineActiveTripPage>(
+            parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-card").Should().NotBeNull());
+        await activeTrip.DidNotReceive().TryAttachLocationAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns(StoredActiveTrip());
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<OfflineActiveTripPage>(
+            parameters => parameters.Add(p => p.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-finish").TextContent.Should().Contain("Terminer la sortie"));
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/ActiveTripServiceTests/BaseActiveTripServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/ActiveTripServiceTests/BaseActiveTripServiceTest.cs
@@ -1,0 +1,59 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Location;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.ActiveTripServiceTests;
+
+public class BaseActiveTripServiceTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    protected readonly ITripStore MockTripStore = Substitute.For<ITripStore>();
+    protected readonly ILocationService MockLocationService = Substitute.For<ILocationService>();
+    protected readonly ILoggingService MockLogging = Substitute.For<ILoggingService>();
+    protected readonly ActiveTripService Sut;
+
+    protected BaseActiveTripServiceTest()
+    {
+        MockTripStore.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((TripModel?)null);
+        MockTripStore.SaveAsync(Arg.Any<TripModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((CatchLocationModel?)null);
+        MockLogging.LogErrorAsync(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        Sut = new ActiveTripService(MockTripStore, MockLocationService, MockLogging);
+    }
+
+    protected static TripModel ActiveTrip(Guid? tripId = null, TripLocationModel? location = null)
+    {
+        return new TripModel(
+            tripId ?? TripId,
+            OwnerUserId,
+            TripConstants.Active,
+            StartedOn,
+            Location: location);
+    }
+
+    protected static CatchLocationModel CapturedLocation()
+    {
+        return new CatchLocationModel(
+            53.4419,
+            -9.2531,
+            8,
+            StartedOn,
+            LocationDefaults.DeviceGps,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/ActiveTripServiceTests/WhenTestingLifecycle.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/ActiveTripServiceTests/WhenTestingLifecycle.cs
@@ -1,0 +1,243 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Trips.Models;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.ActiveTripServiceTests;
+
+public class WhenTestingLifecycle : BaseActiveTripServiceTest
+{
+    [Fact]
+    public async Task ItShouldRejectAStartWithNoOwner()
+    {
+        // Arrange
+        // Act
+        var act = () => Sut.StartAsync(Guid.Empty, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        await MockTripStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNoActiveTripForAnEmptyOwner()
+    {
+        // Arrange
+        // Act
+        var active = await Sut.GetActiveAsync(Guid.Empty, CancellationToken.None);
+
+        // Assert
+        active.Should().BeNull();
+        await MockTripStore.DidNotReceive().GetActiveAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStartATripWithAClientIdentifierAndActiveStatus()
+    {
+        // Arrange
+        // Act
+        var started = await Sut.StartAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        started.Id.Should().NotBe(Guid.Empty);
+        started.OwnerUserId.Should().Be(OwnerUserId);
+        started.Status.Should().Be(TripConstants.Active);
+        started.EndedOn.Should().BeNull();
+        started.Title.Should().BeNull();
+        started.PlaceName.Should().BeNull();
+        started.Location.Should().BeNull();
+        started.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        started.StartedOn.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
+        await MockTripStore.Received(1).SaveAsync(
+            Arg.Is<TripModel>(trip =>
+                trip.Id == started.Id
+                && trip.OwnerUserId == OwnerUserId
+                && trip.Status == TripConstants.Active
+                && trip.EndedOn == null
+                && trip.Location == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldGiveEachStartedTripADistinctIdentifier()
+    {
+        // Arrange
+        var first = await Sut.StartAsync(OwnerUserId, CancellationToken.None);
+        Sut.Invalidate();
+
+        // Act
+        var second = await Sut.StartAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        second.Id.Should().NotBe(first.Id);
+    }
+
+    [Fact]
+    public async Task ItShouldNotCarryLocationFromAPreviousTripIntoANewOne()
+    {
+        // Arrange
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CapturedLocation());
+        var previous = ActiveTrip(location: new TripLocationModel(
+            1, 2, 3, StartedOn, LocationDefaults.DeviceGps, LocationDefaults.Private, LocationDefaults.ConsentVersion));
+        MockTripStore.GetAsync(OwnerUserId, previous.Id, Arg.Any<CancellationToken>()).Returns(previous);
+
+        // Act
+        var started = await Sut.StartAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        started.Location.Should().BeNull();
+        await MockLocationService.DidNotReceive().TryCaptureAsync(
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRaiseStateChangedWhenATripStarts()
+    {
+        // Arrange
+        var raised = 0;
+        Sut.StateChanged += (_, _) => raised += 1;
+
+        // Act
+        await Sut.StartAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        raised.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldFinishTheSameTripWithACompletedStatusAndEndTime()
+    {
+        // Arrange
+        var trip = ActiveTrip();
+
+        // Act
+        var finished = await Sut.FinishAsync(trip, CancellationToken.None);
+
+        // Assert
+        finished.Id.Should().Be(trip.Id);
+        finished.Status.Should().Be(TripConstants.Completed);
+        finished.EndedOn.Should().NotBeNull();
+        finished.EndedOn!.Value.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
+        finished.StartedOn.Should().Be(trip.StartedOn);
+        await MockTripStore.Received(1).SaveAsync(
+            Arg.Is<TripModel>(saved =>
+                saved.Id == trip.Id
+                && saved.Status == TripConstants.Completed
+                && saved.EndedOn != null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportNoActiveTripAfterFinishing()
+    {
+        // Arrange
+        var trip = ActiveTrip();
+        MockTripStore.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>()).Returns(trip);
+        (await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None)).Should().NotBeNull();
+
+        // Act
+        await Sut.FinishAsync(trip, CancellationToken.None);
+
+        // Assert
+        var active = await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+        active.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldRaiseStateChangedWhenATripFinishes()
+    {
+        // Arrange
+        var raised = 0;
+        Sut.StateChanged += (_, _) => raised += 1;
+
+        // Act
+        await Sut.FinishAsync(ActiveTrip(), CancellationToken.None);
+
+        // Assert
+        raised.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldReadTheActiveTripFromTheStoreRatherThanMemory()
+    {
+        // Arrange
+        MockTripStore.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>()).Returns(ActiveTrip());
+
+        // Act
+        var active = await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        active!.Id.Should().Be(TripId);
+        await MockTripStore.Received(1).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotRereadTheStoreForRepeatedLookupsOfTheSameOwner()
+    {
+        // Arrange
+        MockTripStore.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>()).Returns(ActiveTrip());
+
+        // Act
+        await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+        await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+        await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockTripStore.Received(1).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReadAgainForADifferentOwner()
+    {
+        // Arrange
+        MockTripStore.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>()).Returns(ActiveTrip());
+        MockTripStore.GetActiveAsync(OtherUserId, Arg.Any<CancellationToken>()).Returns((TripModel?)null);
+        await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Act
+        var other = await Sut.GetActiveAsync(OtherUserId, CancellationToken.None);
+
+        // Assert
+        other.Should().BeNull();
+        await MockTripStore.Received(1).GetActiveAsync(OtherUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReadTheStoreAgainAfterBeingInvalidated()
+    {
+        // Arrange
+        MockTripStore.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>()).Returns(ActiveTrip());
+        await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Act
+        Sut.Invalidate();
+        await Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockTripStore.Received(2).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSurfaceAStoreFailureFromTheActiveLookup()
+    {
+        // Arrange
+        MockTripStore.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("active-read timed out."));
+
+        // Act
+        var act = () => Sut.GetActiveAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<TimeoutException>();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/ActiveTripServiceTests/WhenTestingTryAttachLocation.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/ActiveTripServiceTests/WhenTestingTryAttachLocation.cs
@@ -1,0 +1,193 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Trips.Models;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.ActiveTripServiceTests;
+
+public class WhenTestingTryAttachLocation : BaseActiveTripServiceTest
+{
+    [Fact]
+    public async Task ItShouldNotCaptureWhenTheTripAlreadyHasALocation()
+    {
+        // Arrange
+        var trip = ActiveTrip(location: new TripLocationModel(
+            1, 2, 3, StartedOn, LocationDefaults.DeviceGps, LocationDefaults.Private, LocationDefaults.ConsentVersion));
+
+        // Act
+        var located = await Sut.TryAttachLocationAsync(trip, CancellationToken.None);
+
+        // Assert
+        located.Should().BeNull();
+        await MockLocationService.DidNotReceive().TryCaptureAsync(
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+        await MockTripStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotCaptureForACompletedTrip()
+    {
+        // Arrange
+        var trip = ActiveTrip() with { Status = TripConstants.Completed, EndedOn = StartedOn.AddHours(2) };
+
+        // Act
+        var located = await Sut.TryAttachLocationAsync(trip, CancellationToken.None);
+
+        // Assert
+        located.Should().BeNull();
+        await MockLocationService.DidNotReceive().TryCaptureAsync(
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotPersistAnythingWhenLocationIsUnavailable()
+    {
+        // Arrange
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((CatchLocationModel?)null);
+
+        // Act
+        var located = await Sut.TryAttachLocationAsync(ActiveTrip(), CancellationToken.None);
+
+        // Assert
+        located.Should().BeNull();
+        await MockTripStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotPersistAnythingWhenLocationCaptureThrows()
+    {
+        // Arrange
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Geolocation is unavailable."));
+
+        // Act
+        var located = await Sut.TryAttachLocationAsync(ActiveTrip(), CancellationToken.None);
+
+        // Assert
+        located.Should().BeNull();
+        await MockTripStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+        await MockLogging.Received(1).LogErrorAsync(
+            "capturing a trip location",
+            Arg.Any<InvalidOperationException>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotAttachToATripThatFinishedWhileCapturing()
+    {
+        // Arrange
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CapturedLocation());
+        var trip = ActiveTrip();
+        MockTripStore.GetAsync(OwnerUserId, trip.Id, Arg.Any<CancellationToken>())
+            .Returns(trip with { Status = TripConstants.Completed, EndedOn = StartedOn.AddHours(1) });
+
+        // Act
+        var located = await Sut.TryAttachLocationAsync(trip, CancellationToken.None);
+
+        // Assert
+        located.Should().BeNull();
+        await MockTripStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotOverwriteALocationSavedWhileCapturing()
+    {
+        // Arrange
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CapturedLocation());
+        var trip = ActiveTrip();
+        MockTripStore.GetAsync(OwnerUserId, trip.Id, Arg.Any<CancellationToken>())
+            .Returns(trip with
+            {
+                Location = new TripLocationModel(
+                    10, 20, 5, StartedOn, LocationDefaults.DeviceGps, LocationDefaults.Private, LocationDefaults.ConsentVersion)
+            });
+
+        // Act
+        var located = await Sut.TryAttachLocationAsync(trip, CancellationToken.None);
+
+        // Assert
+        located.Should().BeNull();
+        await MockTripStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotAttachToATripThatIsNoLongerStored()
+    {
+        // Arrange
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CapturedLocation());
+        MockTripStore.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .Returns((TripModel?)null);
+
+        // Act
+        var located = await Sut.TryAttachLocationAsync(ActiveTrip(), CancellationToken.None);
+
+        // Assert
+        located.Should().BeNull();
+        await MockTripStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistACapturedPrivateLocationWithItsProvenance()
+    {
+        // Arrange
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CapturedLocation());
+        var trip = ActiveTrip();
+        MockTripStore.GetAsync(OwnerUserId, trip.Id, Arg.Any<CancellationToken>()).Returns(trip);
+
+        // Act
+        var located = await Sut.TryAttachLocationAsync(trip, CancellationToken.None);
+
+        // Assert
+        located.Should().NotBeNull();
+        located!.Location!.Latitude.Should().Be(53.4419);
+        located.Location.Longitude.Should().Be(-9.2531);
+        located.Location.AccuracyMetres.Should().Be(8);
+        located.Location.Source.Should().Be(LocationDefaults.DeviceGps);
+        located.Location.Visibility.Should().Be(LocationDefaults.Private);
+        located.Location.ConsentVersion.Should().Be(LocationDefaults.ConsentVersion);
+        await MockTripStore.Received(1).SaveAsync(
+            Arg.Is<TripModel>(saved =>
+                saved.Id == trip.Id
+                && saved.Location != null
+                && saved.Location.Visibility == LocationDefaults.Private),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldCaptureOpportunisticallyRatherThanAsAUserRequest()
+    {
+        // Arrange
+        MockLocationService.TryCaptureAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(CapturedLocation());
+        var trip = ActiveTrip();
+        MockTripStore.GetAsync(OwnerUserId, trip.Id, Arg.Any<CancellationToken>()).Returns(trip);
+
+        // Act
+        await Sut.TryAttachLocationAsync(trip, CancellationToken.None);
+
+        // Assert
+        await MockLocationService.Received(1).TryCaptureAsync(false, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/BaseMainLayoutTest.cs
@@ -6,10 +6,13 @@ using FishingLogBook.Web.Configuration;
 using FishingLogBook.Web.Features.Authentication.Services;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Synchronisers;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Synchronisers;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Features.Profile.Providers;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
@@ -21,6 +24,22 @@ namespace FishingLogBook.Web.Tests.Layouts.MainLayoutTests;
 public class BaseMainLayoutTest
 {
     protected const string SignedInEmail = "tester@example.test";
+
+    protected static IActiveTripService QuietActiveTripService()
+    {
+        var service = Substitute.For<IActiveTripService>();
+        service.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((TripModel?)null);
+        return service;
+    }
+
+    protected static ILocalCatchOwnerService QuietLocalOwner()
+    {
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        owner.GetUserIdAsync(Arg.Any<CancellationToken>())
+            .Returns(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+        return owner;
+    }
 
     protected static BunitContext CreateContext(
         bool isAuthenticated = false,
@@ -61,6 +80,8 @@ public class BaseMainLayoutTest
             diagnosticSynchroniser ?? Substitute.For<IDiagnosticSynchroniser>());
         context.Services.AddSingleton(Substitute.For<ILoggingService>());
         context.Services.AddSingleton(appUpdate ?? Substitute.For<IAppUpdateService>());
+        context.Services.AddSingleton(QuietActiveTripService());
+        context.Services.AddSingleton(QuietLocalOwner());
         context.Services.AddSingleton(profileSummary ?? QuietProfileSummary());
         context.Services.AddSingleton(network ?? Network(isOnline: true));
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();


### PR DESCRIPTION
Closes #174
Part of #108

> **Depends on #182 (T2), which is not yet merged.** This branch was cut from T2, so until #182 lands the diff here also contains T2's commit `443e300`. **Merge #182 first.** Once it does, this reduces to the T3 commit alone — no rebase expected, and T2's changes have not been folded in by hand.

Third Trips slice, and the first real user journey. Architecture/product baseline: [#108 — Agreed V1 implementation baseline](https://github.com/kingkeamo/fishing-logbook/issues/108#issuecomment-5428632438).

## The journey

An angler taps **Start fishing**, lands on the trip immediately, and can **Finish** it. Both ends complete at IndexedDB — **no API call, no network, no form.**

Once a trip is active the logbook offers **Continue** instead of Start, and a banner in the app shell carries the angler back to it from anywhere. Closing and reopening the app recovers the trip from local storage.

## Routes and components

| | |
|---|---|
| `/trips/{TripId:guid}` | `ActiveTrip` — online, `[Authorize]` |
| `/offline/trips/{TripId:guid}` | `OfflineActiveTrip` — `[OfflineRoute]`, `OfflineLayout` |
| `ActiveTripView` · `CompletedTripSummary` | shared presentation across both routes |
| `ActiveTripBanner` | in `MainLayout`, beside the existing `AppUpdateBanner` |
| `IActiveTripService` | start / finish / resolve, with a read-through cache |
| `ITripDisplayService` | local-time and duration formatting |

Start/Continue appears on **both** `/catches` and `/offline/catches`. Record catch is untouched and exactly as reachable as before.

## Location — the design decision worth reviewing

`ILocationService.TryCaptureAsync` carries an 8-second internal timeout. That is far too long to hold up Start fishing, so:

**The trip is created without location and never waits for GPS.** Capture happens on the active trip page after first render, and the result is attached **only after re-reading the trip and confirming it is still Active and still has no location**.

That ordering is the point: a finish that lands mid-capture, or a location saved by another path, cannot be overwritten. Both are tested explicitly. Denied, unavailable, timed out or thrown — the trip simply keeps no location, with no alarming state.

Captured opportunistically (`userRequested: false`), **private by default**, coordinates **never rendered and never logged**. No place lookup, no reverse geocoding, no inheriting a catch's or a previous trip's location.

## Finish

`Completed` and `EndedOn` are persisted **before the recap renders**, so the timestamp records when the angler pressed Finish — not when they finished reading a form. Same trip id, no second record. Elapsed time is derived from stored instants and **never persisted**.

## Recovery and route boundaries

The active trip is always resolved from the **owner-scoped local store**, never component state. The service caches per scope for the banner's benefit, but the store stays authoritative — a cold reload builds a new scope and re-reads. Proven with a real `page.reload()` in the browser suite.

The online page resolves its owner through the usual signed-in path. The **offline page uses `IOfflineOwnerContextService.Owner` only** — a test asserts the online owner service is never called there — performs no API or auth work, and fails closed when the owner is missing. No `if (online)` branching inside a single page: separate orchestration over shared presentation.

## One active trip

The T2 store already refuses a second distinct active trip. The UI now prevents the normal journey reaching that: Continue replaces Start whenever one is active. If a race still produces a conflict, `TripAlreadyActiveException` is caught and **the existing trip is opened** — no raw exception text reaches the angler.

## Tests

**61 new**: 23 service · 14 online page · 7 offline page · 5 banner · 6 online logbook · 3 offline logbook · plus **14 browser tests** (7 specs × Chromium and WebKit) covering start → reload → finish → reload, stored catches untouched, and **zero `/api/` requests during the local journey**.

Full validation: `dotnet format` clean · `dotnet build` clean · **1,806 .NET tests** · vitest **280** · browser **104** · EN/FR parity 418/418 · `git diff --check` clean.

**No credentialed E2E in this slice — stating the boundary honestly.** The journey's defining property is that it completes locally with no network, and the browser suite proves exactly that in two engines including reload recovery. A credentialed E2E would mostly re-prove Cognito login. T9 owns the real end-to-end journeys alongside the physical device matrix. No physical-device acceptance is claimed here.

## Self review

```text
Self review:
- Issue/AC: PASS — every acceptance criterion implemented and tested; two deliberate scope deviations below
- Architecture: PASS — feature-first under Features/Trips; online and offline orchestration separate, presentation shared
- Rules: PASS — three-file components, block-bodied getters, no production comments
- Security/privacy: PASS — owner-scoped throughout; offline route never touches auth or API;
  coordinates never rendered or logged; location private by default
- Database/migrations: N/A — no schema change in this slice
- Tests/coverage: PASS — 61 new, including real-browser reload recovery
- Browser: PASS — 14 tests across two engines
- Web/UI/localisation: PASS — 13 new keys, EN and FR, no hard-coded English
- Code smells: findings 2, 3 (fixed)
- CI/deployment: PASS — no manual steps
```

**Findings discovered during self-review:**

1. **Three shared test bases broke** — `CatchList`, `OfflineCatchList` and `MainLayout` did not register the new dependencies, so unrelated existing tests failed.
2. **The `ActiveTrip` page class collided with its own injected `ActiveTrip` property** (CS0542).
3. **A location race.** My first design attached the captured location unconditionally, which could have resurrected a location onto a trip that had just been finished.

**Fixes made:**

1. Registered quiet defaults in each base — the dependency is real, so the bases needed it; no assertions were adjusted to suit.
2. Renamed the injected property to `ActiveTripService`.
3. Re-read the trip before attaching, and guard on still-Active-and-still-empty. Two tests now cover the finished-meanwhile and location-saved-meanwhile cases.

**Two deliberate deviations from the ticket's scope list**, both to avoid shipping affordances that lie:

- **No Trips drawer link.** There is no `/trips` list until T8, so the link would have nowhere to go.
- **No Record catch button on the active trip page.** T5 owns association; a button there would imply the catch joins the trip when it would not. Record catch stays reachable exactly as before.

**Remaining deliberate gaps:**

- No auto-finish for a forgotten trip — the baseline defers this, and the visible Continue banner is the agreed mitigation.
- Trips are written only as `SavedLocally`; nothing marks them synchronised yet. T4 owns the entire status transition and `SyncedAt`.
- `IActiveTripService` caches per scope, so a trip changed in another browser tab could show stale until reload. Acceptable for V1 and noted for T4, which should call `Invalidate()` after mutating trips.

## Manual post-merge steps

**None.** No migration, no Terraform, no configuration.
