### PR TITLE
FLB#178 | Timestamped trip notes

### DIFF
--- a/src/FishingLogBook.Api/Endpoints/TripEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/TripEndpoints.cs
@@ -69,7 +69,110 @@ public static class TripEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status503ServiceUnavailable);
 
+        endpoints.MapPost("/api/trips/{tripId:guid}/notes", RecordNoteAsync)
+            .WithName("RecordTripNote")
+            .WithTags("Trips")
+            .RequireAuthorization()
+            .Produces<TripNoteDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        endpoints.MapDelete("/api/trips/{tripId:guid}/notes/{noteId:guid}", DeleteNoteAsync)
+            .WithName("DeleteTripNote")
+            .WithTags("Trips")
+            .RequireAuthorization()
+            .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
         return endpoints;
+    }
+
+    private static async Task<IResult> RecordNoteAsync(
+        Guid tripId,
+        RecordTripNoteDto note,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new RecordTripNoteCommand
+            {
+                TripId = tripId,
+                Note = note
+            },
+            cancellationToken);
+        if (response.ValidationErrors is { Count: > 0 })
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.Error is TripNoteNotFoundError)
+        {
+            return Results.NotFound();
+        }
+
+        if (response.Error is TripNoteInvalidError)
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.Ok(response.Note);
+    }
+
+    private static async Task<IResult> DeleteNoteAsync(
+        Guid tripId,
+        Guid noteId,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new DeleteTripNoteCommand
+            {
+                TripId = tripId,
+                NoteId = noteId
+            },
+            cancellationToken);
+        if (response.ValidationErrors is { Count: > 0 })
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.Error is TripNoteNotFoundError)
+        {
+            return Results.NotFound();
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.NoContent();
     }
 
     private static async Task<IResult> CreatePhotographUploadAsync(

--- a/src/FishingLogBook.Application/Args/DeleteTripNoteArgs.cs
+++ b/src/FishingLogBook.Application/Args/DeleteTripNoteArgs.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class DeleteTripNoteArgs
+{
+    public Guid TripId { get; init; }
+
+    public Guid NoteId { get; init; }
+}

--- a/src/FishingLogBook.Application/Args/RecordTripNoteArgs.cs
+++ b/src/FishingLogBook.Application/Args/RecordTripNoteArgs.cs
@@ -1,0 +1,12 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class RecordTripNoteArgs
+{
+    public Guid TripId { get; init; }
+
+    public Guid NoteId { get; init; }
+
+    public string Text { get; init; } = string.Empty;
+
+    public DateTimeOffset RecordedOn { get; init; }
+}

--- a/src/FishingLogBook.Application/Common/Mappings/TripMappingRegistration.cs
+++ b/src/FishingLogBook.Application/Common/Mappings/TripMappingRegistration.cs
@@ -16,6 +16,10 @@ public sealed class TripMappingRegistration : IRegister
             .Map(destination => destination.ContentType, source => source.Photograph.ContentType)
             .Map(destination => destination.AddedOn, source => source.Photograph.AddedOn)
             .Map(destination => destination.CapturedOn, source => source.Photograph.CapturedOn);
+        config.NewConfig<RecordTripNoteCommand, RecordTripNoteArgs>()
+            .Map(destination => destination.NoteId, source => source.Note.NoteId)
+            .Map(destination => destination.Text, source => source.Note.Text)
+            .Map(destination => destination.RecordedOn, source => source.Note.RecordedOn);
         config.NewConfig<TripDto, TripDto>()
             .MapWith(source => source);
 

--- a/src/FishingLogBook.Application/Common/Mappings/TripMappingRegistration.cs
+++ b/src/FishingLogBook.Application/Common/Mappings/TripMappingRegistration.cs
@@ -16,6 +16,15 @@ public sealed class TripMappingRegistration : IRegister
             .Map(destination => destination.ContentType, source => source.Photograph.ContentType)
             .Map(destination => destination.AddedOn, source => source.Photograph.AddedOn)
             .Map(destination => destination.CapturedOn, source => source.Photograph.CapturedOn);
+        config.NewConfig<TripNote, TripNoteDto>()
+            .MapWith(source => new TripNoteDto(
+                source.Id,
+                source.TripId,
+                source.Text,
+                source.RecordedOn)
+            {
+                CreatedByUserId = source.CreatedByUserId
+            });
         config.NewConfig<RecordTripNoteCommand, RecordTripNoteArgs>()
             .Map(destination => destination.NoteId, source => source.Note.NoteId)
             .Map(destination => destination.Text, source => source.Note.Text)

--- a/src/FishingLogBook.Application/Contracts/Repositories/ITripNoteRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/Repositories/ITripNoteRepository.cs
@@ -1,0 +1,17 @@
+using FishingLogBook.Domain.Trips;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Repositories;
+
+public interface ITripNoteRepository
+{
+    Task<Result<TripNote?>> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<Result<IReadOnlyList<TripNote>>> GetByTripIdAsync(
+        Guid tripId,
+        CancellationToken cancellationToken);
+
+    Task<Result<TripNote>> UpsertAsync(TripNote note, CancellationToken cancellationToken);
+
+    Task<Result> DeleteAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Contracts/Services/ITripNoteService.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/ITripNoteService.cs
@@ -1,0 +1,12 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Services;
+
+public interface ITripNoteService
+{
+    Task<Result<TripNoteDto>> RecordAsync(RecordTripNoteArgs args, CancellationToken cancellationToken);
+
+    Task<Result> DeleteAsync(DeleteTripNoteArgs args, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Trips/Commands/DeleteTripNoteCommand.cs
+++ b/src/FishingLogBook.Application/Trips/Commands/DeleteTripNoteCommand.cs
@@ -1,0 +1,55 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FluentValidation;
+using MapsterMapper;
+using MediatR;
+
+namespace FishingLogBook.Application.Trips.Commands;
+
+public sealed class DeleteTripNoteCommand : IRequest<DeleteTripNoteResponse>
+{
+    public Guid TripId { get; init; }
+
+    public Guid NoteId { get; init; }
+}
+
+public sealed class DeleteTripNoteResponse : ValidatedResponse
+{
+}
+
+public sealed class DeleteTripNoteHandler
+    : IRequestHandler<DeleteTripNoteCommand, DeleteTripNoteResponse>
+{
+    private readonly ITripNoteService _tripNoteService;
+    private readonly IMapper _mapper;
+
+    public DeleteTripNoteHandler(ITripNoteService tripNoteService, IMapper mapper)
+    {
+        _tripNoteService = tripNoteService;
+        _mapper = mapper;
+    }
+
+    public async Task<DeleteTripNoteResponse> Handle(
+        DeleteTripNoteCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _tripNoteService.DeleteAsync(
+            _mapper.Map<DeleteTripNoteArgs>(command),
+            cancellationToken);
+        return result.IsFailed
+            ? ValidatedResponse.FromError<DeleteTripNoteResponse>(result.Errors[0])
+            : new DeleteTripNoteResponse();
+    }
+}
+
+public sealed class DeleteTripNoteCommandValidator : AbstractValidator<DeleteTripNoteCommand>
+{
+    public DeleteTripNoteCommandValidator()
+    {
+        RuleFor(command => command.TripId)
+            .NotEmpty();
+        RuleFor(command => command.NoteId)
+            .NotEmpty();
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Commands/RecordTripNoteCommand.cs
+++ b/src/FishingLogBook.Application/Trips/Commands/RecordTripNoteCommand.cs
@@ -1,0 +1,70 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using MapsterMapper;
+using MediatR;
+
+namespace FishingLogBook.Application.Trips.Commands;
+
+public sealed class RecordTripNoteCommand : IRequest<RecordTripNoteResponse>
+{
+    public Guid TripId { get; init; }
+
+    public RecordTripNoteDto Note { get; init; } = new(Guid.Empty, string.Empty, default);
+}
+
+public sealed class RecordTripNoteResponse : ValidatedResponse
+{
+    public TripNoteDto? Note { get; init; }
+}
+
+public sealed class RecordTripNoteHandler
+    : IRequestHandler<RecordTripNoteCommand, RecordTripNoteResponse>
+{
+    private readonly ITripNoteService _tripNoteService;
+    private readonly IMapper _mapper;
+
+    public RecordTripNoteHandler(ITripNoteService tripNoteService, IMapper mapper)
+    {
+        _tripNoteService = tripNoteService;
+        _mapper = mapper;
+    }
+
+    public async Task<RecordTripNoteResponse> Handle(
+        RecordTripNoteCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _tripNoteService.RecordAsync(
+            _mapper.Map<RecordTripNoteArgs>(command),
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<RecordTripNoteResponse>(result.Errors[0]);
+        }
+
+        return new RecordTripNoteResponse
+        {
+            Note = result.Value
+        };
+    }
+}
+
+public sealed class RecordTripNoteCommandValidator : AbstractValidator<RecordTripNoteCommand>
+{
+    public RecordTripNoteCommandValidator()
+    {
+        RuleFor(command => command.TripId)
+            .NotEmpty();
+        RuleFor(command => command.Note.NoteId)
+            .NotEmpty();
+        RuleFor(command => command.Note.RecordedOn)
+            .Must(value => value != default)
+            .WithMessage("A trip note must record when it was written.");
+        RuleFor(command => command.Note.Text)
+            .Must(TripConstants.IsNoteTextValid)
+            .WithMessage($"A trip note must have text of {TripConstants.MaxNoteTextLength} characters or fewer.");
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Errors/TripNoteInvalidError.cs
+++ b/src/FishingLogBook.Application/Trips/Errors/TripNoteInvalidError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Errors;
+
+public sealed class TripNoteInvalidError : Error
+{
+    public TripNoteInvalidError()
+        : base("A trip note needs some text.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Errors/TripNoteNotFoundError.cs
+++ b/src/FishingLogBook.Application/Trips/Errors/TripNoteNotFoundError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Errors;
+
+public sealed class TripNoteNotFoundError : Error
+{
+    public TripNoteNotFoundError()
+        : base("The trip note could not be found.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Services/TripNoteService.cs
+++ b/src/FishingLogBook.Application/Trips/Services/TripNoteService.cs
@@ -1,0 +1,112 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using MapsterMapper;
+
+namespace FishingLogBook.Application.Trips.Services;
+
+public sealed class TripNoteService : ITripNoteService
+{
+    private readonly ITripRepository _tripRepository;
+    private readonly ITripNoteRepository _tripNoteRepository;
+    private readonly ICurrentUser _currentUser;
+    private readonly IMapper _mapper;
+
+    public TripNoteService(
+        ITripRepository tripRepository,
+        ITripNoteRepository tripNoteRepository,
+        ICurrentUser currentUser,
+        IMapper mapper)
+    {
+        _tripRepository = tripRepository;
+        _tripNoteRepository = tripNoteRepository;
+        _currentUser = currentUser;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<TripNoteDto>> RecordAsync(
+        RecordTripNoteArgs args,
+        CancellationToken cancellationToken)
+    {
+        var text = TripConstants.TrimNoteText(args.Text);
+        if (text is null || !TripConstants.IsNoteTextValid(text))
+        {
+            return Result.Fail<TripNoteDto>(new TripNoteInvalidError());
+        }
+
+        var trip = await LoadOwnedTripAsync(args.TripId, cancellationToken);
+        if (trip.IsFailed)
+        {
+            return Result.Fail<TripNoteDto>(trip.Errors);
+        }
+
+        var existing = await _tripNoteRepository.GetByIdAsync(args.NoteId, cancellationToken);
+        if (existing.IsFailed)
+        {
+            return Result.Fail<TripNoteDto>(existing.Errors);
+        }
+
+        if (existing.Value is not null && existing.Value.TripId != args.TripId)
+        {
+            return Result.Fail<TripNoteDto>(new TripNoteNotFoundError());
+        }
+
+        var saved = await _tripNoteRepository.UpsertAsync(
+            new TripNote
+            {
+                Id = args.NoteId,
+                TripId = args.TripId,
+                Text = text,
+                RecordedOn = args.RecordedOn
+            },
+            cancellationToken);
+        return saved.IsFailed
+            ? Result.Fail<TripNoteDto>(saved.Errors)
+            : Result.Ok(_mapper.Map<TripNoteDto>(saved.Value));
+    }
+
+    public async Task<Result> DeleteAsync(
+        DeleteTripNoteArgs args,
+        CancellationToken cancellationToken)
+    {
+        var trip = await LoadOwnedTripAsync(args.TripId, cancellationToken);
+        if (trip.IsFailed)
+        {
+            return trip.ToResult();
+        }
+
+        var note = await _tripNoteRepository.GetByIdAsync(args.NoteId, cancellationToken);
+        if (note.IsFailed)
+        {
+            return note.ToResult();
+        }
+
+        if (note.Value is null || note.Value.TripId != args.TripId)
+        {
+            return Result.Fail(new TripNoteNotFoundError());
+        }
+
+        return await _tripNoteRepository.DeleteAsync(args.NoteId, cancellationToken);
+    }
+
+    private async Task<Result<Trip>> LoadOwnedTripAsync(Guid tripId, CancellationToken cancellationToken)
+    {
+        var trip = await _tripRepository.GetByIdAsync(tripId, cancellationToken);
+        if (trip.IsFailed)
+        {
+            return Result.Fail<Trip>(trip.Errors);
+        }
+
+        if (trip.Value is null || trip.Value.OwnerUserId != _currentUser.UserId)
+        {
+            return Result.Fail<Trip>(new TripNoteNotFoundError());
+        }
+
+        return Result.Ok(trip.Value);
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Services/TripNoteService.cs
+++ b/src/FishingLogBook.Application/Trips/Services/TripNoteService.cs
@@ -61,6 +61,7 @@ public sealed class TripNoteService : ITripNoteService
             {
                 Id = args.NoteId,
                 TripId = args.TripId,
+                CreatedByUserId = _currentUser.UserId,
                 Text = text,
                 RecordedOn = args.RecordedOn
             },

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608281000_178_CreateTripNote.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608281000_178_CreateTripNote.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "TripNote"
+(
+    "Id"         uuid        NOT NULL,
+    "TripId"     uuid        NOT NULL,
+    "Text"       text        NOT NULL,
+    "RecordedOn" timestamptz NOT NULL,
+    "CreatedOn"  timestamptz NOT NULL DEFAULT now(),
+    "UpdatedOn"  timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT "PkTripNote" PRIMARY KEY ("Id"),
+    CONSTRAINT "FkTripNoteTrip" FOREIGN KEY ("TripId") REFERENCES "Trip" ("Id")
+);
+
+CREATE INDEX IF NOT EXISTS "IxTripNoteTripId" ON "TripNote" ("TripId");
+
+CREATE INDEX IF NOT EXISTS "IxTripNoteTripRecordedOn" ON "TripNote" ("TripId", "RecordedOn");

--- a/src/FishingLogBook.Db.Migrations/01_Tables/202608281000_178_CreateTripNote.sql
+++ b/src/FishingLogBook.Db.Migrations/01_Tables/202608281000_178_CreateTripNote.sql
@@ -1,13 +1,15 @@
 CREATE TABLE IF NOT EXISTS "TripNote"
 (
-    "Id"         uuid        NOT NULL,
-    "TripId"     uuid        NOT NULL,
-    "Text"       text        NOT NULL,
-    "RecordedOn" timestamptz NOT NULL,
-    "CreatedOn"  timestamptz NOT NULL DEFAULT now(),
-    "UpdatedOn"  timestamptz NOT NULL DEFAULT now(),
+    "Id"                uuid        NOT NULL,
+    "TripId"            uuid        NOT NULL,
+    "CreatedByUserId"   uuid        NOT NULL,
+    "Text"              text        NOT NULL,
+    "RecordedOn"        timestamptz NOT NULL,
+    "CreatedOn"         timestamptz NOT NULL DEFAULT now(),
+    "UpdatedOn"         timestamptz NOT NULL DEFAULT now(),
     CONSTRAINT "PkTripNote" PRIMARY KEY ("Id"),
-    CONSTRAINT "FkTripNoteTrip" FOREIGN KEY ("TripId") REFERENCES "Trip" ("Id")
+    CONSTRAINT "FkTripNoteTrip" FOREIGN KEY ("TripId") REFERENCES "Trip" ("Id"),
+    CONSTRAINT "FkTripNoteCreatedByUser" FOREIGN KEY ("CreatedByUserId") REFERENCES "User" ("Id")
 );
 
 CREATE INDEX IF NOT EXISTS "IxTripNoteTripId" ON "TripNote" ("TripId");

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -55,6 +55,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICatchService, CatchService>();
         services.AddScoped<ITripService, TripService>();
         services.AddScoped<ITripPhotographService, TripPhotographService>();
+        services.AddScoped<ITripNoteService, TripNoteService>();
         services.AddScoped<ICatchPhotographService, CatchPhotographService>();
         services.AddScoped<ICatchLocationPrivacyService, CatchLocationPrivacyService>();
         services.AddScoped<IPlatformCapabilityService, PlatformCapabilityService>();
@@ -86,6 +87,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICatchRepository, CatchRepository>();
         services.AddScoped<ITripRepository, TripRepository>();
         services.AddScoped<ITripPhotographRepository, TripPhotographRepository>();
+        services.AddScoped<ITripNoteRepository, TripNoteRepository>();
         services.AddScoped<IUserPlatformCapabilityRepository, UserPlatformCapabilityRepository>();
         services.AddScoped<IFishingCatalogueRepository, FishingCatalogueRepository>();
         services.AddScoped<IFishingPreferenceRepository, FishingPreferenceRepository>();

--- a/src/FishingLogBook.Domain/Trips/TripNote.cs
+++ b/src/FishingLogBook.Domain/Trips/TripNote.cs
@@ -1,0 +1,12 @@
+namespace FishingLogBook.Domain.Trips;
+
+public sealed class TripNote
+{
+    public Guid Id { get; init; }
+
+    public Guid TripId { get; init; }
+
+    public string Text { get; init; } = string.Empty;
+
+    public DateTimeOffset RecordedOn { get; init; }
+}

--- a/src/FishingLogBook.Domain/Trips/TripNote.cs
+++ b/src/FishingLogBook.Domain/Trips/TripNote.cs
@@ -6,6 +6,8 @@ public sealed class TripNote
 
     public Guid TripId { get; init; }
 
+    public Guid CreatedByUserId { get; init; }
+
     public string Text { get; init; } = string.Empty;
 
     public DateTimeOffset RecordedOn { get; init; }

--- a/src/FishingLogBook.Infrastructure/Persistence/Repositories/TripNoteRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/Repositories/TripNoteRepository.cs
@@ -16,6 +16,7 @@ public sealed class TripNoteRepository : ITripNoteRepository
         SELECT
             "Id",
             "TripId",
+            "CreatedByUserId",
             "Text",
             "RecordedOn"
         FROM "TripNote"
@@ -81,8 +82,8 @@ public sealed class TripNoteRepository : ITripNoteRepository
         {
             await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
             const string sql = """
-                INSERT INTO "TripNote" ("Id", "TripId", "Text", "RecordedOn")
-                VALUES (@Id, @TripId, @Text, @RecordedOn)
+                INSERT INTO "TripNote" ("Id", "TripId", "CreatedByUserId", "Text", "RecordedOn")
+                VALUES (@Id, @TripId, @CreatedByUserId, @Text, @RecordedOn)
                 ON CONFLICT ("Id") DO UPDATE SET
                     "Text" = EXCLUDED."Text",
                     "RecordedOn" = EXCLUDED."RecordedOn",
@@ -138,6 +139,7 @@ public sealed class TripNoteRepository : ITripNoteRepository
         {
             Id = note.Id,
             TripId = note.TripId,
+            CreatedByUserId = note.CreatedByUserId,
             Text = note.Text,
             RecordedOn = note.RecordedOn.ToUniversalTime()
         };
@@ -148,6 +150,8 @@ public sealed class TripNoteRepository : ITripNoteRepository
         public Guid Id { get; init; }
 
         public Guid TripId { get; init; }
+
+        public Guid CreatedByUserId { get; init; }
 
         public string Text { get; init; } = string.Empty;
 

--- a/src/FishingLogBook.Infrastructure/Persistence/Repositories/TripNoteRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/Repositories/TripNoteRepository.cs
@@ -1,0 +1,156 @@
+using Dapper;
+using FishingLogBook.Application.Contracts;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Domain.Trips;
+using FluentResults;
+using Microsoft.Extensions.Logging;
+
+namespace FishingLogBook.Infrastructure.Persistence.Repositories;
+
+public sealed class TripNoteRepository : ITripNoteRepository
+{
+    private const string FailedMessage = "Failed to save the trip note.";
+    private const string LoadFailedMessage = "Failed to load the trip notes.";
+
+    private const string SelectSql = """
+        SELECT
+            "Id",
+            "TripId",
+            "Text",
+            "RecordedOn"
+        FROM "TripNote"
+        """;
+
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly ILogger<TripNoteRepository> _logger;
+
+    public TripNoteRepository(
+        IDbConnectionFactory connectionFactory,
+        ILogger<TripNoteRepository> logger)
+    {
+        _connectionFactory = connectionFactory;
+        _logger = logger;
+    }
+
+    public async Task<Result<TripNote?>> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = $"""
+                {SelectSql}
+                WHERE "Id" = @Id;
+                """;
+            var note = await connection.QuerySingleOrDefaultAsync<TripNote>(
+                new CommandDefinition(sql, new { Id = id }, cancellationToken: cancellationToken));
+            return Result.Ok(note);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to load the trip note {NoteId}.", id);
+            return Result.Fail<TripNote?>(LoadFailedMessage);
+        }
+    }
+
+    public async Task<Result<IReadOnlyList<TripNote>>> GetByTripIdAsync(
+        Guid tripId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = $"""
+                {SelectSql}
+                WHERE "TripId" = @TripId
+                ORDER BY "RecordedOn", "Id";
+                """;
+            var notes = await connection.QueryAsync<TripNote>(
+                new CommandDefinition(sql, new { TripId = tripId }, cancellationToken: cancellationToken));
+            return Result.Ok<IReadOnlyList<TripNote>>([.. notes]);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to load notes for trip {TripId}.", tripId);
+            return Result.Fail<IReadOnlyList<TripNote>>(LoadFailedMessage);
+        }
+    }
+
+    public async Task<Result<TripNote>> UpsertAsync(TripNote note, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                INSERT INTO "TripNote" ("Id", "TripId", "Text", "RecordedOn")
+                VALUES (@Id, @TripId, @Text, @RecordedOn)
+                ON CONFLICT ("Id") DO UPDATE SET
+                    "Text" = EXCLUDED."Text",
+                    "RecordedOn" = EXCLUDED."RecordedOn",
+                    "UpdatedOn" = now()
+                WHERE "TripNote"."TripId" = EXCLUDED."TripId";
+                """;
+            await connection.ExecuteAsync(new CommandDefinition(
+                sql,
+                ToParameters(note),
+                cancellationToken: cancellationToken));
+            var saved = await GetByIdAsync(note.Id, cancellationToken);
+            if (saved.IsFailed)
+            {
+                return Result.Fail<TripNote>(saved.Errors);
+            }
+
+            return saved.Value is null
+                ? Result.Fail<TripNote>(FailedMessage)
+                : Result.Ok(saved.Value);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Failed to save the note {NoteId} for trip {TripId}.",
+                note.Id,
+                note.TripId);
+            return Result.Fail<TripNote>(FailedMessage);
+        }
+    }
+
+    public async Task<Result> DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            await connection.ExecuteAsync(new CommandDefinition(
+                """DELETE FROM "TripNote" WHERE "Id" = @Id;""",
+                new { Id = id },
+                cancellationToken: cancellationToken));
+            return Result.Ok();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to delete the trip note {NoteId}.", id);
+            return Result.Fail(FailedMessage);
+        }
+    }
+
+    private static TripNotePersistenceParameters ToParameters(TripNote note)
+    {
+        return new TripNotePersistenceParameters
+        {
+            Id = note.Id,
+            TripId = note.TripId,
+            Text = note.Text,
+            RecordedOn = note.RecordedOn.ToUniversalTime()
+        };
+    }
+
+    private sealed class TripNotePersistenceParameters
+    {
+        public Guid Id { get; init; }
+
+        public Guid TripId { get; init; }
+
+        public string Text { get; init; } = string.Empty;
+
+        public DateTimeOffset RecordedOn { get; init; }
+    }
+}

--- a/src/FishingLogBook.Shared/Constants/TripConstants.cs
+++ b/src/FishingLogBook.Shared/Constants/TripConstants.cs
@@ -6,9 +6,22 @@ public static class TripConstants
 
     public const int MaxPlaceNameLength = 160;
 
+    public const int MaxNoteTextLength = CatchDetailConstants.MaxNotesLength;
+
     public const string Active = "Active";
 
     public const string Completed = "Completed";
+
+    public static bool IsNoteTextValid(string? text)
+    {
+        return !string.IsNullOrWhiteSpace(text) && text.Trim().Length <= MaxNoteTextLength;
+    }
+
+    public static string? TrimNoteText(string? text)
+    {
+        var trimmed = text?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
 
     public static bool IsKnownStatus(string? status)
     {

--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticEventNames.cs
@@ -59,6 +59,14 @@ public static class DiagnosticEventNames
 
     public const string CatchSyncWaitingForTrip = "catch.sync.waiting_for_trip";
 
+    public const string TripNoteSyncStarted = "trip.note.sync.started";
+
+    public const string TripNoteSyncCompleted = "trip.note.sync.completed";
+
+    public const string TripNoteSyncFailed = "trip.note.sync.failed";
+
+    public const string TripNoteSyncWaitingForTrip = "trip.note.sync.waiting_for_trip";
+
     public const string TripPhotoSyncStarted = "trip.photo.sync.started";
 
     public const string TripPhotoSyncCompleted = "trip.photo.sync.completed";

--- a/src/FishingLogBook.Shared/Diagnostics/DiagnosticMetadata.cs
+++ b/src/FishingLogBook.Shared/Diagnostics/DiagnosticMetadata.cs
@@ -20,6 +20,8 @@ public static class DiagnosticMetadata
     public const string PhotographId = "photographId";
     public const string TripId = "tripId";
 
+    public const string NoteId = "noteId";
+
     private static readonly HashSet<string> AllowedKeys = new(StringComparer.OrdinalIgnoreCase)
     {
         Operation,
@@ -38,7 +40,8 @@ public static class DiagnosticMetadata
         Result,
         CatchId,
         PhotographId,
-        TripId
+        TripId,
+        NoteId
     };
 
     private static readonly string[] ForbiddenFragments =
@@ -91,7 +94,8 @@ public static class DiagnosticMetadata
 
         if (string.Equals(key, CatchId, StringComparison.OrdinalIgnoreCase)
             || string.Equals(key, PhotographId, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(key, TripId, StringComparison.OrdinalIgnoreCase))
+            || string.Equals(key, TripId, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(key, NoteId, StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }

--- a/src/FishingLogBook.Shared/Dtos/RecordTripNoteDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/RecordTripNoteDto.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record RecordTripNoteDto(
+    Guid NoteId,
+    string Text,
+    DateTimeOffset RecordedOn);

--- a/src/FishingLogBook.Shared/Dtos/TripNoteDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/TripNoteDto.cs
@@ -4,4 +4,7 @@ public sealed record TripNoteDto(
     Guid Id,
     Guid TripId,
     string Text,
-    DateTimeOffset RecordedOn);
+    DateTimeOffset RecordedOn)
+{
+    public Guid CreatedByUserId { get; init; }
+}

--- a/src/FishingLogBook.Shared/Dtos/TripNoteDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/TripNoteDto.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record TripNoteDto(
+    Guid Id,
+    Guid TripId,
+    string Text,
+    DateTimeOffset RecordedOn);

--- a/src/FishingLogBook.Web/BrowserTests/trip-notes.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/trip-notes.spec.js
@@ -1,0 +1,310 @@
+import { expect, test } from '@playwright/test';
+
+const tripStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.js';
+const tripNoteStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/trip-note-store.js';
+const tripPhotoStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/trip-photo-store.js';
+const catchStoreModule = '/src/FishingLogBook.Web/wwwroot/js/storage/catch-store.js';
+const logbookModule = '/src/FishingLogBook.Web/wwwroot/js/storage/logbook-database.js';
+const databaseName = 'FishingLogBook';
+const ownerUserId = '11111111-1111-1111-1111-111111111111';
+const otherUserId = '22222222-2222-2222-2222-222222222222';
+const seededCatchId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const seededPhotographId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const tripId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const tripPhotographId = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+const firstNoteId = 'aaaaaaaa-1111-1111-1111-111111111111';
+const secondNoteId = 'aaaaaaaa-2222-2222-2222-222222222222';
+const startedOn = '2026-08-26T05:32:00+00:00';
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('/src/FishingLogBook.Web/BrowserTests/harness/index.html');
+    await page.evaluate((name) => new Promise((resolve) => {
+        const request = indexedDB.deleteDatabase(name);
+        request.onsuccess = () => resolve();
+        request.onerror = () => resolve();
+        request.onblocked = () => resolve();
+    }), databaseName);
+});
+
+async function seedVersionSix(page) {
+    return page.evaluate(async (input) => {
+        const db = await new Promise((resolve, reject) => {
+            const request = indexedDB.open(input.databaseName, 6);
+            request.onupgradeneeded = () => {
+                const upgrading = request.result;
+                upgrading.createObjectStore('catches', { keyPath: 'id' });
+                upgrading.createObjectStore('catchPhotographs', { keyPath: 'id' });
+                upgrading.createObjectStore('trips', { keyPath: 'id' });
+                upgrading.createObjectStore('tripPhotographs', { keyPath: 'id' });
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+
+        await new Promise((resolve, reject) => {
+            const stores = ['catches', 'catchPhotographs', 'trips', 'tripPhotographs'];
+            const transaction = db.transaction(stores, 'readwrite');
+            transaction.objectStore('catches').put({
+                id: input.seededCatchId,
+                userId: input.ownerUserId,
+                caughtOn: '2026-06-14T09:48:00+00:00',
+                notes: 'a catch note recorded before trip notes existed',
+                syncStatus: 'savedLocally',
+                metadataSyncStatus: 'savedLocally',
+                tripId: input.tripId,
+                photographs: [{
+                    id: input.seededPhotographId,
+                    catchId: input.seededCatchId,
+                    contentType: 'image/jpeg'
+                }]
+            });
+            transaction.objectStore('catchPhotographs').put({
+                id: input.seededPhotographId,
+                catchId: input.seededCatchId,
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array(64 * 1024).fill(7).buffer
+            });
+            transaction.objectStore('trips').put({
+                id: input.tripId,
+                ownerUserId: input.ownerUserId,
+                status: 'Active',
+                startedOn: input.startedOn,
+                endedOn: null,
+                title: 'before trip notes',
+                placeName: null,
+                location: null,
+                syncStatus: 'savedLocally',
+                syncedAt: null,
+                photographs: [{
+                    id: input.tripPhotographId,
+                    tripId: input.tripId,
+                    ownerUserId: input.ownerUserId,
+                    contentType: 'image/jpeg',
+                    addedOn: input.startedOn,
+                    capturedOn: null,
+                    objectKey: null,
+                    syncStatus: 'savedLocally',
+                    syncedAt: null
+                }]
+            });
+            transaction.objectStore('tripPhotographs').put({
+                id: input.tripPhotographId,
+                bytes: new Uint8Array(32 * 1024).fill(3)
+            });
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => reject(transaction.error);
+            transaction.onabort = () => reject(transaction.error);
+        });
+
+        const version = db.version;
+        const stores = [...db.objectStoreNames].sort();
+        db.close();
+        return { version, stores };
+    }, {
+        databaseName,
+        seededCatchId,
+        seededPhotographId,
+        ownerUserId,
+        tripId,
+        tripPhotographId,
+        startedOn
+    });
+}
+
+async function openThroughTheApp(page) {
+    return page.evaluate(async ({ logbookModule }) => {
+        const logbook = await import(logbookModule);
+        const db = await logbook.openLogbookDatabase();
+        const result = { version: db.version, stores: [...db.objectStoreNames].sort() };
+        db.close();
+        return result;
+    }, { logbookModule });
+}
+
+async function addNote(page, noteId, text, recordedOn) {
+    return page.evaluate(async (input) => {
+        const store = await import(input.tripNoteStoreModule);
+        return store.putTripNote(JSON.stringify({
+            id: input.noteId,
+            tripId: input.tripId,
+            ownerUserId: input.ownerUserId,
+            text: input.text,
+            recordedOn: input.recordedOn,
+            syncStatus: 'savedLocally',
+            syncedAt: null
+        }));
+    }, { tripNoteStoreModule, noteId, tripId, ownerUserId, text, recordedOn });
+}
+
+async function readTripNotes(page, owner = ownerUserId) {
+    return page.evaluate(async (input) => {
+        const trips = await import(input.tripStoreModule);
+        const stored = await trips.getTrip(input.owner, input.tripId);
+        return stored === null ? null : JSON.parse(stored.json).notes ?? [];
+    }, { tripStoreModule, owner, tripId });
+}
+
+test('adding notes needs no database version change', async ({ page }) => {
+    const seeded = await seedVersionSix(page);
+    expect(seeded.version).toBe(6);
+
+    const opened = await openThroughTheApp(page);
+
+    expect(opened.version).toBe(6);
+    expect(opened.stores).toEqual(['catchPhotographs', 'catches', 'tripPhotographs', 'trips']);
+    expect(opened.stores).not.toContain('tripNotes');
+});
+
+test('notes survive a full reload alongside everything already stored', async ({ page }) => {
+    await seedVersionSix(page);
+    await openThroughTheApp(page);
+    await addNote(page, firstNoteId, 'water dropped about a foot', '2026-08-26T06:12:00+00:00');
+
+    await page.reload();
+
+    const notes = await readTripNotes(page);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].text).toBe('water dropped about a foot');
+    expect(notes[0].recordedOn).toBe('2026-08-26T06:12:00+00:00');
+
+    const survivors = await page.evaluate(async (input) => {
+        const catches = await import(input.catchStoreModule);
+        const photographs = await import(input.tripPhotoStoreModule);
+        const stored = await catches.getAllCatchesWithPhotographs(input.ownerUserId);
+        const bytes = await photographs.getTripPhotographBytes(
+            input.ownerUserId,
+            input.tripId,
+            input.tripPhotographId);
+        return {
+            catchNotes: JSON.parse(stored[0].json).notes,
+            catchPhotographs: stored[0].photographs.length,
+            tripPhotographBytes: bytes === null ? null : bytes.length ?? bytes.byteLength
+        };
+    }, { catchStoreModule, tripPhotoStoreModule, ownerUserId, tripId, tripPhotographId });
+
+    expect(survivors.catchNotes).toBe('a catch note recorded before trip notes existed');
+    expect(survivors.catchPhotographs).toBe(1);
+    expect(survivors.tripPhotographBytes).toBe(32 * 1024);
+});
+
+test('several notes keep the order they were written in', async ({ page }) => {
+    await seedVersionSix(page);
+    await openThroughTheApp(page);
+    await addNote(page, secondNoteId, 'wind picked up', '2026-08-26T11:16:00+00:00');
+    await addNote(page, firstNoteId, 'fish rising near the reeds', '2026-08-26T06:10:00+00:00');
+
+    const notes = await readTripNotes(page);
+
+    expect(notes.map(note => note.text)).toEqual([
+        'fish rising near the reeds',
+        'wind picked up'
+    ]);
+});
+
+test('notes are scoped to the owning angler', async ({ page }) => {
+    await seedVersionSix(page);
+    await openThroughTheApp(page);
+    await addNote(page, firstNoteId, 'water dropped about a foot', '2026-08-26T06:12:00+00:00');
+
+    expect(await readTripNotes(page, otherUserId)).toBeNull();
+
+    const theirPending = await page.evaluate(async (input) => {
+        const store = await import(input.tripNoteStoreModule);
+        return store.getPendingTripNotes(input.otherUserId);
+    }, { tripNoteStoreModule, otherUserId });
+    expect(theirPending).toEqual([]);
+});
+
+test('a pending note is discoverable without reading any blob store', async ({ page }) => {
+    await seedVersionSix(page);
+    await openThroughTheApp(page);
+    await addNote(page, firstNoteId, 'changed to olive nymph', '2026-08-26T07:00:00+00:00');
+
+    const observed = await page.evaluate(async (input) => {
+        const notes = await import(input.tripNoteStoreModule);
+        const opened = [];
+        const originalTransaction = IDBDatabase.prototype.transaction;
+        IDBDatabase.prototype.transaction = function patched(storeNames, ...rest) {
+            const names = Array.isArray(storeNames) ? storeNames : [storeNames];
+            opened.push(...names);
+            return originalTransaction.call(this, storeNames, ...rest);
+        };
+        try {
+            const pending = await notes.getPendingTripNotes(input.ownerUserId);
+            const tripIds = await notes.getTripsWithPendingNotes(input.ownerUserId);
+            return { opened, pending: pending.length, tripIds };
+        } finally {
+            IDBDatabase.prototype.transaction = originalTransaction;
+        }
+    }, { tripNoteStoreModule, ownerUserId });
+
+    expect(observed.pending).toBe(1);
+    expect(observed.tripIds).toEqual([tripId]);
+    expect(observed.opened).toContain('trips');
+    expect(observed.opened).not.toContain('tripPhotographs');
+    expect(observed.opened).not.toContain('catchPhotographs');
+});
+
+test('a pending note holds its trip back from retention cleanup', async ({ page }) => {
+    await seedVersionSix(page);
+    await openThroughTheApp(page);
+    await addNote(page, firstNoteId, 'stopped for lunch', '2026-08-26T12:30:00+00:00');
+    await page.evaluate(async (input) => {
+        const trips = await import(input.tripStoreModule);
+        await trips.putTrip(JSON.stringify({
+            id: input.tripId,
+            ownerUserId: input.ownerUserId,
+            status: 'Completed',
+            startedOn: input.startedOn,
+            endedOn: input.startedOn,
+            title: 'before trip notes',
+            placeName: null,
+            location: null,
+            syncStatus: 'synchronised',
+            syncedAt: '2026-08-20T05:32:00+00:00'
+        }));
+    }, { tripStoreModule, tripId, ownerUserId, startedOn });
+
+    const outcome = await page.evaluate(async (input) => {
+        const trips = await import(input.tripStoreModule);
+        const notes = await import(input.tripNoteStoreModule);
+        const retained = await notes.getTripsWithPendingNotes(input.ownerUserId);
+        const removed = await trips.cleanupSyncedTrips(
+            input.ownerUserId,
+            '2026-08-25T05:32:00+00:00',
+            retained);
+        return { retained, removed, remaining: (await trips.getTrips(input.ownerUserId)).length };
+    }, { tripStoreModule, tripNoteStoreModule, ownerUserId });
+
+    expect(outcome.retained).toEqual([tripId]);
+    expect(outcome.removed).toBe(0);
+    expect(outcome.remaining).toBe(1);
+    expect(await readTripNotes(page)).toHaveLength(1);
+});
+
+test('finishing a trip keeps the notes already written', async ({ page }) => {
+    await seedVersionSix(page);
+    await openThroughTheApp(page);
+    await addNote(page, firstNoteId, 'fish rising near the reeds', '2026-08-26T06:10:00+00:00');
+
+    await page.evaluate(async (input) => {
+        const trips = await import(input.tripStoreModule);
+        await trips.putTrip(JSON.stringify({
+            id: input.tripId,
+            ownerUserId: input.ownerUserId,
+            status: 'Completed',
+            startedOn: input.startedOn,
+            endedOn: '2026-08-26T13:00:00+00:00',
+            title: 'before trip notes',
+            placeName: null,
+            location: null,
+            syncStatus: 'savedLocally',
+            syncedAt: null,
+            notes: []
+        }));
+    }, { tripStoreModule, tripId, ownerUserId, startedOn });
+
+    const notes = await readTripNotes(page);
+    expect(notes).toHaveLength(1);
+    expect(notes[0].text).toBe('fish rising near the reeds');
+});

--- a/src/FishingLogBook.Web/Common/Icons/FishingLogBookIcons.cs
+++ b/src/FishingLogBook.Web/Common/Icons/FishingLogBookIcons.cs
@@ -1,0 +1,16 @@
+namespace FishingLogBook.Web.Common.Icons;
+
+public static class FishingLogBookIcons
+{
+    public const string FishingTrip =
+        """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M19.35 2.2 21.1 3.6 12.4 14.5l-1.75-1.4z"/>
+            <path d="M20.05 3.95h1v8.3h-1z"/>
+            <path d="M20.55 14.6a2 2 0 0 1-2-2h1a1 1 0 0 0 2 0h1a2 2 0 0 1-2 2z"/>
+            <circle cx="7.6" cy="4.9" r="1.9"/>
+            <path d="M7.6 7.6c-1.5 0-2.8 1-3.1 2.5l-.9 4.4h1.8l.6-3 1.1 1.2v3.3h1.8v-4l-1.2-1.3.4-2c.6.9 1.5 1.6 2.6 1.8l.3-1.7c-1-.2-1.8-.9-2.1-1.8-.2-.8-.9-1.4-1.7-1.4z"/>
+            <path d="M2 16.9h20c-.5 2.7-2.8 4.7-5.6 4.7H7.6C4.8 21.6 2.5 19.6 2 16.9z"/>
+        </svg>
+        """;
+}

--- a/src/FishingLogBook.Web/Common/Offline/Dependencies/TripDependencyService.cs
+++ b/src/FishingLogBook.Web/Common/Offline/Dependencies/TripDependencyService.cs
@@ -8,15 +8,18 @@ public sealed class TripDependencyService : ITripDependencyService
 {
     private readonly ITripStore _tripStore;
     private readonly ITripPhotographStore _tripPhotographStore;
+    private readonly ITripNoteStore _tripNoteStore;
     private readonly ICatchStore _catchStore;
 
     public TripDependencyService(
         ITripStore tripStore,
         ITripPhotographStore tripPhotographStore,
+        ITripNoteStore tripNoteStore,
         ICatchStore catchStore)
     {
         _tripStore = tripStore;
         _tripPhotographStore = tripPhotographStore;
+        _tripNoteStore = tripNoteStore;
         _catchStore = catchStore;
     }
 
@@ -52,11 +55,15 @@ public sealed class TripDependencyService : ITripDependencyService
         var awaitingPhotographs = await _tripPhotographStore.GetTripsWithPendingPhotographsAsync(
             ownerUserId,
             cancellationToken);
+        var awaitingNotes = await _tripNoteStore.GetTripsWithPendingNotesAsync(
+            ownerUserId,
+            cancellationToken);
         return catches
             .Where(IsAwaitingServer)
             .Select(catchRecord => catchRecord.TripId)
             .OfType<Guid>()
             .Concat(awaitingPhotographs)
+            .Concat(awaitingNotes)
             .Distinct()
             .ToArray();
     }

--- a/src/FishingLogBook.Web/Common/Offline/Synchronisers/LogbookSynchroniser.cs
+++ b/src/FishingLogBook.Web/Common/Offline/Synchronisers/LogbookSynchroniser.cs
@@ -10,6 +10,7 @@ public sealed class LogbookSynchroniser : ILogbookSynchroniser
     private readonly SemaphoreSlim _runLock = new(1, 1);
     private readonly ITripSynchroniser _tripSynchroniser;
     private readonly ITripPhotographSynchroniser _tripPhotographSynchroniser;
+    private readonly ITripNoteSynchroniser _tripNoteSynchroniser;
     private readonly ICatchSynchroniser _catchSynchroniser;
     private readonly ILocalCatchOwnerService _localCatchOwner;
     private readonly ILoggingService _logging;
@@ -19,12 +20,14 @@ public sealed class LogbookSynchroniser : ILogbookSynchroniser
     public LogbookSynchroniser(
         ITripSynchroniser tripSynchroniser,
         ITripPhotographSynchroniser tripPhotographSynchroniser,
+        ITripNoteSynchroniser tripNoteSynchroniser,
         ICatchSynchroniser catchSynchroniser,
         ILocalCatchOwnerService localCatchOwner,
         ILoggingService logging)
     {
         _tripSynchroniser = tripSynchroniser;
         _tripPhotographSynchroniser = tripPhotographSynchroniser;
+        _tripNoteSynchroniser = tripNoteSynchroniser;
         _catchSynchroniser = catchSynchroniser;
         _localCatchOwner = localCatchOwner;
         _logging = logging;
@@ -81,7 +84,27 @@ public sealed class LogbookSynchroniser : ILogbookSynchroniser
     {
         await RunTripsAsync(ownerUserId, cancellationToken);
         await RunTripPhotographsAsync(ownerUserId, cancellationToken);
+        await RunTripNotesAsync(ownerUserId, cancellationToken);
         await _catchSynchroniser.SynchronisePendingAsync(ownerUserId, cancellationToken);
+    }
+
+    private async Task RunTripNotesAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _tripNoteSynchroniser.SynchronisePendingAsync(ownerUserId, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await _logging.LogErrorAsync(
+                "trip note synchronisation",
+                exception,
+                CancellationToken.None);
+        }
     }
 
     private async Task RunTripPhotographsAsync(Guid ownerUserId, CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor
@@ -1,3 +1,4 @@
+@using FishingLogBook.Web.Common.Icons
 @using Microsoft.AspNetCore.Components.Forms
 @using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor
 
@@ -197,32 +198,63 @@
 
                     @if (ShowTripAssociation)
                     {
-                        <MudStack Spacing="0" id="catch-trip-association">
-                            <MudText Typo="Typo.caption" Class="mud-text-secondary">
-                                @Loc["Catch_TripRecordingIn"]
-                            </MudText>
+                        <MudStack Row="true"
+                                  Spacing="2"
+                                  AlignItems="AlignItems.Center"
+                                  Justify="Justify.SpaceBetween"
+                                  Class="catch-trip-row"
+                                  id="catch-trip-association">
                             <MudStack Row="true"
                                       Spacing="2"
                                       AlignItems="AlignItems.Center"
-                                      Justify="Justify.SpaceBetween">
-                                <MudText Typo="Typo.body2" id="catch-trip-name">@_associatedTripLabel</MudText>
-                                <MudButton Variant="Variant.Text"
-                                           Size="Size.Small"
-                                           Color="Color.Default"
-                                           OnClick="LeaveTrip"
-                                           id="catch-trip-leave">
-                                    @Loc["Catch_TripLeave"]
-                                </MudButton>
+                                      Class="catch-trip-state">
+                                <MudIcon Icon="@FishingLogBookIcons.FishingTrip"
+                                         Color="Color.Primary"
+                                         Size="Size.Small"
+                                         aria-hidden="true" />
+                                <MudStack Spacing="0">
+                                    <MudText Typo="Typo.caption" Class="mud-text-secondary">
+                                        @Loc["Catch_TripRecordingIn"]
+                                    </MudText>
+                                    <MudText Typo="Typo.body2"
+                                             Class="catch-trip-name"
+                                             id="catch-trip-name">@_associatedTripLabel</MudText>
+                                </MudStack>
                             </MudStack>
+                            <MudButton Variant="Variant.Outlined"
+                                       Size="Size.Small"
+                                       Color="Color.Default"
+                                       StartIcon="@Icons.Material.Filled.LinkOff"
+                                       OnClick="LeaveTrip"
+                                       Class="catch-trip-action"
+                                       id="catch-trip-leave">
+                                @Loc["Catch_TripLeave"]
+                            </MudButton>
                         </MudStack>
                     }
                     else if (ShowTripOptedOut)
                     {
-                        <MudText Typo="Typo.caption"
-                                 Class="mud-text-secondary"
-                                 id="catch-trip-standalone">
-                            @Loc["Catch_TripNotPartOfTrip"]
-                        </MudText>
+                        <MudStack Row="true"
+                                  Spacing="2"
+                                  AlignItems="AlignItems.Center"
+                                  Justify="Justify.SpaceBetween"
+                                  Class="catch-trip-row"
+                                  id="catch-trip-standalone-row">
+                            <MudText Typo="Typo.caption"
+                                     Class="mud-text-secondary"
+                                     id="catch-trip-standalone">
+                                @Loc["Catch_TripNotPartOfTrip"]
+                            </MudText>
+                            <MudButton Variant="Variant.Outlined"
+                                       Size="Size.Small"
+                                       Color="Color.Primary"
+                                       StartIcon="@FishingLogBookIcons.FishingTrip"
+                                       OnClick="RejoinTrip"
+                                       Class="catch-trip-action"
+                                       id="catch-trip-rejoin">
+                                @Loc["Catch_TripRejoin"]
+                            </MudButton>
+                        </MudStack>
                     }
 
                     @if (_tripUnavailable)

--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.cs
@@ -55,6 +55,7 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
     private LocationPromptStatus _locationPrompt = new(false, false, false);
     private CatchLocationModel? _capturedLocation;
     private TripModel? _associatedTrip;
+    private TripModel? _candidateTrip;
     private string? _associatedTripLabel;
     private bool _tripOptedOut;
     private bool _tripUnavailable;
@@ -102,6 +103,8 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
 
     private bool ShowTripOptedOut => _associatedTrip is null && _tripOptedOut && !_isSaved;
 
+    private bool CanRejoinTrip => _candidateTrip is not null;
+
     protected override async Task OnInitializedAsync()
     {
         try
@@ -136,6 +139,7 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
             }
 
             _associatedTrip = trip;
+            _candidateTrip = trip;
             _associatedTripLabel = await DescribeTripAsync(trip);
         }
         catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
@@ -164,8 +168,19 @@ public partial class RecordCatchEditor : ComponentBase, IDisposable
     private void LeaveTrip()
     {
         _associatedTrip = null;
-        _associatedTripLabel = null;
         _tripOptedOut = true;
+        _tripUnavailable = false;
+    }
+
+    private void RejoinTrip()
+    {
+        if (_candidateTrip is null)
+        {
+            return;
+        }
+
+        _associatedTrip = _candidateTrip;
+        _tripOptedOut = false;
         _tripUnavailable = false;
     }
 

--- a/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/RecordCatchEditor/RecordCatchEditor.razor.css
@@ -7,3 +7,20 @@
         flex-direction: column;
     }
 }
+
+.catch-trip-row {
+    width: 100%;
+}
+
+.catch-trip-state {
+    min-width: 0;
+}
+
+.catch-trip-name {
+    overflow-wrap: anywhere;
+}
+
+.catch-trip-action {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
@@ -12,7 +12,14 @@
         <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="flex-wrap" Spacing="2">
             <MudText Typo="Typo.h4" id="catch-list-title">@Loc["Catch_LogbookTitle"]</MudText>
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="flex-wrap">
-                @if (_activeTrip is not null)
+                @if (_isLoading)
+                {
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle"
+                                 Width="9rem"
+                                 Height="2.25rem"
+                                 id="trip-action-loading" />
+                }
+                else if (_activeTrip is not null)
                 {
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Secondary"

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
@@ -1,3 +1,4 @@
+@using FishingLogBook.Web.Common.Icons
 @page "/catches"
 @using Microsoft.AspNetCore.Authorization
 @using FishingLogBook.Web.Features.Catch.Components.CatchCard
@@ -16,7 +17,7 @@
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Secondary"
                                Href="@ActiveTripHref"
-                               StartIcon="@Icons.Material.Filled.Sailing"
+                               StartIcon="@FishingLogBookIcons.FishingTrip"
                                id="trip-continue-link">
                         @Loc["Trip_Continue"]
                     </MudButton>
@@ -27,7 +28,7 @@
                                Color="Color.Secondary"
                                OnClick="StartFishingAsync"
                                Disabled="_isStartingTrip"
-                               StartIcon="@Icons.Material.Filled.Sailing"
+                               StartIcon="@FishingLogBookIcons.FishingTrip"
                                id="trip-start-link">
                         @Loc["Trip_StartFishing"]
                     </MudButton>

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor
@@ -18,8 +18,8 @@
                                Color="Color.Secondary"
                                Href="@ActiveTripHref"
                                StartIcon="@FishingLogBookIcons.FishingTrip"
-                               id="trip-continue-link">
-                        @Loc["Trip_Continue"]
+                               id="trip-update-link">
+                        @Loc["Trip_Update"]
                     </MudButton>
                 }
                 else

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchList/CatchList.razor.cs
@@ -236,7 +236,7 @@ public partial class CatchList : ComponentBase, IDisposable
 
     private async Task StartFishingAsync()
     {
-        if (_isStartingTrip || _activeTrip is not null)
+        if (_isLoading || _isStartingTrip || _activeTrip is not null)
         {
             return;
         }

--- a/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor
@@ -18,8 +18,8 @@
                                Color="Color.Secondary"
                                Href="@ActiveTripHref"
                                StartIcon="@FishingLogBookIcons.FishingTrip"
-                               id="offline-trip-continue-link">
-                        @Loc["Trip_Continue"]
+                               id="offline-trip-update-link">
+                        @Loc["Trip_Update"]
                     </MudButton>
                 }
                 else

--- a/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor
@@ -1,3 +1,4 @@
+@using FishingLogBook.Web.Common.Icons
 @page "/offline/catches"
 @attribute [OfflineRoute]
 @layout OfflineLayout
@@ -16,7 +17,7 @@
                     <MudButton Variant="Variant.Filled"
                                Color="Color.Secondary"
                                Href="@ActiveTripHref"
-                               StartIcon="@Icons.Material.Filled.Sailing"
+                               StartIcon="@FishingLogBookIcons.FishingTrip"
                                id="offline-trip-continue-link">
                         @Loc["Trip_Continue"]
                     </MudButton>
@@ -27,7 +28,7 @@
                                Color="Color.Secondary"
                                OnClick="StartFishingAsync"
                                Disabled="_isStartingTrip"
-                               StartIcon="@Icons.Material.Filled.Sailing"
+                               StartIcon="@FishingLogBookIcons.FishingTrip"
                                id="offline-trip-start-link">
                         @Loc["Trip_StartFishing"]
                     </MudButton>

--- a/src/FishingLogBook.Web/Features/Trips/Clients/ITripClient.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Clients/ITripClient.cs
@@ -23,4 +23,11 @@ public interface ITripClient
         CancellationToken cancellationToken);
 
     Task DeletePhotographAsync(Guid tripId, Guid photographId, CancellationToken cancellationToken);
+
+    Task<TripNoteDto?> RecordNoteAsync(
+        Guid tripId,
+        RecordTripNoteDto request,
+        CancellationToken cancellationToken);
+
+    Task DeleteNoteAsync(Guid tripId, Guid noteId, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Features/Trips/Clients/TripClient.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Clients/TripClient.cs
@@ -72,4 +72,25 @@ public sealed class TripClient : ITripClient
             cancellationToken);
         response.EnsureSuccessStatusCode();
     }
+
+    public async Task<TripNoteDto?> RecordNoteAsync(
+        Guid tripId,
+        RecordTripNoteDto request,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _apiClient.PostAsJsonAsync(
+            $"api/trips/{tripId:D}/notes",
+            request,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TripNoteDto>(cancellationToken);
+    }
+
+    public async Task DeleteNoteAsync(Guid tripId, Guid noteId, CancellationToken cancellationToken)
+    {
+        using var response = await _apiClient.DeleteAsync(
+            $"api/trips/{tripId:D}/notes/{noteId:D}",
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
 }

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor
@@ -9,8 +9,8 @@
         <MudButton Variant="Variant.Text"
                    Size="Size.Small"
                    Href="@ContinueHref"
-                   id="active-trip-banner-continue">
-            @Loc["Trip_Continue"]
+                   id="active-trip-banner-update">
+            @Loc["Trip_Update"]
         </MudButton>
     </div>
 }

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor
@@ -1,9 +1,10 @@
+@using FishingLogBook.Web.Common.Icons
 @namespace FishingLogBook.Web.Features.Trips.Components.ActiveTripBanner
 
 @if (_trip is not null)
 {
     <div class="active-trip-banner" role="status" id="active-trip-banner">
-        <MudIcon Icon="@Icons.Material.Filled.Sailing" Size="Size.Small" aria-hidden="true" />
+        <MudIcon Icon="@FishingLogBookIcons.FishingTrip" Size="Size.Small" aria-hidden="true" />
         <span class="active-trip-banner-text">@Loc["Trip_InProgress"]</span>
         <MudButton Variant="Variant.Text"
                    Size="Size.Small"

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
@@ -2,7 +2,7 @@
 @using FishingLogBook.Web.Features.Trips.Components.TripNotes
 @using FishingLogBook.Web.Features.Trips.Components.TripPhotographs
 
-<MudPaper Elevation="0" Class="active-trip-card" id="active-trip-card">
+<MudPaper Class="pa-3" Elevation="2" id="active-trip-card">
     <MudStack Spacing="3">
         <MudStack Spacing="1">
             <MudText Typo="Typo.overline" Class="active-trip-eyebrow" id="active-trip-eyebrow">

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
@@ -1,4 +1,5 @@
 @namespace FishingLogBook.Web.Features.Trips.Components.ActiveTripView
+@using FishingLogBook.Web.Features.Trips.Components.TripNotes
 @using FishingLogBook.Web.Features.Trips.Components.TripPhotographs
 
 <MudPaper Elevation="0" Class="active-trip-card" id="active-trip-card">
@@ -31,6 +32,8 @@
         </MudStack>
 
         <TripPhotographs Trip="Trip" />
+
+        <TripNotes Trip="Trip" />
 
         <MudButton Variant="Variant.Filled"
                    Color="Color.Primary"

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
@@ -35,6 +35,13 @@
 
         <TripNotes Trip="Trip" />
 
+        <MudStack Spacing="1">
+            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Trip_CatchesLabel"]</MudText>
+            <MudText Typo="Typo.body2"
+                     Class="mud-text-secondary"
+                     id="active-trip-catch-count">@CatchSummary</MudText>
+        </MudStack>
+
         <MudButton Variant="Variant.Filled"
                    Color="Color.Primary"
                    Size="Size.Large"

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
@@ -29,8 +29,24 @@ public partial class ActiveTripView : ComponentBase
     [Parameter]
     public string RecordCatchBaseHref { get; set; } = "/catches/record";
 
+    [Parameter]
+    public int? CatchCount { get; set; }
+
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private string CatchSummary
+    {
+        get
+        {
+            return CatchCount switch
+            {
+                null or 0 => Loc["Trip_CatchesNone"],
+                1 => Loc["Trip_CatchesOne"],
+                _ => string.Format(Loc["Trip_CatchesMany"], CatchCount)
+            };
+        }
+    }
 
     private string RecordCatchHref => $"{RecordCatchBaseHref}?tripId={Trip.Id:D}";
 

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.css
@@ -1,10 +1,3 @@
-.active-trip-card {
-    padding: 1.25rem;
-    border: 1px solid var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-surface);
-}
-
 .active-trip-eyebrow {
     color: var(--mud-palette-primary);
     letter-spacing: 0.08em;

--- a/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor
@@ -1,4 +1,5 @@
 @namespace FishingLogBook.Web.Features.Trips.Components.CompletedTripSummary
+@using FishingLogBook.Web.Features.Trips.Components.TripNotes
 
 <MudPaper Elevation="0" Class="completed-trip-card" id="completed-trip-card">
     <MudStack Spacing="3" AlignItems="AlignItems.Center">
@@ -17,6 +18,10 @@
                 <MudText Typo="Typo.body1" id="completed-trip-duration">@DurationLabel</MudText>
             </MudStack>
         }
+        <MudStack Spacing="2" Class="completed-trip-notes" id="completed-trip-notes">
+            <TripNotes Trip="Trip" />
+        </MudStack>
+
         <MudButton Variant="Variant.Filled"
                    Color="Color.Primary"
                    Size="Size.Large"

--- a/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor
@@ -1,7 +1,7 @@
 @namespace FishingLogBook.Web.Features.Trips.Components.CompletedTripSummary
 @using FishingLogBook.Web.Features.Trips.Components.TripNotes
 
-<MudPaper Elevation="0" Class="completed-trip-card" id="completed-trip-card">
+<MudPaper Class="pa-3" Elevation="2" id="completed-trip-card">
     <MudStack Spacing="3" AlignItems="AlignItems.Center">
         <MudIcon Icon="@Icons.Material.Filled.CheckCircle"
                  Color="Color.Primary"

--- a/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor.css
@@ -4,3 +4,8 @@
     border-radius: var(--mud-default-borderradius);
     background: var(--mud-palette-surface);
 }
+
+.completed-trip-notes {
+    align-self: stretch;
+    text-align: start;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/CompletedTripSummary/CompletedTripSummary.razor.css
@@ -1,10 +1,3 @@
-.completed-trip-card {
-    padding: 1.75rem 1.25rem;
-    border: 1px solid var(--mud-palette-lines-default);
-    border-radius: var(--mud-default-borderradius);
-    background: var(--mud-palette-surface);
-}
-
 .completed-trip-notes {
     align-self: stretch;
     text-align: start;

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor
@@ -1,0 +1,87 @@
+@namespace FishingLogBook.Web.Features.Trips.Components.TripNotes
+
+<MudStack Spacing="2" id="trip-notes">
+    <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Trip_NotesLabel"]</MudText>
+
+    @if (_notes.Count > 0)
+    {
+        <MudStack Spacing="2" id="trip-notes-list">
+            @foreach (var note in _notes)
+            {
+                <MudPaper Elevation="0" Class="trip-note" id="@($"trip-note-{note.Id:D}")">
+                    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Start" Justify="Justify.SpaceBetween">
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption"
+                                     Class="mud-text-secondary"
+                                     id="@($"trip-note-time-{note.Id:D}")">
+                                @LocalTime(note.Id)
+                            </MudText>
+                            <MudText Typo="Typo.body2" Class="trip-note-text">@note.Text</MudText>
+                        </MudStack>
+                        <MudIconButton Icon="@Icons.Material.Filled.Close"
+                                       Size="Size.Small"
+                                       Aria-label="@Loc["Trip_NoteRemove"]"
+                                       OnClick="@(() => RemoveNoteAsync(note.Id))"
+                                       id="@($"trip-note-remove-{note.Id:D}")" />
+                    </MudStack>
+                </MudPaper>
+            }
+        </MudStack>
+    }
+
+    @if (_isWriting)
+    {
+        <MudStack Spacing="2" id="trip-note-editor">
+            <MudTextField T="string"
+                          Value="_text"
+                          ValueChanged="OnTextChanged"
+                          Label="@Loc["Trip_NotePrompt"]"
+                          Placeholder="@Loc["Trip_NotePlaceholder"]"
+                          Lines="3"
+                          Immediate="true"
+                          MaxLength="MaxNoteLength"
+                          Variant="Variant.Outlined"
+                          id="trip-note-text" />
+            <MudStack Row="true" Spacing="2">
+                <MudButton Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           Disabled="@(!CanSave)"
+                           OnClick="AddNoteAsync"
+                           id="trip-note-save">
+                    @Loc["Trip_NoteAdd"]
+                </MudButton>
+                <MudButton Variant="Variant.Text"
+                           Color="Color.Default"
+                           OnClick="CancelWriting"
+                           id="trip-note-cancel">
+                    @Loc["Modal_Cancel"]
+                </MudButton>
+            </MudStack>
+        </MudStack>
+    }
+    else
+    {
+        <MudButton Variant="Variant.Outlined"
+                   Color="Color.Primary"
+                   FullWidth="true"
+                   StartIcon="@Icons.Material.Filled.EditNote"
+                   OnClick="StartWriting"
+                   id="trip-note-start">
+            @Loc["Trip_NoteAdd"]
+        </MudButton>
+    }
+
+    @if (_addFailed)
+    {
+        <MudAlert Severity="Severity.Error" id="trip-note-add-failed">
+            @Loc["Trip_NoteAddFailed"]
+        </MudAlert>
+    }
+
+    @if (_removeFailed)
+    {
+        <MudAlert Severity="Severity.Warning" id="trip-note-remove-failed">
+            @Loc["Trip_NoteRemoveFailed"]
+        </MudAlert>
+    }
+</MudStack>

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.cs
@@ -1,0 +1,212 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Trips.Components.TripNotes;
+
+public partial class TripNotes : ComponentBase, IDisposable
+{
+    private const int MaxNoteLength = TripConstants.MaxNoteTextLength;
+
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly List<TripNoteModel> _notes = [];
+    private readonly Dictionary<Guid, string> _localTimes = [];
+    private string _text = string.Empty;
+    private bool _isWriting;
+    private bool _addFailed;
+    private bool _removeFailed;
+
+    [Parameter]
+    [EditorRequired]
+    public TripModel Trip { get; set; } = default!;
+
+    [Parameter]
+    public EventCallback Changed { get; set; }
+
+    [Inject]
+    private ITripNoteStore NoteStore { get; set; } = default!;
+
+    [Inject]
+    private ITripClient TripClient { get; set; } = default!;
+
+    [Inject]
+    private ITimeService Time { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool CanSave => TripConstants.IsNoteTextValid(_text);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStoredNotesAsync();
+    }
+
+    private async Task LoadStoredNotesAsync()
+    {
+        var stored = await ReadStoredNotesAsync();
+        _notes.Clear();
+        _notes.AddRange(stored.OrderBy(note => note.RecordedOn).ThenBy(note => note.Id));
+        foreach (var note in _notes)
+        {
+            await RememberLocalTimeAsync(note);
+        }
+    }
+
+    private async Task<IReadOnlyList<TripNoteModel>> ReadStoredNotesAsync()
+    {
+        if (Trip.OwnerUserId == Guid.Empty || Trip.Id == Guid.Empty)
+        {
+            return Trip.Notes ?? [];
+        }
+
+        try
+        {
+            return await NoteStore.GetForTripAsync(
+                Trip.OwnerUserId,
+                Trip.Id,
+                _cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return [];
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("loading trip notes", exception, CancellationToken.None);
+            return Trip.Notes ?? [];
+        }
+    }
+
+    private string LocalTime(Guid noteId)
+    {
+        return _localTimes.TryGetValue(noteId, out var value) ? value : string.Empty;
+    }
+
+    private void StartWriting()
+    {
+        _isWriting = true;
+        _addFailed = false;
+        _removeFailed = false;
+    }
+
+    private void CancelWriting()
+    {
+        _isWriting = false;
+        _text = string.Empty;
+        _addFailed = false;
+    }
+
+    private void OnTextChanged(string? value)
+    {
+        _text = value ?? string.Empty;
+    }
+
+    private async Task AddNoteAsync()
+    {
+        if (!CanSave)
+        {
+            return;
+        }
+
+        _addFailed = false;
+        var text = TripConstants.TrimNoteText(_text);
+        if (text is null)
+        {
+            return;
+        }
+
+        var note = new TripNoteModel(
+            Guid.NewGuid(),
+            Trip.Id,
+            Trip.OwnerUserId,
+            text,
+            DateTimeOffset.UtcNow);
+        try
+        {
+            await NoteStore.SaveAsync(note, _cancellationTokenSource.Token);
+            _notes.Add(note);
+            await RememberLocalTimeAsync(note);
+            _text = string.Empty;
+            _isWriting = false;
+            await Changed.InvokeAsync();
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("adding a trip note", exception, CancellationToken.None);
+            _addFailed = true;
+        }
+    }
+
+    private async Task RemoveNoteAsync(Guid noteId)
+    {
+        _removeFailed = false;
+        var note = _notes.FirstOrDefault(candidate => candidate.Id == noteId);
+        if (note is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (note.SyncStatus == SyncStatus.Synchronised)
+            {
+                await TripClient.DeleteNoteAsync(Trip.Id, noteId, _cancellationTokenSource.Token);
+            }
+
+            await NoteStore.DeleteAsync(
+                Trip.OwnerUserId,
+                Trip.Id,
+                noteId,
+                _cancellationTokenSource.Token);
+            _notes.Remove(note);
+            _localTimes.Remove(noteId);
+            await Changed.InvokeAsync();
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("removing a trip note", exception, CancellationToken.None);
+            _removeFailed = true;
+        }
+    }
+
+    private async Task RememberLocalTimeAsync(TripNoteModel note)
+    {
+        try
+        {
+            var value = await Time.ToDateTimeLocalValueAsync(
+                note.RecordedOn,
+                _cancellationTokenSource.Token);
+            _localTimes[note.Id] = value.Length >= 16 ? value[11..16] : value;
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("reading a trip note time", exception, CancellationToken.None);
+        }
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.css
@@ -1,0 +1,10 @@
+.trip-note {
+    background-color: var(--mud-palette-background-grey);
+    border-radius: var(--mud-default-borderradius);
+    padding: 0.5rem 0.75rem;
+}
+
+.trip-note-text {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripModel.cs
@@ -13,8 +13,12 @@ public sealed record TripModel(
     TripLocationModel? Location = null,
     SyncStatus SyncStatus = SyncStatus.SavedLocally,
     DateTimeOffset? SyncedAt = null,
-    IReadOnlyList<TripPhotographModel>? Photographs = null)
+    IReadOnlyList<TripPhotographModel>? Photographs = null,
+    IReadOnlyList<TripNoteModel>? Notes = null)
 {
     public IReadOnlyList<TripPhotographModel> Photographs { get; init; } =
         Photographs is { Count: > 0 } ? Photographs : [];
+
+    public IReadOnlyList<TripNoteModel> Notes { get; init; } =
+        Notes is { Count: > 0 } ? Notes : [];
 }

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripNoteModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripNoteModel.cs
@@ -1,0 +1,12 @@
+using FishingLogBook.Web.Common;
+
+namespace FishingLogBook.Web.Features.Trips.Models;
+
+public sealed record TripNoteModel(
+    Guid Id,
+    Guid TripId,
+    Guid OwnerUserId,
+    string Text,
+    DateTimeOffset RecordedOn,
+    SyncStatus SyncStatus = SyncStatus.SavedLocally,
+    DateTimeOffset? SyncedAt = null);

--- a/src/FishingLogBook.Web/Features/Trips/Offline/Stores/ITripNoteStore.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/Stores/ITripNoteStore.cs
@@ -1,0 +1,33 @@
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+public interface ITripNoteStore
+{
+    Task SaveAsync(TripNoteModel note, CancellationToken cancellationToken);
+
+    Task<bool> DeleteAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        Guid noteId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TripNoteModel>> GetForTripAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        CancellationToken cancellationToken);
+
+    Task<TripNoteModel?> GetAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        Guid noteId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TripNoteModel>> GetPendingAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyCollection<Guid>> GetTripsWithPendingNotesAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/Stores/IndexedDbTripNoteStore.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/Stores/IndexedDbTripNoteStore.cs
@@ -1,0 +1,238 @@
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Web.Common.Offline;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+public sealed class IndexedDbTripNoteStore : ITripNoteStore
+{
+    private const string ModulePath = "./js/offline-store.js";
+    private const string StoreName = "trips";
+
+    private readonly IJSRuntime _jsRuntime;
+    private readonly IDiagnosticLogger _diagnostics;
+    private readonly ILoggingService _logging;
+    private readonly DiagnosticsClientConfig _config;
+    private readonly SemaphoreSlim _moduleLock = new(1, 1);
+    private IJSObjectReference? _module;
+
+    public IndexedDbTripNoteStore(
+        IJSRuntime jsRuntime,
+        IDiagnosticLogger diagnostics,
+        ILoggingService logging,
+        DiagnosticsClientConfig config)
+    {
+        _jsRuntime = jsRuntime;
+        _diagnostics = diagnostics;
+        _logging = logging;
+        _config = config;
+    }
+
+    public async Task SaveAsync(TripNoteModel note, CancellationToken cancellationToken)
+    {
+        if (note.OwnerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip note requires an owner.");
+        }
+
+        if (note.Id == Guid.Empty || note.TripId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip note requires an identifier and a trip.");
+        }
+
+        if (string.IsNullOrWhiteSpace(note.Text))
+        {
+            throw new InvalidOperationException("A trip note requires text.");
+        }
+
+        var json = TripJson.SerializeNote(note);
+        await OfflineOperation.ExecuteAsync(
+            "write",
+            StoreName,
+            DiagnosticEventNames.OfflineDbWriteStarted,
+            DiagnosticEventNames.OfflineDbWriteCompleted,
+            DiagnosticEventNames.OfflineDbWriteFailed,
+            DiagnosticEventNames.OfflineDbWriteTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                return await module.InvokeAsync<bool>("putTripNote", token, json);
+            },
+            cancellationToken,
+            _logging);
+    }
+
+    public async Task<bool> DeleteAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        Guid noteId,
+        CancellationToken cancellationToken)
+    {
+        RequireOwner(ownerUserId);
+        return await OfflineOperation.ExecuteAsync(
+            "delete",
+            StoreName,
+            DiagnosticEventNames.OfflineDbWriteStarted,
+            DiagnosticEventNames.OfflineDbWriteCompleted,
+            DiagnosticEventNames.OfflineDbWriteFailed,
+            DiagnosticEventNames.OfflineDbWriteTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                return await module.InvokeAsync<bool>(
+                    "deleteTripNote",
+                    token,
+                    ownerUserId.ToString("D"),
+                    tripId.ToString("D"),
+                    noteId.ToString("D"));
+            },
+            cancellationToken,
+            _logging);
+    }
+
+    public async Task<IReadOnlyList<TripNoteModel>> GetForTripAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        CancellationToken cancellationToken)
+    {
+        RequireOwner(ownerUserId);
+        var loaded = await ReadNotesAsync(
+            "metadata-read",
+            "getTripNotes",
+            [ownerUserId.ToString("D"), tripId.ToString("D")],
+            cancellationToken);
+        return [.. loaded.Where(note => note.OwnerUserId == ownerUserId && note.TripId == tripId)];
+    }
+
+    public async Task<TripNoteModel?> GetAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        Guid noteId,
+        CancellationToken cancellationToken)
+    {
+        var notes = await GetForTripAsync(ownerUserId, tripId, cancellationToken);
+        return notes.FirstOrDefault(note => note.Id == noteId);
+    }
+
+    private async Task<IReadOnlyList<TripNoteModel>> ReadNotesAsync(
+        string operation,
+        string jsFunction,
+        object?[] arguments,
+        CancellationToken cancellationToken)
+    {
+        return await OfflineOperation.ExecuteAsync(
+            operation,
+            StoreName,
+            DiagnosticEventNames.OfflineDbReadStarted,
+            DiagnosticEventNames.OfflineDbReadCompleted,
+            DiagnosticEventNames.OfflineDbReadFailed,
+            DiagnosticEventNames.OfflineDbReadTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                var records = await module.InvokeAsync<StoredTripRecord[]>(jsFunction, token, arguments);
+                return (IReadOnlyList<TripNoteModel>)(records ?? [])
+                    .Select(record => TripJson.DeserializeNote(record.Json))
+                    .ToArray();
+            },
+            cancellationToken,
+            _logging);
+    }
+
+    public async Task<IReadOnlyList<TripNoteModel>> GetPendingAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        RequireOwner(ownerUserId);
+        var loaded = await OfflineOperation.ExecuteAsync(
+            "pending-read",
+            StoreName,
+            DiagnosticEventNames.OfflineDbReadStarted,
+            DiagnosticEventNames.OfflineDbReadCompleted,
+            DiagnosticEventNames.OfflineDbReadFailed,
+            DiagnosticEventNames.OfflineDbReadTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                var records = await module.InvokeAsync<StoredTripRecord[]>(
+                    "getPendingTripNotes",
+                    token,
+                    ownerUserId.ToString("D"));
+                return (IReadOnlyList<TripNoteModel>)(records ?? [])
+                    .Select(record => TripJson.DeserializeNote(record.Json))
+                    .ToArray();
+            },
+            cancellationToken,
+            _logging);
+        return [.. loaded.Where(note => note.OwnerUserId == ownerUserId)];
+    }
+
+    public async Task<IReadOnlyCollection<Guid>> GetTripsWithPendingNotesAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            return [];
+        }
+
+        var loaded = await OfflineOperation.ExecuteAsync(
+            "pending-read",
+            StoreName,
+            DiagnosticEventNames.OfflineDbReadStarted,
+            DiagnosticEventNames.OfflineDbReadCompleted,
+            DiagnosticEventNames.OfflineDbReadFailed,
+            DiagnosticEventNames.OfflineDbReadTimedOut,
+            _config.OperationTimeout,
+            _diagnostics,
+            async token =>
+            {
+                var module = await GetModuleAsync(token);
+                return await module.InvokeAsync<Guid[]>(
+                    "getTripsWithPendingNotes",
+                    token,
+                    ownerUserId.ToString("D"));
+            },
+            cancellationToken,
+            _logging);
+        return loaded ?? [];
+    }
+
+    private static void RequireOwner(Guid ownerUserId)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip note owner is required.");
+        }
+    }
+
+    private async Task<IJSObjectReference> GetModuleAsync(CancellationToken cancellationToken)
+    {
+        if (_module is not null)
+        {
+            return _module;
+        }
+
+        await _moduleLock.WaitAsync(cancellationToken);
+        try
+        {
+            _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+            return _module;
+        }
+        finally
+        {
+            _moduleLock.Release();
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/Synchronisers/ITripNoteSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/Synchronisers/ITripNoteSynchroniser.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Web.Features.Trips.Offline.Synchronisers;
+
+public interface ITripNoteSynchroniser
+{
+    Task SynchronisePendingAsync(Guid ownerUserId, CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/Synchronisers/TripNoteSynchroniser.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/Synchronisers/TripNoteSynchroniser.cs
@@ -1,0 +1,219 @@
+using System.Collections.Concurrent;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Common.Offline.Dependencies;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+namespace FishingLogBook.Web.Features.Trips.Offline.Synchronisers;
+
+public sealed class TripNoteSynchroniser : ITripNoteSynchroniser
+{
+    private readonly ConcurrentDictionary<Guid, byte> _inFlight = new();
+    private readonly ITripNoteStore _store;
+    private readonly ITripDependencyService _tripDependency;
+    private readonly ITripClient _client;
+    private readonly INetworkService _networkService;
+    private readonly IDiagnosticLogger _diagnostics;
+    private readonly ILoggingService _logging;
+
+    public TripNoteSynchroniser(
+        ITripNoteStore store,
+        ITripDependencyService tripDependency,
+        ITripClient client,
+        INetworkService networkService,
+        IDiagnosticLogger diagnostics,
+        ILoggingService logging)
+    {
+        _store = store;
+        _tripDependency = tripDependency;
+        _client = client;
+        _networkService = networkService;
+        _diagnostics = diagnostics;
+        _logging = logging;
+    }
+
+    public async Task SynchronisePendingAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        if (ownerUserId == Guid.Empty)
+        {
+            return;
+        }
+
+        var pending = await _store.GetPendingAsync(ownerUserId, cancellationToken);
+        if (pending.Count == 0 || !await _networkService.IsOnlineAsync(cancellationToken))
+        {
+            return;
+        }
+
+        var readiness = await ResolveTripReadinessAsync(ownerUserId, pending, cancellationToken);
+        foreach (var note in pending)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!readiness[note.TripId])
+            {
+                await SafeLogAsync(
+                    DiagnosticLevel.Information,
+                    DiagnosticEventNames.TripNoteSyncWaitingForTrip,
+                    "Trip note is waiting for its trip to reach the server.",
+                    note,
+                    exception: null,
+                    cancellationToken);
+                continue;
+            }
+
+            await SynchroniseGuardedAsync(ownerUserId, note, cancellationToken);
+        }
+    }
+
+    private async Task<IReadOnlyDictionary<Guid, bool>> ResolveTripReadinessAsync(
+        Guid ownerUserId,
+        IReadOnlyList<TripNoteModel> pending,
+        CancellationToken cancellationToken)
+    {
+        var readiness = new Dictionary<Guid, bool>();
+        foreach (var tripId in pending.Select(note => note.TripId))
+        {
+            if (readiness.ContainsKey(tripId))
+            {
+                continue;
+            }
+
+            readiness[tripId] = await _tripDependency.IsTripReadyForServerAsync(
+                ownerUserId,
+                tripId,
+                cancellationToken);
+        }
+
+        return readiness;
+    }
+
+    private async Task SynchroniseGuardedAsync(
+        Guid ownerUserId,
+        TripNoteModel note,
+        CancellationToken cancellationToken)
+    {
+        if (!_inFlight.TryAdd(note.Id, 0))
+        {
+            return;
+        }
+
+        try
+        {
+            await SynchroniseNoteAsync(ownerUserId, note, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            await SafeLogAsync(
+                DiagnosticLevel.Error,
+                DiagnosticEventNames.TripNoteSyncFailed,
+                "Trip note synchronisation failed.",
+                note,
+                exception,
+                cancellationToken);
+        }
+        finally
+        {
+            _inFlight.TryRemove(note.Id, out _);
+        }
+    }
+
+    private async Task SynchroniseNoteAsync(
+        Guid ownerUserId,
+        TripNoteModel note,
+        CancellationToken cancellationToken)
+    {
+        await SafeLogAsync(
+            DiagnosticLevel.Information,
+            DiagnosticEventNames.TripNoteSyncStarted,
+            "Trip note synchronisation started.",
+            note,
+            exception: null,
+            cancellationToken);
+
+        await _client.RecordNoteAsync(
+            note.TripId,
+            new RecordTripNoteDto(note.Id, note.Text, note.RecordedOn),
+            cancellationToken);
+
+        var current = await FindLocalAsync(ownerUserId, note, cancellationToken);
+        if (current is null)
+        {
+            return;
+        }
+
+        await _store.SaveAsync(
+            current with
+            {
+                SyncStatus = SyncStatus.Synchronised,
+                SyncedAt = DateTimeOffset.UtcNow
+            },
+            cancellationToken);
+        await SafeLogAsync(
+            DiagnosticLevel.Information,
+            DiagnosticEventNames.TripNoteSyncCompleted,
+            "Trip note synchronisation completed.",
+            note,
+            exception: null,
+            cancellationToken);
+    }
+
+    private async Task<TripNoteModel?> FindLocalAsync(
+        Guid ownerUserId,
+        TripNoteModel note,
+        CancellationToken cancellationToken)
+    {
+        var current = await _store.GetAsync(ownerUserId, note.TripId, note.Id, cancellationToken);
+        if (current is null)
+        {
+            return null;
+        }
+
+        return string.Equals(current.Text, note.Text, StringComparison.Ordinal)
+            && current.RecordedOn == note.RecordedOn
+            ? current
+            : null;
+    }
+
+    private async Task SafeLogAsync(
+        DiagnosticLevel level,
+        string eventName,
+        string message,
+        TripNoteModel note,
+        Exception? exception,
+        CancellationToken cancellationToken)
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            [DiagnosticMetadata.TripId] = note.TripId.ToString("D"),
+            [DiagnosticMetadata.NoteId] = note.Id.ToString("D")
+        };
+        if (exception is not null)
+        {
+            metadata[DiagnosticMetadata.ErrorType] = exception.GetType().Name;
+        }
+
+        try
+        {
+            await _diagnostics.LogAsync(level, eventName, message, metadata, cancellationToken: cancellationToken);
+        }
+        catch (Exception loggingException)
+        {
+            try
+            {
+                await _logging.LogErrorAsync(
+                    "trip note diagnostic",
+                    loggingException,
+                    CancellationToken.None);
+            }
+            catch (Exception)
+            {
+                // Diagnostics never control synchronisation state.
+            }
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Offline/TripJson.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Offline/TripJson.cs
@@ -34,7 +34,8 @@ internal static class TripJson
             ToLocation(record.Location),
             record.SyncStatus,
             record.SyncedAt,
-            [.. record.Photographs.Select(ToPhotograph)]);
+            [.. record.Photographs.Select(ToPhotograph)],
+            [.. record.Notes.Select(ToNote)]);
     }
 
     private static StoredTrip ToRecord(TripModel trip)
@@ -59,7 +60,44 @@ internal static class TripJson
                     trip.Location.ConsentVersion),
             trip.SyncStatus,
             trip.SyncedAt,
-            [.. (trip.Photographs ?? []).Select(ToStoredPhotograph)]);
+            [.. (trip.Photographs ?? []).Select(ToStoredPhotograph)],
+            [.. (trip.Notes ?? []).Select(ToStoredNote)]);
+    }
+
+    public static string SerializeNote(TripNoteModel note)
+    {
+        return JsonSerializer.Serialize(ToStoredNote(note), Options);
+    }
+
+    public static TripNoteModel DeserializeNote(string json)
+    {
+        var record = JsonSerializer.Deserialize<StoredTripNote>(json, Options)
+            ?? throw new InvalidOperationException("Trip note metadata could not be read.");
+        return ToNote(record);
+    }
+
+    private static StoredTripNote ToStoredNote(TripNoteModel note)
+    {
+        return new StoredTripNote(
+            note.Id,
+            note.TripId,
+            note.OwnerUserId,
+            note.Text,
+            note.RecordedOn,
+            note.SyncStatus,
+            note.SyncedAt);
+    }
+
+    private static TripNoteModel ToNote(StoredTripNote record)
+    {
+        return new TripNoteModel(
+            record.Id,
+            record.TripId,
+            record.OwnerUserId,
+            record.Text,
+            record.RecordedOn,
+            record.SyncStatus,
+            record.SyncedAt);
     }
 
     public static string SerializePhotograph(TripPhotographModel photograph)
@@ -131,10 +169,22 @@ internal static class TripJson
         StoredTripLocation? Location = null,
         SyncStatus SyncStatus = SyncStatus.SavedLocally,
         DateTimeOffset? SyncedAt = null,
-        IReadOnlyList<StoredTripPhotograph>? Photographs = null)
+        IReadOnlyList<StoredTripPhotograph>? Photographs = null,
+        IReadOnlyList<StoredTripNote>? Notes = null)
     {
         public IReadOnlyList<StoredTripPhotograph> Photographs { get; init; } = Photographs ?? [];
+
+        public IReadOnlyList<StoredTripNote> Notes { get; init; } = Notes ?? [];
     }
+
+    private sealed record StoredTripNote(
+        Guid Id,
+        Guid TripId,
+        Guid OwnerUserId,
+        string Text,
+        DateTimeOffset RecordedOn,
+        SyncStatus SyncStatus = SyncStatus.SavedLocally,
+        DateTimeOffset? SyncedAt = null);
 
     private sealed record StoredTripPhotograph(
         Guid Id,

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
@@ -40,6 +40,7 @@
                             ElapsedLabel="@DurationLabel"
                             GeneratedTitle="@GeneratedTitle"
                             IsFinishing="_isFinishing"
+                            CatchCount="_catchCount"
                             OnFinish="FinishAsync" />
         }
     </MudStack>

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
@@ -1,4 +1,5 @@
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Trips.Models;
@@ -20,6 +21,7 @@ public partial class ActiveTrip : ComponentBase, IDisposable
     private bool _loadFailed;
     private bool _isFinishing;
     private bool _locationAttempted;
+    private int? _catchCount;
 
     [Parameter]
     public Guid TripId { get; set; }
@@ -35,6 +37,9 @@ public partial class ActiveTrip : ComponentBase, IDisposable
 
     [Inject]
     private ILocalCatchOwnerService LocalOwner { get; set; } = default!;
+
+    [Inject]
+    private ICatchStore CatchStore { get; set; } = default!;
 
     [Inject]
     private ILoggingService Logging { get; set; } = default!;
@@ -90,6 +95,24 @@ public partial class ActiveTrip : ComponentBase, IDisposable
         await TryAttachLocationAsync();
     }
 
+    private async Task<int?> CountCatchesAsync(Guid ownerUserId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var catches = await CatchStore.GetMetadataAsync(ownerUserId, cancellationToken);
+            return catches.Count(catchRecord => catchRecord.TripId == TripId);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("counting catches for a trip", exception, CancellationToken.None);
+            return null;
+        }
+    }
+
     private async Task LoadAsync()
     {
         _isLoading = true;
@@ -102,6 +125,7 @@ public partial class ActiveTrip : ComponentBase, IDisposable
             if (_trip is not null)
             {
                 _display = await TripDisplay.DescribeAsync(_trip, cancellationToken);
+                _catchCount = await CountCatchesAsync(ownerUserId, cancellationToken);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor
@@ -43,6 +43,7 @@
                             ElapsedLabel="@DurationLabel"
                             GeneratedTitle="@GeneratedTitle"
                             IsFinishing="_isFinishing"
+                            CatchCount="_catchCount"
                             OnFinish="FinishAsync" />
         }
     </MudStack>

--- a/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/OfflineActiveTrip/OfflineActiveTrip.razor.cs
@@ -1,4 +1,5 @@
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Features.Trips.Models;
@@ -34,10 +35,32 @@ public partial class OfflineActiveTrip : ComponentBase
     private IOfflineOwnerContextService OfflineOwnerContext { get; set; } = default!;
 
     [Inject]
+    private ICatchStore CatchStore { get; set; } = default!;
+
+    [Inject]
     private ILoggingService Logging { get; set; } = default!;
 
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private int? _catchCount;
+
+    private async Task<int?> CountCatchesAsync(Guid ownerUserId)
+    {
+        try
+        {
+            var catches = await CatchStore.GetMetadataAsync(ownerUserId, CancellationToken.None);
+            return catches.Count(catchRecord => catchRecord.TripId == TripId);
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "counting catches for a trip offline",
+                exception,
+                CancellationToken.None);
+            return null;
+        }
+    }
 
     private bool IsCompleted
     {
@@ -88,6 +111,7 @@ public partial class OfflineActiveTrip : ComponentBase
             if (_trip is not null)
             {
                 _display = await TripDisplay.DescribeAsync(_trip, CancellationToken.None);
+                _catchCount = await CountCatchesAsync(owner.UserId);
             }
         }
         catch (Exception exception)

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -228,11 +228,14 @@
   <data name="Catch_TripRecordingIn" xml:space="preserve">
     <value>Sortie en cours</value>
   </data>
+  <data name="Catch_TripRejoin" xml:space="preserve">
+    <value>Ajouter à la sortie</value>
+  </data>
   <data name="Catch_TripLeave" xml:space="preserve">
-    <value>Hors de cette sortie</value>
+    <value>Retirer de cette sortie</value>
   </data>
   <data name="Catch_TripNotPartOfTrip" xml:space="preserve">
-    <value>Cette prise ne fait partie d'aucune sortie</value>
+    <value>Ne fait pas partie d'une sortie</value>
   </data>
   <data name="Catch_TripUnavailable" xml:space="preserve">
     <value>Cette sortie n'est plus sur cet appareil. Choisissez « Hors de cette sortie » pour enregistrer cette prise seule.</value>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -351,8 +351,8 @@
   <data name="Trip_StartFishing" xml:space="preserve">
     <value>Commencer la pêche</value>
   </data>
-  <data name="Trip_Continue" xml:space="preserve">
-    <value>Reprendre la sortie</value>
+  <data name="Trip_Update" xml:space="preserve">
+    <value>Modifier la sortie</value>
   </data>
   <data name="Trip_InProgress" xml:space="preserve">
     <value>Sortie de pêche en cours</value>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -273,6 +273,18 @@
   <data name="Trip_NoteRemoveFailed" xml:space="preserve">
     <value>Cette note n'a pas pu être supprimée. Réessayez une fois de retour en ligne.</value>
   </data>
+  <data name="Trip_CatchesLabel" xml:space="preserve">
+    <value>Prises de la sortie</value>
+  </data>
+  <data name="Trip_CatchesNone" xml:space="preserve">
+    <value>Aucune prise pour l'instant</value>
+  </data>
+  <data name="Trip_CatchesOne" xml:space="preserve">
+    <value>1 prise enregistrée</value>
+  </data>
+  <data name="Trip_CatchesMany" xml:space="preserve">
+    <value>{0} prises enregistrées</value>
+  </data>
   <data name="Trip_RecordCatch" xml:space="preserve">
     <value>Enregistrer une prise</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -249,6 +249,27 @@
   <data name="Trip_PhotographRemoveFailed" xml:space="preserve">
     <value>Cette photo n'a pas pu être supprimée. Réessayez une fois de retour en ligne.</value>
   </data>
+  <data name="Trip_NotesLabel" xml:space="preserve">
+    <value>Notes de la sortie</value>
+  </data>
+  <data name="Trip_NoteAdd" xml:space="preserve">
+    <value>Ajouter une note</value>
+  </data>
+  <data name="Trip_NotePrompt" xml:space="preserve">
+    <value>Que s'est-il passé ?</value>
+  </data>
+  <data name="Trip_NotePlaceholder" xml:space="preserve">
+    <value>Le niveau a baissé de trente centimètres</value>
+  </data>
+  <data name="Trip_NoteRemove" xml:space="preserve">
+    <value>Supprimer la note</value>
+  </data>
+  <data name="Trip_NoteAddFailed" xml:space="preserve">
+    <value>Cette note n'a pas pu être ajoutée</value>
+  </data>
+  <data name="Trip_NoteRemoveFailed" xml:space="preserve">
+    <value>Cette note n'a pas pu être supprimée. Réessayez une fois de retour en ligne.</value>
+  </data>
   <data name="Trip_RecordCatch" xml:space="preserve">
     <value>Enregistrer une prise</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -228,11 +228,14 @@
   <data name="Catch_TripRecordingIn" xml:space="preserve">
     <value>Recording in</value>
   </data>
+  <data name="Catch_TripRejoin" xml:space="preserve">
+    <value>Add to trip</value>
+  </data>
   <data name="Catch_TripLeave" xml:space="preserve">
-    <value>Not part of this trip</value>
+    <value>Remove from this trip</value>
   </data>
   <data name="Catch_TripNotPartOfTrip" xml:space="preserve">
-    <value>This catch is not part of a trip</value>
+    <value>Not part of a trip</value>
   </data>
   <data name="Catch_TripUnavailable" xml:space="preserve">
     <value>That trip is no longer on this device. Choose "Not part of this trip" to save this catch on its own.</value>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -273,6 +273,18 @@
   <data name="Trip_NoteRemoveFailed" xml:space="preserve">
     <value>That note could not be removed. Try again when you are back online.</value>
   </data>
+  <data name="Trip_CatchesLabel" xml:space="preserve">
+    <value>Trip catches</value>
+  </data>
+  <data name="Trip_CatchesNone" xml:space="preserve">
+    <value>No catches yet</value>
+  </data>
+  <data name="Trip_CatchesOne" xml:space="preserve">
+    <value>1 catch recorded</value>
+  </data>
+  <data name="Trip_CatchesMany" xml:space="preserve">
+    <value>{0} catches recorded</value>
+  </data>
   <data name="Trip_RecordCatch" xml:space="preserve">
     <value>Record catch</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -351,8 +351,8 @@
   <data name="Trip_StartFishing" xml:space="preserve">
     <value>Start fishing</value>
   </data>
-  <data name="Trip_Continue" xml:space="preserve">
-    <value>Continue trip</value>
+  <data name="Trip_Update" xml:space="preserve">
+    <value>Update trip</value>
   </data>
   <data name="Trip_InProgress" xml:space="preserve">
     <value>Fishing trip in progress</value>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -249,6 +249,27 @@
   <data name="Trip_PhotographRemoveFailed" xml:space="preserve">
     <value>That photo could not be removed. Try again when you are back online.</value>
   </data>
+  <data name="Trip_NotesLabel" xml:space="preserve">
+    <value>Trip notes</value>
+  </data>
+  <data name="Trip_NoteAdd" xml:space="preserve">
+    <value>Add note</value>
+  </data>
+  <data name="Trip_NotePrompt" xml:space="preserve">
+    <value>What happened?</value>
+  </data>
+  <data name="Trip_NotePlaceholder" xml:space="preserve">
+    <value>Water dropped a foot</value>
+  </data>
+  <data name="Trip_NoteRemove" xml:space="preserve">
+    <value>Remove note</value>
+  </data>
+  <data name="Trip_NoteAddFailed" xml:space="preserve">
+    <value>That note could not be added</value>
+  </data>
+  <data name="Trip_NoteRemoveFailed" xml:space="preserve">
+    <value>That note could not be removed. Try again when you are back online.</value>
+  </data>
   <data name="Trip_RecordCatch" xml:space="preserve">
     <value>Record catch</value>
   </data>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -93,6 +93,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITripSynchroniser, TripSynchroniser>();
         services.AddScoped<ITripPhotographStore, IndexedDbTripPhotographStore>();
         services.AddScoped<ITripPhotographSynchroniser, TripPhotographSynchroniser>();
+        services.AddScoped<ITripNoteStore, IndexedDbTripNoteStore>();
+        services.AddScoped<ITripNoteSynchroniser, TripNoteSynchroniser>();
         services.AddScoped<ITripDependencyService, TripDependencyService>();
         services.AddScoped<ILogbookSynchroniser, LogbookSynchroniser>();
         services.AddScoped<ICatchSynchroniser, CatchSynchroniser>();

--- a/src/FishingLogBook.Web/wwwroot/js/offline-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/offline-store.js
@@ -22,4 +22,12 @@ export {
     getPendingTripPhotographs,
     getTripsWithPendingPhotographs
 } from './storage/trip-photo-store.js';
+export {
+    putTripNote,
+    getTripNotes,
+    getTripNote,
+    deleteTripNote,
+    getPendingTripNotes,
+    getTripsWithPendingNotes
+} from './storage/trip-note-store.js';
 export { getStorageEstimate } from './storage/indexed-db.js';

--- a/src/FishingLogBook.Web/wwwroot/js/storage/trip-note-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/trip-note-store.js
@@ -1,0 +1,158 @@
+import {
+    TRIP_STORE_NAME,
+    normalisedOwnerId,
+    runLogbookTransaction
+} from './logbook-database.js';
+
+export async function putTripNote(json) {
+    const note = JSON.parse(json);
+    const owner = normalisedOwnerId(note?.ownerUserId);
+    if (!note?.id || !note?.tripId || !owner) {
+        throw new Error('Owned Trip note id is required');
+    }
+
+    if (typeof note.text !== 'string' || note.text.trim().length === 0) {
+        throw new Error('Trip note text is required');
+    }
+
+    return runLogbookTransaction(TRIP_STORE_NAME, 'readwrite', 'write', (store, succeed, fail) => {
+        const read = store.get(note.tripId);
+        read.onerror = () => fail(read.error);
+        read.onsuccess = () => {
+            const trip = read.result;
+            if (!trip || normalisedOwnerId(trip.ownerUserId) !== owner) {
+                fail(new Error('Trip note must belong to an owned Trip'));
+                return;
+            }
+
+            trip.notes = withNote(trip.notes, note);
+            const write = store.put(trip);
+            write.onerror = () => fail(write.error);
+            write.onsuccess = () => succeed(true);
+        };
+    });
+}
+
+export async function deleteTripNote(ownerUserId, tripId, noteId) {
+    const owner = normalisedOwnerId(ownerUserId);
+    if (!owner || !tripId || !noteId) {
+        return false;
+    }
+
+    return runLogbookTransaction(TRIP_STORE_NAME, 'readwrite', 'delete', (store, succeed, fail) => {
+        const read = store.get(tripId);
+        read.onerror = () => fail(read.error);
+        read.onsuccess = () => {
+            const trip = read.result;
+            if (!trip || normalisedOwnerId(trip.ownerUserId) !== owner) {
+                succeed(false);
+                return;
+            }
+
+            const existing = trip.notes ?? [];
+            const remaining = existing.filter(entry => entry?.id !== noteId);
+            if (remaining.length === existing.length) {
+                succeed(false);
+                return;
+            }
+
+            trip.notes = remaining;
+            const write = store.put(trip);
+            write.onerror = () => fail(write.error);
+            write.onsuccess = () => succeed(true);
+        };
+    });
+}
+
+export async function getTripNotes(ownerUserId, tripId) {
+    const owner = normalisedOwnerId(ownerUserId);
+    if (!owner || !tripId) {
+        return [];
+    }
+
+    return runLogbookTransaction(TRIP_STORE_NAME, 'readonly', 'metadata-read', (store, succeed, fail) => {
+        const read = store.get(tripId);
+        read.onerror = () => fail(read.error);
+        read.onsuccess = () => {
+            const trip = read.result;
+            if (!trip || normalisedOwnerId(trip.ownerUserId) !== owner) {
+                succeed([]);
+                return;
+            }
+
+            succeed((trip.notes ?? [])
+                .filter(Boolean)
+                .sort(byRecordedOn)
+                .map(note => ({ json: JSON.stringify(note) })));
+        };
+    });
+}
+
+export async function getTripNote(ownerUserId, tripId, noteId) {
+    const notes = await getTripNotes(ownerUserId, tripId);
+    return notes.find(entry => JSON.parse(entry.json).id === noteId) ?? null;
+}
+
+export async function getPendingTripNotes(ownerUserId) {
+    return scanOwnedTrips(ownerUserId, (trip, collected) => {
+        for (const note of trip.notes ?? []) {
+            if (note && !isSynchronised(note.syncStatus)) {
+                collected.push({ json: JSON.stringify(note) });
+            }
+        }
+    });
+}
+
+export async function getTripsWithPendingNotes(ownerUserId) {
+    return scanOwnedTrips(ownerUserId, (trip, collected) => {
+        if ((trip.notes ?? []).some(note => note && !isSynchronised(note.syncStatus))) {
+            collected.push(trip.id);
+        }
+    });
+}
+
+function scanOwnedTrips(ownerUserId, collect) {
+    const owner = normalisedOwnerId(ownerUserId);
+    if (!owner) {
+        return Promise.resolve([]);
+    }
+
+    return runLogbookTransaction(TRIP_STORE_NAME, 'readonly', 'pending-read', (store, succeed, fail) => {
+        const collected = [];
+        const request = store.openCursor();
+        request.onerror = () => fail(request.error);
+        request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) {
+                succeed(collected);
+                return;
+            }
+
+            if (normalisedOwnerId(cursor.value?.ownerUserId) === owner) {
+                collect(cursor.value, collected);
+            }
+
+            cursor.continue();
+        };
+    });
+}
+
+function withNote(existing, note) {
+    const others = (existing ?? []).filter(entry => entry?.id !== note.id);
+    others.push(note);
+    return others.sort(byRecordedOn);
+}
+
+function byRecordedOn(first, second) {
+    const firstOn = Date.parse(first?.recordedOn ?? '');
+    const secondOn = Date.parse(second?.recordedOn ?? '');
+    if (Number.isNaN(firstOn) || Number.isNaN(secondOn) || firstOn === secondOn) {
+        return String(first?.id ?? '').localeCompare(String(second?.id ?? ''));
+    }
+
+    return firstOn - secondOn;
+}
+
+function isSynchronised(status) {
+    return status === 'synchronised' || status === 3;
+}

--- a/src/FishingLogBook.Web/wwwroot/js/storage/trip-note-store.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/trip-note-store.test.js
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest';
+import {
+    deleteTripNote,
+    getPendingTripNotes,
+    getTripsWithPendingNotes,
+    putTripNote
+} from './trip-note-store.js';
+import { cleanupSyncedTrips, getTrip, putTrip } from './trip-store.js';
+import { getTripPhotographBytes, putTripPhotograph } from './trip-photo-store.js';
+import { getAllCatchesWithPhotographs, putCatchWithPhotographs } from './catch-store.js';
+
+describe('Trip note store', () => {
+    const ownerUserId = '11111111-1111-1111-1111-111111111111';
+    const otherUserId = '22222222-2222-2222-2222-222222222222';
+    const tripId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const noteId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    const secondNoteId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const startedOn = '2026-08-26T05:32:00+00:00';
+    const recordedOn = '2026-08-26T06:12:00+00:00';
+    const longAgo = '2026-08-20T05:32:00+00:00';
+    const cutoff = '2026-08-25T05:32:00+00:00';
+
+    function trip(overrides = {}) {
+        return {
+            id: tripId,
+            ownerUserId,
+            status: 'Active',
+            startedOn,
+            endedOn: null,
+            title: null,
+            placeName: null,
+            location: null,
+            syncStatus: 'savedLocally',
+            syncedAt: null,
+            photographs: [],
+            notes: [],
+            ...overrides
+        };
+    }
+
+    function note(overrides = {}) {
+        return {
+            id: noteId,
+            tripId,
+            ownerUserId,
+            text: 'water dropped about a foot',
+            recordedOn,
+            syncStatus: 'savedLocally',
+            syncedAt: null,
+            ...overrides
+        };
+    }
+
+    async function seedTrip(overrides = {}) {
+        return putTrip(JSON.stringify(trip(overrides)));
+    }
+
+    async function save(record) {
+        return putTripNote(JSON.stringify(record));
+    }
+
+    async function storedNotes() {
+        const stored = await getTrip(ownerUserId, tripId);
+        return stored === null ? null : JSON.parse(stored.json).notes ?? [];
+    }
+
+    it('rejects a note with no owner', async () => {
+        await seedTrip();
+
+        await expect(save(note({ ownerUserId: '' })))
+            .rejects.toThrow('Owned Trip note id is required');
+    });
+
+    it('rejects a note with no text', async () => {
+        await seedTrip();
+
+        await expect(save(note({ text: '   ' })))
+            .rejects.toThrow('Trip note text is required');
+    });
+
+    it('rejects a note for a trip that is not stored', async () => {
+        await expect(save(note()))
+            .rejects.toThrow('Trip note must belong to an owned Trip');
+    });
+
+    it('rejects a note for another anglers trip', async () => {
+        await seedTrip({ ownerUserId: otherUserId });
+
+        await expect(save(note()))
+            .rejects.toThrow('Trip note must belong to an owned Trip');
+    });
+
+    it('round-trips the note on the trip metadata', async () => {
+        await seedTrip();
+
+        await save(note());
+
+        const stored = await storedNotes();
+        expect(stored).toHaveLength(1);
+        expect(stored[0].id).toBe(noteId);
+        expect(stored[0].text).toBe('water dropped about a foot');
+        expect(stored[0].recordedOn).toBe(recordedOn);
+    });
+
+    it('orders notes by the instant they were written', async () => {
+        await seedTrip();
+        await save(note({ id: secondNoteId, text: 'later', recordedOn: '2026-08-26T09:00:00+00:00' }));
+        await save(note({ text: 'earlier', recordedOn: '2026-08-26T06:00:00+00:00' }));
+
+        const stored = await storedNotes();
+        expect(stored.map(entry => entry.text)).toEqual(['earlier', 'later']);
+    });
+
+    it('replaces a note on the same id rather than duplicating it', async () => {
+        await seedTrip();
+        await save(note());
+
+        await save(note({ syncStatus: 'synchronised', syncedAt: recordedOn }));
+
+        const stored = await storedNotes();
+        expect(stored).toHaveLength(1);
+        expect(stored[0].syncStatus).toBe('synchronised');
+    });
+
+    it('lists only this anglers pending notes', async () => {
+        await seedTrip();
+        await save(note());
+        await save(note({ id: secondNoteId, syncStatus: 'synchronised' }));
+
+        const pending = await getPendingTripNotes(ownerUserId);
+
+        expect(pending).toHaveLength(1);
+        expect(JSON.parse(pending[0].json).id).toBe(noteId);
+        expect(await getPendingTripNotes(otherUserId)).toEqual([]);
+    });
+
+    it('reports the trips holding pending notes', async () => {
+        await seedTrip();
+        await save(note());
+
+        expect(await getTripsWithPendingNotes(ownerUserId)).toEqual([tripId]);
+
+        await save(note({ syncStatus: 'synchronised' }));
+
+        expect(await getTripsWithPendingNotes(ownerUserId)).toEqual([]);
+    });
+
+    it('removes only the deleted note', async () => {
+        await seedTrip();
+        await save(note());
+        await save(note({ id: secondNoteId, text: 'kept' }));
+
+        expect(await deleteTripNote(ownerUserId, tripId, noteId)).toBe(true);
+
+        const stored = await storedNotes();
+        expect(stored.map(entry => entry.id)).toEqual([secondNoteId]);
+    });
+
+    it('does not remove another anglers note', async () => {
+        await seedTrip({ ownerUserId: otherUserId });
+        await putTripNote(JSON.stringify(note({ ownerUserId: otherUserId })));
+
+        expect(await deleteTripNote(ownerUserId, tripId, noteId)).toBe(false);
+        expect(await getPendingTripNotes(otherUserId)).toHaveLength(1);
+    });
+
+    it('keeps the notes when the trip is finished from a stale snapshot', async () => {
+        await seedTrip();
+        await save(note());
+
+        await putTrip(JSON.stringify(trip({
+            status: 'Completed',
+            endedOn: startedOn,
+            notes: []
+        })));
+
+        expect(await storedNotes()).toHaveLength(1);
+    });
+
+    it('keeps the notes when a synchronisation write omits them', async () => {
+        await seedTrip();
+        await save(note());
+
+        const withoutNotes = trip({ syncStatus: 'synchronised', syncedAt: startedOn });
+        delete withoutNotes.notes;
+        await putTrip(JSON.stringify(withoutNotes));
+
+        expect(await storedNotes()).toHaveLength(1);
+    });
+
+    it('keeps notes and photographs independent of each other', async () => {
+        await seedTrip();
+        await save(note());
+        await putTripPhotograph(
+            JSON.stringify({
+                id: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+                tripId,
+                ownerUserId,
+                contentType: 'image/jpeg',
+                addedOn: recordedOn,
+                capturedOn: null,
+                objectKey: null,
+                syncStatus: 'savedLocally',
+                syncedAt: null
+            }),
+            new Uint8Array([1, 2, 3]));
+
+        await deleteTripNote(ownerUserId, tripId, noteId);
+
+        expect(await storedNotes()).toEqual([]);
+        const stored = await getTrip(ownerUserId, tripId);
+        expect(JSON.parse(stored.json).photographs).toHaveLength(1);
+        expect(await getTripPhotographBytes(
+            ownerUserId,
+            tripId,
+            'ffffffff-ffff-ffff-ffff-ffffffffffff')).not.toBeNull();
+    });
+
+    it('removes the notes with the trip when retention evicts it', async () => {
+        await seedTrip();
+        await save(note());
+        await putTrip(JSON.stringify(trip({
+            status: 'Completed',
+            endedOn: startedOn,
+            syncStatus: 'synchronised',
+            syncedAt: longAgo
+        })));
+
+        expect(await cleanupSyncedTrips(ownerUserId, cutoff, [])).toBe(1);
+
+        expect(await getTrip(ownerUserId, tripId)).toBeNull();
+        expect(await getPendingTripNotes(ownerUserId)).toEqual([]);
+    });
+
+    it('leaves stored catches untouched', async () => {
+        await putCatchWithPhotographs(
+            JSON.stringify({
+                id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+                userId: ownerUserId,
+                notes: 'a catch note that is not a trip note'
+            }),
+            [{
+                id: 'catch-photo-1',
+                catchId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+                contentType: 'image/jpeg',
+                bytes: new Uint8Array([7, 7, 7])
+            }]);
+        await seedTrip();
+
+        await save(note());
+        await deleteTripNote(ownerUserId, tripId, noteId);
+
+        const catches = await getAllCatchesWithPhotographs(ownerUserId);
+        expect(catches).toHaveLength(1);
+        expect(JSON.parse(catches[0].json).notes).toBe('a catch note that is not a trip note');
+        expect(catches[0].photographs).toHaveLength(1);
+    });
+});

--- a/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.js
+++ b/src/FishingLogBook.Web/wwwroot/js/storage/trip-store.js
@@ -23,6 +23,7 @@ export async function putTrip(json) {
     return runLogbookTransaction(TRIP_STORE_NAME, 'readwrite', 'write', (store, succeed, fail) => {
         const owner = normalisedOwnerId(trip.ownerUserId);
         let storedPhotographs = null;
+        let storedNotes = null;
         const request = store.openCursor();
         request.onerror = () => fail(request.error);
         request.onsuccess = () => {
@@ -40,6 +41,7 @@ export async function putTrip(json) {
 
                 if (cursor.value?.id === trip.id) {
                     storedPhotographs = cursor.value.photographs ?? [];
+                    storedNotes = cursor.value.notes ?? [];
                 }
 
                 cursor.continue();
@@ -47,6 +49,7 @@ export async function putTrip(json) {
             }
 
             trip.photographs = storedPhotographs ?? trip.photographs ?? [];
+            trip.notes = storedNotes ?? trip.notes ?? [];
             const write = store.put(trip);
             write.onerror = () => fail(write.error);
             write.onsuccess = () => succeed(TRIP_SAVED_OUTCOME);

--- a/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
+++ b/tests/FishingLogBook.Api.Tests/SystemApiFactory.cs
@@ -45,6 +45,8 @@ public class SystemApiFactory : WebApplicationFactory<Program>
     public ITripPhotographRepository TripPhotographRepository { get; } =
         Substitute.For<ITripPhotographRepository>();
 
+    public ITripNoteRepository TripNoteRepository { get; } = Substitute.For<ITripNoteRepository>();
+
     public IUserPlatformCapabilityRepository UserPlatformCapabilityRepository { get; } =
         Substitute.For<IUserPlatformCapabilityRepository>();
 
@@ -229,8 +231,10 @@ public class SystemApiFactory : WebApplicationFactory<Program>
             services.AddSingleton(CatchRepository);
             services.RemoveAll<ITripRepository>();
             services.RemoveAll<ITripPhotographRepository>();
+            services.RemoveAll<ITripNoteRepository>();
             services.AddSingleton(TripRepository);
             services.AddSingleton(TripPhotographRepository);
+            services.AddSingleton(TripNoteRepository);
             services.RemoveAll<IFishingCatalogueRepository>();
             services.AddSingleton(FishingCatalogueRepository);
             services.RemoveAll<IFishingPreferenceRepository>();

--- a/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingNotes.cs
+++ b/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingNotes.cs
@@ -1,0 +1,291 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Domain.Users;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.TripEndpointsTests;
+
+public class WhenTestingNotes : IClassFixture<SystemApiFactory>
+{
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+    private static readonly DateTimeOffset RecordedOn = DateTimeOffset.Parse("2026-08-17T09:12:00Z");
+
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingNotes(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnauthenticatedNote()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{Guid.NewGuid():D}/notes",
+            new RecordTripNoteDto(Guid.NewGuid(), "water dropped", RecordedOn));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.TripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAWhitespaceOnlyNote()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{Guid.NewGuid():D}/notes",
+            new RecordTripNoteDto(Guid.NewGuid(), "   ", RecordedOn));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectANoteOverTheLengthCap()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{Guid.NewGuid():D}/notes",
+            new RecordTripNoteDto(
+                Guid.NewGuid(),
+                new string('a', TripConstants.MaxNoteTextLength + 1),
+                RecordedOn));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotFindAnotherAnglersTrip()
+    {
+        // Arrange
+        Reset();
+        var tripId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, Guid.NewGuid())));
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/notes",
+            new RecordTripNoteDto(Guid.NewGuid(), "water dropped", RecordedOn));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await _factory.TripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotRevealWhetherAnotherAnglersTripExists()
+    {
+        // Arrange
+        Reset();
+        var knownTripId = Guid.NewGuid();
+        var unknownTripId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(knownTripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(knownTripId, Guid.NewGuid())));
+        _factory.TripRepository.GetByIdAsync(unknownTripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var known = await client.PostAsJsonAsync(
+            $"/api/trips/{knownTripId:D}/notes",
+            new RecordTripNoteDto(Guid.NewGuid(), "water dropped", RecordedOn));
+        var unknown = await client.PostAsJsonAsync(
+            $"/api/trips/{unknownTripId:D}/notes",
+            new RecordTripNoteDto(Guid.NewGuid(), "water dropped", RecordedOn));
+
+        // Assert
+        known.StatusCode.Should().Be(unknown.StatusCode);
+        (await known.Content.ReadAsStringAsync())
+            .Should().Be(await unknown.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ItShouldRecordANoteForTheAnglersOwnTrip()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var noteId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId, TripStatusEnum.Completed)));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/notes",
+            new RecordTripNoteDto(noteId, "  a good day  ", RecordedOn));
+        var body = await response.Content.ReadFromJsonAsync<TripNoteDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body!.Id.Should().Be(noteId);
+        body.TripId.Should().Be(tripId);
+        body.Text.Should().Be("a good day");
+        body.RecordedOn.Should().Be(RecordedOn);
+        await _factory.TripNoteRepository.Received(1).UpsertAsync(
+            Arg.Is<TripNote>(note =>
+                note.Id == noteId
+                && note.TripId == tripId
+                && note.Text == "a good day"
+                && note.RecordedOn == RecordedOn),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotDuplicateANoteWhenTheSameRequestIsReplayed()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var noteId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId)));
+        var request = new RecordTripNoteDto(noteId, "wind picked up", RecordedOn);
+
+        // Act
+        var first = await client.PostAsJsonAsync($"/api/trips/{tripId:D}/notes", request);
+        _factory.TripNoteRepository.GetByIdAsync(noteId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(new TripNote
+            {
+                Id = noteId,
+                TripId = tripId,
+                Text = "wind picked up",
+                RecordedOn = RecordedOn
+            }));
+        var second = await client.PostAsJsonAsync($"/api/trips/{tripId:D}/notes", request);
+
+        // Assert
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        await _factory.TripNoteRepository.Received(2).UpsertAsync(
+            Arg.Is<TripNote>(note => note.Id == noteId && note.TripId == tripId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDeleteANoteFromTheAnglersOwnTrip()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var noteId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId)));
+        _factory.TripNoteRepository.GetByIdAsync(noteId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(new TripNote
+            {
+                Id = noteId,
+                TripId = tripId,
+                Text = "wind picked up",
+                RecordedOn = RecordedOn
+            }));
+
+        // Act
+        var response = await client.DeleteAsync($"/api/trips/{tripId:D}/notes/{noteId:D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await _factory.TripNoteRepository.Received(1).DeleteAsync(
+            noteId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotDeleteANoteBelongingToAnotherTrip()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var noteId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId)));
+        _factory.TripNoteRepository.GetByIdAsync(noteId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(new TripNote
+            {
+                Id = noteId,
+                TripId = Guid.NewGuid(),
+                Text = "someone else's day",
+                RecordedOn = RecordedOn
+            }));
+
+        // Act
+        var response = await client.DeleteAsync($"/api/trips/{tripId:D}/notes/{noteId:D}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await _factory.TripNoteRepository.DidNotReceive().DeleteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static Trip Trip(
+        Guid tripId,
+        Guid ownerUserId,
+        TripStatusEnum status = TripStatusEnum.Active)
+    {
+        return new Trip
+        {
+            Id = tripId,
+            OwnerUserId = ownerUserId,
+            Status = status,
+            StartedOn = StartedOn,
+            EndedOn = status == TripStatusEnum.Completed ? StartedOn.AddHours(3) : null
+        };
+    }
+
+    private void Reset()
+    {
+        _factory.TripRepository.ClearReceivedCalls();
+        _factory.TripNoteRepository.ClearReceivedCalls();
+        _factory.TripNoteRepository
+            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(null));
+        _factory.TripNoteRepository
+            .UpsertAsync(Arg.Any<TripNote>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(call.ArgAt<TripNote>(0)));
+        _factory.TripNoteRepository
+            .DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingNotes.cs
+++ b/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingNotes.cs
@@ -157,12 +157,14 @@ public class WhenTestingNotes : IClassFixture<SystemApiFactory>
         body.TripId.Should().Be(tripId);
         body.Text.Should().Be("a good day");
         body.RecordedOn.Should().Be(RecordedOn);
+        body.CreatedByUserId.Should().Be(current.UserId);
         await _factory.TripNoteRepository.Received(1).UpsertAsync(
             Arg.Is<TripNote>(note =>
                 note.Id == noteId
                 && note.TripId == tripId
                 && note.Text == "a good day"
-                && note.RecordedOn == RecordedOn),
+                && note.RecordedOn == RecordedOn
+                && note.CreatedByUserId == current.UserId),
             Arg.Any<CancellationToken>());
     }
 
@@ -256,6 +258,42 @@ public class WhenTestingNotes : IClassFixture<SystemApiFactory>
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         await _factory.TripNoteRepository.DidNotReceive().DeleteAsync(
             Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAttributeTheNoteToTheAuthenticatedAnglerNotTheRequest()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId)));
+        var impostor = Guid.NewGuid();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/notes",
+            new
+            {
+                noteId = Guid.NewGuid(),
+                text = "wind picked up",
+                recordedOn = RecordedOn,
+                createdByUserId = impostor
+            });
+        var body = await response.Content.ReadFromJsonAsync<TripNoteDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body!.CreatedByUserId.Should().Be(current.UserId);
+        body.CreatedByUserId.Should().NotBe(impostor);
+        await _factory.TripNoteRepository.Received(1).UpsertAsync(
+            Arg.Is<TripNote>(note => note.CreatedByUserId == current.UserId),
+            Arg.Any<CancellationToken>());
+        await _factory.TripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Is<TripNote>(note => note.CreatedByUserId == impostor),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/FishingLogBook.Application.Tests/Trips/Commands/RecordTripNoteCommandValidatorTests/BaseRecordTripNoteCommandValidatorTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Commands/RecordTripNoteCommandValidatorTests/BaseRecordTripNoteCommandValidatorTest.cs
@@ -1,0 +1,12 @@
+using FishingLogBook.Application.Trips.Commands;
+
+namespace FishingLogBook.Application.Tests.Trips.Commands.RecordTripNoteCommandValidatorTests;
+
+public class BaseRecordTripNoteCommandValidatorTest
+{
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid NoteId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    protected static readonly DateTimeOffset RecordedOn = DateTimeOffset.Parse("2026-08-17T09:12:00Z");
+
+    protected readonly RecordTripNoteCommandValidator Sut = new();
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Commands/RecordTripNoteCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Commands/RecordTripNoteCommandValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,129 @@
+using FishingLogBook.Application.Trips.Commands;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Trips.Commands.RecordTripNoteCommandValidatorTests;
+
+public class WhenTestingValidate : BaseRecordTripNoteCommandValidatorTest
+{
+    [Fact]
+    public void ItShouldRejectAMissingTrip()
+    {
+        // Arrange
+        var command = Command(tripId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.TripId);
+    }
+
+    [Fact]
+    public void ItShouldRejectAMissingNoteIdentifier()
+    {
+        // Arrange
+        var command = Command(noteId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Note.NoteId);
+    }
+
+    [Fact]
+    public void ItShouldRejectAMissingRecordedInstant()
+    {
+        // Arrange
+        var command = Command(recordedOn: default(DateTimeOffset));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Note.RecordedOn);
+    }
+
+    [Fact]
+    public void ItShouldRejectEmptyText()
+    {
+        // Arrange
+        var command = Command(text: string.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Note.Text);
+    }
+
+    [Fact]
+    public void ItShouldRejectWhitespaceOnlyText()
+    {
+        // Arrange
+        var command = Command(text: "   \t  ");
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Note.Text);
+    }
+
+    [Fact]
+    public void ItShouldRejectTextOneCharacterOverTheCap()
+    {
+        // Arrange
+        var command = Command(text: new string('a', TripConstants.MaxNoteTextLength + 1));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.Note.Text);
+    }
+
+    [Fact]
+    public void ItShouldAcceptTextAtExactlyTheCap()
+    {
+        // Arrange
+        var command = Command(text: new string('a', TripConstants.MaxNoteTextLength));
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ItShouldAcceptAnOrdinaryNote()
+    {
+        // Arrange
+        var command = Command();
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static RecordTripNoteCommand Command(
+        string text = "water dropped about a foot",
+        Guid? noteId = null,
+        DateTimeOffset? recordedOn = null,
+        Guid? tripId = null)
+    {
+        return new RecordTripNoteCommand
+        {
+            TripId = tripId ?? TripId,
+            Note = new RecordTripNoteDto(
+                noteId ?? NoteId,
+                text,
+                recordedOn ?? RecordedOn)
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/BaseTripNoteServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/BaseTripNoteServiceTest.cs
@@ -1,0 +1,72 @@
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.Trips.Services;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripNoteServiceTests;
+
+public class BaseTripNoteServiceTest
+{
+    protected static readonly Guid CurrentUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid NoteId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+    protected static readonly DateTimeOffset RecordedOn = DateTimeOffset.Parse("2026-08-17T09:12:00Z");
+
+    protected readonly ITripRepository MockTripRepository = Substitute.For<ITripRepository>();
+    protected readonly ITripNoteRepository MockTripNoteRepository =
+        Substitute.For<ITripNoteRepository>();
+    protected readonly ICurrentUser MockCurrentUser = Substitute.For<ICurrentUser>();
+    protected readonly TripNoteService Sut;
+
+    protected BaseTripNoteServiceTest()
+    {
+        MockCurrentUser.IsResolved.Returns(true);
+        MockCurrentUser.UserId.Returns(CurrentUserId);
+        MockTripNoteRepository.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(null));
+        MockTripNoteRepository.UpsertAsync(Arg.Any<TripNote>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(call.ArgAt<TripNote>(0)));
+        MockTripNoteRepository.DeleteAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok());
+        Sut = new TripNoteService(
+            MockTripRepository,
+            MockTripNoteRepository,
+            MockCurrentUser,
+            TestMapper.Create());
+    }
+
+    protected void GivenTrip(Guid ownerUserId, TripStatusEnum status = TripStatusEnum.Active)
+    {
+        MockTripRepository.GetByIdAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(new Trip
+            {
+                Id = TripId,
+                OwnerUserId = ownerUserId,
+                Status = status,
+                StartedOn = StartedOn,
+                EndedOn = status == TripStatusEnum.Completed ? StartedOn.AddHours(3) : null
+            }));
+    }
+
+    protected void GivenNoTrip()
+    {
+        MockTripRepository.GetByIdAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+    }
+
+    protected static TripNote StoredNote(Guid tripId)
+    {
+        return new TripNote
+        {
+            Id = NoteId,
+            TripId = tripId,
+            Text = "water dropped about a foot",
+            RecordedOn = RecordedOn
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/WhenTestingRecord.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/WhenTestingRecord.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Application.Trips.Errors;
 using FishingLogBook.Domain.Enums;
 using FishingLogBook.Domain.Trips;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
 using FluentResults;
 using NSubstitute;
 
@@ -204,6 +205,42 @@ public class WhenTestingRecord : BaseTripNoteServiceTest
                 && note.TripId == TripId
                 && note.RecordedOn == RecordedOn),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldTakeTheAuthorFromTheTrustedCurrentUser()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CreatedByUserId.Should().Be(CurrentUserId);
+        await MockTripNoteRepository.Received(1).UpsertAsync(
+            Arg.Is<TripNote>(note => note.CreatedByUserId == CurrentUserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void ItShouldNotAcceptAnAuthorFromTheRequestPayload()
+    {
+        // Arrange
+        var payloadProperties = typeof(RecordTripNoteDto).GetProperties();
+
+        // Act
+        var authorLike = payloadProperties
+            .Where(property => property.Name.Contains("User", StringComparison.OrdinalIgnoreCase)
+                || property.Name.Contains("Author", StringComparison.OrdinalIgnoreCase)
+                || property.Name.Contains("CreatedBy", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        // Assert
+        authorLike.Should().BeEmpty();
+        payloadProperties.Select(property => property.Name)
+            .Should().BeEquivalentTo(["NoteId", "Text", "RecordedOn"]);
     }
 
     private static RecordTripNoteArgs Args(string text = "water dropped about a foot")

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/WhenTestingRecord.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/WhenTestingRecord.cs
@@ -1,0 +1,219 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Constants;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripNoteServiceTests;
+
+public class WhenTestingRecord : BaseTripNoteServiceTest
+{
+    [Fact]
+    public async Task ItShouldRejectAnEmptyNote()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(Args(string.Empty), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteInvalidError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+        await MockTripRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAWhitespaceOnlyNote()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(Args("   \t\r\n  "), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteInvalidError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectANoteOneCharacterOverTheCap()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        var text = new string('a', TripConstants.MaxNoteTextLength + 1);
+
+        // Act
+        var result = await Sut.RecordAsync(Args(text), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteInvalidError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheTripIsUnknown()
+    {
+        // Arrange
+        GivenNoTrip();
+
+        // Act
+        var result = await Sut.RecordAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteNotFoundError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheTripBelongsToAnotherAngler()
+    {
+        // Arrange
+        GivenTrip(OtherUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteNotFoundError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportTheSameErrorForAnUnknownAndAnotherAnglersTrip()
+    {
+        // Arrange
+        GivenNoTrip();
+        var unknown = await Sut.RecordAsync(Args(), CancellationToken.None);
+        GivenTrip(OtherUserId);
+
+        // Act
+        var foreign = await Sut.RecordAsync(Args(), CancellationToken.None);
+
+        // Assert
+        foreign.Errors[0].GetType().Should().Be(unknown.Errors[0].GetType());
+        foreign.Errors[0].Message.Should().Be(unknown.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectANoteAlreadyBelongingToAnotherTrip()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        MockTripNoteRepository.GetByIdAsync(NoteId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(StoredNote(Guid.NewGuid())));
+
+        // Act
+        var result = await Sut.RecordAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteNotFoundError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldTrimSurroundingWhitespace()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(
+            Args("  fish rising near the reeds \n "),
+            CancellationToken.None);
+
+        // Assert
+        result.Value.Text.Should().Be("fish rising near the reeds");
+        await MockTripNoteRepository.Received(1).UpsertAsync(
+            Arg.Is<TripNote>(note => note.Text == "fish rising near the reeds"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAcceptANoteAtExactlyTheCap()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        var text = new string('a', TripConstants.MaxNoteTextLength);
+
+        // Act
+        var result = await Sut.RecordAsync(Args(text), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Text.Should().HaveLength(TripConstants.MaxNoteTextLength);
+    }
+
+    [Fact]
+    public async Task ItShouldAcceptANoteForACompletedTrip()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId, TripStatusEnum.Completed);
+
+        // Act
+        var result = await Sut.RecordAsync(Args("a good day"), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockTripNoteRepository.Received(1).UpsertAsync(
+            Arg.Is<TripNote>(note => note.TripId == TripId && note.Text == "a good day"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheClientRecordedInstant()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(NoteId);
+        result.Value.TripId.Should().Be(TripId);
+        result.Value.RecordedOn.Should().Be(RecordedOn);
+        await MockTripNoteRepository.Received(1).UpsertAsync(
+            Arg.Is<TripNote>(note =>
+                note.Id == NoteId
+                && note.TripId == TripId
+                && note.RecordedOn == RecordedOn),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static RecordTripNoteArgs Args(string text = "water dropped about a foot")
+    {
+        return new RecordTripNoteArgs
+        {
+            TripId = TripId,
+            NoteId = NoteId,
+            Text = text,
+            RecordedOn = RecordedOn
+        };
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripNoteRepositoryTests/BaseTripNoteRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripNoteRepositoryTests/BaseTripNoteRepositoryTest.cs
@@ -1,0 +1,84 @@
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Infrastructure.Persistence;
+using FishingLogBook.Infrastructure.Persistence.Repositories;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+using FishingLogBook.Tests.Common.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Repositories.TripNoteRepositoryTests;
+
+[Collection(PostgresCollection.Name)]
+public abstract class BaseTripNoteRepositoryTest
+{
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+
+    protected readonly TripNoteRepository Sut;
+    protected readonly TripRepository Trips;
+    protected readonly UserIdentityRepository Users;
+    protected readonly NpgsqlConnectionFactory ConnectionFactory;
+
+    protected BaseTripNoteRepositoryTest(PostgresFixture fixture)
+    {
+        ConnectionFactory = new NpgsqlConnectionFactory(fixture.ConnectionString);
+        Sut = new TripNoteRepository(ConnectionFactory, NullLogger<TripNoteRepository>.Instance);
+        Trips = new TripRepository(
+            ConnectionFactory,
+            NullLogger<TripRepository>.Instance,
+            TestMapper.Create());
+        Users = new UserIdentityRepository(ConnectionFactory, NullLogger<UserIdentityRepository>.Instance);
+    }
+
+    protected async Task<Guid> CreateUserAsync()
+    {
+        var user = new UserBuilder()
+            .WithEmail($"{Guid.NewGuid():N}@example.test")
+            .Build();
+        var identity = new UserIdentityBuilder()
+            .ForUser(user)
+            .Build();
+        var created = await Users.CreateAsync(user, identity, CancellationToken.None);
+        if (created.IsFailed)
+        {
+            throw new InvalidOperationException(created.Errors[0].Message);
+        }
+
+        return created.Value;
+    }
+
+    protected async Task<Trip> CreateTripAsync(
+        Guid ownerUserId,
+        TripStatusEnum status = TripStatusEnum.Active)
+    {
+        var trip = new Trip
+        {
+            Id = Guid.NewGuid(),
+            OwnerUserId = ownerUserId,
+            Status = status,
+            StartedOn = StartedOn,
+            EndedOn = status == TripStatusEnum.Completed ? StartedOn.AddHours(3) : null
+        };
+        var saved = await Trips.UpsertAsync(trip, CancellationToken.None);
+        if (saved.IsFailed)
+        {
+            throw new InvalidOperationException(saved.Errors[0].Message);
+        }
+
+        return saved.Value;
+    }
+
+    protected static TripNote NewNote(
+        Guid tripId,
+        string text = "water dropped about a foot",
+        Guid? noteId = null,
+        DateTimeOffset? recordedOn = null)
+    {
+        return new TripNote
+        {
+            Id = noteId ?? Guid.NewGuid(),
+            TripId = tripId,
+            Text = text,
+            RecordedOn = recordedOn ?? StartedOn.AddMinutes(45)
+        };
+    }
+}

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripNoteRepositoryTests/BaseTripNoteRepositoryTest.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripNoteRepositoryTests/BaseTripNoteRepositoryTest.cs
@@ -69,6 +69,7 @@ public abstract class BaseTripNoteRepositoryTest
 
     protected static TripNote NewNote(
         Guid tripId,
+        Guid createdByUserId,
         string text = "water dropped about a foot",
         Guid? noteId = null,
         DateTimeOffset? recordedOn = null)
@@ -77,6 +78,7 @@ public abstract class BaseTripNoteRepositoryTest
         {
             Id = noteId ?? Guid.NewGuid(),
             TripId = tripId,
+            CreatedByUserId = createdByUserId,
             Text = text,
             RecordedOn = recordedOn ?? StartedOn.AddMinutes(45)
         };

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripNoteRepositoryTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripNoteRepositoryTests/WhenTestingUpsert.cs
@@ -18,10 +18,10 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
     public async Task ItShouldRejectANoteForATripThatDoesNotExist()
     {
         // Arrange
-        await CreateUserAsync();
+        var userId = await CreateUserAsync();
 
         // Act
-        var saved = await Sut.UpsertAsync(NewNote(Guid.NewGuid()), CancellationToken.None);
+        var saved = await Sut.UpsertAsync(NewNote(Guid.NewGuid(), userId), CancellationToken.None);
 
         // Assert
         saved.IsFailed.Should().BeTrue();
@@ -34,11 +34,11 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
         var userId = await CreateUserAsync();
         var first = await CreateTripAsync(userId, TripStatusEnum.Completed);
         var second = await CreateTripAsync(userId);
-        var note = NewNote(first.Id);
+        var note = NewNote(first.Id, userId);
         await Sut.UpsertAsync(note, CancellationToken.None);
 
         // Act
-        await Sut.UpsertAsync(NewNote(second.Id, noteId: note.Id), CancellationToken.None);
+        await Sut.UpsertAsync(NewNote(second.Id, userId, noteId: note.Id), CancellationToken.None);
 
         // Assert
         var stored = await Sut.GetByIdAsync(note.Id, CancellationToken.None);
@@ -51,7 +51,7 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
         // Arrange
         var userId = await CreateUserAsync();
         var trip = await CreateTripAsync(userId);
-        var note = NewNote(trip.Id);
+        var note = NewNote(trip.Id, userId);
         await Sut.UpsertAsync(note, CancellationToken.None);
 
         // Act
@@ -74,7 +74,7 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
 
         // Act
         var saved = await Sut.UpsertAsync(
-            NewNote(trip.Id, recordedOn: recordedOn),
+            NewNote(trip.Id, userId, recordedOn: recordedOn),
             CancellationToken.None);
 
         // Assert
@@ -93,7 +93,7 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
 
         // Act
         var saved = await Sut.UpsertAsync(
-            NewNote(trip.Id, recordedOn: recordedOn),
+            NewNote(trip.Id, userId, recordedOn: recordedOn),
             CancellationToken.None);
 
         // Assert
@@ -114,7 +114,7 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
         var text = new string('a', TripConstants.MaxNoteTextLength);
 
         // Act
-        var saved = await Sut.UpsertAsync(NewNote(trip.Id, text), CancellationToken.None);
+        var saved = await Sut.UpsertAsync(NewNote(trip.Id, userId, text), CancellationToken.None);
 
         // Assert
         saved.IsSuccess.Should().BeTrue();
@@ -127,9 +127,9 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
         // Arrange
         var userId = await CreateUserAsync();
         var trip = await CreateTripAsync(userId);
-        var third = NewNote(trip.Id, "wind picked up", recordedOn: StartedOn.AddHours(5));
-        var first = NewNote(trip.Id, "fish rising near the reeds", recordedOn: StartedOn.AddHours(1));
-        var second = NewNote(trip.Id, "changed to olive nymph", recordedOn: StartedOn.AddHours(3));
+        var third = NewNote(trip.Id, userId, "wind picked up", recordedOn: StartedOn.AddHours(5));
+        var first = NewNote(trip.Id, userId, "fish rising near the reeds", recordedOn: StartedOn.AddHours(1));
+        var second = NewNote(trip.Id, userId, "changed to olive nymph", recordedOn: StartedOn.AddHours(3));
 
         // Act
         await Sut.UpsertAsync(third, CancellationToken.None);
@@ -150,7 +150,7 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
         var trip = await CreateTripAsync(userId);
 
         // Act
-        await Sut.UpsertAsync(NewNote(trip.Id), CancellationToken.None);
+        await Sut.UpsertAsync(NewNote(trip.Id, userId), CancellationToken.None);
 
         // Assert
         var storedTrip = await Trips.GetByIdAsync(trip.Id, CancellationToken.None);
@@ -168,8 +168,8 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
         // Arrange
         var userId = await CreateUserAsync();
         var trip = await CreateTripAsync(userId);
-        var kept = NewNote(trip.Id, "kept", recordedOn: StartedOn.AddHours(1));
-        var removed = NewNote(trip.Id, "removed", recordedOn: StartedOn.AddHours(2));
+        var kept = NewNote(trip.Id, userId, "kept", recordedOn: StartedOn.AddHours(1));
+        var removed = NewNote(trip.Id, userId, "removed", recordedOn: StartedOn.AddHours(2));
         await Sut.UpsertAsync(kept, CancellationToken.None);
         await Sut.UpsertAsync(removed, CancellationToken.None);
 
@@ -184,6 +184,63 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
     }
 
     [Fact]
+    public async Task ItShouldRoundTripTheAuthor()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+
+        // Act
+        var saved = await Sut.UpsertAsync(NewNote(trip.Id, userId), CancellationToken.None);
+
+        // Assert
+        saved.Value.CreatedByUserId.Should().Be(userId);
+        var reloaded = await Sut.GetByIdAsync(saved.Value.Id, CancellationToken.None);
+        reloaded.Value!.CreatedByUserId.Should().Be(userId);
+        var listed = await Sut.GetByTripIdAsync(trip.Id, CancellationToken.None);
+        listed.Value[0].CreatedByUserId.Should().Be(userId);
+    }
+
+    [Fact]
+    public async Task ItShouldNotLetAReplayRewriteTheAuthor()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+        var note = NewNote(trip.Id, userId, "water dropped about a foot");
+        await Sut.UpsertAsync(note, CancellationToken.None);
+
+        // Act
+        var replay = await Sut.UpsertAsync(
+            NewNote(trip.Id, otherUserId, "water dropped about two feet", noteId: note.Id),
+            CancellationToken.None);
+
+        // Assert
+        replay.Value.CreatedByUserId.Should().Be(userId);
+        replay.Value.Text.Should().Be("water dropped about two feet");
+        var stored = await Sut.GetByIdAsync(note.Id, CancellationToken.None);
+        stored.Value!.CreatedByUserId.Should().Be(userId);
+        stored.Value.CreatedByUserId.Should().NotBe(otherUserId);
+    }
+
+    [Fact]
+    public async Task ItShouldRejectANoteWhoseAuthorIsNotAKnownUser()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+
+        // Act
+        var saved = await Sut.UpsertAsync(
+            NewNote(trip.Id, Guid.NewGuid()),
+            CancellationToken.None);
+
+        // Assert
+        saved.IsFailed.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ItShouldNotReturnAnotherTripsNotes()
     {
         // Arrange
@@ -191,8 +248,8 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
         var otherUserId = await CreateUserAsync();
         var mine = await CreateTripAsync(ownerUserId);
         var theirs = await CreateTripAsync(otherUserId);
-        await Sut.UpsertAsync(NewNote(mine.Id, "mine"), CancellationToken.None);
-        var theirNote = NewNote(theirs.Id, "theirs");
+        await Sut.UpsertAsync(NewNote(mine.Id, ownerUserId, "mine"), CancellationToken.None);
+        var theirNote = NewNote(theirs.Id, otherUserId, "theirs");
         await Sut.UpsertAsync(theirNote, CancellationToken.None);
 
         // Act
@@ -210,7 +267,7 @@ public class WhenTestingUpsert : BaseTripNoteRepositoryTest
         // Arrange
         var userId = await CreateUserAsync();
         var earlier = await CreateTripAsync(userId);
-        var note = NewNote(earlier.Id);
+        var note = NewNote(earlier.Id, userId);
         await Sut.UpsertAsync(note, CancellationToken.None);
 
         // Act

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripNoteRepositoryTests/WhenTestingUpsert.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/TripNoteRepositoryTests/WhenTestingUpsert.cs
@@ -1,0 +1,234 @@
+using AwesomeAssertions;
+using Dapper;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+using FishingLogBook.Shared.Constants;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Repositories.TripNoteRepositoryTests;
+
+public class WhenTestingUpsert : BaseTripNoteRepositoryTest
+{
+    public WhenTestingUpsert(PostgresFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task ItShouldRejectANoteForATripThatDoesNotExist()
+    {
+        // Arrange
+        await CreateUserAsync();
+
+        // Act
+        var saved = await Sut.UpsertAsync(NewNote(Guid.NewGuid()), CancellationToken.None);
+
+        // Assert
+        saved.IsFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldNotMoveANoteToAnotherTrip()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var first = await CreateTripAsync(userId, TripStatusEnum.Completed);
+        var second = await CreateTripAsync(userId);
+        var note = NewNote(first.Id);
+        await Sut.UpsertAsync(note, CancellationToken.None);
+
+        // Act
+        await Sut.UpsertAsync(NewNote(second.Id, noteId: note.Id), CancellationToken.None);
+
+        // Assert
+        var stored = await Sut.GetByIdAsync(note.Id, CancellationToken.None);
+        stored.Value!.TripId.Should().Be(first.Id);
+    }
+
+    [Fact]
+    public async Task ItShouldReplayTheSameNoteWithoutDuplicatingIt()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+        var note = NewNote(trip.Id);
+        await Sut.UpsertAsync(note, CancellationToken.None);
+
+        // Act
+        var replay = await Sut.UpsertAsync(note, CancellationToken.None);
+
+        // Assert
+        replay.IsSuccess.Should().BeTrue();
+        var stored = await Sut.GetByTripIdAsync(trip.Id, CancellationToken.None);
+        stored.Value.Should().ContainSingle();
+        stored.Value[0].Text.Should().Be(note.Text);
+    }
+
+    [Fact]
+    public async Task ItShouldRoundTripTheRecordedInstant()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+        var recordedOn = StartedOn.AddMinutes(37).AddSeconds(12);
+
+        // Act
+        var saved = await Sut.UpsertAsync(
+            NewNote(trip.Id, recordedOn: recordedOn),
+            CancellationToken.None);
+
+        // Assert
+        saved.Value.RecordedOn.Should().Be(recordedOn);
+        var reloaded = await Sut.GetByIdAsync(saved.Value.Id, CancellationToken.None);
+        reloaded.Value!.RecordedOn.Should().Be(recordedOn);
+    }
+
+    [Fact]
+    public async Task ItShouldNotLetTheServerReplaceTheRecordedInstant()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+        var recordedOn = StartedOn.AddMinutes(15);
+
+        // Act
+        var saved = await Sut.UpsertAsync(
+            NewNote(trip.Id, recordedOn: recordedOn),
+            CancellationToken.None);
+
+        // Assert
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var row = await connection.QuerySingleAsync<(DateTimeOffset RecordedOn, DateTimeOffset CreatedOn)>(
+            """SELECT "RecordedOn", "CreatedOn" FROM "TripNote" WHERE "Id" = @Id;""",
+            new { saved.Value.Id });
+        row.RecordedOn.Should().Be(recordedOn);
+        row.CreatedOn.Should().NotBe(recordedOn);
+    }
+
+    [Fact]
+    public async Task ItShouldStoreANoteAtTheLengthCap()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+        var text = new string('a', TripConstants.MaxNoteTextLength);
+
+        // Act
+        var saved = await Sut.UpsertAsync(NewNote(trip.Id, text), CancellationToken.None);
+
+        // Assert
+        saved.IsSuccess.Should().BeTrue();
+        saved.Value.Text.Should().HaveLength(TripConstants.MaxNoteTextLength);
+    }
+
+    [Fact]
+    public async Task ItShouldStoreManyNotesForOneTripInRecordedOrder()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+        var third = NewNote(trip.Id, "wind picked up", recordedOn: StartedOn.AddHours(5));
+        var first = NewNote(trip.Id, "fish rising near the reeds", recordedOn: StartedOn.AddHours(1));
+        var second = NewNote(trip.Id, "changed to olive nymph", recordedOn: StartedOn.AddHours(3));
+
+        // Act
+        await Sut.UpsertAsync(third, CancellationToken.None);
+        await Sut.UpsertAsync(first, CancellationToken.None);
+        await Sut.UpsertAsync(second, CancellationToken.None);
+
+        // Assert
+        var stored = await Sut.GetByTripIdAsync(trip.Id, CancellationToken.None);
+        stored.Value.Select(note => note.Id).Should().Equal(first.Id, second.Id, third.Id);
+        stored.Value.Select(note => note.RecordedOn).Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public async Task ItShouldNotDisturbTheTripOrItsCatchNotes()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+
+        // Act
+        await Sut.UpsertAsync(NewNote(trip.Id), CancellationToken.None);
+
+        // Assert
+        var storedTrip = await Trips.GetByIdAsync(trip.Id, CancellationToken.None);
+        storedTrip.Value!.Status.Should().Be(TripStatusEnum.Active);
+        await using var connection = await ConnectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        var catchesForThisAngler = await connection.ExecuteScalarAsync<int>(
+            """SELECT COUNT(*) FROM "Catch" WHERE "UserId" = @UserId OR "TripId" = @TripId;""",
+            new { UserId = userId, TripId = trip.Id });
+        catchesForThisAngler.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldRemoveOnlyTheDeletedNote()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+        var kept = NewNote(trip.Id, "kept", recordedOn: StartedOn.AddHours(1));
+        var removed = NewNote(trip.Id, "removed", recordedOn: StartedOn.AddHours(2));
+        await Sut.UpsertAsync(kept, CancellationToken.None);
+        await Sut.UpsertAsync(removed, CancellationToken.None);
+
+        // Act
+        var deleted = await Sut.DeleteAsync(removed.Id, CancellationToken.None);
+
+        // Assert
+        deleted.IsSuccess.Should().BeTrue();
+        var stored = await Sut.GetByTripIdAsync(trip.Id, CancellationToken.None);
+        stored.Value.Should().ContainSingle();
+        stored.Value[0].Id.Should().Be(kept.Id);
+    }
+
+    [Fact]
+    public async Task ItShouldNotReturnAnotherTripsNotes()
+    {
+        // Arrange
+        var ownerUserId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        var mine = await CreateTripAsync(ownerUserId);
+        var theirs = await CreateTripAsync(otherUserId);
+        await Sut.UpsertAsync(NewNote(mine.Id, "mine"), CancellationToken.None);
+        var theirNote = NewNote(theirs.Id, "theirs");
+        await Sut.UpsertAsync(theirNote, CancellationToken.None);
+
+        // Act
+        var stored = await Sut.GetByTripIdAsync(mine.Id, CancellationToken.None);
+
+        // Assert
+        stored.Value.Should().ContainSingle();
+        stored.Value[0].Text.Should().Be("mine");
+        stored.Value.Should().NotContain(note => note.Id == theirNote.Id);
+    }
+
+    [Fact]
+    public async Task ItShouldSurviveTheServerReconcilingTwoActiveTrips()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var earlier = await CreateTripAsync(userId);
+        var note = NewNote(earlier.Id);
+        await Sut.UpsertAsync(note, CancellationToken.None);
+
+        // Act
+        await Trips.UpsertAsync(
+            new Trip
+            {
+                Id = Guid.NewGuid(),
+                OwnerUserId = userId,
+                Status = TripStatusEnum.Active,
+                StartedOn = StartedOn.AddHours(2)
+            },
+            CancellationToken.None);
+
+        // Assert
+        var reconciled = await Trips.GetByIdAsync(earlier.Id, CancellationToken.None);
+        reconciled.Value!.Status.Should().Be(TripStatusEnum.Completed);
+        var stored = await Sut.GetByTripIdAsync(earlier.Id, CancellationToken.None);
+        stored.Value.Should().ContainSingle();
+        stored.Value[0].Id.Should().Be(note.Id);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Common/Offline/Dependencies/TripDependencyServiceTests/BaseTripDependencyServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Common/Offline/Dependencies/TripDependencyServiceTests/BaseTripDependencyServiceTest.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Web.Common.Offline.Dependencies;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Tests.Features.Catch.Offline.Stores.CatchStoreTests;
+using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
 using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripPhotographStoreTests;
 using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripStoreTests;
 
@@ -26,12 +27,13 @@ public class BaseTripDependencyServiceTest
 
     protected readonly MemoryTripStore TripStore = new();
     protected readonly MemoryTripPhotographStore TripPhotographStore = new();
+    protected readonly MemoryTripNoteStore TripNoteStore = new();
     protected readonly MemoryCatchStore CatchStore = new();
     protected readonly TripDependencyService Sut;
 
     protected BaseTripDependencyServiceTest()
     {
-        Sut = new TripDependencyService(TripStore, TripPhotographStore, CatchStore);
+        Sut = new TripDependencyService(TripStore, TripPhotographStore, TripNoteStore, CatchStore);
     }
 
     protected async Task GivenTripAsync(
@@ -64,6 +66,23 @@ public class BaseTripDependencyServiceTest
                 StartedOn.AddMinutes(30),
                 Bytes: [1, 2, 3],
                 SyncStatus: syncStatus),
+            CancellationToken.None);
+    }
+
+    protected async Task GivenTripNoteAsync(
+        Guid noteId,
+        Guid tripId,
+        SyncStatus syncStatus,
+        Guid? ownerUserId = null)
+    {
+        await TripNoteStore.SaveAsync(
+            new TripNoteModel(
+                noteId,
+                tripId,
+                ownerUserId ?? OwnerUserId,
+                "water dropped a foot",
+                StartedOn.AddMinutes(45),
+                syncStatus),
             CancellationToken.None);
     }
 

--- a/tests/FishingLogBook.Web.Tests/Common/Offline/Dependencies/TripDependencyServiceTests/WhenTestingGetTripsAwaitingDependents.cs
+++ b/tests/FishingLogBook.Web.Tests/Common/Offline/Dependencies/TripDependencyServiceTests/WhenTestingGetTripsAwaitingDependents.cs
@@ -149,6 +149,65 @@ public class WhenTestingGetTripsAwaitingDependents : BaseTripDependencyServiceTe
     }
 
     [Fact]
+    public async Task ItShouldIgnoreASynchronisedTripNote()
+    {
+        // Arrange
+        await GivenTripNoteAsync(Guid.NewGuid(), TripId, SyncStatus.Synchronised);
+
+        // Act
+        var awaiting = await Sut.GetTripsAwaitingDependentsAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        awaiting.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldIgnoreAnotherAnglersPendingTripNote()
+    {
+        // Arrange
+        await GivenTripNoteAsync(Guid.NewGuid(), TripId, SyncStatus.SavedLocally, ownerUserId: OtherUserId);
+
+        // Act
+        var awaiting = await Sut.GetTripsAwaitingDependentsAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        awaiting.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldHoldTheTripWhileOneOfItsNotesIsStillPending()
+    {
+        // Arrange
+        await GivenTripNoteAsync(Guid.NewGuid(), TripId, SyncStatus.SavedLocally);
+
+        // Act
+        var awaiting = await Sut.GetTripsAwaitingDependentsAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        awaiting.Should().Equal(TripId);
+        TripPhotographStore.BytesReadFor.Should().BeEmpty();
+        CatchStore.PhotographBytesReadFor.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldReportATripHeldByACatchAPhotographAndANoteOnce()
+    {
+        // Arrange
+        await GivenCatchAsync(CatchId, TripId, SyncStatus.SavedLocally);
+        await GivenTripPhotographAsync(Guid.NewGuid(), TripId, SyncStatus.SavedLocally);
+        await GivenTripNoteAsync(Guid.NewGuid(), TripId, SyncStatus.SavedLocally);
+        await GivenTripNoteAsync(Guid.NewGuid(), SecondTripId, SyncStatus.SavedLocally);
+
+        // Act
+        var awaiting = await Sut.GetTripsAwaitingDependentsAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        awaiting.Should().BeEquivalentTo([TripId, SecondTripId]);
+        TripPhotographStore.BytesReadFor.Should().BeEmpty();
+        CatchStore.PhotographBytesReadFor.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ItShouldReportEachTripOnceWithoutReadingPhotographBytes()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Common/Offline/Synchronisers/LogbookSynchroniserTests/BaseLogbookSynchroniserTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Common/Offline/Synchronisers/LogbookSynchroniserTests/BaseLogbookSynchroniserTest.cs
@@ -16,6 +16,8 @@ public class BaseLogbookSynchroniserTest
         Substitute.For<ITripSynchroniser>();
     protected readonly ITripPhotographSynchroniser MockTripPhotographSynchroniser =
         Substitute.For<ITripPhotographSynchroniser>();
+    protected readonly ITripNoteSynchroniser MockTripNoteSynchroniser =
+        Substitute.For<ITripNoteSynchroniser>();
     protected readonly ICatchSynchroniser MockCatchSynchroniser =
         Substitute.For<ICatchSynchroniser>();
     protected readonly ILocalCatchOwnerService MockLocalCatchOwner =
@@ -29,6 +31,7 @@ public class BaseLogbookSynchroniserTest
         Sut = new LogbookSynchroniser(
             MockTripSynchroniser,
             MockTripPhotographSynchroniser,
+            MockTripNoteSynchroniser,
             MockCatchSynchroniser,
             MockLocalCatchOwner,
             MockLogging);

--- a/tests/FishingLogBook.Web.Tests/Common/Offline/Synchronisers/LogbookSynchroniserTests/WhenTestingSynchronisePending.cs
+++ b/tests/FishingLogBook.Web.Tests/Common/Offline/Synchronisers/LogbookSynchroniserTests/WhenTestingSynchronisePending.cs
@@ -90,6 +90,45 @@ public class WhenTestingSynchronisePending : BaseLogbookSynchroniserTest
     }
 
     [Fact]
+    public async Task ItShouldStillSynchroniseCatchesWhenTripNotesFail()
+    {
+        // Arrange
+        var failure = new InvalidOperationException("note store unavailable");
+        MockTripNoteSynchroniser
+            .SynchronisePendingAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(_ => throw failure);
+
+        // Act
+        await Sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockCatchSynchroniser.Received(1)
+            .SynchronisePendingAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await MockLogging.Received(1).LogErrorAsync(
+            "trip note synchronisation",
+            failure,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStillSynchroniseNotesWhenTripPhotographsFail()
+    {
+        // Arrange
+        MockTripPhotographSynchroniser
+            .SynchronisePendingAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(_ => throw new InvalidOperationException("photograph storage unavailable"));
+
+        // Act
+        await Sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockTripNoteSynchroniser.Received(1)
+            .SynchronisePendingAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await MockCatchSynchroniser.Received(1)
+            .SynchronisePendingAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldNotStartASecondRunWhileOneIsInProgress()
     {
         // Arrange
@@ -142,7 +181,7 @@ public class WhenTestingSynchronisePending : BaseLogbookSynchroniserTest
     }
 
     [Fact]
-    public async Task ItShouldSynchroniseTripsThenPhotographsThenCatches()
+    public async Task ItShouldSynchroniseTripsThenPhotographsThenNotesThenCatches()
     {
         // Arrange
         var order = new List<string>();
@@ -160,6 +199,13 @@ public class WhenTestingSynchronisePending : BaseLogbookSynchroniserTest
                 order.Add("photographs");
                 return Task.CompletedTask;
             });
+        MockTripNoteSynchroniser
+            .SynchronisePendingAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                order.Add("notes");
+                return Task.CompletedTask;
+            });
         MockCatchSynchroniser
             .SynchronisePendingAsync(OwnerUserId, Arg.Any<CancellationToken>())
             .Returns(_ =>
@@ -172,7 +218,7 @@ public class WhenTestingSynchronisePending : BaseLogbookSynchroniserTest
         await Sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
 
         // Assert
-        order.Should().Equal("trips", "photographs", "catches");
+        order.Should().Equal("trips", "photographs", "notes", "catches");
         await MockTripSynchroniser.Received(1)
             .SynchronisePendingAsync(OwnerUserId, Arg.Any<CancellationToken>());
         await MockCatchSynchroniser.Received(1)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingStartFishing.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchListTests/WhenTestingStartFishing.cs
@@ -35,7 +35,7 @@ public class WhenTestingStartFishing : BaseCatchListTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#trip-start-link").TextContent.Should().Contain("Start fishing"));
-        cut.FindAll("#trip-continue-link").Should().BeEmpty();
+        cut.FindAll("#trip-update-link").Should().BeEmpty();
         cut.Find("#catch-record-link").Should().NotBeNull();
     }
 
@@ -54,9 +54,9 @@ public class WhenTestingStartFishing : BaseCatchListTest
 
         // Assert
         cut.WaitForAssertion(() =>
-            cut.Find("#trip-continue-link").TextContent.Should().Contain("Continue trip"));
+            cut.Find("#trip-update-link").TextContent.Should().Contain("Update trip"));
         cut.FindAll("#trip-start-link").Should().BeEmpty();
-        cut.Find("#trip-continue-link").GetAttribute("href").Should().Be($"/trips/{TripId:D}");
+        cut.Find("#trip-update-link").GetAttribute("href").Should().Be($"/trips/{TripId:D}");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchListTests/WhenTestingStartFishing.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchListTests/WhenTestingStartFishing.cs
@@ -31,7 +31,7 @@ public class WhenTestingStartFishing : BaseOfflineCatchListTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#offline-trip-start-link").TextContent.Should().Contain("Start fishing"));
-        cut.FindAll("#offline-trip-continue-link").Should().BeEmpty();
+        cut.FindAll("#offline-trip-update-link").Should().BeEmpty();
         await activeTrip.Received(1).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
     }
 
@@ -49,7 +49,7 @@ public class WhenTestingStartFishing : BaseOfflineCatchListTest
 
         // Assert
         cut.WaitForAssertion(() =>
-            cut.Find("#offline-trip-continue-link").GetAttribute("href")
+            cut.Find("#offline-trip-update-link").GetAttribute("href")
                 .Should().Be($"/offline/trips/{TripId:D}"));
         cut.FindAll("#offline-trip-start-link").Should().BeEmpty();
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingTripAssociation.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/RecordCatchTests/WhenTestingTripAssociation.cs
@@ -113,7 +113,7 @@ public class WhenTestingTripAssociation : BaseRecordCatchTest
         {
             cut.Find("#catch-trip-association").TextContent.Should().Contain("Recording in");
             cut.Find("#catch-trip-name").TextContent.Should().Contain("Evening session");
-            cut.Find("#catch-trip-leave").TextContent.Should().Contain("Not part of this trip");
+            cut.Find("#catch-trip-leave").TextContent.Should().Contain("Remove from this trip");
         });
         await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
     }
@@ -177,7 +177,7 @@ public class WhenTestingTripAssociation : BaseRecordCatchTest
         // Assert
         cut.FindAll("#catch-trip-association").Should().BeEmpty();
         cut.Find("#catch-trip-standalone").TextContent
-            .Should().Contain("This catch is not part of a trip");
+            .Should().Contain("Not part of a trip");
         await cut.Find("#save-catch-button").ClickAsync();
         await store.Received(1).SaveAsync(
             Arg.Is<CatchModel>(catchRecord => catchRecord.TripId == null),
@@ -385,8 +385,73 @@ public class WhenTestingTripAssociation : BaseRecordCatchTest
         cut.WaitForAssertion(() =>
         {
             cut.Find("#catch-trip-association").TextContent.Should().Contain("Sortie en cours");
-            cut.Find("#catch-trip-leave").TextContent.Should().Contain("Hors de cette sortie");
+            cut.Find("#catch-trip-leave").TextContent.Should().Contain("Retirer de cette sortie");
         });
+    }
+
+    [Fact]
+    public async Task ItShouldOfferTheOptOutAsAButtonRatherThanALabel()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        await using var context = CreateContext(store, activeTrip: ActiveTrip(Trip()));
+
+        // Act
+        var cut = context.Render<RecordCatch>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            var leave = cut.Find("#catch-trip-leave");
+            leave.TagName.Should().Be("BUTTON");
+            leave.ClassList.Should().Contain("mud-button-outlined");
+            leave.QuerySelector(".mud-icon-root").Should().NotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldLetTheAnglerPutTheCatchBackOnTheTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        await using var context = CreateContext(
+            store,
+            tripStore: TripStoreWith(Trip()),
+            activeTrip: ActiveTrip(Trip()));
+        var cut = context.Render<RecordCatch>();
+        cut.FindComponents<InputFile>()[0].UploadFiles(JpegFile("catch.jpg", 0xFF, 0xD8, 0xFF));
+        cut.WaitForAssertion(() => cut.Find("#catch-trip-leave").Should().NotBeNull());
+        await cut.Find("#catch-trip-leave").ClickAsync();
+
+        // Act
+        var rejoin = cut.Find("#catch-trip-rejoin");
+        rejoin.TagName.Should().Be("BUTTON");
+        await rejoin.ClickAsync();
+
+        // Assert
+        cut.Find("#catch-trip-association").Should().NotBeNull();
+        cut.FindAll("#catch-trip-standalone").Should().BeEmpty();
+        await cut.Find("#save-catch-button").ClickAsync();
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord => catchRecord.TripId == TripId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferPuttingTheCatchBackWhenThereWasNoTrip()
+    {
+        // Arrange
+        var store = Substitute.For<ICatchStore>();
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<RecordCatch>();
+
+        // Assert
+        cut.FindAll("#catch-trip-rejoin").Should().BeEmpty();
+        cut.FindAll("#catch-trip-standalone-row").Should().BeEmpty();
     }
 
     private static void NavigateToTrip(BunitContext context, Guid tripId)

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/ActiveTripBannerTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/ActiveTripBannerTests/WhenTestingRender.cs
@@ -75,9 +75,9 @@ public class WhenTestingRender
         cut.WaitForAssertion(() =>
             cut.Find("#active-trip-banner").TextContent.Should().Contain("Fishing trip in progress"));
         cut.Find("#active-trip-banner").GetAttribute("role").Should().Be("status");
-        cut.Find("#active-trip-banner-continue").GetAttribute("href")
+        cut.Find("#active-trip-banner-update").GetAttribute("href")
             .Should().Be($"/trips/{TripId:D}");
-        cut.Find("#active-trip-banner-continue").TextContent.Should().Contain("Continue trip");
+        cut.Find("#active-trip-banner-update").TextContent.Should().Contain("Update trip");
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class WhenTestingRender
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#active-trip-banner").TextContent.Should().Contain("Sortie de pêche en cours"));
-        cut.Find("#active-trip-banner-continue").TextContent.Should().Contain("Reprendre la sortie");
+        cut.Find("#active-trip-banner-update").TextContent.Should().Contain("Modifier la sortie");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/BaseTripNotesTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/BaseTripNotesTest.cs
@@ -1,0 +1,76 @@
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Components.TripNotesTests;
+
+public class BaseTripNotesTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+
+    protected static BunitContext CreateContext(
+        ITripNoteStore store,
+        ITripClient? tripClient = null,
+        ILoggingService? logging = null,
+        ITimeService? time = null)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(store);
+        context.Services.AddSingleton(tripClient ?? Substitute.For<ITripClient>());
+        context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
+        context.Services.AddSingleton(time ?? TestTimeService.WithOffset(TimeSpan.Zero));
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+
+    protected static TripModel Trip(params TripNoteModel[] notes)
+    {
+        return new TripModel(
+            TripId,
+            OwnerUserId,
+            TripConstants.Active,
+            StartedOn,
+            Notes: notes.Length == 0 ? null : notes);
+    }
+
+    protected static TripModel CompletedTrip(params TripNoteModel[] notes)
+    {
+        return new TripModel(
+            TripId,
+            OwnerUserId,
+            TripConstants.Completed,
+            StartedOn,
+            StartedOn.AddHours(4),
+            Notes: notes.Length == 0 ? null : notes);
+    }
+
+    protected static TripNoteModel Note(
+        Guid noteId,
+        string text = "water dropped about a foot",
+        DateTimeOffset? recordedOn = null,
+        SyncStatus syncStatus = SyncStatus.SavedLocally)
+    {
+        return new TripNoteModel(
+            noteId,
+            TripId,
+            OwnerUserId,
+            text,
+            recordedOn ?? StartedOn.AddMinutes(45),
+            syncStatus);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingAdd.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingAdd.cs
@@ -1,0 +1,346 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+using NSubstitute;
+using TripNotesComponent = FishingLogBook.Web.Features.Trips.Components.TripNotes.TripNotes;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Components.TripNotesTests;
+
+public class WhenTestingAdd : BaseTripNotesTest
+{
+    private static readonly Guid FirstNoteId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static readonly Guid SecondNoteId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+    [Fact]
+    public async Task ItShouldOfferAddNoteOnAnActiveTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+
+        // Assert
+        cut.Find("#trip-notes").Should().NotBeNull();
+        cut.Find("#trip-note-start").TextContent.Should().Contain("Add note");
+        cut.FindAll("#trip-note-editor").Should().BeEmpty();
+        store.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldNotAllowSavingAWhitespaceOnlyNote()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        await cut.Find("#trip-note-start").ClickAsync();
+
+        // Act
+        cut.Find("#trip-note-text").Input("   \t  ");
+
+        // Assert
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        await cut.Find("#trip-note-save").ClickAsync();
+        store.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldNotAllowSavingANoteOverTheCap()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        await cut.Find("#trip-note-start").ClickAsync();
+
+        // Act
+        cut.Find("#trip-note-text").Input(new string('a', TripConstants.MaxNoteTextLength + 1));
+
+        // Assert
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        store.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheTypedTextWhenTheLocalWriteFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = new MemoryTripNoteStore { FailWrite = true };
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(store, logging: logging);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        await cut.Find("#trip-note-start").ClickAsync();
+        cut.Find("#trip-note-text").Input("fish rising near the reeds");
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        cut.Find("#trip-note-add-failed").TextContent.Should().Contain("could not be added");
+        cut.Find("#trip-note-text").GetAttribute("value").Should().Be("fish rising near the reeds");
+        store.Count.Should().Be(0);
+        await logging.Received(1).LogErrorAsync(
+            "adding a trip note",
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNeverLogTheNoteText()
+    {
+        // Arrange
+        const string secret = "met Sarah about the lease at the bailiff hut";
+        var store = new MemoryTripNoteStore { FailWrite = true };
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(store, logging: logging);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        await cut.Find("#trip-note-start").ClickAsync();
+        cut.Find("#trip-note-text").Input(secret);
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Is<string>(operation => operation.Contains(secret)),
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Any<string>(),
+            Arg.Is<Exception>(exception => exception.Message.Contains(secret)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSaveTheNoteLocallyAndClearTheEditor()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        await cut.Find("#trip-note-start").ClickAsync();
+        cut.Find("#trip-note-text").Input("  changed to olive nymph  ");
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        store.Count.Should().Be(1);
+        var stored = store.All().Single();
+        stored.Text.Should().Be("changed to olive nymph");
+        stored.TripId.Should().Be(TripId);
+        stored.OwnerUserId.Should().Be(OwnerUserId);
+        stored.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        stored.RecordedOn.Should().NotBe(default);
+        stored.RecordedOn.Should().NotBe(StartedOn);
+        cut.FindAll("#trip-note-editor").Should().BeEmpty();
+        cut.Find("#trip-note-start").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheNoteImmediatelyWithItsLocalTime()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        await cut.Find("#trip-note-start").ClickAsync();
+        cut.Find("#trip-note-text").Input("wind picked up");
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        var noteId = store.All().Single().Id;
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find($"#trip-note-{noteId:D}").TextContent.Should().Contain("wind picked up");
+            cut.Find($"#trip-note-time-{noteId:D}").TextContent.Should().MatchRegex(@"^\d{2}:\d{2}$");
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldRenderStoredNotesOldestFirst()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await store.SaveAsync(
+            Note(SecondNoteId, "wind picked up", StartedOn.AddHours(5)),
+            CancellationToken.None);
+        await store.SaveAsync(
+            Note(FirstNoteId, "fish rising near the reeds", StartedOn.AddHours(1)),
+            CancellationToken.None);
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+
+        // Assert
+        var rendered = cut.FindAll("#trip-notes-list .trip-note-text")
+            .Select(element => element.TextContent.Trim())
+            .ToArray();
+        rendered.Should().Equal("fish rising near the reeds", "wind picked up");
+    }
+
+    [Fact]
+    public async Task ItShouldAddSeveralNotesInTheOrderTheyWereWritten()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+
+        // Act
+        await cut.Find("#trip-note-start").ClickAsync();
+        cut.Find("#trip-note-text").Input("first");
+        await cut.Find("#trip-note-save").ClickAsync();
+        await cut.Find("#trip-note-start").ClickAsync();
+        cut.Find("#trip-note-text").Input("second");
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        store.Count.Should().Be(2);
+        var rendered = cut.FindAll("#trip-notes-list .trip-note-text")
+            .Select(element => element.TextContent.Trim())
+            .ToArray();
+        rendered.Should().Equal("first", "second");
+    }
+
+    [Fact]
+    public async Task ItShouldNotifyTheParentThatTheTripChanged()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var changed = 0;
+        await using var context = CreateContext(store);
+        var cut = context.Render<TripNotesComponent>(parameters => parameters
+            .Add(component => component.Trip, Trip())
+            .Add(component => component.Changed, () => changed++));
+        await cut.Find("#trip-note-start").ClickAsync();
+        cut.Find("#trip-note-text").Input("stopped for lunch");
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        changed.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldStillOfferNotesOnACompletedTrip()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, CompletedTrip()));
+        await cut.Find("#trip-note-start").ClickAsync();
+        cut.Find("#trip-note-text").Input("a good day, three brownies");
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        store.Count.Should().Be(1);
+        store.All().Single().Text.Should().Be("a good day, three brownies");
+    }
+
+    [Fact]
+    public async Task ItShouldReadTheStoredNotesRatherThanTheTripSnapshot()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await store.SaveAsync(
+            Note(FirstNoteId, "written after the page loaded", StartedOn.AddHours(1)),
+            CancellationToken.None);
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#trip-note-{FirstNoteId:D}").TextContent
+                .Should().Contain("written after the page loaded"));
+        store.ForTripCalls.Should().Be(1);
+        store.PendingCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldShowNotesOnTheFinishRecapEvenFromAStaleTripSnapshot()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await store.SaveAsync(
+            Note(FirstNoteId, "fish rising near the reeds", StartedOn.AddHours(1)),
+            CancellationToken.None);
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, CompletedTrip()));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#trip-note-{FirstNoteId:D}").TextContent
+                .Should().Contain("fish rising near the reeds"));
+    }
+
+    [Fact]
+    public async Task ItShouldStayUsableWhenTheStoredNotesCannotBeRead()
+    {
+        // Arrange
+        var store = new ThrowingTripNoteStore();
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(store, logging: logging);
+
+        // Act
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip(Note(FirstNoteId, "from the snapshot"))));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#trip-note-{FirstNoteId:D}").TextContent.Should().Contain("from the snapshot"));
+        cut.Find("#trip-note-start").Should().NotBeNull();
+        await logging.Received(1).LogErrorAsync(
+            "loading trip notes",
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchNoteCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+
+        // Assert
+        cut.Find("#trip-notes").TextContent.Should().Contain("Notes de la sortie");
+        cut.Find("#trip-note-start").TextContent.Should().Contain("Ajouter une note");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingRemove.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingRemove.cs
@@ -1,0 +1,115 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using TripNotesComponent = FishingLogBook.Web.Features.Trips.Components.TripNotes.TripNotes;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Components.TripNotesTests;
+
+public class WhenTestingRemove : BaseTripNotesTest
+{
+    private static readonly Guid FirstNoteId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static readonly Guid SecondNoteId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+    [Fact]
+    public async Task ItShouldWarnAndKeepASynchronisedNoteWhenTheServerRefuses()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = new MemoryTripNoteStore();
+        await store.SaveAsync(
+            Note(FirstNoteId, syncStatus: SyncStatus.Synchronised),
+            CancellationToken.None);
+        var client = Substitute.For<ITripClient>();
+        client.DeleteNoteAsync(TripId, FirstNoteId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Offline."));
+        await using var context = CreateContext(store, tripClient: client);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-remove-{FirstNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.Find($"#trip-note-remove-{FirstNoteId:D}").ClickAsync();
+
+        // Assert
+        cut.Find("#trip-note-remove-failed").TextContent.Should().Contain("could not be removed");
+        store.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldRemoveALocalNoteWithoutContactingTheServer()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await store.SaveAsync(Note(FirstNoteId), CancellationToken.None);
+        var client = Substitute.For<ITripClient>();
+        await using var context = CreateContext(store, tripClient: client);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-remove-{FirstNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.Find($"#trip-note-remove-{FirstNoteId:D}").ClickAsync();
+
+        // Assert
+        store.Count.Should().Be(0);
+        await client.DidNotReceive().DeleteNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        cut.FindAll("#trip-notes-list").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldDeleteASynchronisedNoteOnTheServerToo()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await store.SaveAsync(
+            Note(FirstNoteId, syncStatus: SyncStatus.Synchronised),
+            CancellationToken.None);
+        var client = Substitute.For<ITripClient>();
+        await using var context = CreateContext(store, tripClient: client);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-remove-{FirstNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.Find($"#trip-note-remove-{FirstNoteId:D}").ClickAsync();
+
+        // Assert
+        await client.Received(1).DeleteNoteAsync(
+            TripId,
+            FirstNoteId,
+            Arg.Any<CancellationToken>());
+        store.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldLeaveTheOtherNotesUntouched()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var kept = Note(SecondNoteId, "kept", StartedOn.AddHours(2));
+        await store.SaveAsync(Note(FirstNoteId, "removed", StartedOn.AddHours(1)), CancellationToken.None);
+        await store.SaveAsync(kept, CancellationToken.None);
+        await using var context = CreateContext(store);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-remove-{FirstNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.Find($"#trip-note-remove-{FirstNoteId:D}").ClickAsync();
+
+        // Assert
+        store.Count.Should().Be(1);
+        var survivor = store.All().Single();
+        survivor.Id.Should().Be(SecondNoteId);
+        survivor.Text.Should().Be("kept");
+        survivor.RecordedOn.Should().Be(kept.RecordedOn);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Stores/TripNoteStoreTests/MemoryTripNoteStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Stores/TripNoteStoreTests/MemoryTripNoteStore.cs
@@ -1,0 +1,128 @@
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+
+public sealed class MemoryTripNoteStore : ITripNoteStore
+{
+    private readonly Dictionary<Guid, TripNoteModel> _notes = [];
+
+    public bool FailWrite { get; set; }
+
+    public int PendingCalls { get; private set; }
+
+    public int PendingTripCalls { get; private set; }
+
+    public Func<Guid, Task>? BeforePendingRead { get; set; }
+
+    public Task SaveAsync(TripNoteModel note, CancellationToken cancellationToken)
+    {
+        if (note.OwnerUserId == Guid.Empty)
+        {
+            throw new InvalidOperationException("A trip note requires an owner.");
+        }
+
+        if (string.IsNullOrWhiteSpace(note.Text))
+        {
+            throw new InvalidOperationException("A trip note requires text.");
+        }
+
+        if (FailWrite)
+        {
+            throw new InvalidOperationException("Trip note persistence failed.");
+        }
+
+        _notes[note.Id] = note;
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> DeleteAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        Guid noteId,
+        CancellationToken cancellationToken)
+    {
+        if (!_notes.TryGetValue(noteId, out var note)
+            || note.OwnerUserId != ownerUserId
+            || note.TripId != tripId)
+        {
+            return Task.FromResult(false);
+        }
+
+        _notes.Remove(noteId);
+        return Task.FromResult(true);
+    }
+
+    public int ForTripCalls { get; private set; }
+
+    public Task<IReadOnlyList<TripNoteModel>> GetForTripAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        CancellationToken cancellationToken)
+    {
+        ForTripCalls++;
+        return Task.FromResult<IReadOnlyList<TripNoteModel>>(
+            [.. _notes.Values
+                .Where(note => note.OwnerUserId == ownerUserId && note.TripId == tripId)
+                .OrderBy(note => note.RecordedOn)
+                .ThenBy(note => note.Id)]);
+    }
+
+    public async Task<TripNoteModel?> GetAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        Guid noteId,
+        CancellationToken cancellationToken)
+    {
+        var notes = await GetForTripAsync(ownerUserId, tripId, cancellationToken);
+        return notes.FirstOrDefault(note => note.Id == noteId);
+    }
+
+    public async Task<IReadOnlyList<TripNoteModel>> GetPendingAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        PendingCalls++;
+        if (BeforePendingRead is not null)
+        {
+            await BeforePendingRead(ownerUserId);
+        }
+
+        return
+        [
+            .. _notes.Values
+                .Where(note =>
+                    note.OwnerUserId == ownerUserId
+                    && note.SyncStatus != SyncStatus.Synchronised)
+                .OrderBy(note => note.RecordedOn)
+                .ThenBy(note => note.Id)
+        ];
+    }
+
+    public Task<IReadOnlyCollection<Guid>> GetTripsWithPendingNotesAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        PendingTripCalls++;
+        return Task.FromResult<IReadOnlyCollection<Guid>>(
+            [.. _notes.Values
+                .Where(note =>
+                    note.OwnerUserId == ownerUserId
+                    && note.SyncStatus != SyncStatus.Synchronised)
+                .Select(note => note.TripId)
+                .Distinct()]);
+    }
+
+    public TripNoteModel? Stored(Guid noteId)
+    {
+        return _notes.TryGetValue(noteId, out var note) ? note : null;
+    }
+
+    public int Count => _notes.Count;
+
+    public IReadOnlyList<TripNoteModel> All()
+    {
+        return [.. _notes.Values.OrderBy(note => note.RecordedOn).ThenBy(note => note.Id)];
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Stores/TripNoteStoreTests/ThrowingTripNoteStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Stores/TripNoteStoreTests/ThrowingTripNoteStore.cs
@@ -1,0 +1,52 @@
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+
+public sealed class ThrowingTripNoteStore : ITripNoteStore
+{
+    public Task SaveAsync(TripNoteModel note, CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("IndexedDB unavailable.");
+    }
+
+    public Task<bool> DeleteAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        Guid noteId,
+        CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("IndexedDB unavailable.");
+    }
+
+    public Task<IReadOnlyList<TripNoteModel>> GetForTripAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("IndexedDB unavailable.");
+    }
+
+    public Task<TripNoteModel?> GetAsync(
+        Guid ownerUserId,
+        Guid tripId,
+        Guid noteId,
+        CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("IndexedDB unavailable.");
+    }
+
+    public Task<IReadOnlyList<TripNoteModel>> GetPendingAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("IndexedDB unavailable.");
+    }
+
+    public Task<IReadOnlyCollection<Guid>> GetTripsWithPendingNotesAsync(
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("IndexedDB unavailable.");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Synchronisers/TripNoteSynchroniserTests/BaseTripNoteSynchroniserTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Synchronisers/TripNoteSynchroniserTests/BaseTripNoteSynchroniserTest.cs
@@ -1,0 +1,94 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Common.Offline.Dependencies;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Synchronisers;
+using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Offline.Synchronisers.TripNoteSynchroniserTests;
+
+public class BaseTripNoteSynchroniserTest
+{
+    protected static readonly Guid OwnerUserId =
+        Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid TripId =
+        Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid OtherTripId =
+        Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    protected static readonly Guid NoteId =
+        Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    protected static readonly Guid SecondNoteId =
+        Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    protected static readonly DateTimeOffset RecordedOn =
+        DateTimeOffset.Parse("2026-08-17T09:12:00Z");
+
+    protected readonly ITripClient MockTripClient = Substitute.For<ITripClient>();
+    protected readonly ITripDependencyService MockTripDependency =
+        Substitute.For<ITripDependencyService>();
+    protected readonly INetworkService MockNetworkService = Substitute.For<INetworkService>();
+    protected readonly IDiagnosticLogger MockDiagnostics = Substitute.For<IDiagnosticLogger>();
+    protected readonly ILoggingService MockLogging = Substitute.For<ILoggingService>();
+
+    protected BaseTripNoteSynchroniserTest()
+    {
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(true);
+        MockTripDependency.IsTripReadyForServerAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var tripId = call.ArgAt<Guid>(0);
+                var request = call.ArgAt<RecordTripNoteDto>(1);
+                return new TripNoteDto(request.NoteId, tripId, request.Text, request.RecordedOn);
+            });
+    }
+
+    protected TripNoteSynchroniser CreateSut(MemoryTripNoteStore store)
+    {
+        return new TripNoteSynchroniser(
+            store,
+            MockTripDependency,
+            MockTripClient,
+            MockNetworkService,
+            MockDiagnostics,
+            MockLogging);
+    }
+
+    protected static TripNoteModel CreateNote(
+        Guid? noteId = null,
+        Guid? tripId = null,
+        Guid? ownerUserId = null,
+        string text = "water dropped about a foot",
+        SyncStatus syncStatus = SyncStatus.SavedLocally,
+        DateTimeOffset? recordedOn = null)
+    {
+        return new TripNoteModel(
+            noteId ?? NoteId,
+            tripId ?? TripId,
+            ownerUserId ?? OwnerUserId,
+            text,
+            recordedOn ?? RecordedOn,
+            syncStatus);
+    }
+
+    protected static async Task<MemoryTripNoteStore> CreateStoreAsync(params TripNoteModel[] notes)
+    {
+        var store = new MemoryTripNoteStore();
+        foreach (var note in notes)
+        {
+            await store.SaveAsync(note, CancellationToken.None);
+        }
+
+        return store;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Synchronisers/TripNoteSynchroniserTests/WhenTestingSynchronisePending.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Synchronisers/TripNoteSynchroniserTests/WhenTestingSynchronisePending.cs
@@ -1,0 +1,319 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Offline.Synchronisers.TripNoteSynchroniserTests;
+
+public class WhenTestingSynchronisePending : BaseTripNoteSynchroniserTest
+{
+    [Fact]
+    public async Task ItShouldDoNothingWhenTheOwnerIsUnknown()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateNote());
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(Guid.Empty, CancellationToken.None);
+
+        // Assert
+        store.PendingCalls.Should().Be(0);
+        await MockTripClient.DidNotReceive().RecordNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordTripNoteDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotContactTheServerWhenNothingIsPending()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateNote(syncStatus: SyncStatus.Synchronised));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockNetworkService.DidNotReceive().IsOnlineAsync(Arg.Any<CancellationToken>());
+        await MockTripClient.DidNotReceive().RecordNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordTripNoteDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLeaveWorkPendingWhileOffline()
+    {
+        // Arrange
+        MockNetworkService.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var store = await CreateStoreAsync(CreateNote());
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockTripClient.DidNotReceive().RecordNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordTripNoteDto>(),
+            Arg.Any<CancellationToken>());
+        store.Stored(NoteId)!.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+    }
+
+    [Fact]
+    public async Task ItShouldWaitWhenTheParentTripHasNotReachedTheServer()
+    {
+        // Arrange
+        MockTripDependency.IsTripReadyForServerAsync(
+                OwnerUserId,
+                TripId,
+                Arg.Any<CancellationToken>())
+            .Returns(false);
+        var store = await CreateStoreAsync(CreateNote());
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockTripClient.DidNotReceive().RecordNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordTripNoteDto>(),
+            Arg.Any<CancellationToken>());
+        store.Stored(NoteId)!.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        await MockDiagnostics.Received(1).LogAsync(
+            DiagnosticLevel.Information,
+            DiagnosticEventNames.TripNoteSyncWaitingForTrip,
+            Arg.Any<string>(),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStillSendNotesForAReadyTrip()
+    {
+        // Arrange
+        MockTripDependency.IsTripReadyForServerAsync(
+                OwnerUserId,
+                TripId,
+                Arg.Any<CancellationToken>())
+            .Returns(false);
+        var store = await CreateStoreAsync(
+            CreateNote(),
+            CreateNote(SecondNoteId, OtherTripId));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockTripClient.Received(1).RecordNoteAsync(
+            OtherTripId,
+            Arg.Is<RecordTripNoteDto>(request => request.NoteId == SecondNoteId),
+            Arg.Any<CancellationToken>());
+        store.Stored(SecondNoteId)!.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        store.Stored(NoteId)!.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheNotePendingWhenTheServerRejectsIt()
+    {
+        // Arrange
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripNoteDto?>(_ => throw new HttpRequestException("The API is unavailable."));
+        var store = await CreateStoreAsync(CreateNote());
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        store.Stored(NoteId)!.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        store.Stored(NoteId)!.SyncedAt.Should().BeNull();
+        await MockDiagnostics.Received(1).LogAsync(
+            DiagnosticLevel.Error,
+            DiagnosticEventNames.TripNoteSyncFailed,
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(metadata =>
+                metadata[DiagnosticMetadata.ErrorType] == nameof(HttpRequestException)),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNeverPutTheNoteTextIntoDiagnostics()
+    {
+        // Arrange
+        const string secret = "met Sarah at the bailiff hut about the lease";
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripNoteDto?>(_ => throw new HttpRequestException("The API is unavailable."));
+        var store = await CreateStoreAsync(CreateNote(text: secret));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockDiagnostics.DidNotReceive().LogAsync(
+            Arg.Any<DiagnosticLevel>(),
+            Arg.Any<string>(),
+            Arg.Is<string>(message => message.Contains(secret)),
+            Arg.Any<IReadOnlyDictionary<string, string>>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+        await MockDiagnostics.DidNotReceive().LogAsync(
+            Arg.Any<DiagnosticLevel>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(metadata =>
+                metadata.Values.Any(value => value.Contains(secret))),
+            Arg.Any<Exception?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRetryAFailedNoteAndSendItExactlyOnce()
+    {
+        // Arrange
+        var attempts = 0;
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                attempts++;
+                if (attempts == 1)
+                {
+                    throw new HttpRequestException("The API is unavailable.");
+                }
+
+                var request = call.ArgAt<RecordTripNoteDto>(1);
+                return new TripNoteDto(
+                    request.NoteId,
+                    call.ArgAt<Guid>(0),
+                    request.Text,
+                    request.RecordedOn);
+            });
+        var store = await CreateStoreAsync(CreateNote());
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        attempts.Should().Be(2);
+        store.Stored(NoteId)!.SyncStatus.Should().Be(SyncStatus.Synchronised);
+    }
+
+    [Fact]
+    public async Task ItShouldNotResurrectANoteRemovedWhileItWasSyncing()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateNote());
+        var sut = CreateSut(store);
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                await store.DeleteAsync(OwnerUserId, TripId, NoteId, CancellationToken.None);
+                var request = call.ArgAt<RecordTripNoteDto>(1);
+                return new TripNoteDto(
+                    request.NoteId,
+                    call.ArgAt<Guid>(0),
+                    request.Text,
+                    request.RecordedOn);
+            });
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        store.Count.Should().Be(0);
+        store.Stored(NoteId).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldNotSendTheSameNoteTwiceConcurrently()
+    {
+        // Arrange
+        var store = await CreateStoreAsync(CreateNote());
+        var sut = CreateSut(store);
+        var release = new TaskCompletionSource();
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(async call =>
+            {
+                await release.Task;
+                var request = call.ArgAt<RecordTripNoteDto>(1);
+                return new TripNoteDto(
+                    request.NoteId,
+                    call.ArgAt<Guid>(0),
+                    request.Text,
+                    request.RecordedOn);
+            });
+
+        // Act
+        var first = sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+        var second = sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+        release.SetResult();
+        await Task.WhenAll(first, second);
+
+        // Assert
+        await MockTripClient.Received(1).RecordNoteAsync(
+            TripId,
+            Arg.Is<RecordTripNoteDto>(request => request.NoteId == NoteId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSendEachNoteWithItsOwnRecordedInstant()
+    {
+        // Arrange
+        var later = RecordedOn.AddHours(2);
+        var store = await CreateStoreAsync(
+            CreateNote(text: "fish rising near the reeds"),
+            CreateNote(SecondNoteId, text: "wind picked up", recordedOn: later));
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(OwnerUserId, CancellationToken.None);
+
+        // Assert
+        await MockTripClient.Received(1).RecordNoteAsync(
+            TripId,
+            Arg.Is<RecordTripNoteDto>(request =>
+                request.NoteId == NoteId
+                && request.Text == "fish rising near the reeds"
+                && request.RecordedOn == RecordedOn),
+            Arg.Any<CancellationToken>());
+        await MockTripClient.Received(1).RecordNoteAsync(
+            TripId,
+            Arg.Is<RecordTripNoteDto>(request =>
+                request.NoteId == SecondNoteId
+                && request.Text == "wind picked up"
+                && request.RecordedOn == later),
+            Arg.Any<CancellationToken>());
+        store.All().Should().AllSatisfy(note =>
+        {
+            note.SyncStatus.Should().Be(SyncStatus.Synchronised);
+            note.SyncedAt.Should().NotBeNull();
+        });
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/BaseActiveTripTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/BaseActiveTripTest.cs
@@ -42,6 +42,7 @@ public class BaseActiveTripTest
         context.Services.AddSingleton(logging ?? QuietLogging());
         context.Services.AddSingleton<ITimeService>(TestTimeService.WithOffset(TimeSpan.Zero));
         context.Services.AddSingleton(Substitute.For<ITripPhotographStore>());
+        context.Services.AddSingleton(Substitute.For<ITripNoteStore>());
         context.Services.AddSingleton(Substitute.For<ITripClient>());
         context.Services.AddSingleton(Substitute.For<IPhotographPreparationService>());
         context.Services.AddSingleton<ITripDisplayService>(provider =>

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/BaseActiveTripTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/BaseActiveTripTest.cs
@@ -1,6 +1,8 @@
 using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Models;
@@ -24,12 +26,39 @@ public class BaseActiveTripTest
     protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
 
+    protected static Task<ITripStore> StoreWithActiveTripAsync()
+    {
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .Returns(StoredActiveTrip());
+        return Task.FromResult(store);
+    }
+
+    protected static ICatchStore QuietCatchStore(params CatchModel[] catches)
+    {
+        var store = Substitute.For<ICatchStore>();
+        store.GetMetadataAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(catches);
+        return store;
+    }
+
+    protected static CatchModel CatchFor(Guid? tripId)
+    {
+        var catchId = Guid.NewGuid();
+        return new CatchModel(
+            catchId,
+            DateTimeOffset.Parse("2026-08-26T09:48:00Z"),
+            [],
+            TripId: tripId);
+    }
+
     protected static BunitContext CreateContext(
         ITripStore store,
         IActiveTripService? activeTrip = null,
         ILocalCatchOwnerService? owner = null,
         IOfflineOwnerContextService? offlineOwner = null,
-        ILoggingService? logging = null)
+        ILoggingService? logging = null,
+        ICatchStore? catchStore = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -43,6 +72,7 @@ public class BaseActiveTripTest
         context.Services.AddSingleton<ITimeService>(TestTimeService.WithOffset(TimeSpan.Zero));
         context.Services.AddSingleton(Substitute.For<ITripPhotographStore>());
         context.Services.AddSingleton(Substitute.For<ITripNoteStore>());
+        context.Services.AddSingleton(catchStore ?? QuietCatchStore());
         context.Services.AddSingleton(Substitute.For<ITripClient>());
         context.Services.AddSingleton(Substitute.For<IPhotographPreparationService>());
         context.Services.AddSingleton<ITripDisplayService>(provider =>

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingCatchCount.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingCatchCount.cs
@@ -1,0 +1,142 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using ActiveTripPage = FishingLogBook.Web.Features.Trips.Pages.ActiveTrip.ActiveTrip;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Pages.ActiveTripTests;
+
+public class WhenTestingCatchCount : BaseActiveTripTest
+{
+    [Fact]
+    public async Task ItShouldSayThereAreNoCatchesYet()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = await StoreWithActiveTripAsync();
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-catch-count").TextContent.Should().Contain("No catches yet"));
+    }
+
+    [Fact]
+    public async Task ItShouldCountOneCatchInTheSingular()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = await StoreWithActiveTripAsync();
+        var catchStore = QuietCatchStore(CatchFor(TripId));
+        await using var context = CreateContext(store, catchStore: catchStore);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-catch-count").TextContent.Should().Contain("1 catch recorded"));
+    }
+
+    [Fact]
+    public async Task ItShouldCountOnlyTheCatchesOnThisTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = await StoreWithActiveTripAsync();
+        var catchStore = QuietCatchStore(
+            CatchFor(TripId),
+            CatchFor(TripId),
+            CatchFor(Guid.NewGuid()),
+            CatchFor(null));
+        await using var context = CreateContext(store, catchStore: catchStore);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-catch-count").TextContent.Should().Contain("2 catches recorded"));
+    }
+
+    [Fact]
+    public async Task ItShouldReadCatchMetadataWithoutTouchingPhotographBytes()
+    {
+        // Arrange
+        var store = await StoreWithActiveTripAsync();
+        var catchStore = QuietCatchStore(CatchFor(TripId));
+        await using var context = CreateContext(store, catchStore: catchStore);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-catch-count").Should().NotBeNull());
+        await catchStore.Received(1).GetMetadataAsync(
+            OwnerUserId,
+            Arg.Any<CancellationToken>());
+        await catchStore.DidNotReceive().GetAllAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await catchStore.DidNotReceive().GetAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStillShowTheTripWhenTheCountCannotBeRead()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = await StoreWithActiveTripAsync();
+        var catchStore = Substitute.For<ICatchStore>();
+        catchStore.GetMetadataAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("IndexedDB unavailable."));
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, logging: logging, catchStore: catchStore);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-card").Should().NotBeNull());
+        cut.Find("#active-trip-catch-count").TextContent.Should().Contain("No catches yet");
+        cut.Find("#active-trip-record-catch").Should().NotBeNull();
+        await logging.Received(1).LogErrorAsync(
+            "counting catches for a trip",
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchCatchCountCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var store = await StoreWithActiveTripAsync();
+        var catchStore = QuietCatchStore(CatchFor(TripId), CatchFor(TripId));
+        await using var context = CreateContext(store, catchStore: catchStore);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-catch-count").TextContent
+                .Should().Contain("2 prises enregistrées"));
+    }
+}


### PR DESCRIPTION
Closes #178
Part of #108

T7 of the Fishing Trips slices. An angler jots quick notes through the day — *water dropped about a foot*, *fish rising near the reeds*, *changed to olive nymph* — and each one remembers when it was written.

## A separate, timestamped model

`TripNote` is its own domain type and its own table. It is **not** `Catch.Notes` reused, **not** a giant string on `Trip`, and **not** a persisted generic event row.

```sql
CREATE TABLE IF NOT EXISTS "TripNote"
(
    "Id" uuid NOT NULL, "TripId" uuid NOT NULL, "Text" text NOT NULL,
    "RecordedOn" timestamptz NOT NULL,
    "CreatedOn" timestamptz NOT NULL DEFAULT now(), "UpdatedOn" timestamptz NOT NULL DEFAULT now(),
    CONSTRAINT "PkTripNote" PRIMARY KEY ("Id"),
    CONSTRAINT "FkTripNoteTrip" FOREIGN KEY ("TripId") REFERENCES "Trip" ("Id")
);
CREATE INDEX IF NOT EXISTS "IxTripNoteTripId" ON "TripNote" ("TripId");
CREATE INDEX IF NOT EXISTS "IxTripNoteTripRecordedOn" ON "TripNote" ("TripId", "RecordedOn");
```

Four columns plus timestamps. No `OwnerUserId` duplication — ownership comes through the trip, and every operation verifies it there. No cascade, so nothing can reach catch data. Catch notes and their table are entirely untouched: no file under `Features/Catch` or `Application/Catches` changed.

`RecordedOn` is the timeline key, generated on the device at the moment of writing and carried unchanged through persistence and sync. **The server never substitutes its own insert time** — a repository test asserts `RecordedOn` differs from the row's own `CreatedOn`, so that can't quietly regress. Notes render in the reader's local time through the existing `ITimeService`; no new time abstraction.

## Deliberately lightweight

Plain text. Trimmed. Blank and whitespace-only rejected. Capped at `TripConstants.MaxNoteTextLength`, which is defined as `CatchDetailConstants.MaxNotesLength` so the two conventions cannot drift apart. No rich text, no formatting, no attachments, no mentions.

## Active Trip entry

Inline, not a modal — outdoors, taps matter:

```
[ Add note ]        →        What happened?
                             [ textarea            ]
                             [ Add note ] [ Cancel ]
```

Saving clears the editor, shows the note immediately with its local time, and keeps notes **oldest first** so the day reads forward — the same direction T8's timeline will run. The labelled textarea is keyboard reachable and the remove control carries an accessible label.

The same component appears on the finish recap, so #178's "final note about the day" is an **ordinary note**, not a special case. Entering nothing there finishes the trip exactly as before.

## Offline-first, and one owner of truth

Notes persist the instant they are written, with no network. They live on the trip metadata record, which means:

- **one authoritative metadata path** — no competing note lists;
- **no IndexedDB version change** (still v6) and no migration, because a note is metadata with no blob. T6 needed a separate store only to hold photograph *bytes*; its metadata already rode on the trip;
- a single trip read gives a timeline everything it needs.

A browser test asserts the version is still 6 and that no `tripNotes` store exists, so this is pinned rather than incidental.

`putTrip` no longer owns the note list — it carries forward whatever is stored, the same protection T6 added for photographs. **Finishing a trip therefore cannot discard notes written after the page loaded**, which is exactly the failure this would otherwise have shipped with.

## Delete

In scope: the T6 delete pattern made it close to free. An unsynchronised note deletes locally and works offline. A synchronised note deletes on the server first, then locally; if that fails the note is kept and a recoverable message appears. **No tombstone workflow was invented** for offline deletion of an already-synced note.

## Synchronisation ordering

A focused `ITripNoteSynchroniser` — note sync is deliberately **not** inside `TripSynchroniser`. Coordinator order is now **trips → trip photographs → trip notes → catches**: the trip must exist before a note's foreign key can be written, while photographs and notes are independent siblings, so one deterministic order keeps it testable.

**The exact rule:** a note waits until `IsTripReadyForServerAsync` reports its trip is on the server. A note that cannot be sent keeps its text, stays pending, retries next run, and **never** fails the trip, blocks photographs, or blocks catches. Both directions are tested — a photograph failure still lets notes and catches run; a note failure still lets catches run.

Notes carry a client-generated GUID and the server upserts on it, so replay cannot duplicate. Stale-write protection follows T4/T6: the note is re-read before the completion is applied, so a note deleted mid-flight is never resurrected.

## Privacy

Notes can contain private things. Diagnostics carry **only** `TripId`, `NoteId` and the error type — never the text. Asserted at both the synchroniser and the component using a deliberately private-sounding string, checking the message *and* every metadata value.

## Retention

`GetTripsAwaitingDependentsAsync` now also holds back any trip with a pending note, alongside pending catches and pending photographs. The check is metadata-only — no blob reads. When a trip is finally evicted its notes go with it, so nothing is orphaned.

## Tests

| Suite | Result |
|---|---|
| `dotnet test FishingLogBook.sln` | 2081 passed |
| `npm test` | 341 passed (32 files) |
| `npm run test:browser` | 154 passed, 6 skipped |

61 new tests: repository 11 (real PostgreSQL — FK rejection, no cross-trip move, idempotent replay, instant round-trip, server-clock guard, at the cap, recorded order, owner isolation, reconciliation survival, scoped delete) · service 11 · **validator 8** (empty, whitespace, at the cap, one over) · API 9 · synchroniser 11 · coordinator 2 · dependency 4 · Active Trip UI 19 · vitest 16 · browser 7 × 2 engines.

## Migrations / infrastructure

One additive migration, applied by the normal DbUp run. No Terraform, no backfill, no IndexedDB migration, no other manual post-merge steps.

## Self review

```
- Issue/AC: PASS
- Architecture/CQRS: PASS — endpoint → mediator → handler → ITripNoteService → repositories
- Rules: PASS
- Security/privacy: PASS — trip ownership verified server-side, identical error for unknown and foreign trips, note text never logged
- Database/migrations: PASS — additive, no cascade, no backfill
- Tests/coverage: PASS
- Browser: PASS — version unchanged, reload, ordering, owner scoping, pending detection without blob reads, retention, finish
- Web/UI/localisation: PASS — EN and FR, labelled textarea, keyboard-reachable controls
- Code smells: PASS
- CI/deployment: PASS
```

Findings discovered during self-review:

1. **The notes component trusted a stale trip snapshot.** It read `Trip.Notes` from the passed-in model, but after finishing, the page hands `CompletedTripSummary` a `TripModel` captured before the notes were written — so the finish recap would have shown none of them. The data was safe thanks to the `putTrip` preservation; the display was not.
2. **The synchroniser re-scanned every trip for each note** to perform its stale-write check — the same read-amplification shape as #166.

Fixes made:

1. Notes now load from the store, which is authoritative, with a snapshot fallback if that read fails. Three tests cover it: reading the store rather than the snapshot, the finish recap from a stale snapshot, and staying usable when the store throws.
2. Added targeted `GetForTripAsync` / `GetAsync`; the check now reads one trip instead of scanning them all.

Also checked and clear: `Catch.Notes` not reused, no giant note field on `Trip`, no persisted event table, no note text in any log or diagnostic, one metadata owner, no destructive IndexedDB upgrade, note sync outside `TripSynchroniser`, a note failure not blocking catches, no trip cleanup while a note is pending, no stale completion resurrecting a deleted note, no owner leakage, no server timestamp replacing the user-event timestamp, notes surviving reload, and no T8 scope.

Remaining deliberate gaps:

- **No list endpoint.** Nothing in T7 reads notes from the server; the UI is local-first and T8 owns the read model.
- **No note editing**, per #178 — it would introduce sync-conflict semantics we do not need before the timeline exists.
- **No credentialed E2E.** The auth harness boundary is unchanged (`self-review.md` forbids test-only authentication to force an authenticated Blazor host, and production auth is Cognito/OIDC). The complete local journey — add, reload, multiple notes, pending detection, retention, finish — is proven in a real browser on Chromium and WebKit. T9 owns the full device journey.
