### PR TITLE
FLB#179 | attach existing catches, note any owned trip, and tidy trip screens

### DIFF
--- a/src/FishingLogBook.Api/Endpoints/TripEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/TripEndpoints.cs
@@ -121,7 +121,7 @@ public static class TripEndpoints
             return Results.NotFound();
         }
 
-        if (response.Error is TripNoteInvalidError)
+        if (response.Error is TripNoteInvalidError or TripNoteOutsideTripError)
         {
             return Results.BadRequest(response);
         }

--- a/src/FishingLogBook.Api/Endpoints/TripEndpoints.cs
+++ b/src/FishingLogBook.Api/Endpoints/TripEndpoints.cs
@@ -89,7 +89,56 @@ public static class TripEndpoints
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status503ServiceUnavailable);
 
+        endpoints.MapPost("/api/trips/{tripId:guid}/catches", AssociateCatchesAsync)
+            .WithName("AssociateTripCatches")
+            .WithTags("Trips")
+            .RequireAuthorization()
+            .Produces<TripCatchAssociationDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
         return endpoints;
+    }
+
+    private static async Task<IResult> AssociateCatchesAsync(
+        Guid tripId,
+        AssociateTripCatchesDto request,
+        IMediator mediator,
+        ICurrentUser currentUser,
+        CancellationToken cancellationToken)
+    {
+        if (!currentUser.IsResolved)
+        {
+            return Results.Unauthorized();
+        }
+
+        var response = await mediator.Send(
+            new AssociateTripCatchesCommand
+            {
+                TripId = tripId,
+                CatchIds = request.CatchIds
+            },
+            cancellationToken);
+        if (response.ValidationErrors is { Count: > 0 })
+        {
+            return Results.BadRequest(response);
+        }
+
+        if (response.Error is TripNotFoundError)
+        {
+            return Results.NotFound();
+        }
+
+        if (response.IsFailure)
+        {
+            return Results.Problem(
+                title: response.ErrorMessage,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.Ok(response.Association);
     }
 
     private static async Task<IResult> RecordNoteAsync(

--- a/src/FishingLogBook.Api/FishingLogBook.Api.http
+++ b/src/FishingLogBook.Api/FishingLogBook.Api.http
@@ -139,6 +139,106 @@ Authorization: Bearer <access-token>
 
 ###
 
+### Trips (requires a Cognito access token; never commit real tokens)
+
+POST {{FishingLogBook.Api_HostAddress}}/api/trips
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <access-token>
+
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "status": "Active",
+  "startedOn": "2026-08-17T07:00:00Z",
+  "endedOn": null,
+  "location": {
+    "latitude": 53.4419,
+    "longitude": -9.2531,
+    "accuracyMetres": 8,
+    "capturedOn": "2026-08-17T07:00:00Z",
+    "source": "DeviceGps",
+    "visibility": "Private",
+    "consentVersion": "1"
+  },
+  "title": "Evening session",
+  "placeName": "Corrib shoreline"
+}
+
+###
+
+GET {{FishingLogBook.Api_HostAddress}}/api/trips
+Accept: application/json
+Authorization: Bearer <access-token>
+
+###
+
+GET {{FishingLogBook.Api_HostAddress}}/api/trips/00000000-0000-0000-0000-000000000000
+Accept: application/json
+Authorization: Bearer <access-token>
+
+###
+
+POST {{FishingLogBook.Api_HostAddress}}/api/trips/00000000-0000-0000-0000-000000000000/photographs/upload-url
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <access-token>
+
+{
+  "photographId": "11111111-1111-1111-1111-111111111111",
+  "contentType": "image/jpeg"
+}
+
+###
+
+POST {{FishingLogBook.Api_HostAddress}}/api/trips/00000000-0000-0000-0000-000000000000/photographs
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <access-token>
+
+{
+  "photographId": "11111111-1111-1111-1111-111111111111",
+  "objectKey": "trips/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111",
+  "contentType": "image/jpeg",
+  "addedOn": "2026-08-17T09:20:00Z",
+  "capturedOn": "2026-08-17T09:12:00Z"
+}
+
+###
+
+DELETE {{FishingLogBook.Api_HostAddress}}/api/trips/00000000-0000-0000-0000-000000000000/photographs/11111111-1111-1111-1111-111111111111
+Authorization: Bearer <access-token>
+
+###
+
+POST {{FishingLogBook.Api_HostAddress}}/api/trips/00000000-0000-0000-0000-000000000000/notes
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <access-token>
+
+{
+  "noteId": "22222222-2222-2222-2222-222222222222",
+  "text": "Water dropped after lunch",
+  "recordedOn": "2026-08-17T13:40:00Z"
+}
+
+###
+
+DELETE {{FishingLogBook.Api_HostAddress}}/api/trips/00000000-0000-0000-0000-000000000000/notes/22222222-2222-2222-2222-222222222222
+Authorization: Bearer <access-token>
+
+###
+
+POST {{FishingLogBook.Api_HostAddress}}/api/trips/00000000-0000-0000-0000-000000000000/catches
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer <access-token>
+
+{
+  "catchIds": ["11111111-1111-1111-1111-111111111111"]
+}
+
+###
+
 ### Fishing preferences (requires a Cognito access token; never commit real tokens)
 
 GET {{FishingLogBook.Api_HostAddress}}/api/fishing-catalogue

--- a/src/FishingLogBook.Application/Args/AssociateTripCatchesArgs.cs
+++ b/src/FishingLogBook.Application/Args/AssociateTripCatchesArgs.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class AssociateTripCatchesArgs
+{
+    public Guid TripId { get; init; }
+
+    public IReadOnlyList<Guid> CatchIds { get; init; } = [];
+}

--- a/src/FishingLogBook.Application/Args/PersistCatchTripArgs.cs
+++ b/src/FishingLogBook.Application/Args/PersistCatchTripArgs.cs
@@ -1,0 +1,10 @@
+namespace FishingLogBook.Application.Args;
+
+public sealed class PersistCatchTripArgs
+{
+    public Guid CatchId { get; init; }
+
+    public Guid UserId { get; init; }
+
+    public Guid TripId { get; init; }
+}

--- a/src/FishingLogBook.Application/Contracts/Repositories/ICatchRepository.cs
+++ b/src/FishingLogBook.Application/Contracts/Repositories/ICatchRepository.cs
@@ -20,6 +20,10 @@ public interface ICatchRepository
 
     Task<Result<Catch>> UpsertAsync(Catch catchRecord, CancellationToken cancellationToken);
 
+    Task<Result<bool>> AssociateTripAsync(
+        PersistCatchTripArgs args,
+        CancellationToken cancellationToken);
+
     Task<Result> UpdateLocationVisibilityAsync(
         PersistCatchLocationVisibilityArgs args,
         CancellationToken cancellationToken);

--- a/src/FishingLogBook.Application/Contracts/Services/ITripCatchService.cs
+++ b/src/FishingLogBook.Application/Contracts/Services/ITripCatchService.cs
@@ -1,0 +1,12 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.Contracts.Services;
+
+public interface ITripCatchService
+{
+    Task<Result<TripCatchAssociationDto>> AssociateAsync(
+        AssociateTripCatchesArgs args,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Application/Trips/Commands/AssociateTripCatchesCommand.cs
+++ b/src/FishingLogBook.Application/Trips/Commands/AssociateTripCatchesCommand.cs
@@ -1,0 +1,73 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Common.Responses;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Shared.Dtos;
+using FluentValidation;
+using MediatR;
+
+namespace FishingLogBook.Application.Trips.Commands;
+
+public sealed class AssociateTripCatchesCommand : IRequest<AssociateTripCatchesResponse>
+{
+    public Guid TripId { get; init; }
+
+    public IReadOnlyList<Guid> CatchIds { get; init; } = [];
+}
+
+public sealed class AssociateTripCatchesResponse : ValidatedResponse
+{
+    public TripCatchAssociationDto? Association { get; init; }
+}
+
+public sealed class AssociateTripCatchesHandler
+    : IRequestHandler<AssociateTripCatchesCommand, AssociateTripCatchesResponse>
+{
+    private readonly ITripCatchService _tripCatchService;
+
+    public AssociateTripCatchesHandler(ITripCatchService tripCatchService)
+    {
+        _tripCatchService = tripCatchService;
+    }
+
+    public async Task<AssociateTripCatchesResponse> Handle(
+        AssociateTripCatchesCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _tripCatchService.AssociateAsync(
+            new AssociateTripCatchesArgs
+            {
+                TripId = command.TripId,
+                CatchIds = command.CatchIds
+            },
+            cancellationToken);
+        if (result.IsFailed)
+        {
+            return ValidatedResponse.FromError<AssociateTripCatchesResponse>(result.Errors[0]);
+        }
+
+        return new AssociateTripCatchesResponse
+        {
+            Association = result.Value
+        };
+    }
+}
+
+public sealed class AssociateTripCatchesCommandValidator
+    : AbstractValidator<AssociateTripCatchesCommand>
+{
+    private const int MaxCatchesPerRequest = 50;
+
+    public AssociateTripCatchesCommandValidator()
+    {
+        RuleFor(command => command.TripId)
+            .NotEmpty();
+        RuleFor(command => command.CatchIds)
+            .NotEmpty()
+            .WithMessage("Choose at least one catch to add to the trip.");
+        RuleFor(command => command.CatchIds)
+            .Must(catchIds => catchIds.Count <= MaxCatchesPerRequest)
+            .WithMessage($"A trip accepts at most {MaxCatchesPerRequest} catches in one request.");
+        RuleForEach(command => command.CatchIds)
+            .NotEmpty();
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Commands/AssociateTripCatchesCommand.cs
+++ b/src/FishingLogBook.Application/Trips/Commands/AssociateTripCatchesCommand.cs
@@ -3,6 +3,7 @@ using FishingLogBook.Application.Common.Responses;
 using FishingLogBook.Application.Contracts.Services;
 using FishingLogBook.Shared.Dtos;
 using FluentValidation;
+using MapsterMapper;
 using MediatR;
 
 namespace FishingLogBook.Application.Trips.Commands;
@@ -23,10 +24,12 @@ public sealed class AssociateTripCatchesHandler
     : IRequestHandler<AssociateTripCatchesCommand, AssociateTripCatchesResponse>
 {
     private readonly ITripCatchService _tripCatchService;
+    private readonly IMapper _mapper;
 
-    public AssociateTripCatchesHandler(ITripCatchService tripCatchService)
+    public AssociateTripCatchesHandler(ITripCatchService tripCatchService, IMapper mapper)
     {
         _tripCatchService = tripCatchService;
+        _mapper = mapper;
     }
 
     public async Task<AssociateTripCatchesResponse> Handle(
@@ -34,11 +37,7 @@ public sealed class AssociateTripCatchesHandler
         CancellationToken cancellationToken)
     {
         var result = await _tripCatchService.AssociateAsync(
-            new AssociateTripCatchesArgs
-            {
-                TripId = command.TripId,
-                CatchIds = command.CatchIds
-            },
+            _mapper.Map<AssociateTripCatchesArgs>(command),
             cancellationToken);
         if (result.IsFailed)
         {

--- a/src/FishingLogBook.Application/Trips/Errors/TripNoteOutsideTripError.cs
+++ b/src/FishingLogBook.Application/Trips/Errors/TripNoteOutsideTripError.cs
@@ -1,0 +1,11 @@
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Errors;
+
+public sealed class TripNoteOutsideTripError : Error
+{
+    public TripNoteOutsideTripError()
+        : base("A trip note must be recorded within the trip.")
+    {
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Services/TripCatchService.cs
+++ b/src/FishingLogBook.Application/Trips/Services/TripCatchService.cs
@@ -1,0 +1,119 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+
+namespace FishingLogBook.Application.Trips.Services;
+
+public sealed class TripCatchService : ITripCatchService
+{
+    private static readonly TimeSpan ClockSkewAllowance = TimeSpan.FromMinutes(5);
+
+    private readonly ITripRepository _tripRepository;
+    private readonly ICatchRepository _catchRepository;
+    private readonly ICurrentUser _currentUser;
+
+    public TripCatchService(
+        ITripRepository tripRepository,
+        ICatchRepository catchRepository,
+        ICurrentUser currentUser)
+    {
+        _tripRepository = tripRepository;
+        _catchRepository = catchRepository;
+        _currentUser = currentUser;
+    }
+
+    public async Task<Result<TripCatchAssociationDto>> AssociateAsync(
+        AssociateTripCatchesArgs args,
+        CancellationToken cancellationToken)
+    {
+        var trip = await LoadOwnedTripAsync(args.TripId, cancellationToken);
+        if (trip.IsFailed)
+        {
+            return Result.Fail<TripCatchAssociationDto>(trip.Errors);
+        }
+
+        var associated = new List<Guid>();
+        var rejected = new List<Guid>();
+        foreach (var catchId in args.CatchIds.Distinct())
+        {
+            var outcome = await AssociateOneAsync(trip.Value, catchId, cancellationToken);
+            if (outcome.IsFailed)
+            {
+                return Result.Fail<TripCatchAssociationDto>(outcome.Errors);
+            }
+
+            if (outcome.Value)
+            {
+                associated.Add(catchId);
+            }
+            else
+            {
+                rejected.Add(catchId);
+            }
+        }
+
+        return Result.Ok(new TripCatchAssociationDto(associated, rejected));
+    }
+
+    private async Task<Result<bool>> AssociateOneAsync(
+        Trip trip,
+        Guid catchId,
+        CancellationToken cancellationToken)
+    {
+        var candidate = await _catchRepository.GetByIdAsync(catchId, cancellationToken);
+        if (candidate.IsFailed)
+        {
+            return Result.Fail<bool>(candidate.Errors);
+        }
+
+        if (!IsEligible(candidate.Value, trip))
+        {
+            return Result.Ok(false);
+        }
+
+        return await _catchRepository.AssociateTripAsync(
+            new PersistCatchTripArgs
+            {
+                CatchId = catchId,
+                UserId = _currentUser.UserId,
+                TripId = trip.Id
+            },
+            cancellationToken);
+    }
+
+    private bool IsEligible(Catch? candidate, Trip trip)
+    {
+        if (candidate is null || candidate.UserId != _currentUser.UserId || candidate.TripId is not null)
+        {
+            return false;
+        }
+
+        if (candidate.CaughtOn < trip.StartedOn)
+        {
+            return false;
+        }
+
+        return candidate.CaughtOn <= (trip.EndedOn ?? DateTimeOffset.UtcNow.Add(ClockSkewAllowance));
+    }
+
+    private async Task<Result<Trip>> LoadOwnedTripAsync(Guid tripId, CancellationToken cancellationToken)
+    {
+        var trip = await _tripRepository.GetByIdAsync(tripId, cancellationToken);
+        if (trip.IsFailed)
+        {
+            return Result.Fail<Trip>(trip.Errors);
+        }
+
+        if (trip.Value is null || trip.Value.OwnerUserId != _currentUser.UserId)
+        {
+            return Result.Fail<Trip>(new TripNotFoundError());
+        }
+
+        return Result.Ok(trip.Value);
+    }
+}

--- a/src/FishingLogBook.Application/Trips/Services/TripNoteService.cs
+++ b/src/FishingLogBook.Application/Trips/Services/TripNoteService.cs
@@ -12,6 +12,8 @@ namespace FishingLogBook.Application.Trips.Services;
 
 public sealed class TripNoteService : ITripNoteService
 {
+    private static readonly TimeSpan ClockSkewAllowance = TimeSpan.FromMinutes(5);
+
     private readonly ITripRepository _tripRepository;
     private readonly ITripNoteRepository _tripNoteRepository;
     private readonly ICurrentUser _currentUser;
@@ -43,6 +45,11 @@ public sealed class TripNoteService : ITripNoteService
         if (trip.IsFailed)
         {
             return Result.Fail<TripNoteDto>(trip.Errors);
+        }
+
+        if (!IsWithinTrip(trip.Value, args.RecordedOn))
+        {
+            return Result.Fail<TripNoteDto>(new TripNoteOutsideTripError());
         }
 
         var existing = await _tripNoteRepository.GetByIdAsync(args.NoteId, cancellationToken);
@@ -93,6 +100,16 @@ public sealed class TripNoteService : ITripNoteService
         }
 
         return await _tripNoteRepository.DeleteAsync(args.NoteId, cancellationToken);
+    }
+
+    private static bool IsWithinTrip(Trip trip, DateTimeOffset recordedOn)
+    {
+        if (recordedOn < trip.StartedOn)
+        {
+            return false;
+        }
+
+        return recordedOn <= (trip.EndedOn ?? DateTimeOffset.UtcNow.Add(ClockSkewAllowance));
     }
 
     private async Task<Result<Trip>> LoadOwnedTripAsync(Guid tripId, CancellationToken cancellationToken)

--- a/src/FishingLogBook.Application/Trips/Services/TripNoteService.cs
+++ b/src/FishingLogBook.Application/Trips/Services/TripNoteService.cs
@@ -68,7 +68,7 @@ public sealed class TripNoteService : ITripNoteService
             {
                 Id = args.NoteId,
                 TripId = args.TripId,
-                CreatedByUserId = _currentUser.UserId,
+                CreatedByUserId = existing.Value?.CreatedByUserId ?? _currentUser.UserId,
                 Text = text,
                 RecordedOn = args.RecordedOn
             },

--- a/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.DependencyInjection/ServiceCollectionExtensions.cs
@@ -58,6 +58,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITripDetailService, TripDetailService>();
         services.AddScoped<ITripPhotographService, TripPhotographService>();
         services.AddScoped<ITripNoteService, TripNoteService>();
+        services.AddScoped<ITripCatchService, TripCatchService>();
         services.AddScoped<ICatchPhotographService, CatchPhotographService>();
         services.AddScoped<ICatchLocationPrivacyService, CatchLocationPrivacyService>();
         services.AddScoped<IPlatformCapabilityService, PlatformCapabilityService>();

--- a/src/FishingLogBook.Infrastructure/Persistence/Repositories/CatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/Repositories/CatchRepository.cs
@@ -187,7 +187,7 @@ public sealed class CatchRepository : ICatchRepository
         catch (Exception exception)
         {
             _logger.LogError(exception, "Failed to associate catch {CatchId} with a trip.", args.CatchId);
-            return Result.Fail<bool>("Failed to save the catch.");
+            return Result.Fail<bool>(FailedMessage);
         }
     }
 

--- a/src/FishingLogBook.Infrastructure/Persistence/Repositories/CatchRepository.cs
+++ b/src/FishingLogBook.Infrastructure/Persistence/Repositories/CatchRepository.cs
@@ -159,6 +159,38 @@ public sealed class CatchRepository : ICatchRepository
         }
     }
 
+    public async Task<Result<bool>> AssociateTripAsync(
+        PersistCatchTripArgs args,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            const string sql = """
+                UPDATE "Catch"
+                SET "TripId" = @TripId
+                WHERE "Id" = @CatchId
+                  AND "UserId" = @UserId
+                  AND "TripId" IS NULL;
+                """;
+            var updated = await connection.ExecuteAsync(new CommandDefinition(
+                sql,
+                new
+                {
+                    args.CatchId,
+                    args.UserId,
+                    args.TripId
+                },
+                cancellationToken: cancellationToken));
+            return Result.Ok(updated == 1);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to associate catch {CatchId} with a trip.", args.CatchId);
+            return Result.Fail<bool>("Failed to save the catch.");
+        }
+    }
+
     public async Task<Result> UpdateLocationVisibilityAsync(
         PersistCatchLocationVisibilityArgs args,
         CancellationToken cancellationToken)

--- a/src/FishingLogBook.Shared/Dtos/AssociateTripCatchesDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/AssociateTripCatchesDto.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record AssociateTripCatchesDto(IReadOnlyList<Guid> CatchIds);

--- a/src/FishingLogBook.Shared/Dtos/TripCatchAssociationDto.cs
+++ b/src/FishingLogBook.Shared/Dtos/TripCatchAssociationDto.cs
@@ -1,0 +1,5 @@
+namespace FishingLogBook.Shared.Dtos;
+
+public sealed record TripCatchAssociationDto(
+    IReadOnlyList<Guid> AssociatedCatchIds,
+    IReadOnlyList<Guid> RejectedCatchIds);

--- a/src/FishingLogBook.Web/Features/Catch/Components/CatchSelector/CatchSelector.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Components/CatchSelector/CatchSelector.razor
@@ -1,49 +1,54 @@
 @namespace FishingLogBook.Web.Features.Catch.Components.CatchSelector
 
-<MudStack Spacing="2" id="catch-selector">
-    @if (Catches.Count == 0)
+<MudStack Spacing="1" id="catch-selector">
+    @foreach (var candidate in Catches)
     {
-        <MudText Typo="Typo.body2" Class="mud-text-secondary" id="catch-selector-empty">
-            @EmptyLabel
-        </MudText>
-    }
-    else
-    {
-        <MudStack Spacing="1" id="catch-selector-options">
-            @foreach (var candidate in Catches)
-            {
-                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="catch-selector-row">
-                    @if (MediaSource(candidate) is { } source)
-                    {
-                        <img src="@source" alt="" class="catch-selector-thumbnail" />
-                    }
-                    else
-                    {
-                        <div class="catch-selector-thumbnail catch-selector-thumbnail-placeholder" aria-hidden="true">
-                            <MudIcon Icon="@Icons.Material.Filled.PhotoCamera" Size="Size.Small" />
-                        </div>
-                    }
-                    <MudCheckBox T="bool"
-                                 Value="@IsSelected(candidate.Id)"
-                                 ValueChanged="@((bool selected) => ToggleAsync(candidate.Id, selected))"
-                                 Color="Color.Primary"
-                                 Dense="true"
-                                 Disabled="Disabled"
-                                 Label="@Describe(candidate)"
-                                 Class="catch-selector-option-checkbox"
-                                 id="@($"catch-selector-option-{candidate.Id:D}")" />
-                </MudStack>
-            }
-        </MudStack>
+        <MudPaper Elevation="0"
+                  Class="catch-selector-row"
+                  id="@($"catch-selector-row-{candidate.Id:D}")">
+            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                <MudCheckBox T="bool"
+                             Value="@IsSelected(candidate.Id)"
+                             ValueChanged="@((bool selected) => ToggleAsync(candidate.Id, selected))"
+                             Color="Color.Primary"
+                             Dense="true"
+                             Disabled="Disabled"
+                             aria-label="@SpeciesLabel(candidate)"
+                             Class="catch-selector-option-checkbox"
+                             id="@($"catch-selector-option-{candidate.Id:D}")" />
 
-        <MudButton Variant="Variant.Filled"
-                   Color="Color.Primary"
-                   FullWidth="true"
-                   StartIcon="@Icons.Material.Filled.PlaylistAdd"
-                   Disabled="@(Disabled || _selected.Count == 0)"
-                   OnClick="ConfirmAsync"
-                   id="catch-selector-confirm">
-            @ConfirmLabel
-        </MudButton>
+                @if (MediaSource(candidate) is { } source)
+                {
+                    <img src="@source" alt="" class="catch-selector-thumbnail" />
+                }
+                else
+                {
+                    <div class="catch-selector-thumbnail catch-selector-thumbnail-placeholder" aria-hidden="true">
+                        <MudIcon Icon="@Icons.Material.Filled.PhotoCamera" Size="Size.Small" />
+                    </div>
+                }
+
+                <MudStack Spacing="0" Class="catch-selector-detail">
+                    <MudText Typo="Typo.body2"
+                             Class="catch-selector-species"
+                             id="@($"catch-selector-species-{candidate.Id:D}")">
+                        @SpeciesLabel(candidate)
+                    </MudText>
+                    <MudText Typo="Typo.caption"
+                             Class="mud-text-secondary"
+                             id="@($"catch-selector-facts-{candidate.Id:D}")">
+                        @Facts(candidate)
+                    </MudText>
+                    @if (MethodLabel(candidate) is { } method)
+                    {
+                        <MudText Typo="Typo.caption"
+                                 Class="mud-text-secondary catch-selector-method"
+                                 id="@($"catch-selector-method-{candidate.Id:D}")">
+                            @method
+                        </MudText>
+                    }
+                </MudStack>
+            </MudStack>
+        </MudPaper>
     }
 </MudStack>

--- a/src/FishingLogBook.Web/Features/Catch/Components/CatchSelector/CatchSelector.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Components/CatchSelector/CatchSelector.razor.cs
@@ -1,29 +1,31 @@
 using System.Globalization;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace FishingLogBook.Web.Features.Catch.Components.CatchSelector;
 
 public partial class CatchSelector : ComponentBase, IDisposable
 {
+    private const int LocalValueLength = 16;
+    private const int TimePartIndex = 11;
+    private const int TimePartLength = 5;
+
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly HashSet<Guid> _selected = [];
     private readonly Dictionary<Guid, string> _mediaSources = [];
     private readonly HashSet<Guid> _mediaRequested = [];
+    private readonly Dictionary<Guid, string> _localTimes = [];
 
     [Parameter]
     [EditorRequired]
     public IReadOnlyList<CatchModel> Catches { get; set; } = [];
-
-    [Parameter]
-    [EditorRequired]
-    public string ConfirmLabel { get; set; } = string.Empty;
-
-    [Parameter]
-    [EditorRequired]
-    public string EmptyLabel { get; set; } = string.Empty;
 
     [Parameter]
     public string UnknownSpeciesLabel { get; set; } = string.Empty;
@@ -35,19 +37,70 @@ public partial class CatchSelector : ComponentBase, IDisposable
     public Guid OwnerUserId { get; set; }
 
     [Parameter]
-    public EventCallback<IReadOnlyList<Guid>> OnConfirm { get; set; }
+    public WeightUnitEnum WeightUnit { get; set; } = WeightUnitEnum.Kg;
+
+    [Parameter]
+    public LengthUnitEnum LengthUnit { get; set; } = LengthUnitEnum.Cm;
+
+    [Parameter]
+    public EventCallback<IReadOnlyList<Guid>> SelectedChanged { get; set; }
 
     [Inject]
     private ICatchStore CatchStore { get; set; } = default!;
 
     [Inject]
+    private ITimeService Time { get; set; } = default!;
+
+    [Inject]
+    private IMeasurementService Measurement { get; set; } = default!;
+
+    [Inject]
     private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     protected override async Task OnParametersSetAsync()
     {
         var available = Catches.Select(candidate => candidate.Id).ToHashSet();
-        _selected.RemoveWhere(id => !available.Contains(id));
+        if (_selected.RemoveWhere(id => !available.Contains(id)) > 0)
+        {
+            await PublishSelectionAsync();
+        }
+
+        await RememberLocalTimesAsync();
         await LoadThumbnailsAsync();
+    }
+
+    private async Task RememberLocalTimesAsync()
+    {
+        var pending = Catches
+            .Where(candidate => !_localTimes.ContainsKey(candidate.Id))
+            .ToArray();
+        if (pending.Length == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var values = await Task.WhenAll(pending.Select(candidate =>
+                Time.ToDateTimeLocalValueAsync(candidate.CaughtOn, _cancellationTokenSource.Token)));
+            for (var index = 0; index < pending.Length; index++)
+            {
+                var value = values[index];
+                _localTimes[pending[index].Id] = value.Length >= LocalValueLength
+                    ? value.Substring(TimePartIndex, TimePartLength)
+                    : value;
+            }
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("reading a catch selector time", exception, CancellationToken.None);
+        }
     }
 
     private async Task LoadThumbnailsAsync()
@@ -107,7 +160,7 @@ public partial class CatchSelector : ComponentBase, IDisposable
         return _selected.Contains(catchId);
     }
 
-    private Task ToggleAsync(Guid catchId, bool selected)
+    private async Task ToggleAsync(Guid catchId, bool selected)
     {
         if (selected)
         {
@@ -118,31 +171,68 @@ public partial class CatchSelector : ComponentBase, IDisposable
             _selected.Remove(catchId);
         }
 
-        return Task.CompletedTask;
+        await PublishSelectionAsync();
     }
 
-    private async Task ConfirmAsync()
+    private async Task PublishSelectionAsync()
     {
-        if (_selected.Count == 0 || !OnConfirm.HasDelegate)
+        if (!SelectedChanged.HasDelegate)
         {
             return;
         }
 
-        var chosen = Catches
-            .Where(candidate => _selected.Contains(candidate.Id))
-            .Select(candidate => candidate.Id)
-            .ToArray();
-        await OnConfirm.InvokeAsync(chosen);
+        await SelectedChanged.InvokeAsync(
+        [
+            .. Catches
+                .Where(candidate => _selected.Contains(candidate.Id))
+                .Select(candidate => candidate.Id)
+        ]);
     }
 
-    private string Describe(CatchModel candidate)
+    private string SpeciesLabel(CatchModel candidate)
     {
-        var species = string.IsNullOrWhiteSpace(candidate.SpeciesName)
+        return string.IsNullOrWhiteSpace(candidate.SpeciesName)
             ? UnknownSpeciesLabel
             : candidate.SpeciesName!;
-        var caughtOn = candidate.CaughtOn.ToString("d MMM HH:mm", CultureInfo.CurrentCulture);
-        return $"{species} · {caughtOn}";
     }
+
+    private string Facts(CatchModel candidate)
+    {
+        var parts = new List<string> { LocalTime(candidate) };
+        var weight = Measurement.ToDisplayWeight(candidate.Weight, WeightUnit);
+        if (weight is not null)
+        {
+            parts.Add($"{weight.Value.ToString("0.##", CultureInfo.CurrentCulture)} {WeightUnitLabel}");
+        }
+
+        var length = Measurement.ToDisplayLength(candidate.Length, LengthUnit);
+        if (length is not null)
+        {
+            parts.Add($"{length.Value.ToString("0.##", CultureInfo.CurrentCulture)} {LengthUnitLabel}");
+        }
+
+        return string.Join(" · ", parts.Where(part => !string.IsNullOrWhiteSpace(part)));
+    }
+
+    private string LocalTime(CatchModel candidate)
+    {
+        return _localTimes.TryGetValue(candidate.Id, out var value)
+            ? value
+            : candidate.CaughtOn.ToString("HH:mm", CultureInfo.CurrentCulture);
+    }
+
+    private static string? MethodLabel(CatchModel candidate)
+    {
+        return string.IsNullOrWhiteSpace(candidate.Method) ? null : candidate.Method;
+    }
+
+    private string WeightUnitLabel => WeightUnit == WeightUnitEnum.Lb
+        ? Loc["Catch_WeightUnitShort_Lb"]
+        : Loc["Catch_WeightUnitShort_Kg"];
+
+    private string LengthUnitLabel => LengthUnit == LengthUnitEnum.In
+        ? Loc["Catch_LengthUnitShort_In"]
+        : Loc["Catch_LengthUnitShort_Cm"];
 
     public void Dispose()
     {

--- a/src/FishingLogBook.Web/Features/Catch/Components/CatchSelector/CatchSelector.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Components/CatchSelector/CatchSelector.razor.css
@@ -1,15 +1,12 @@
-#catch-selector-options {
-    max-height: 18rem;
-    overflow-y: auto;
-}
-
 .catch-selector-row {
     min-width: 0;
+    padding: 0.25rem 0.25rem 0.25rem 0;
+    background-color: transparent;
 }
 
 .catch-selector-thumbnail {
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 3rem;
+    height: 3rem;
     object-fit: cover;
     border-radius: var(--mud-default-borderradius);
     flex: 0 0 auto;
@@ -23,6 +20,18 @@
     color: var(--mud-palette-text-secondary);
 }
 
+.catch-selector-detail {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.catch-selector-species,
+.catch-selector-method {
+    overflow-wrap: anywhere;
+}
+
 ::deep .catch-selector-option-checkbox {
     min-width: 0;
+    flex: 0 0 auto;
+    margin-inline-end: 0;
 }

--- a/src/FishingLogBook.Web/Features/Trips/Clients/ITripClient.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Clients/ITripClient.cs
@@ -28,6 +28,11 @@ public interface ITripClient
 
     Task DeletePhotographAsync(Guid tripId, Guid photographId, CancellationToken cancellationToken);
 
+    Task<TripCatchAssociationDto?> AssociateCatchesAsync(
+        Guid tripId,
+        AssociateTripCatchesDto request,
+        CancellationToken cancellationToken);
+
     Task<TripNoteDto?> RecordNoteAsync(
         Guid tripId,
         RecordTripNoteDto request,

--- a/src/FishingLogBook.Web/Features/Trips/Clients/TripClient.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Clients/TripClient.cs
@@ -94,6 +94,19 @@ public sealed class TripClient : ITripClient
         response.EnsureSuccessStatusCode();
     }
 
+    public async Task<TripCatchAssociationDto?> AssociateCatchesAsync(
+        Guid tripId,
+        AssociateTripCatchesDto request,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _apiClient.PostAsJsonAsync(
+            $"api/trips/{tripId:D}/catches",
+            request,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TripCatchAssociationDto>(cancellationToken);
+    }
+
     public async Task<TripNoteDto?> RecordNoteAsync(
         Guid tripId,
         RecordTripNoteDto request,

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
@@ -74,20 +74,23 @@
                       OwnerUserId="Trip.OwnerUserId"
                       TripId="Trip.Id"
                       AllowLocalMedia="AllowLocalMedia"
-                      CanDeleteNotes="CanEdit"
+                      CanDeleteNotes="CanAddNotes"
                       OnDeleteNote="DeleteNoteAsync"
                       CatchBaseHref="@CatchBaseHref"
                       WeightUnit="WeightUnit"
                       LengthUnit="LengthUnit" />
 
-        @if (CanEdit)
+        @if (CanAddNotes)
         {
             <TripNotes @ref="_notes"
                        Trip="Trip"
                        ShowList="false"
                        UseFloatingTrigger="true"
                        Changed="OnContentChanged" />
+        }
 
+        @if (CanEdit)
+        {
             @if (_showPhotographPicker)
             {
                 <TripPhotographs Trip="Trip" ShowGallery="false" Changed="OnContentChanged" />

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
@@ -86,6 +86,7 @@
                        Trip="Trip"
                        ShowList="false"
                        UseFloatingTrigger="true"
+                       NoteStorage="NoteStorage"
                        Changed="OnContentChanged" />
         }
 

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor
@@ -28,54 +28,67 @@
                 </MudChip>
             </MudStack>
 
-            <MudStack Row="true" Spacing="3" Class="flex-wrap active-trip-facts">
+            <MudGrid Spacing="1" Class="active-trip-facts" id="active-trip-facts">
                 @if (HasPlace)
                 {
-                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="active-trip-fact">
-                        <MudIcon Icon="@Icons.Material.Filled.Place" Size="Size.Small" aria-hidden="true" />
-                        <MudText Typo="Typo.body2"
-                                 Class="active-trip-place"
-                                 id="active-trip-place">@Trip.PlaceName</MudText>
-                    </MudStack>
+                    <MudItem xs="6" Class="active-trip-fact-place">
+                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Start">
+                            <MudIcon Icon="@Icons.Material.Filled.Place" Size="Size.Small" aria-hidden="true" />
+                            <MudText Typo="Typo.body2"
+                                     Class="active-trip-place"
+                                     id="active-trip-place">@Trip.PlaceName</MudText>
+                        </MudStack>
+                    </MudItem>
                 }
                 @if (StartedLabel is not null)
                 {
-                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="active-trip-fact">
-                        <MudIcon Icon="@Icons.Material.Filled.Schedule" Size="Size.Small" aria-hidden="true" />
-                        <MudText Typo="Typo.body2" id="active-trip-started">@StartedLabel</MudText>
-                    </MudStack>
+                    <MudItem xs="@(HasPlace ? 3 : 6)" Class="active-trip-fact-started">
+                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Start">
+                            <MudIcon Icon="@Icons.Material.Filled.Schedule" Size="Size.Small" aria-hidden="true" />
+                            <MudText Typo="Typo.body2" id="active-trip-started">@StartedLabel</MudText>
+                        </MudStack>
+                    </MudItem>
                 }
                 @if (ElapsedLabel is not null)
                 {
-                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="active-trip-fact">
-                        <MudIcon Icon="@Icons.Material.Filled.Timer" Size="Size.Small" aria-hidden="true" />
-                        <MudText Typo="Typo.body2" id="active-trip-elapsed">@ElapsedLabel</MudText>
-                    </MudStack>
+                    <MudItem xs="@(HasPlace ? 3 : 6)" Class="active-trip-fact-elapsed">
+                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Start">
+                            <MudIcon Icon="@Icons.Material.Filled.Timer" Size="Size.Small" aria-hidden="true" />
+                            <MudText Typo="Typo.body2" id="active-trip-elapsed">@ElapsedLabel</MudText>
+                        </MudStack>
+                    </MudItem>
                 }
-            </MudStack>
+            </MudGrid>
         </MudStack>
 
-        <MudStack Row="true" Spacing="4" Class="flex-wrap active-trip-stats" id="active-trip-stats">
-            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                <MudIcon Icon="@Icons.Material.Filled.Grade" Size="Size.Small" Color="Color.Primary" aria-hidden="true" />
-                <MudText Typo="Typo.body2" id="active-trip-catch-count">@CatchSummary</MudText>
-            </MudStack>
-            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                <MudIcon Icon="@Icons.Material.Filled.PhotoCamera" Size="Size.Small" aria-hidden="true" />
-                <MudText Typo="Typo.body2" id="active-trip-photograph-count">@PhotographSummary</MudText>
-            </MudStack>
-            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                <MudIcon Icon="@Icons.Material.Filled.Notes" Size="Size.Small" aria-hidden="true" />
-                <MudText Typo="Typo.body2" id="active-trip-note-count">@NoteSummary</MudText>
-            </MudStack>
-        </MudStack>
+        <MudGrid Spacing="1" Class="active-trip-stats" id="active-trip-stats">
+            <MudItem xs="6" Class="active-trip-stat-catches">
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Start">
+                    <MudIcon Icon="@Icons.Material.Filled.Grade" Size="Size.Small" Color="Color.Primary" aria-hidden="true" />
+                    <MudText Typo="Typo.body2" id="active-trip-catch-count">@CatchSummary</MudText>
+                </MudStack>
+            </MudItem>
+            <MudItem xs="3" Class="active-trip-stat-photos">
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Start">
+                    <MudIcon Icon="@Icons.Material.Filled.PhotoCamera" Size="Size.Small" aria-hidden="true" />
+                    <MudText Typo="Typo.body2" id="active-trip-photograph-count">@PhotographSummary</MudText>
+                </MudStack>
+            </MudItem>
+            <MudItem xs="3" Class="active-trip-stat-notes">
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Start">
+                    <MudIcon Icon="@Icons.Material.Filled.Notes" Size="Size.Small" aria-hidden="true" />
+                    <MudText Typo="Typo.body2" id="active-trip-note-count">@NoteSummary</MudText>
+                </MudStack>
+            </MudItem>
+        </MudGrid>
 
         <TripTimeline Items="Timeline"
                       OwnerUserId="Trip.OwnerUserId"
                       TripId="Trip.Id"
                       AllowLocalMedia="AllowLocalMedia"
-                      CanDeleteNotes="CanAddNotes"
+                      CanEditNotes="CanAddNotes"
                       OnDeleteNote="DeleteNoteAsync"
+                      OnEditNote="EditNoteAsync"
                       CatchBaseHref="@CatchBaseHref"
                       WeightUnit="WeightUnit"
                       LengthUnit="LengthUnit" />
@@ -90,67 +103,96 @@
                        Changed="OnContentChanged" />
         }
 
-        @if (CanEdit)
+        @if (CanAddCatches)
         {
-            @if (_showPhotographPicker)
-            {
-                <TripPhotographs Trip="Trip" ShowGallery="false" Changed="OnContentChanged" />
-            }
-
-            @if (_showCatchPicker)
-            {
-                <TripCatches Trip="Trip"
-                             RecordCatchBaseHref="@RecordCatchBaseHref"
-                             ShowRecordAction="false"
-                             StartOpen="true"
-                             OnCatchesAttached="OnContentChanged" />
-            }
-
-            <MudStack Row="true" Spacing="2" Class="flex-wrap active-trip-actions" id="active-trip-actions">
-                <MudButton Variant="Variant.Filled"
-                           Color="Color.Primary"
-                           Href="@RecordCatchHref"
-                           StartIcon="@FishingLogBookIcons.FishingTrip"
-                           Class="active-trip-action"
-                           id="active-trip-record-catch">
-                    @Loc["Trip_RecordCatch"]
-                </MudButton>
-                <MudButton Variant="Variant.Outlined"
-                           Color="Color.Primary"
-                           StartIcon="@Icons.Material.Filled.Grade"
-                           OnClick="ToggleCatchPicker"
-                           Class="active-trip-action"
-                           id="active-trip-add-catch">
-                    @Loc["Trip_AddExistingCatch"]
-                </MudButton>
-                <MudButton Variant="Variant.Outlined"
-                           Color="Color.Primary"
-                           StartIcon="@Icons.Material.Filled.PhotoCamera"
-                           OnClick="TogglePhotographPicker"
-                           Class="active-trip-action"
-                           id="active-trip-add-photo">
-                    @Loc["Trip_AddPhotograph"]
-                </MudButton>
-                <MudButton Variant="Variant.Outlined"
-                           Color="Color.Primary"
-                           Href="@EditHref"
-                           StartIcon="@Icons.Material.Filled.Edit"
-                           Class="active-trip-action"
-                           id="active-trip-update">
-                    @Loc["Trip_Update"]
-                </MudButton>
-                <MudButton Variant="Variant.Outlined"
-                           Color="Color.Secondary"
-                           Disabled="IsFinishing"
-                           OnClick="OnFinish"
-                           StartIcon="@Icons.Material.Filled.Flag"
-                           Class="active-trip-action"
-                           id="active-trip-finish">
-                    @Loc["Trip_Finish"]
-                </MudButton>
-            </MudStack>
+            <TripCatches @ref="_catches"
+                         Trip="Trip"
+                         RecordCatchBaseHref="@RecordCatchBaseHref"
+                         CatchStorage="NoteStorage"
+                         ShowRecordAction="false"
+                         ShowAddAction="false"
+                         WeightUnit="WeightUnit"
+                         LengthUnit="LengthUnit"
+                         OnCatchesAttached="OnContentChanged" />
         }
-        else
+
+        @if (CanEdit && _showPhotographPicker)
+        {
+            <TripPhotographs Trip="Trip" ShowGallery="false" Changed="OnContentChanged" />
+        }
+
+        @if (CanEdit || CanAddCatches)
+        {
+            <MudGrid Spacing="2" Class="active-trip-actions" id="active-trip-actions">
+                @if (CanEdit)
+                {
+                    <MudItem xs="4">
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   Href="@RecordCatchHref"
+                                   StartIcon="@FishingLogBookIcons.FishingTrip"
+                                   FullWidth="true"
+                                   Class="active-trip-action"
+                                   id="active-trip-record-catch">
+                            @Loc["Trip_RecordCatch"]
+                        </MudButton>
+                    </MudItem>
+                }
+                @if (CanAddCatches)
+                {
+                    <MudItem xs="4">
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.Grade"
+                                   OnClick="AddCatchesAsync"
+                                   FullWidth="true"
+                                   Class="active-trip-action"
+                                   id="active-trip-add-catch">
+                            @Loc["Trip_AddExistingCatch"]
+                        </MudButton>
+                    </MudItem>
+                }
+                @if (CanEdit)
+                {
+                    <MudItem xs="4">
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.PhotoCamera"
+                                   OnClick="TogglePhotographPicker"
+                                   FullWidth="true"
+                                   Class="active-trip-action"
+                                   id="active-trip-add-photo">
+                            @Loc["Trip_AddPhotograph"]
+                        </MudButton>
+                    </MudItem>
+                    <MudItem xs="4">
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Primary"
+                                   Href="@EditHref"
+                                   StartIcon="@Icons.Material.Filled.Edit"
+                                   FullWidth="true"
+                                   Class="active-trip-action"
+                                   id="active-trip-update">
+                            @Loc["Trip_Update"]
+                        </MudButton>
+                    </MudItem>
+                    <MudItem xs="4">
+                        <MudButton Variant="Variant.Outlined"
+                                   Color="Color.Secondary"
+                                   Disabled="IsFinishing"
+                                   OnClick="OnFinish"
+                                   StartIcon="@Icons.Material.Filled.Flag"
+                                   FullWidth="true"
+                                   Class="active-trip-action"
+                                   id="active-trip-finish">
+                            @Loc["Trip_Finish"]
+                        </MudButton>
+                    </MudItem>
+                }
+            </MudGrid>
+        }
+
+        @if (!CanEdit)
         {
             <MudButton Variant="Variant.Outlined"
                        Color="Color.Primary"

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
+using TripCatchesComponent = FishingLogBook.Web.Features.Trips.Components.TripCatches.TripCatches;
 using TripNotesComponent = FishingLogBook.Web.Features.Trips.Components.TripNotes.TripNotes;
 
 namespace FishingLogBook.Web.Features.Trips.Components.ActiveTripView;
@@ -12,8 +13,8 @@ namespace FishingLogBook.Web.Features.Trips.Components.ActiveTripView;
 public partial class ActiveTripView : ComponentBase
 {
     private TripNotesComponent? _notes;
+    private TripCatchesComponent? _catches;
     private bool _showPhotographPicker;
-    private bool _showCatchPicker;
 
     [Parameter]
     [EditorRequired]
@@ -71,7 +72,10 @@ public partial class ActiveTripView : ComponentBase
     public bool CanAddNotes { get; set; } = true;
 
     [Parameter]
-    public TripNoteStorageEnum NoteStorage { get; set; } = TripNoteStorageEnum.LocalFirst;
+    public TripStorageEnum NoteStorage { get; set; } = TripStorageEnum.LocalFirst;
+
+    [Parameter]
+    public bool CanAddCatches { get; set; } = true;
 
     [Parameter]
     public WeightUnitEnum WeightUnit { get; set; } = WeightUnitEnum.Kg;
@@ -144,13 +148,27 @@ public partial class ActiveTripView : ComponentBase
     private void TogglePhotographPicker()
     {
         _showPhotographPicker = !_showPhotographPicker;
-        _showCatchPicker = false;
     }
 
-    private void ToggleCatchPicker()
+    private async Task AddCatchesAsync()
     {
-        _showCatchPicker = !_showCatchPicker;
+        if (_catches is null)
+        {
+            return;
+        }
+
         _showPhotographPicker = false;
+        await _catches.AddCatchesAsync();
+    }
+
+    private async Task EditNoteAsync(TripTimelineItemModel item)
+    {
+        if (_notes is null || item.NoteId is not { } noteId)
+        {
+            return;
+        }
+
+        await _notes.EditNoteAsync(noteId, item.Text ?? string.Empty, item.OccurredOn);
     }
 
     private async Task DeleteNoteAsync(Guid noteId)

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
@@ -67,6 +67,9 @@ public partial class ActiveTripView : ComponentBase
     public bool CanEdit { get; set; } = true;
 
     [Parameter]
+    public bool CanAddNotes { get; set; } = true;
+
+    [Parameter]
     public WeightUnitEnum WeightUnit { get; set; } = WeightUnitEnum.Kg;
 
     [Parameter]

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.cs
@@ -1,5 +1,6 @@
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
@@ -68,6 +69,9 @@ public partial class ActiveTripView : ComponentBase
 
     [Parameter]
     public bool CanAddNotes { get; set; } = true;
+
+    [Parameter]
+    public TripNoteStorageEnum NoteStorage { get; set; } = TripNoteStorageEnum.LocalFirst;
 
     [Parameter]
     public WeightUnitEnum WeightUnit { get; set; } = WeightUnitEnum.Kg;

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripView/ActiveTripView.razor.css
@@ -6,27 +6,29 @@
     overflow-wrap: anywhere;
 }
 
-.active-trip-facts {
-    row-gap: 0.25rem;
-}
-
-.active-trip-fact {
-    min-width: 0;
-}
-
 .active-trip-place {
     overflow-wrap: anywhere;
 }
 
-.active-trip-stats {
-    row-gap: 0.25rem;
+::deep .active-trip-facts .mud-grid-item,
+::deep .active-trip-stats .mud-grid-item,
+::deep .active-trip-actions .mud-grid-item {
+    min-width: 0;
 }
 
-.active-trip-actions {
-    row-gap: 0.5rem;
+::deep .active-trip-facts .mud-icon-root,
+::deep .active-trip-stats .mud-icon-root {
+    flex-shrink: 0;
 }
 
 ::deep .active-trip-action {
-    flex: 1 1 9rem;
+    min-width: 0;
     min-height: 2.75rem;
+    height: 100%;
+}
+
+::deep .active-trip-action .mud-button-label {
+    white-space: normal;
+    line-height: 1.15;
+    text-align: center;
 }

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripCatches/TripCatches.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripCatches/TripCatches.razor
@@ -1,59 +1,44 @@
 @namespace FishingLogBook.Web.Features.Trips.Components.TripCatches
-@using FishingLogBook.Web.Features.Catch.Components.CatchSelector
 
 <MudStack Spacing="2" id="trip-catches">
-    @if (ShowRecordAction)
+    @if (ShowRecordAction || ShowAddAction)
     {
-        <MudButton Variant="Variant.Filled"
-                   Color="Color.Primary"
-                   Size="Size.Large"
-                   FullWidth="true"
-                   Href="@RecordCatchHref"
-                   StartIcon="@Icons.Material.Filled.PhotoCamera"
-                   id="trip-catches-record">
-            @Loc["Trip_RecordCatch"]
-        </MudButton>
+        <MudGrid Spacing="2" Class="trip-catches-actions" id="trip-catches-actions">
+            @if (ShowRecordAction)
+            {
+                <MudItem xs="@(ShowAddAction ? 6 : 12)">
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               FullWidth="true"
+                               Href="@RecordCatchHref"
+                               StartIcon="@Icons.Material.Filled.PhotoCamera"
+                               id="trip-catches-record">
+                        @Loc["Trip_RecordCatch"]
+                    </MudButton>
+                </MudItem>
+            }
+
+            @if (ShowAddAction)
+            {
+                <MudItem xs="@(ShowRecordAction ? 6 : 12)">
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               FullWidth="true"
+                               StartIcon="@Icons.Material.Filled.PlaylistAdd"
+                               Disabled="_isBusy"
+                               OnClick="AddCatchesAsync"
+                               id="trip-catches-add">
+                        @Loc["Trip_AddExistingCatch"]
+                    </MudButton>
+                </MudItem>
+            }
+        </MudGrid>
     }
 
-    @if (_isOpen)
+    @if (_someWereRejected)
     {
-        <MudPaper Class="pa-3" Elevation="1" id="trip-catches-picker">
-            <MudStack Spacing="2">
-                <MudText Typo="Typo.subtitle2">@Loc["Trip_AddExistingCatchTitle"]</MudText>
-                <CatchSelector Catches="_unassigned"
-                               OwnerUserId="Trip.OwnerUserId"
-                               ConfirmLabel="@Loc["Trip_AddExistingCatchConfirm"]"
-                               EmptyLabel="@Loc["Trip_AddExistingCatchEmpty"]"
-                               UnknownSpeciesLabel="@Loc["Trip_Timeline_CatchUnknownSpecies"]"
-                               Disabled="_isSaving"
-                               OnConfirm="AttachAsync" />
-                @if (_saveFailed)
-                {
-                    <MudAlert Severity="Severity.Error" id="trip-catches-failed">
-                        @Loc["Trip_AddExistingCatchFailed"]
-                    </MudAlert>
-                }
-                <MudButton Variant="Variant.Text"
-                           Color="Color.Default"
-                           Size="Size.Small"
-                           Disabled="_isSaving"
-                           OnClick="Close"
-                           id="trip-catches-cancel">
-                    @Loc["Modal_Cancel"]
-                </MudButton>
-            </MudStack>
-        </MudPaper>
-    }
-    else if (ShowAddAction)
-    {
-        <MudButton Variant="Variant.Outlined"
-                   Color="Color.Primary"
-                   Size="Size.Large"
-                   FullWidth="true"
-                   StartIcon="@Icons.Material.Filled.PlaylistAdd"
-                   OnClick="OpenAsync"
-                   id="trip-catches-add">
-            @Loc["Trip_AddExistingCatch"]
-        </MudButton>
+        <MudAlert Severity="Severity.Warning" id="trip-catches-partial">
+            @Loc["Trip_AddCatchesRejected"]
+        </MudAlert>
     }
 </MudStack>

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripCatches/TripCatches.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripCatches/TripCatches.razor.cs
@@ -1,6 +1,7 @@
-using FishingLogBook.Web.Features.Catch.Models;
-using FishingLogBook.Web.Features.Catch.Offline.Stores;
-using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
@@ -12,10 +13,8 @@ public partial class TripCatches : ComponentBase, IDisposable
 {
     private readonly CancellationTokenSource _cancellationTokenSource = new();
 
-    private IReadOnlyList<CatchModel> _unassigned = [];
-    private bool _isOpen;
-    private bool _isSaving;
-    private bool _saveFailed;
+    private bool _isBusy;
+    private bool _someWereRejected;
 
     [Parameter]
     [EditorRequired]
@@ -34,106 +33,56 @@ public partial class TripCatches : ComponentBase, IDisposable
     public bool ShowAddAction { get; set; } = true;
 
     [Parameter]
-    public bool StartOpen { get; set; }
+    public TripStorageEnum CatchStorage { get; set; } = TripStorageEnum.LocalFirst;
+
+    [Parameter]
+    public WeightUnitEnum WeightUnit { get; set; } = WeightUnitEnum.Kg;
+
+    [Parameter]
+    public LengthUnitEnum LengthUnit { get; set; } = LengthUnitEnum.Cm;
 
     [Inject]
-    private ICatchStore CatchStore { get; set; } = default!;
-
-    [Inject]
-    private ILoggingService Logging { get; set; } = default!;
+    private IModalService ModalService { get; set; } = default!;
 
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     private string RecordCatchHref => $"{RecordCatchBaseHref}?tripId={Trip.Id:D}";
 
-    protected override async Task OnInitializedAsync()
+    public async Task AddCatchesAsync()
     {
-        if (StartOpen)
-        {
-            await OpenAsync();
-        }
-    }
-
-    private async Task OpenAsync()
-    {
-        _isOpen = true;
-        _saveFailed = false;
-        await LoadUnassignedAsync();
-    }
-
-    private void Close()
-    {
-        _isOpen = false;
-        _unassigned = [];
-        _saveFailed = false;
-    }
-
-    private async Task LoadUnassignedAsync()
-    {
-        try
-        {
-            var catches = await CatchStore.GetMetadataAsync(
-                Trip.OwnerUserId,
-                _cancellationTokenSource.Token);
-            _unassigned =
-            [
-                .. catches
-                    .Where(catchRecord => catchRecord.TripId is null)
-                    .OrderByDescending(catchRecord => catchRecord.CaughtOn)
-            ];
-        }
-        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
-        {
-        }
-        catch (Exception exception)
-        {
-            _unassigned = [];
-            _saveFailed = true;
-            await Logging.LogErrorAsync(
-                "reading catches that are not on a trip",
-                exception,
-                CancellationToken.None);
-        }
-    }
-
-    private async Task AttachAsync(IReadOnlyList<Guid> catchIds)
-    {
-        if (catchIds.Count == 0 || _isSaving)
+        if (_isBusy)
         {
             return;
         }
 
-        _isSaving = true;
-        _saveFailed = false;
+        _isBusy = true;
+        _someWereRejected = false;
         try
         {
-            foreach (var catchId in catchIds)
-            {
-                await CatchStore.UpdateTripAsync(
-                    Trip.OwnerUserId,
-                    catchId,
-                    Trip.Id,
+            var added = await ModalService
+                .ShowAsync<AddTripCatchesModal, AddTripCatchesModalModel, AddTripCatchesModalResult>(
+                    new AddTripCatchesModalModel(
+                        new TripCatchScopeModel(
+                            Trip.Id,
+                            Trip.OwnerUserId,
+                            Trip.StartedOn,
+                            Trip.EndedOn),
+                        CatchStorage,
+                        WeightUnit,
+                        LengthUnit),
                     _cancellationTokenSource.Token);
+            if (added is null || added.AssociatedCatchIds.Count == 0)
+            {
+                return;
             }
 
-            Close();
-            if (OnCatchesAttached.HasDelegate)
-            {
-                await OnCatchesAttached.InvokeAsync();
-            }
-        }
-        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
-        {
-        }
-        catch (Exception exception)
-        {
-            _saveFailed = true;
-            await Logging.LogErrorAsync("adding catches to a trip", exception, CancellationToken.None);
+            _someWereRejected = added.RejectedCatchIds.Count > 0;
+            await OnCatchesAttached.InvokeAsync();
         }
         finally
         {
-            _isSaving = false;
+            _isBusy = false;
         }
     }
 

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripCatches/TripCatches.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripCatches/TripCatches.razor.css
@@ -1,3 +1,7 @@
 #trip-catches {
     min-width: 0;
 }
+
+::deep .trip-catches-actions .mud-grid-item {
+    min-width: 0;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripEditor/TripEditor.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripEditor/TripEditor.razor
@@ -79,6 +79,8 @@
 
             <TripCatches Trip="Trip"
                          RecordCatchBaseHref="@RecordCatchBaseHref"
+                         WeightUnit="WeightUnit"
+                         LengthUnit="LengthUnit"
                          OnCatchesAttached="OnContentChanged" />
         </MudStack>
 

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor
@@ -32,37 +32,7 @@
         </MudStack>
     }
 
-    @if (_isWriting)
-    {
-        <MudStack Spacing="2" id="trip-note-editor">
-            <MudTextField T="string"
-                          Value="_text"
-                          ValueChanged="OnTextChanged"
-                          Label="@Loc["Trip_NotePrompt"]"
-                          Placeholder="@Loc["Trip_NotePlaceholder"]"
-                          Lines="3"
-                          Immediate="true"
-                          MaxLength="MaxNoteLength"
-                          Variant="Variant.Outlined"
-                          id="trip-note-text" />
-            <MudStack Row="true" Spacing="2">
-                <MudButton Variant="Variant.Filled"
-                           Color="Color.Primary"
-                           Disabled="@(!CanSave)"
-                           OnClick="AddNoteAsync"
-                           id="trip-note-save">
-                    @Loc["Trip_NoteAdd"]
-                </MudButton>
-                <MudButton Variant="Variant.Text"
-                           Color="Color.Default"
-                           OnClick="CancelWriting"
-                           id="trip-note-cancel">
-                    @Loc["Modal_Cancel"]
-                </MudButton>
-            </MudStack>
-        </MudStack>
-    }
-    else if (UseFloatingTrigger)
+    @if (UseFloatingTrigger)
     {
         <MudStack Row="true" Justify="Justify.FlexEnd" Class="trip-note-floating">
             <MudFab Color="Color.Primary"
@@ -70,7 +40,7 @@
                     StartIcon="@Icons.Material.Filled.EditNote"
                     aria-label="@Loc["Trip_NoteAdd"]"
                     Title="@Loc["Trip_NoteAdd"]"
-                    OnClick="StartWriting"
+                    OnClick="AddNoteAsync"
                     id="trip-note-start" />
         </MudStack>
     }
@@ -80,17 +50,10 @@
                    Color="Color.Primary"
                    FullWidth="true"
                    StartIcon="@Icons.Material.Filled.EditNote"
-                   OnClick="StartWriting"
+                   OnClick="AddNoteAsync"
                    id="trip-note-start">
             @Loc["Trip_NoteAdd"]
         </MudButton>
-    }
-
-    @if (_addFailed)
-    {
-        <MudAlert Severity="Severity.Error" id="trip-note-add-failed">
-            @Loc["Trip_NoteAddFailed"]
-        </MudAlert>
     }
 
     @if (_removeFailed)

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.cs
@@ -2,10 +2,11 @@ using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Diagnostics.Services;
-using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -32,11 +33,14 @@ public partial class TripNotes : ComponentBase, IDisposable
     [Parameter]
     public bool UseFloatingTrigger { get; set; }
 
+    [Parameter]
+    public TripNoteStorageEnum NoteStorage { get; set; } = TripNoteStorageEnum.LocalFirst;
+
     [Inject]
     private ITripNoteStore NoteStore { get; set; } = default!;
 
     [Inject]
-    private ITripClient TripClient { get; set; } = default!;
+    private ITripNoteWriteService NoteWriter { get; set; } = default!;
 
     [Inject]
     private IModalService ModalService { get; set; } = default!;
@@ -68,7 +72,9 @@ public partial class TripNotes : ComponentBase, IDisposable
 
     private async Task<IReadOnlyList<TripNoteModel>> ReadStoredNotesAsync()
     {
-        if (Trip.OwnerUserId == Guid.Empty || Trip.Id == Guid.Empty)
+        if (NoteStorage == TripNoteStorageEnum.Server
+            || Trip.OwnerUserId == Guid.Empty
+            || Trip.Id == Guid.Empty)
         {
             return Trip.Notes ?? [];
         }
@@ -101,7 +107,12 @@ public partial class TripNotes : ComponentBase, IDisposable
         _removeFailed = false;
         var added = await ModalService
             .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
-                new AddTripNoteModalModel(Trip.Id, Trip.OwnerUserId, Trip.StartedOn),
+                new AddTripNoteModalModel(
+                    Trip.Id,
+                    Trip.OwnerUserId,
+                    Trip.StartedOn,
+                    Trip.EndedOn,
+                    NoteStorage),
                 _cancellationTokenSource.Token);
         if (added is null)
         {
@@ -124,7 +135,7 @@ public partial class TripNotes : ComponentBase, IDisposable
     {
         _removeFailed = false;
         var note = _notes.FirstOrDefault(candidate => candidate.Id == noteId);
-        if (note is null)
+        if (note is null && NoteStorage != TripNoteStorageEnum.Server)
         {
             return;
         }
@@ -144,17 +155,19 @@ public partial class TripNotes : ComponentBase, IDisposable
 
         try
         {
-            if (note.SyncStatus == SyncStatus.Synchronised)
+            await NoteWriter.RemoveAsync(
+                new TripNoteRemovalModel(
+                    Trip.Id,
+                    Trip.OwnerUserId,
+                    noteId,
+                    note?.SyncStatus ?? SyncStatus.Synchronised),
+                NoteStorage,
+                _cancellationTokenSource.Token);
+            if (note is not null)
             {
-                await TripClient.DeleteNoteAsync(Trip.Id, noteId, _cancellationTokenSource.Token);
+                _notes.Remove(note);
             }
 
-            await NoteStore.DeleteAsync(
-                Trip.OwnerUserId,
-                Trip.Id,
-                noteId,
-                _cancellationTokenSource.Token);
-            _notes.Remove(note);
             _localTimes.Remove(noteId);
             await Changed.InvokeAsync();
         }

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.cs
@@ -34,7 +34,7 @@ public partial class TripNotes : ComponentBase, IDisposable
     public bool UseFloatingTrigger { get; set; }
 
     [Parameter]
-    public TripNoteStorageEnum NoteStorage { get; set; } = TripNoteStorageEnum.LocalFirst;
+    public TripStorageEnum NoteStorage { get; set; } = TripStorageEnum.LocalFirst;
 
     [Inject]
     private ITripNoteStore NoteStore { get; set; } = default!;
@@ -72,7 +72,7 @@ public partial class TripNotes : ComponentBase, IDisposable
 
     private async Task<IReadOnlyList<TripNoteModel>> ReadStoredNotesAsync()
     {
-        if (NoteStorage == TripNoteStorageEnum.Server
+        if (NoteStorage == TripStorageEnum.Server
             || Trip.OwnerUserId == Guid.Empty
             || Trip.Id == Guid.Empty)
         {
@@ -125,6 +125,39 @@ public partial class TripNotes : ComponentBase, IDisposable
         await Changed.InvokeAsync();
     }
 
+    public async Task EditNoteAsync(Guid noteId, string text, DateTimeOffset recordedOn)
+    {
+        _removeFailed = false;
+        var existing = _notes.FirstOrDefault(candidate => candidate.Id == noteId)
+            ?? new TripNoteModel(
+                noteId,
+                Trip.Id,
+                Trip.OwnerUserId,
+                text,
+                recordedOn,
+                SyncStatus.Synchronised);
+        var edited = await ModalService
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                new AddTripNoteModalModel(
+                    Trip.Id,
+                    Trip.OwnerUserId,
+                    Trip.StartedOn,
+                    Trip.EndedOn,
+                    NoteStorage,
+                    existing),
+                _cancellationTokenSource.Token);
+        if (edited is null)
+        {
+            return;
+        }
+
+        _notes.RemoveAll(candidate => candidate.Id == edited.Note.Id);
+        _notes.Add(edited.Note);
+        _notes.Sort(Chronologically);
+        await RememberLocalTimeAsync(edited.Note);
+        await Changed.InvokeAsync();
+    }
+
     private static int Chronologically(TripNoteModel left, TripNoteModel right)
     {
         var byRecordedOn = left.RecordedOn.CompareTo(right.RecordedOn);
@@ -135,7 +168,7 @@ public partial class TripNotes : ComponentBase, IDisposable
     {
         _removeFailed = false;
         var note = _notes.FirstOrDefault(candidate => candidate.Id == noteId);
-        if (note is null && NoteStorage != TripNoteStorageEnum.Server)
+        if (note is null && NoteStorage != TripStorageEnum.Server)
         {
             return;
         }

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripNotes/TripNotes.razor.cs
@@ -1,9 +1,9 @@
-using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Features.Trips.Offline.Stores;
 using FishingLogBook.Web.Localization;
@@ -14,14 +14,9 @@ namespace FishingLogBook.Web.Features.Trips.Components.TripNotes;
 
 public partial class TripNotes : ComponentBase, IDisposable
 {
-    private const int MaxNoteLength = TripConstants.MaxNoteTextLength;
-
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly List<TripNoteModel> _notes = [];
     private readonly Dictionary<Guid, string> _localTimes = [];
-    private string _text = string.Empty;
-    private bool _isWriting;
-    private bool _addFailed;
     private bool _removeFailed;
 
     [Parameter]
@@ -54,8 +49,6 @@ public partial class TripNotes : ComponentBase, IDisposable
 
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
-
-    private bool CanSave => TripConstants.IsNoteTextValid(_text);
 
     protected override async Task OnInitializedAsync()
     {
@@ -103,62 +96,28 @@ public partial class TripNotes : ComponentBase, IDisposable
         return _localTimes.TryGetValue(noteId, out var value) ? value : string.Empty;
     }
 
-    private void StartWriting()
-    {
-        _isWriting = true;
-        _addFailed = false;
-        _removeFailed = false;
-    }
-
-    private void CancelWriting()
-    {
-        _isWriting = false;
-        _text = string.Empty;
-        _addFailed = false;
-    }
-
-    private void OnTextChanged(string? value)
-    {
-        _text = value ?? string.Empty;
-    }
-
     private async Task AddNoteAsync()
     {
-        if (!CanSave)
+        _removeFailed = false;
+        var added = await ModalService
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                new AddTripNoteModalModel(Trip.Id, Trip.OwnerUserId, Trip.StartedOn),
+                _cancellationTokenSource.Token);
+        if (added is null)
         {
             return;
         }
 
-        _addFailed = false;
-        var text = TripConstants.TrimNoteText(_text);
-        if (text is null)
-        {
-            return;
-        }
+        _notes.Add(added.Note);
+        _notes.Sort(Chronologically);
+        await RememberLocalTimeAsync(added.Note);
+        await Changed.InvokeAsync();
+    }
 
-        var note = new TripNoteModel(
-            Guid.NewGuid(),
-            Trip.Id,
-            Trip.OwnerUserId,
-            text,
-            DateTimeOffset.UtcNow);
-        try
-        {
-            await NoteStore.SaveAsync(note, _cancellationTokenSource.Token);
-            _notes.Add(note);
-            await RememberLocalTimeAsync(note);
-            _text = string.Empty;
-            _isWriting = false;
-            await Changed.InvokeAsync();
-        }
-        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
-        {
-        }
-        catch (Exception exception)
-        {
-            await Logging.LogErrorAsync("adding a trip note", exception, CancellationToken.None);
-            _addFailed = true;
-        }
+    private static int Chronologically(TripNoteModel left, TripNoteModel right)
+    {
+        var byRecordedOn = left.RecordedOn.CompareTo(right.RecordedOn);
+        return byRecordedOn != 0 ? byRecordedOn : left.Id.CompareTo(right.Id);
     }
 
     public async Task RemoveNoteAsync(Guid noteId)

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripTimeline/TripTimeline.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripTimeline/TripTimeline.razor
@@ -88,15 +88,26 @@ else
                                           Class="trip-timeline-note">
                                     <MudText Typo="Typo.body2"
                                              Class="trip-timeline-note-text">@item.Text</MudText>
-                                    @if (CanDeleteNotes && item.NoteId is { } noteId)
+                                    @if (CanEditNotes && item.NoteId is { } noteId)
                                     {
-                                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                                       Size="Size.Small"
-                                                       Color="Color.Inherit"
-                                                       Class="trip-timeline-note-remove"
-                                                       aria-label="@Loc["Trip_NoteRemove"]"
-                                                       OnClick="@(() => OnDeleteNote.InvokeAsync(noteId))"
-                                                       id="@($"trip-timeline-note-remove-{noteId:D}")" />
+                                        <MudStack Row="true" Spacing="0" Class="trip-timeline-note-actions">
+                                            <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                                           Size="Size.Small"
+                                                           Color="Color.Inherit"
+                                                           Class="trip-timeline-note-action"
+                                                           aria-label="@Loc["Trip_NoteEdit"]"
+                                                           title="@Loc["Trip_NoteEdit"]"
+                                                           OnClick="@(() => OnEditNote.InvokeAsync(item))"
+                                                           id="@($"trip-timeline-note-edit-{noteId:D}")" />
+                                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                           Size="Size.Small"
+                                                           Color="Color.Inherit"
+                                                           Class="trip-timeline-note-action trip-timeline-note-remove"
+                                                           aria-label="@Loc["Trip_NoteRemove"]"
+                                                           title="@Loc["Trip_NoteRemove"]"
+                                                           OnClick="@(() => OnDeleteNote.InvokeAsync(noteId))"
+                                                           id="@($"trip-timeline-note-remove-{noteId:D}")" />
+                                        </MudStack>
                                     }
                                 </MudStack>
 

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripTimeline/TripTimeline.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripTimeline/TripTimeline.razor.cs
@@ -35,10 +35,13 @@ public partial class TripTimeline : ComponentBase, IDisposable
     public bool AllowLocalMedia { get; set; } = true;
 
     [Parameter]
-    public bool CanDeleteNotes { get; set; }
+    public bool CanEditNotes { get; set; }
 
     [Parameter]
     public EventCallback<Guid> OnDeleteNote { get; set; }
+
+    [Parameter]
+    public EventCallback<TripTimelineItemModel> OnEditNote { get; set; }
 
     [Parameter]
     public string CatchBaseHref { get; set; } = "/catches";

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripTimeline/TripTimeline.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripTimeline/TripTimeline.razor.css
@@ -70,7 +70,11 @@
     min-width: 0;
 }
 
-::deep .trip-timeline-note-remove {
+.trip-timeline-note-actions {
+    flex: 0 0 auto;
+}
+
+::deep .trip-timeline-note-action {
     flex: 0 0 auto;
     opacity: 0.7;
 }

--- a/src/FishingLogBook.Web/Features/Trips/Enums/TripNoteStorageEnum.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Enums/TripNoteStorageEnum.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Web.Features.Trips.Enums;
+
+public enum TripNoteStorageEnum
+{
+    LocalFirst = 0,
+    Server = 1
+}

--- a/src/FishingLogBook.Web/Features/Trips/Enums/TripStorageEnum.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Enums/TripStorageEnum.cs
@@ -1,6 +1,6 @@
 namespace FishingLogBook.Web.Features.Trips.Enums;
 
-public enum TripNoteStorageEnum
+public enum TripStorageEnum
 {
     LocalFirst = 0,
     Server = 1

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripCatches/AddTripCatchesModal.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripCatches/AddTripCatchesModal.razor
@@ -1,0 +1,80 @@
+@namespace FishingLogBook.Web.Features.Trips.Modals.AddTripCatches
+@using FishingLogBook.Web.Features.Catch.Components.CatchSelector
+
+<MudDialog id="trip-catches-modal">
+    <TitleContent>
+        <MudText Typo="Typo.h6" id="trip-catches-modal-title">@Loc["Trip_AddCatchesTitle"]</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="3" AlignItems="AlignItems.Stretch">
+            @if (_isLoading)
+            {
+                <MudProgressCircular Indeterminate="true"
+                                     Color="Color.Primary"
+                                     Class="align-self-center"
+                                     id="trip-catches-loading" />
+            }
+            else if (_loadFailed)
+            {
+                <MudAlert Severity="Severity.Error" id="trip-catches-load-failed">
+                    @Loc["Trip_AddCatchesLoadFailed"]
+                </MudAlert>
+            }
+            else if (_candidates.Count == 0)
+            {
+                <MudStack Spacing="1" AlignItems="AlignItems.Center" id="trip-catches-empty">
+                    <MudIcon Icon="@Icons.Material.Filled.Grade" Color="Color.Default" aria-hidden="true" />
+                    <MudText Typo="Typo.subtitle1">@Loc["Trip_AddCatchesEmpty"]</MudText>
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary">
+                        @Loc["Trip_AddCatchesEmptyHint"]
+                    </MudText>
+                </MudStack>
+            }
+            else
+            {
+                <MudText Typo="Typo.body2" Class="mud-text-secondary" id="trip-catches-subtitle">
+                    @Loc["Trip_AddCatchesSubtitle"]
+                </MudText>
+                <CatchSelector Catches="_candidates"
+                               OwnerUserId="Model.Scope.OwnerUserId"
+                               UnknownSpeciesLabel="@Loc["Trip_Timeline_CatchUnknownSpecies"]"
+                               WeightUnit="Model.WeightUnit"
+                               LengthUnit="Model.LengthUnit"
+                               Disabled="_isSaving"
+                               SelectedChanged="OnSelectionChanged" />
+            }
+
+            @if (_rejected)
+            {
+                <MudAlert Severity="Severity.Warning" id="trip-catches-rejected">
+                    @Loc["Trip_AddCatchesRejected"]
+                </MudAlert>
+            }
+
+            @if (_saveFailedMessage is not null)
+            {
+                <MudAlert Severity="Severity.Error" id="trip-catches-failed">
+                    @_saveFailedMessage
+                </MudAlert>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text"
+                   Color="Color.Default"
+                   OnClick="Cancel"
+                   id="trip-catches-cancel">
+            @Loc["Modal_Cancel"]
+        </MudButton>
+        @if (!_isLoading && !_loadFailed && _candidates.Count > 0)
+        {
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       Disabled="@(_isSaving || _selected.Count == 0)"
+                       OnClick="SaveAsync"
+                       id="trip-catches-confirm">
+                @ConfirmLabel
+            </MudButton>
+        }
+    </DialogActions>
+</MudDialog>

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripCatches/AddTripCatchesModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripCatches/AddTripCatchesModal.razor.cs
@@ -1,0 +1,152 @@
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+
+namespace FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
+
+public partial class AddTripCatchesModal : ComponentBase, IDisposable
+{
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    private IReadOnlyList<CatchModel> _candidates = [];
+    private IReadOnlyList<Guid> _selected = [];
+    private string? _saveFailedMessage;
+    private bool _isLoading = true;
+    private bool _isSaving;
+    private bool _loadFailed;
+    private bool _rejected;
+
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter]
+    public AddTripCatchesModalModel Model { get; set; } = default!;
+
+    [Inject]
+    private ITripCatchService TripCatches { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private string ConfirmLabel => _selected.Count == 1
+        ? Loc["Trip_AddCatchesConfirmOne"]
+        : Loc["Trip_AddCatchesConfirmMany", _selected.Count];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _loadFailed = false;
+        try
+        {
+            _candidates = await TripCatches.GetEligibleAsync(
+                Model.Scope,
+                Model.Storage,
+                _cancellationTokenSource.Token);
+            _selected = [];
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            _candidates = [];
+            _loadFailed = true;
+            await Logging.LogErrorAsync(
+                "reading the catches that can join a trip",
+                exception,
+                CancellationToken.None);
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private void OnSelectionChanged(IReadOnlyList<Guid> selected)
+    {
+        _selected = selected;
+        _saveFailedMessage = null;
+        _rejected = false;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (_isSaving || _selected.Count == 0)
+        {
+            return;
+        }
+
+        _isSaving = true;
+        _saveFailedMessage = null;
+        _rejected = false;
+        try
+        {
+            var association = await TripCatches.AssociateAsync(
+                Model.Scope,
+                _selected,
+                Model.Storage,
+                _cancellationTokenSource.Token);
+            if (association.AssociatedCatchIds.Count == 0)
+            {
+                _rejected = true;
+                await LoadAsync();
+                return;
+            }
+
+            MudDialog.Close(DialogResult.Ok(new AddTripCatchesModalResult(
+                association.AssociatedCatchIds,
+                association.RejectedCatchIds)));
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (HttpRequestException exception)
+        {
+            await FailAsync(exception, exception.StatusCode is null);
+        }
+        catch (TaskCanceledException exception)
+        {
+            await FailAsync(exception, unreachable: true);
+        }
+        catch (Exception exception)
+        {
+            await FailAsync(exception, unreachable: false);
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task FailAsync(Exception exception, bool unreachable)
+    {
+        await Logging.LogErrorAsync("adding catches to a trip", exception, CancellationToken.None);
+        _saveFailedMessage = unreachable && Model.Storage == TripStorageEnum.Server
+            ? Loc["Trip_AddCatchesOnlineRequired"].Value
+            : Loc["Trip_AddCatchesFailed"].Value;
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripCatches/AddTripCatchesModalModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripCatches/AddTripCatchesModalModel.cs
@@ -1,0 +1,11 @@
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
+
+public sealed record AddTripCatchesModalModel(
+    TripCatchScopeModel Scope,
+    TripStorageEnum Storage = TripStorageEnum.LocalFirst,
+    WeightUnitEnum WeightUnit = WeightUnitEnum.Kg,
+    LengthUnitEnum LengthUnit = LengthUnitEnum.Cm);

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripCatches/AddTripCatchesModalResult.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripCatches/AddTripCatchesModalResult.cs
@@ -1,0 +1,5 @@
+namespace FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
+
+public sealed record AddTripCatchesModalResult(
+    IReadOnlyList<Guid> AssociatedCatchIds,
+    IReadOnlyList<Guid> RejectedCatchIds);

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor
@@ -7,13 +7,23 @@
     <DialogContent>
         <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
             <MudTextField T="string"
-                          Value="_recordedOnLocal"
-                          ValueChanged="OnRecordedOnChanged"
-                          Label="@Loc["Trip_NoteRecordedOn"]"
+                          Value="_dateLocal"
+                          ValueChanged="OnDateChanged"
+                          Label="@Loc["Trip_NoteDateLabel"]"
+                          Immediate="true"
+                          InputType="InputType.Date"
+                          min="@EarliestDate"
+                          max="@LatestDate"
+                          id="trip-note-date" />
+
+            <MudTextField T="string"
+                          Value="_timeLocal"
+                          ValueChanged="OnTimeChanged"
+                          Label="@Loc["Trip_NoteTimeLabel"]"
                           HelperText="@Loc["Trip_NoteRecordedOnHelp"]"
                           Immediate="true"
-                          InputType="InputType.DateTimeLocal"
-                          id="trip-note-recorded-on" />
+                          InputType="InputType.Time"
+                          id="trip-note-time" />
 
             <MudTextField T="string"
                           Value="_text"
@@ -26,17 +36,17 @@
                           Variant="Variant.Outlined"
                           id="trip-note-text" />
 
-            @if (_recordedOnInvalid)
+            @if (_validationMessage is not null)
             {
                 <MudAlert Severity="Severity.Error" id="trip-note-recorded-on-invalid">
-                    @Loc["Trip_NoteRecordedOnInvalid"]
+                    @_validationMessage
                 </MudAlert>
             }
 
-            @if (_saveFailed)
+            @if (_saveFailedMessage is not null)
             {
                 <MudAlert Severity="Severity.Error" id="trip-note-add-failed">
-                    @Loc["Trip_NoteAddFailed"]
+                    @_saveFailedMessage
                 </MudAlert>
             }
         </MudStack>

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor
@@ -2,7 +2,7 @@
 
 <MudDialog id="trip-note-modal">
     <TitleContent>
-        <MudText Typo="Typo.h6" id="trip-note-modal-title">@Loc["Trip_NoteAdd"]</MudText>
+        <MudText Typo="Typo.h6" id="trip-note-modal-title">@Title</MudText>
     </TitleContent>
     <DialogContent>
         <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
@@ -63,7 +63,7 @@
                    Disabled="@(!CanSave)"
                    OnClick="SaveAsync"
                    id="trip-note-save">
-            @Loc["Trip_NoteAdd"]
+            @SaveLabel
         </MudButton>
     </DialogActions>
 </MudDialog>

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor
@@ -1,0 +1,59 @@
+@namespace FishingLogBook.Web.Features.Trips.Modals.AddTripNote
+
+<MudDialog id="trip-note-modal">
+    <TitleContent>
+        <MudText Typo="Typo.h6" id="trip-note-modal-title">@Loc["Trip_NoteAdd"]</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
+            <MudTextField T="string"
+                          Value="_recordedOnLocal"
+                          ValueChanged="OnRecordedOnChanged"
+                          Label="@Loc["Trip_NoteRecordedOn"]"
+                          HelperText="@Loc["Trip_NoteRecordedOnHelp"]"
+                          Immediate="true"
+                          InputType="InputType.DateTimeLocal"
+                          id="trip-note-recorded-on" />
+
+            <MudTextField T="string"
+                          Value="_text"
+                          ValueChanged="OnTextChanged"
+                          Label="@Loc["Trip_NotePrompt"]"
+                          Placeholder="@Loc["Trip_NotePlaceholder"]"
+                          Lines="3"
+                          Immediate="true"
+                          MaxLength="MaxNoteLength"
+                          Variant="Variant.Outlined"
+                          id="trip-note-text" />
+
+            @if (_recordedOnInvalid)
+            {
+                <MudAlert Severity="Severity.Error" id="trip-note-recorded-on-invalid">
+                    @Loc["Trip_NoteRecordedOnInvalid"]
+                </MudAlert>
+            }
+
+            @if (_saveFailed)
+            {
+                <MudAlert Severity="Severity.Error" id="trip-note-add-failed">
+                    @Loc["Trip_NoteAddFailed"]
+                </MudAlert>
+            }
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text"
+                   Color="Color.Default"
+                   OnClick="Cancel"
+                   id="trip-note-cancel">
+            @Loc["Modal_Cancel"]
+        </MudButton>
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   Disabled="@(!CanSave)"
+                   OnClick="SaveAsync"
+                   id="trip-note-save">
+            @Loc["Trip_NoteAdd"]
+        </MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor.cs
@@ -1,0 +1,188 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using MudBlazor;
+
+namespace FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
+
+public partial class AddTripNoteModal : ComponentBase, IDisposable
+{
+    private const int MaxNoteLength = TripConstants.MaxNoteTextLength;
+    private const int LocalValueLength = 16;
+    private const int TimePartIndex = 11;
+
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private string _recordedOnLocal = string.Empty;
+    private string _text = string.Empty;
+    private bool _isSaving;
+    private bool _recordedOnInvalid;
+    private bool _saveFailed;
+
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter]
+    public AddTripNoteModalModel Model { get; set; } = default!;
+
+    [Inject]
+    private ITripNoteStore NoteStore { get; set; } = default!;
+
+    [Inject]
+    private ITimeService Time { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool CanSave => !_isSaving && TripConstants.IsNoteTextValid(_text);
+
+    protected override async Task OnInitializedAsync()
+    {
+        _recordedOnLocal = await ResolveDefaultRecordedOnAsync();
+    }
+
+    private async Task<string> ResolveDefaultRecordedOnAsync()
+    {
+        try
+        {
+            var tripLocal = await Time.ToDateTimeLocalValueAsync(
+                Model.TripStartedOn,
+                _cancellationTokenSource.Token);
+            var nowLocal = await Time.ToDateTimeLocalValueAsync(
+                DateTimeOffset.UtcNow,
+                _cancellationTokenSource.Token);
+            return OnTripDate(tripLocal, nowLocal);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "reading a trip note time",
+                exception,
+                CancellationToken.None);
+            return string.Empty;
+        }
+    }
+
+    private static string OnTripDate(string tripLocal, string nowLocal)
+    {
+        if (tripLocal.Length < LocalValueLength || nowLocal.Length < LocalValueLength)
+        {
+            return nowLocal;
+        }
+
+        var candidate = string.Concat(
+            tripLocal.AsSpan(0, TimePartIndex),
+            nowLocal.AsSpan(TimePartIndex, LocalValueLength - TimePartIndex));
+        return string.CompareOrdinal(candidate, tripLocal) < 0 ? tripLocal : candidate;
+    }
+
+    private void OnRecordedOnChanged(string? value)
+    {
+        _recordedOnLocal = value ?? string.Empty;
+        _recordedOnInvalid = false;
+        _saveFailed = false;
+    }
+
+    private void OnTextChanged(string? value)
+    {
+        _text = value ?? string.Empty;
+        _saveFailed = false;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (!CanSave)
+        {
+            return;
+        }
+
+        _recordedOnInvalid = false;
+        _saveFailed = false;
+        var text = TripConstants.TrimNoteText(_text);
+        if (text is null)
+        {
+            return;
+        }
+
+        var recordedOn = await ResolveRecordedOnAsync();
+        if (recordedOn is null)
+        {
+            _recordedOnInvalid = true;
+            return;
+        }
+
+        var note = new TripNoteModel(
+            Guid.NewGuid(),
+            Model.TripId,
+            Model.OwnerUserId,
+            text,
+            recordedOn.Value);
+        _isSaving = true;
+        try
+        {
+            await NoteStore.SaveAsync(note, _cancellationTokenSource.Token);
+            MudDialog.Close(DialogResult.Ok(new AddTripNoteModalResult(note)));
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("adding a trip note", exception, CancellationToken.None);
+            _saveFailed = true;
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task<DateTimeOffset?> ResolveRecordedOnAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_recordedOnLocal))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await Time.FromDateTimeLocalValueAsync(
+                _recordedOnLocal,
+                _cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return null;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "reading a trip note time",
+                exception,
+                CancellationToken.None);
+            return null;
+        }
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor.cs
@@ -56,6 +56,12 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
 
     private DateTimeOffset Ceiling => Model.TripEndedOn ?? DateTimeOffset.UtcNow;
 
+    private bool IsEditing => Model.ExistingNote is not null;
+
+    private string Title => IsEditing ? Loc["Trip_NoteEdit"] : Loc["Trip_NoteAdd"];
+
+    private string SaveLabel => IsEditing ? Loc["Modal_Save"] : Loc["Trip_NoteAdd"];
+
     private bool CanSave =>
         !_isSaving
         && TripConstants.IsNoteTextValid(_text)
@@ -69,11 +75,17 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
         var initial = await InitialLocalValueAsync();
         _dateLocal = DatePartOf(initial);
         _timeLocal = TimePartOf(initial);
+        _text = Model.ExistingNote?.Text ?? string.Empty;
         await ValidateAsync();
     }
 
     private async Task<string> InitialLocalValueAsync()
     {
+        if (Model.ExistingNote is { } existing)
+        {
+            return await LocalValueAsync(existing.RecordedOn);
+        }
+
         if (Model.TripEndedOn is not null)
         {
             return _latestLocal;
@@ -168,10 +180,7 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
         _isSaving = true;
         try
         {
-            var note = await NoteWriter.AddAsync(
-                new TripNoteDraftModel(Model.TripId, Model.OwnerUserId, text, recordedOn),
-                Model.Storage,
-                _cancellationTokenSource.Token);
+            var note = await PersistAsync(text, recordedOn);
             MudDialog.Close(DialogResult.Ok(new AddTripNoteModalResult(note)));
         }
         catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
@@ -195,10 +204,26 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
         }
     }
 
+    private async Task<TripNoteModel> PersistAsync(string text, DateTimeOffset recordedOn)
+    {
+        if (Model.ExistingNote is { } existing)
+        {
+            return await NoteWriter.UpdateAsync(
+                existing with { Text = text, RecordedOn = recordedOn },
+                Model.Storage,
+                _cancellationTokenSource.Token);
+        }
+
+        return await NoteWriter.AddAsync(
+            new TripNoteDraftModel(Model.TripId, Model.OwnerUserId, text, recordedOn),
+            Model.Storage,
+            _cancellationTokenSource.Token);
+    }
+
     private async Task FailAsync(Exception exception, bool unreachable)
     {
-        await Logging.LogErrorAsync("adding a trip note", exception, CancellationToken.None);
-        _saveFailedMessage = unreachable && Model.Storage == TripNoteStorageEnum.Server
+        await Logging.LogErrorAsync(Operation, exception, CancellationToken.None);
+        _saveFailedMessage = unreachable && Model.Storage == TripStorageEnum.Server
             ? Loc["Trip_NoteOnlineRequired"].Value
             : Loc["Trip_NoteAddFailed"].Value;
     }
@@ -286,6 +311,8 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
             ? parsed
             : null;
     }
+
+    private string Operation => IsEditing ? "editing a trip note" : "adding a trip note";
 
     private void Cancel()
     {

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModal.razor.cs
@@ -1,8 +1,10 @@
+using System.Globalization;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Features.Trips.Models;
-using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -13,15 +15,22 @@ namespace FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 public partial class AddTripNoteModal : ComponentBase, IDisposable
 {
     private const int MaxNoteLength = TripConstants.MaxNoteTextLength;
+    private const string LocalValueFormat = "yyyy-MM-ddTHH:mm";
     private const int LocalValueLength = 16;
+    private const int DatePartLength = 10;
     private const int TimePartIndex = 11;
+    private const int TimePartLength = 5;
 
     private readonly CancellationTokenSource _cancellationTokenSource = new();
-    private string _recordedOnLocal = string.Empty;
+    private string _earliestLocal = string.Empty;
+    private string _latestLocal = string.Empty;
+    private string _dateLocal = string.Empty;
+    private string _timeLocal = string.Empty;
     private string _text = string.Empty;
+    private DateTimeOffset? _recordedOn;
+    private string? _validationMessage;
+    private string? _saveFailedMessage;
     private bool _isSaving;
-    private bool _recordedOnInvalid;
-    private bool _saveFailed;
 
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = default!;
@@ -30,7 +39,7 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
     public AddTripNoteModalModel Model { get; set; } = default!;
 
     [Inject]
-    private ITripNoteStore NoteStore { get; set; } = default!;
+    private ITripNoteWriteService NoteWriter { get; set; } = default!;
 
     [Inject]
     private ITimeService Time { get; set; } = default!;
@@ -41,63 +50,105 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
-    private bool CanSave => !_isSaving && TripConstants.IsNoteTextValid(_text);
+    private string EarliestDate => DatePartOf(_earliestLocal);
+
+    private string LatestDate => DatePartOf(_latestLocal);
+
+    private DateTimeOffset Ceiling => Model.TripEndedOn ?? DateTimeOffset.UtcNow;
+
+    private bool CanSave =>
+        !_isSaving
+        && TripConstants.IsNoteTextValid(_text)
+        && _validationMessage is null
+        && _recordedOn is not null;
 
     protected override async Task OnInitializedAsync()
     {
-        _recordedOnLocal = await ResolveDefaultRecordedOnAsync();
+        _earliestLocal = await LocalValueAsync(Model.TripStartedOn);
+        _latestLocal = await LocalValueAsync(Ceiling);
+        var initial = await InitialLocalValueAsync();
+        _dateLocal = DatePartOf(initial);
+        _timeLocal = TimePartOf(initial);
+        await ValidateAsync();
     }
 
-    private async Task<string> ResolveDefaultRecordedOnAsync()
+    private async Task<string> InitialLocalValueAsync()
     {
-        try
+        if (Model.TripEndedOn is not null)
         {
-            var tripLocal = await Time.ToDateTimeLocalValueAsync(
-                Model.TripStartedOn,
-                _cancellationTokenSource.Token);
-            var nowLocal = await Time.ToDateTimeLocalValueAsync(
-                DateTimeOffset.UtcNow,
-                _cancellationTokenSource.Token);
-            return OnTripDate(tripLocal, nowLocal);
+            return _latestLocal;
         }
-        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
-        {
-            return string.Empty;
-        }
-        catch (Exception exception)
-        {
-            await Logging.LogErrorAsync(
-                "reading a trip note time",
-                exception,
-                CancellationToken.None);
-            return string.Empty;
-        }
-    }
 
-    private static string OnTripDate(string tripLocal, string nowLocal)
-    {
-        if (tripLocal.Length < LocalValueLength || nowLocal.Length < LocalValueLength)
+        var nowLocal = await LocalValueAsync(DateTimeOffset.UtcNow);
+        if (_earliestLocal.Length < LocalValueLength || nowLocal.Length < LocalValueLength)
         {
-            return nowLocal;
+            return _latestLocal.Length < LocalValueLength ? nowLocal : _latestLocal;
         }
 
         var candidate = string.Concat(
-            tripLocal.AsSpan(0, TimePartIndex),
-            nowLocal.AsSpan(TimePartIndex, LocalValueLength - TimePartIndex));
-        return string.CompareOrdinal(candidate, tripLocal) < 0 ? tripLocal : candidate;
+            _earliestLocal.AsSpan(0, TimePartIndex),
+            nowLocal.AsSpan(TimePartIndex, TimePartLength));
+        var instant = await ToInstantAsync(candidate);
+        if (instant is null || instant < Model.TripStartedOn)
+        {
+            return _earliestLocal;
+        }
+
+        return instant > Ceiling ? _latestLocal : candidate;
     }
 
-    private void OnRecordedOnChanged(string? value)
+    private async Task OnDateChanged(string? value)
     {
-        _recordedOnLocal = value ?? string.Empty;
-        _recordedOnInvalid = false;
-        _saveFailed = false;
+        _dateLocal = value ?? string.Empty;
+        _saveFailedMessage = null;
+        await ValidateAsync();
+    }
+
+    private async Task OnTimeChanged(string? value)
+    {
+        _timeLocal = value ?? string.Empty;
+        _saveFailedMessage = null;
+        await ValidateAsync();
     }
 
     private void OnTextChanged(string? value)
     {
         _text = value ?? string.Empty;
-        _saveFailed = false;
+        _saveFailedMessage = null;
+    }
+
+    private async Task ValidateAsync()
+    {
+        _validationMessage = null;
+        _recordedOn = null;
+        if (ComposedLocalValue() is not { } composed)
+        {
+            _validationMessage = Loc["Trip_NoteRecordedOnInvalid"].Value;
+            return;
+        }
+
+        var instant = await ToInstantAsync(composed);
+        if (instant is null)
+        {
+            _validationMessage = Loc["Trip_NoteRecordedOnInvalid"].Value;
+            return;
+        }
+
+        if (instant < Model.TripStartedOn)
+        {
+            _validationMessage = Loc["Trip_NoteBeforeTripStart", Display(_earliestLocal)].Value;
+            return;
+        }
+
+        if (instant > Ceiling)
+        {
+            _validationMessage = Model.TripEndedOn is null
+                ? Loc["Trip_NoteAfterNow"].Value
+                : Loc["Trip_NoteAfterTripEnd", Display(_latestLocal)].Value;
+            return;
+        }
+
+        _recordedOn = instant;
     }
 
     private async Task SaveAsync()
@@ -107,40 +158,36 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
             return;
         }
 
-        _recordedOnInvalid = false;
-        _saveFailed = false;
+        _saveFailedMessage = null;
         var text = TripConstants.TrimNoteText(_text);
-        if (text is null)
+        if (text is null || _recordedOn is not { } recordedOn)
         {
             return;
         }
 
-        var recordedOn = await ResolveRecordedOnAsync();
-        if (recordedOn is null)
-        {
-            _recordedOnInvalid = true;
-            return;
-        }
-
-        var note = new TripNoteModel(
-            Guid.NewGuid(),
-            Model.TripId,
-            Model.OwnerUserId,
-            text,
-            recordedOn.Value);
         _isSaving = true;
         try
         {
-            await NoteStore.SaveAsync(note, _cancellationTokenSource.Token);
+            var note = await NoteWriter.AddAsync(
+                new TripNoteDraftModel(Model.TripId, Model.OwnerUserId, text, recordedOn),
+                Model.Storage,
+                _cancellationTokenSource.Token);
             MudDialog.Close(DialogResult.Ok(new AddTripNoteModalResult(note)));
         }
         catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
         }
+        catch (HttpRequestException exception)
+        {
+            await FailAsync(exception, exception.StatusCode is null);
+        }
+        catch (TaskCanceledException exception)
+        {
+            await FailAsync(exception, unreachable: true);
+        }
         catch (Exception exception)
         {
-            await Logging.LogErrorAsync("adding a trip note", exception, CancellationToken.None);
-            _saveFailed = true;
+            await FailAsync(exception, unreachable: false);
         }
         finally
         {
@@ -148,17 +195,31 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
         }
     }
 
-    private async Task<DateTimeOffset?> ResolveRecordedOnAsync()
+    private async Task FailAsync(Exception exception, bool unreachable)
     {
-        if (string.IsNullOrWhiteSpace(_recordedOnLocal))
+        await Logging.LogErrorAsync("adding a trip note", exception, CancellationToken.None);
+        _saveFailedMessage = unreachable && Model.Storage == TripNoteStorageEnum.Server
+            ? Loc["Trip_NoteOnlineRequired"].Value
+            : Loc["Trip_NoteAddFailed"].Value;
+    }
+
+    private string? ComposedLocalValue()
+    {
+        if (_dateLocal.Length != DatePartLength || _timeLocal.Length < TimePartLength)
         {
             return null;
         }
 
+        var value = $"{_dateLocal}T{_timeLocal[..TimePartLength]}";
+        return Parse(value) is null ? null : value;
+    }
+
+    private async Task<DateTimeOffset?> ToInstantAsync(string localValue)
+    {
         try
         {
             return await Time.FromDateTimeLocalValueAsync(
-                _recordedOnLocal,
+                localValue,
                 _cancellationTokenSource.Token);
         }
         catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
@@ -173,6 +234,57 @@ public partial class AddTripNoteModal : ComponentBase, IDisposable
                 CancellationToken.None);
             return null;
         }
+    }
+
+    private async Task<string> LocalValueAsync(DateTimeOffset instant)
+    {
+        try
+        {
+            return await Time.ToDateTimeLocalValueAsync(instant, _cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "reading a trip note time",
+                exception,
+                CancellationToken.None);
+            return string.Empty;
+        }
+    }
+
+    private static string DatePartOf(string localValue)
+    {
+        return localValue.Length >= LocalValueLength ? localValue[..DatePartLength] : string.Empty;
+    }
+
+    private static string TimePartOf(string localValue)
+    {
+        return localValue.Length >= LocalValueLength
+            ? localValue.Substring(TimePartIndex, TimePartLength)
+            : string.Empty;
+    }
+
+    private static string Display(string localValue)
+    {
+        return Parse(localValue) is { } parsed
+            ? parsed.ToString("g", CultureInfo.CurrentCulture)
+            : localValue;
+    }
+
+    private static DateTime? Parse(string localValue)
+    {
+        return DateTime.TryParseExact(
+            localValue,
+            LocalValueFormat,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed)
+            ? parsed
+            : null;
     }
 
     private void Cancel()

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModalModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModalModel.cs
@@ -1,6 +1,10 @@
+using FishingLogBook.Web.Features.Trips.Enums;
+
 namespace FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 
 public sealed record AddTripNoteModalModel(
     Guid TripId,
     Guid OwnerUserId,
-    DateTimeOffset TripStartedOn);
+    DateTimeOffset TripStartedOn,
+    DateTimeOffset? TripEndedOn = null,
+    TripNoteStorageEnum Storage = TripNoteStorageEnum.LocalFirst);

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModalModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModalModel.cs
@@ -1,0 +1,6 @@
+namespace FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
+
+public sealed record AddTripNoteModalModel(
+    Guid TripId,
+    Guid OwnerUserId,
+    DateTimeOffset TripStartedOn);

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModalModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModalModel.cs
@@ -1,4 +1,5 @@
 using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
 
 namespace FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 
@@ -7,4 +8,5 @@ public sealed record AddTripNoteModalModel(
     Guid OwnerUserId,
     DateTimeOffset TripStartedOn,
     DateTimeOffset? TripEndedOn = null,
-    TripNoteStorageEnum Storage = TripNoteStorageEnum.LocalFirst);
+    TripStorageEnum Storage = TripStorageEnum.LocalFirst,
+    TripNoteModel? ExistingNote = null);

--- a/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModalResult.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Modals/AddTripNote/AddTripNoteModalResult.cs
@@ -1,0 +1,5 @@
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
+
+public sealed record AddTripNoteModalResult(TripNoteModel Note);

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripCatchAssociationModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripCatchAssociationModel.cs
@@ -1,0 +1,5 @@
+namespace FishingLogBook.Web.Features.Trips.Models;
+
+public sealed record TripCatchAssociationModel(
+    IReadOnlyList<Guid> AssociatedCatchIds,
+    IReadOnlyList<Guid> RejectedCatchIds);

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripCatchScopeModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripCatchScopeModel.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Web.Features.Trips.Models;
+
+public sealed record TripCatchScopeModel(
+    Guid TripId,
+    Guid OwnerUserId,
+    DateTimeOffset StartedOn,
+    DateTimeOffset? EndedOn = null);

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripNoteDraftModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripNoteDraftModel.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Web.Features.Trips.Models;
+
+public sealed record TripNoteDraftModel(
+    Guid TripId,
+    Guid OwnerUserId,
+    string Text,
+    DateTimeOffset RecordedOn);

--- a/src/FishingLogBook.Web/Features/Trips/Models/TripNoteRemovalModel.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Models/TripNoteRemovalModel.cs
@@ -1,0 +1,9 @@
+using FishingLogBook.Web.Common;
+
+namespace FishingLogBook.Web.Features.Trips.Models;
+
+public sealed record TripNoteRemovalModel(
+    Guid TripId,
+    Guid OwnerUserId,
+    Guid NoteId,
+    SyncStatus SyncStatus = SyncStatus.Synchronised);

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
@@ -39,6 +39,7 @@
                             AllowLocalMedia="!_isReadOnlyHistory"
                             CanEdit="CanEdit"
                             CanAddNotes="CanAddNotes"
+                            NoteStorage="NoteStorage"
                             WeightUnit="_weightUnit"
                             LengthUnit="_lengthUnit"
                             OnContentChanged="LoadAsync"

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
@@ -39,6 +39,7 @@
                             AllowLocalMedia="!_isReadOnlyHistory"
                             CanEdit="CanEdit"
                             CanAddNotes="CanAddNotes"
+                            CanAddCatches="CanAddCatches"
                             NoteStorage="NoteStorage"
                             WeightUnit="_weightUnit"
                             LengthUnit="_lengthUnit"

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor
@@ -38,6 +38,7 @@
                             Timeline="_timeline"
                             AllowLocalMedia="!_isReadOnlyHistory"
                             CanEdit="CanEdit"
+                            CanAddNotes="CanAddNotes"
                             WeightUnit="_weightUnit"
                             LengthUnit="_lengthUnit"
                             OnContentChanged="LoadAsync"

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
@@ -84,6 +84,14 @@ public partial class ActiveTrip : ComponentBase, IDisposable
         }
     }
 
+    private bool CanAddNotes
+    {
+        get
+        {
+            return !_isReadOnlyHistory;
+        }
+    }
+
     private string? GeneratedTitle
     {
         get

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
@@ -90,7 +90,7 @@ public partial class ActiveTrip : ComponentBase, IDisposable
         }
     }
 
-    private bool CanAddNotes
+    private bool CanContribute
     {
         get
         {
@@ -98,11 +98,15 @@ public partial class ActiveTrip : ComponentBase, IDisposable
         }
     }
 
-    private TripNoteStorageEnum NoteStorage
+    private bool CanAddNotes => CanContribute;
+
+    private bool CanAddCatches => CanContribute;
+
+    private TripStorageEnum NoteStorage
     {
         get
         {
-            return _isReadOnlyHistory ? TripNoteStorageEnum.Server : TripNoteStorageEnum.LocalFirst;
+            return _isReadOnlyHistory ? TripStorageEnum.Server : TripStorageEnum.LocalFirst;
         }
     }
 

--- a/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/ActiveTrip/ActiveTrip.razor.cs
@@ -1,6 +1,7 @@
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
@@ -8,6 +9,7 @@ using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Profile.Providers;
 using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Features.Trips.Offline.Stores;
 using FishingLogBook.Web.Features.Trips.Services;
@@ -34,6 +36,7 @@ public partial class ActiveTrip : ComponentBase, IDisposable
     private WeightUnitEnum _weightUnit = WeightUnitEnum.Kg;
     private LengthUnitEnum _lengthUnit = LengthUnitEnum.Cm;
     private bool _isReadOnlyHistory;
+    private bool _isOnline = true;
 
     [Parameter]
     public Guid TripId { get; set; }
@@ -55,6 +58,9 @@ public partial class ActiveTrip : ComponentBase, IDisposable
 
     [Inject]
     private ITripClient TripClient { get; set; } = default!;
+
+    [Inject]
+    private INetworkService Network { get; set; } = default!;
 
     [Inject]
     private ITripTimelineService TripTimeline { get; set; } = default!;
@@ -88,7 +94,15 @@ public partial class ActiveTrip : ComponentBase, IDisposable
     {
         get
         {
-            return !_isReadOnlyHistory;
+            return !_isReadOnlyHistory || _isOnline;
+        }
+    }
+
+    private TripNoteStorageEnum NoteStorage
+    {
+        get
+        {
+            return _isReadOnlyHistory ? TripNoteStorageEnum.Server : TripNoteStorageEnum.LocalFirst;
         }
     }
 
@@ -116,9 +130,52 @@ public partial class ActiveTrip : ComponentBase, IDisposable
         }
     }
 
+    protected override void OnInitialized()
+    {
+        Network.ConnectivityChanged += OnConnectivityChanged;
+    }
+
     protected override async Task OnInitializedAsync()
     {
         await LoadAsync();
+        await RefreshConnectivityAsync();
+    }
+
+    private void OnConnectivityChanged(bool isOnline)
+    {
+        _ = UpdateConnectivityAsync(isOnline);
+    }
+
+    private async Task UpdateConnectivityAsync(bool isOnline)
+    {
+        if (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
+        await InvokeAsync(() =>
+        {
+            _isOnline = isOnline;
+            StateHasChanged();
+        });
+    }
+
+    private async Task RefreshConnectivityAsync()
+    {
+        try
+        {
+            _isOnline = await Network.IsOnlineAsync(_cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "reading connectivity for a trip",
+                exception,
+                CancellationToken.None);
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -315,6 +372,7 @@ public partial class ActiveTrip : ComponentBase, IDisposable
 
     public void Dispose()
     {
+        Network.ConnectivityChanged -= OnConnectivityChanged;
         _cancellationTokenSource.Cancel();
         _cancellationTokenSource.Dispose();
     }

--- a/src/FishingLogBook.Web/Features/Trips/Pages/TripList/TripList.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/TripList/TripList.razor
@@ -60,7 +60,20 @@
                                       AlignItems="AlignItems.Center"
                                       Justify="Justify.SpaceBetween">
                                 <MudStack Spacing="0" Class="trip-list-heading-group">
-                                    <MudText Typo="Typo.subtitle1" Class="trip-list-title">@Title(trip)</MudText>
+                                    <MudStack Row="true"
+                                              Spacing="2"
+                                              AlignItems="AlignItems.Baseline"
+                                              Class="flex-wrap trip-list-heading-row">
+                                        <MudText Typo="Typo.subtitle1"
+                                                 Class="trip-list-title"
+                                                 id="@($"trip-list-date-{trip.Id:D}")">@DateLabel(trip)</MudText>
+                                        @if (HasCustomTitle(trip))
+                                        {
+                                            <MudText Typo="Typo.subtitle1"
+                                                     Class="trip-list-title"
+                                                     id="@($"trip-list-title-{trip.Id:D}")">@trip.Title</MudText>
+                                        }
+                                    </MudStack>
                                     @if (!string.IsNullOrWhiteSpace(trip.PlaceName))
                                     {
                                         <MudText Typo="Typo.body2"

--- a/src/FishingLogBook.Web/Features/Trips/Pages/TripList/TripList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Pages/TripList/TripList.razor.cs
@@ -227,13 +227,13 @@ public partial class TripList : ComponentBase, IDisposable
             : null;
     }
 
-    private string Title(TripListItemModel trip)
+    private static bool HasCustomTitle(TripListItemModel trip)
     {
-        if (!string.IsNullOrWhiteSpace(trip.Title))
-        {
-            return trip.Title!;
-        }
+        return !string.IsNullOrWhiteSpace(trip.Title);
+    }
 
+    private string DateLabel(TripListItemModel trip)
+    {
         return _startedLabels.TryGetValue(trip.Id, out var label)
             ? label
             : trip.StartedOn.ToString("d MMM yyyy", CultureInfo.CurrentCulture);

--- a/src/FishingLogBook.Web/Features/Trips/Services/ITripCatchService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/ITripCatchService.cs
@@ -1,0 +1,19 @@
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Services;
+
+public interface ITripCatchService
+{
+    Task<IReadOnlyList<CatchModel>> GetEligibleAsync(
+        TripCatchScopeModel scope,
+        TripStorageEnum storage,
+        CancellationToken cancellationToken);
+
+    Task<TripCatchAssociationModel> AssociateAsync(
+        TripCatchScopeModel scope,
+        IReadOnlyList<Guid> catchIds,
+        TripStorageEnum storage,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Trips/Services/ITripNoteWriteService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/ITripNoteWriteService.cs
@@ -7,11 +7,16 @@ public interface ITripNoteWriteService
 {
     Task<TripNoteModel> AddAsync(
         TripNoteDraftModel draft,
-        TripNoteStorageEnum storage,
+        TripStorageEnum storage,
+        CancellationToken cancellationToken);
+
+    Task<TripNoteModel> UpdateAsync(
+        TripNoteModel note,
+        TripStorageEnum storage,
         CancellationToken cancellationToken);
 
     Task RemoveAsync(
         TripNoteRemovalModel removal,
-        TripNoteStorageEnum storage,
+        TripStorageEnum storage,
         CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Web/Features/Trips/Services/ITripNoteWriteService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/ITripNoteWriteService.cs
@@ -1,0 +1,17 @@
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Services;
+
+public interface ITripNoteWriteService
+{
+    Task<TripNoteModel> AddAsync(
+        TripNoteDraftModel draft,
+        TripNoteStorageEnum storage,
+        CancellationToken cancellationToken);
+
+    Task RemoveAsync(
+        TripNoteRemovalModel removal,
+        TripNoteStorageEnum storage,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Trips/Services/TripCatchService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/TripCatchService.cs
@@ -65,16 +65,28 @@ public sealed class TripCatchService : ITripCatchService
                     association.RejectedCatchIds);
         }
 
-        foreach (var catchId in catchIds)
+        var eligible = (await GetEligibleAsync(scope, storage, cancellationToken))
+            .Select(candidate => candidate.Id)
+            .ToHashSet();
+        var associated = new List<Guid>();
+        var rejected = new List<Guid>();
+        foreach (var catchId in catchIds.Distinct())
         {
+            if (!eligible.Contains(catchId))
+            {
+                rejected.Add(catchId);
+                continue;
+            }
+
             await _catchStore.UpdateTripAsync(
                 scope.OwnerUserId,
                 catchId,
                 scope.TripId,
                 cancellationToken);
+            associated.Add(catchId);
         }
 
-        return new TripCatchAssociationModel(catchIds, []);
+        return new TripCatchAssociationModel(associated, rejected);
     }
 
     private static bool IsEligible(CatchModel candidate, TripCatchScopeModel scope)

--- a/src/FishingLogBook.Web/Features/Trips/Services/TripCatchService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/TripCatchService.cs
@@ -1,0 +1,116 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+
+namespace FishingLogBook.Web.Features.Trips.Services;
+
+public sealed class TripCatchService : ITripCatchService
+{
+    private readonly ICatchStore _catchStore;
+    private readonly ICatchClient _catchClient;
+    private readonly ITripClient _tripClient;
+
+    public TripCatchService(
+        ICatchStore catchStore,
+        ICatchClient catchClient,
+        ITripClient tripClient)
+    {
+        _catchStore = catchStore;
+        _catchClient = catchClient;
+        _tripClient = tripClient;
+    }
+
+    public async Task<IReadOnlyList<CatchModel>> GetEligibleAsync(
+        TripCatchScopeModel scope,
+        TripStorageEnum storage,
+        CancellationToken cancellationToken)
+    {
+        var candidates = storage == TripStorageEnum.Server
+            ? (await _catchClient.GetAllAsync(cancellationToken)).Select(ToCatchModel)
+            : await _catchStore.GetMetadataAsync(scope.OwnerUserId, cancellationToken);
+        return
+        [
+            .. candidates
+                .Where(candidate => IsEligible(candidate, scope))
+                .OrderBy(candidate => candidate.CaughtOn)
+        ];
+    }
+
+    public async Task<TripCatchAssociationModel> AssociateAsync(
+        TripCatchScopeModel scope,
+        IReadOnlyList<Guid> catchIds,
+        TripStorageEnum storage,
+        CancellationToken cancellationToken)
+    {
+        if (catchIds.Count == 0)
+        {
+            return new TripCatchAssociationModel([], []);
+        }
+
+        if (storage == TripStorageEnum.Server)
+        {
+            var association = await _tripClient.AssociateCatchesAsync(
+                scope.TripId,
+                new AssociateTripCatchesDto(catchIds),
+                cancellationToken);
+            return association is null
+                ? new TripCatchAssociationModel([], catchIds)
+                : new TripCatchAssociationModel(
+                    association.AssociatedCatchIds,
+                    association.RejectedCatchIds);
+        }
+
+        foreach (var catchId in catchIds)
+        {
+            await _catchStore.UpdateTripAsync(
+                scope.OwnerUserId,
+                catchId,
+                scope.TripId,
+                cancellationToken);
+        }
+
+        return new TripCatchAssociationModel(catchIds, []);
+    }
+
+    private static bool IsEligible(CatchModel candidate, TripCatchScopeModel scope)
+    {
+        if (candidate.TripId is not null || candidate.UserId != scope.OwnerUserId)
+        {
+            return false;
+        }
+
+        if (candidate.CaughtOn < scope.StartedOn)
+        {
+            return false;
+        }
+
+        return candidate.CaughtOn <= (scope.EndedOn ?? DateTimeOffset.UtcNow);
+    }
+
+    private static CatchModel ToCatchModel(CatchViewDto dto)
+    {
+        return new CatchModel(
+            dto.Id,
+            dto.CaughtOn,
+            [.. dto.Photographs.Select(photograph => new CatchPhotographModel(
+                photograph.Id,
+                dto.Id,
+                photograph.ContentType,
+                RemoteUrl: photograph.Url))],
+            SpeciesName: dto.SpeciesName,
+            UserId: dto.UserId,
+            SyncStatus: SyncStatus.Synchronised,
+            MetadataSyncStatus: SyncStatus.Synchronised,
+            AnglerUserId: dto.AnglerUserId,
+            RecordedByUserId: dto.RecordedByUserId,
+            Weight: dto.Weight,
+            Length: dto.Length,
+            Method: dto.Method,
+            TripId: dto.TripId);
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Services/TripNoteWriteService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/TripNoteWriteService.cs
@@ -20,11 +20,11 @@ public sealed class TripNoteWriteService : ITripNoteWriteService
 
     public async Task<TripNoteModel> AddAsync(
         TripNoteDraftModel draft,
-        TripNoteStorageEnum storage,
+        TripStorageEnum storage,
         CancellationToken cancellationToken)
     {
         var noteId = Guid.NewGuid();
-        if (storage != TripNoteStorageEnum.Server)
+        if (storage != TripStorageEnum.Server)
         {
             var note = new TripNoteModel(
                 noteId,
@@ -50,12 +50,42 @@ public sealed class TripNoteWriteService : ITripNoteWriteService
             DateTimeOffset.UtcNow);
     }
 
-    public async Task RemoveAsync(
-        TripNoteRemovalModel removal,
-        TripNoteStorageEnum storage,
+    public async Task<TripNoteModel> UpdateAsync(
+        TripNoteModel note,
+        TripStorageEnum storage,
         CancellationToken cancellationToken)
     {
-        if (storage == TripNoteStorageEnum.Server)
+        if (storage != TripStorageEnum.Server)
+        {
+            var pending = note with
+            {
+                SyncStatus = note.SyncStatus == SyncStatus.Synchronised
+                    ? SyncStatus.WaitingToSynchronise
+                    : note.SyncStatus
+            };
+            await _noteStore.SaveAsync(pending, cancellationToken);
+            return pending;
+        }
+
+        var recorded = await _tripClient.RecordNoteAsync(
+            note.TripId,
+            new RecordTripNoteDto(note.Id, note.Text, note.RecordedOn),
+            cancellationToken);
+        return note with
+        {
+            Text = recorded?.Text ?? note.Text,
+            RecordedOn = recorded?.RecordedOn ?? note.RecordedOn,
+            SyncStatus = SyncStatus.Synchronised,
+            SyncedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    public async Task RemoveAsync(
+        TripNoteRemovalModel removal,
+        TripStorageEnum storage,
+        CancellationToken cancellationToken)
+    {
+        if (storage == TripStorageEnum.Server)
         {
             await _tripClient.DeleteNoteAsync(removal.TripId, removal.NoteId, cancellationToken);
             return;

--- a/src/FishingLogBook.Web/Features/Trips/Services/TripNoteWriteService.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Services/TripNoteWriteService.cs
@@ -1,0 +1,75 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+
+namespace FishingLogBook.Web.Features.Trips.Services;
+
+public sealed class TripNoteWriteService : ITripNoteWriteService
+{
+    private readonly ITripNoteStore _noteStore;
+    private readonly ITripClient _tripClient;
+
+    public TripNoteWriteService(ITripNoteStore noteStore, ITripClient tripClient)
+    {
+        _noteStore = noteStore;
+        _tripClient = tripClient;
+    }
+
+    public async Task<TripNoteModel> AddAsync(
+        TripNoteDraftModel draft,
+        TripNoteStorageEnum storage,
+        CancellationToken cancellationToken)
+    {
+        var noteId = Guid.NewGuid();
+        if (storage != TripNoteStorageEnum.Server)
+        {
+            var note = new TripNoteModel(
+                noteId,
+                draft.TripId,
+                draft.OwnerUserId,
+                draft.Text,
+                draft.RecordedOn);
+            await _noteStore.SaveAsync(note, cancellationToken);
+            return note;
+        }
+
+        var recorded = await _tripClient.RecordNoteAsync(
+            draft.TripId,
+            new RecordTripNoteDto(noteId, draft.Text, draft.RecordedOn),
+            cancellationToken);
+        return new TripNoteModel(
+            recorded?.Id ?? noteId,
+            draft.TripId,
+            draft.OwnerUserId,
+            recorded?.Text ?? draft.Text,
+            recorded?.RecordedOn ?? draft.RecordedOn,
+            SyncStatus.Synchronised,
+            DateTimeOffset.UtcNow);
+    }
+
+    public async Task RemoveAsync(
+        TripNoteRemovalModel removal,
+        TripNoteStorageEnum storage,
+        CancellationToken cancellationToken)
+    {
+        if (storage == TripNoteStorageEnum.Server)
+        {
+            await _tripClient.DeleteNoteAsync(removal.TripId, removal.NoteId, cancellationToken);
+            return;
+        }
+
+        if (removal.SyncStatus == SyncStatus.Synchronised)
+        {
+            await _tripClient.DeleteNoteAsync(removal.TripId, removal.NoteId, cancellationToken);
+        }
+
+        await _noteStore.DeleteAsync(
+            removal.OwnerUserId,
+            removal.TripId,
+            removal.NoteId,
+            cancellationToken);
+    }
+}

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1147,18 +1147,6 @@
   <data name="Trip_AddCatchesOnlineRequired" xml:space="preserve">
     <value>Vous devez être en ligne pour ajouter des prises à cette sortie.</value>
   </data>
-  <data name="Trip_AddExistingCatchTitle" xml:space="preserve">
-    <value>Prises sans sortie</value>
-  </data>
-  <data name="Trip_AddExistingCatchConfirm" xml:space="preserve">
-    <value>Ajouter à cette sortie</value>
-  </data>
-  <data name="Trip_AddExistingCatchEmpty" xml:space="preserve">
-    <value>Toutes vos prises sont déjà associées à une sortie.</value>
-  </data>
-  <data name="Trip_AddExistingCatchFailed" xml:space="preserve">
-    <value>Ces prises n'ont pas pu être ajoutées à la sortie.</value>
-  </data>
   <data name="Trip_ListPhotographsNone" xml:space="preserve">
     <value>Aucune photo</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -264,8 +264,20 @@
   <data name="Trip_NotePlaceholder" xml:space="preserve">
     <value>Le niveau a baissé de trente centimètres</value>
   </data>
-  <data name="Trip_NoteRecordedOn" xml:space="preserve">
-    <value>Date et heure de la note</value>
+  <data name="Trip_NoteDateLabel" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="Trip_NoteTimeLabel" xml:space="preserve">
+    <value>Heure</value>
+  </data>
+  <data name="Trip_NoteBeforeTripStart" xml:space="preserve">
+    <value>C'est avant le début de la sortie à {0}. Choisissez une heure plus tardive.</value>
+  </data>
+  <data name="Trip_NoteAfterTripEnd" xml:space="preserve">
+    <value>C'est après la fin de la sortie à {0}. Choisissez une heure plus tôt.</value>
+  </data>
+  <data name="Trip_NoteAfterNow" xml:space="preserve">
+    <value>C'est dans le futur. Choisissez une heure jusqu'à maintenant.</value>
   </data>
   <data name="Trip_NoteRecordedOnHelp" xml:space="preserve">
     <value>Modifiez l'heure pour placer cette note sur la chronologie de la sortie.</value>
@@ -275,6 +287,9 @@
   </data>
   <data name="Trip_NoteRemove" xml:space="preserve">
     <value>Supprimer la note</value>
+  </data>
+  <data name="Trip_NoteOnlineRequired" xml:space="preserve">
+    <value>Vous devez être en ligne pour ajouter une note à cette sortie.</value>
   </data>
   <data name="Trip_NoteAddFailed" xml:space="preserve">
     <value>Cette note n'a pas pu être ajoutée</value>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -285,6 +285,9 @@
   <data name="Trip_NoteRecordedOnInvalid" xml:space="preserve">
     <value>Saisissez une date et une heure valides pour cette note.</value>
   </data>
+  <data name="Trip_NoteEdit" xml:space="preserve">
+    <value>Modifier la note</value>
+  </data>
   <data name="Trip_NoteRemove" xml:space="preserve">
     <value>Supprimer la note</value>
   </data>
@@ -1113,6 +1116,36 @@
   </data>
   <data name="Trip_AddExistingCatch" xml:space="preserve">
     <value>Ajouter une prise</value>
+  </data>
+  <data name="Trip_AddCatchesTitle" xml:space="preserve">
+    <value>Ajouter des prises</value>
+  </data>
+  <data name="Trip_AddCatchesSubtitle" xml:space="preserve">
+    <value>Choisissez les prises à ajouter à cette sortie</value>
+  </data>
+  <data name="Trip_AddCatchesEmpty" xml:space="preserve">
+    <value>Aucune prise à ajouter</value>
+  </data>
+  <data name="Trip_AddCatchesEmptyHint" xml:space="preserve">
+    <value>Toutes les prises enregistrées pendant cette sortie y sont déjà associées.</value>
+  </data>
+  <data name="Trip_AddCatchesConfirmOne" xml:space="preserve">
+    <value>Ajouter 1 prise</value>
+  </data>
+  <data name="Trip_AddCatchesConfirmMany" xml:space="preserve">
+    <value>Ajouter {0} prises</value>
+  </data>
+  <data name="Trip_AddCatchesLoadFailed" xml:space="preserve">
+    <value>Ces prises n'ont pas pu être lues. Réessayez dans un instant.</value>
+  </data>
+  <data name="Trip_AddCatchesFailed" xml:space="preserve">
+    <value>Ces prises n'ont pas pu être ajoutées à la sortie.</value>
+  </data>
+  <data name="Trip_AddCatchesRejected" xml:space="preserve">
+    <value>Ces prises ne sont plus disponibles. La liste a été actualisée.</value>
+  </data>
+  <data name="Trip_AddCatchesOnlineRequired" xml:space="preserve">
+    <value>Vous devez être en ligne pour ajouter des prises à cette sortie.</value>
   </data>
   <data name="Trip_AddExistingCatchTitle" xml:space="preserve">
     <value>Prises sans sortie</value>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -264,6 +264,15 @@
   <data name="Trip_NotePlaceholder" xml:space="preserve">
     <value>Le niveau a baissé de trente centimètres</value>
   </data>
+  <data name="Trip_NoteRecordedOn" xml:space="preserve">
+    <value>Date et heure de la note</value>
+  </data>
+  <data name="Trip_NoteRecordedOnHelp" xml:space="preserve">
+    <value>Modifiez l'heure pour placer cette note sur la chronologie de la sortie.</value>
+  </data>
+  <data name="Trip_NoteRecordedOnInvalid" xml:space="preserve">
+    <value>Saisissez une date et une heure valides pour cette note.</value>
+  </data>
   <data name="Trip_NoteRemove" xml:space="preserve">
     <value>Supprimer la note</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -264,6 +264,15 @@
   <data name="Trip_NotePlaceholder" xml:space="preserve">
     <value>Water dropped a foot</value>
   </data>
+  <data name="Trip_NoteRecordedOn" xml:space="preserve">
+    <value>Note date and time</value>
+  </data>
+  <data name="Trip_NoteRecordedOnHelp" xml:space="preserve">
+    <value>Change the time to place this note on the trip timeline.</value>
+  </data>
+  <data name="Trip_NoteRecordedOnInvalid" xml:space="preserve">
+    <value>Enter a valid date and time for this note.</value>
+  </data>
   <data name="Trip_NoteRemove" xml:space="preserve">
     <value>Remove note</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -285,6 +285,9 @@
   <data name="Trip_NoteRecordedOnInvalid" xml:space="preserve">
     <value>Enter a valid date and time for this note.</value>
   </data>
+  <data name="Trip_NoteEdit" xml:space="preserve">
+    <value>Edit note</value>
+  </data>
   <data name="Trip_NoteRemove" xml:space="preserve">
     <value>Remove note</value>
   </data>
@@ -1113,6 +1116,36 @@
   </data>
   <data name="Trip_AddExistingCatch" xml:space="preserve">
     <value>Add catch</value>
+  </data>
+  <data name="Trip_AddCatchesTitle" xml:space="preserve">
+    <value>Add catches</value>
+  </data>
+  <data name="Trip_AddCatchesSubtitle" xml:space="preserve">
+    <value>Select catches to add to this trip</value>
+  </data>
+  <data name="Trip_AddCatchesEmpty" xml:space="preserve">
+    <value>No catches to add</value>
+  </data>
+  <data name="Trip_AddCatchesEmptyHint" xml:space="preserve">
+    <value>All catches recorded during this trip are already associated.</value>
+  </data>
+  <data name="Trip_AddCatchesConfirmOne" xml:space="preserve">
+    <value>Add 1 catch</value>
+  </data>
+  <data name="Trip_AddCatchesConfirmMany" xml:space="preserve">
+    <value>Add {0} catches</value>
+  </data>
+  <data name="Trip_AddCatchesLoadFailed" xml:space="preserve">
+    <value>Those catches could not be read. Try again in a moment.</value>
+  </data>
+  <data name="Trip_AddCatchesFailed" xml:space="preserve">
+    <value>Those catches could not be added to the trip.</value>
+  </data>
+  <data name="Trip_AddCatchesRejected" xml:space="preserve">
+    <value>Those catches are no longer available to add. The list has been refreshed.</value>
+  </data>
+  <data name="Trip_AddCatchesOnlineRequired" xml:space="preserve">
+    <value>You need to be online to add catches to this trip.</value>
   </data>
   <data name="Trip_AddExistingCatchTitle" xml:space="preserve">
     <value>Catches not on a trip</value>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -264,8 +264,20 @@
   <data name="Trip_NotePlaceholder" xml:space="preserve">
     <value>Water dropped a foot</value>
   </data>
-  <data name="Trip_NoteRecordedOn" xml:space="preserve">
-    <value>Note date and time</value>
+  <data name="Trip_NoteDateLabel" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="Trip_NoteTimeLabel" xml:space="preserve">
+    <value>Time</value>
+  </data>
+  <data name="Trip_NoteBeforeTripStart" xml:space="preserve">
+    <value>That is before the trip started at {0}. Choose a later time.</value>
+  </data>
+  <data name="Trip_NoteAfterTripEnd" xml:space="preserve">
+    <value>That is after the trip finished at {0}. Choose an earlier time.</value>
+  </data>
+  <data name="Trip_NoteAfterNow" xml:space="preserve">
+    <value>That is in the future. Choose a time up to now.</value>
   </data>
   <data name="Trip_NoteRecordedOnHelp" xml:space="preserve">
     <value>Change the time to place this note on the trip timeline.</value>
@@ -275,6 +287,9 @@
   </data>
   <data name="Trip_NoteRemove" xml:space="preserve">
     <value>Remove note</value>
+  </data>
+  <data name="Trip_NoteOnlineRequired" xml:space="preserve">
+    <value>You need to be online to add a note to this trip.</value>
   </data>
   <data name="Trip_NoteAddFailed" xml:space="preserve">
     <value>That note could not be added</value>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1147,18 +1147,6 @@
   <data name="Trip_AddCatchesOnlineRequired" xml:space="preserve">
     <value>You need to be online to add catches to this trip.</value>
   </data>
-  <data name="Trip_AddExistingCatchTitle" xml:space="preserve">
-    <value>Catches not on a trip</value>
-  </data>
-  <data name="Trip_AddExistingCatchConfirm" xml:space="preserve">
-    <value>Add to this trip</value>
-  </data>
-  <data name="Trip_AddExistingCatchEmpty" xml:space="preserve">
-    <value>Every catch is already on a trip.</value>
-  </data>
-  <data name="Trip_AddExistingCatchFailed" xml:space="preserve">
-    <value>Those catches could not be added to the trip.</value>
-  </data>
   <data name="Trip_ListPhotographsNone" xml:space="preserve">
     <value>No photos</value>
   </data>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -92,6 +92,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITripDisplayService, TripDisplayService>();
         services.AddScoped<ITripTimelineService, TripTimelineService>();
         services.AddScoped<ITripNoteWriteService, TripNoteWriteService>();
+        services.AddScoped<ITripCatchService, TripCatchService>();
         services.AddScoped<ITripClient, TripClient>();
         services.AddScoped<ITripSynchroniser, TripSynchroniser>();
         services.AddScoped<ITripPhotographStore, IndexedDbTripPhotographStore>();

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -91,6 +91,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IActiveTripService, ActiveTripService>();
         services.AddScoped<ITripDisplayService, TripDisplayService>();
         services.AddScoped<ITripTimelineService, TripTimelineService>();
+        services.AddScoped<ITripNoteWriteService, TripNoteWriteService>();
         services.AddScoped<ITripClient, TripClient>();
         services.AddScoped<ITripSynchroniser, TripSynchroniser>();
         services.AddScoped<ITripPhotographStore, IndexedDbTripPhotographStore>();

--- a/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingCatches.cs
+++ b/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingCatches.cs
@@ -1,0 +1,248 @@
+using System.Net;
+using System.Net.Http.Json;
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Domain.Users;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Api.Tests.TripEndpointsTests;
+
+public class WhenTestingCatches : IClassFixture<SystemApiFactory>
+{
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+    private static readonly DateTimeOffset CaughtOn = DateTimeOffset.Parse("2026-08-17T09:12:00Z");
+
+    private readonly SystemApiFactory _factory;
+
+    public WhenTestingCatches(SystemApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnauthenticatedRequest()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{Guid.NewGuid():D}/catches",
+            new AssociateTripCatchesDto([Guid.NewGuid()]));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await _factory.CatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnEmptyCatchList()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{Guid.NewGuid():D}/catches",
+            new AssociateTripCatchesDto([]));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.CatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotFindAnotherAnglersTrip()
+    {
+        // Arrange
+        Reset();
+        var tripId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, Guid.NewGuid())));
+        var client = _factory.CreateAuthenticatedClient();
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/catches",
+            new AssociateTripCatchesDto([Guid.NewGuid()]));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await _factory.CatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchBelongingToAnotherAngler()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var catchId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId)));
+        _factory.CatchRepository.GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(CatchRecord(catchId, Guid.NewGuid())));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/catches",
+            new AssociateTripCatchesDto([catchId]));
+        var body = await response.Content.ReadFromJsonAsync<TripCatchAssociationDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body!.AssociatedCatchIds.Should().BeEmpty();
+        body.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(catchId);
+        await _factory.CatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchAlreadyAssociatedWithAnotherTrip()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var catchId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId)));
+        _factory.CatchRepository.GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(CatchRecord(catchId, current.UserId, tripId: Guid.NewGuid())));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/catches",
+            new AssociateTripCatchesDto([catchId]));
+        var body = await response.Content.ReadFromJsonAsync<TripCatchAssociationDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body!.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(catchId);
+        await _factory.CatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchOutsideTheTripTimeframe()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var catchId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId, TripStatusEnum.Completed)));
+        _factory.CatchRepository.GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(CatchRecord(catchId, current.UserId, StartedOn.AddHours(4))));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/catches",
+            new AssociateTripCatchesDto([catchId]));
+        var body = await response.Content.ReadFromJsonAsync<TripCatchAssociationDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body!.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(catchId);
+        await _factory.CatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAssociateAnEligibleCatchWithTheAnglersOwnTrip()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var catchId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId)));
+        _factory.CatchRepository.GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(CatchRecord(catchId, current.UserId)));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/catches",
+            new AssociateTripCatchesDto([catchId]));
+        var body = await response.Content.ReadFromJsonAsync<TripCatchAssociationDto>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body!.AssociatedCatchIds.Should().ContainSingle().Which.Should().Be(catchId);
+        body.RejectedCatchIds.Should().BeEmpty();
+        await _factory.CatchRepository.Received(1).AssociateTripAsync(
+            Arg.Is<PersistCatchTripArgs>(args =>
+                args.CatchId == catchId
+                && args.TripId == tripId
+                && args.UserId == current.UserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static Trip Trip(
+        Guid tripId,
+        Guid ownerUserId,
+        TripStatusEnum status = TripStatusEnum.Active)
+    {
+        return new Trip
+        {
+            Id = tripId,
+            OwnerUserId = ownerUserId,
+            Status = status,
+            StartedOn = StartedOn,
+            EndedOn = status == TripStatusEnum.Completed ? StartedOn.AddHours(3) : null
+        };
+    }
+
+    private static Catch CatchRecord(
+        Guid catchId,
+        Guid userId,
+        DateTimeOffset? caughtOn = null,
+        Guid? tripId = null)
+    {
+        return new Catch
+        {
+            Id = catchId,
+            UserId = userId,
+            AnglerUserId = userId,
+            RecordedByUserId = userId,
+            CaughtOn = caughtOn ?? CaughtOn,
+            TripId = tripId
+        };
+    }
+
+    private void Reset()
+    {
+        _factory.TripRepository.ClearReceivedCalls();
+        _factory.CatchRepository.ClearReceivedCalls();
+        _factory.CatchRepository
+            .GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(null));
+        _factory.CatchRepository
+            .AssociateTripAsync(Arg.Any<PersistCatchTripArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(true));
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingCatches.cs
+++ b/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingCatches.cs
@@ -171,6 +171,38 @@ public class WhenTestingCatches : IClassFixture<SystemApiFactory>
     }
 
     [Fact]
+    public async Task ItShouldReportServiceUnavailableWhenPersistenceFails()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        var catchId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId)));
+        _factory.CatchRepository.GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(CatchRecord(catchId, current.UserId)));
+        _factory.CatchRepository
+            .AssociateTripAsync(Arg.Any<PersistCatchTripArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<bool>("Failed to save the catch."));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/catches",
+            new AssociateTripCatchesDto([catchId]));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        await _factory.CatchRepository.Received(1).AssociateTripAsync(
+            Arg.Is<PersistCatchTripArgs>(args =>
+                args.CatchId == catchId
+                && args.TripId == tripId
+                && args.UserId == current.UserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldAssociateAnEligibleCatchWithTheAnglersOwnTrip()
     {
         // Arrange

--- a/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingNotes.cs
+++ b/tests/FishingLogBook.Api.Tests/TripEndpointsTests/WhenTestingNotes.cs
@@ -297,6 +297,52 @@ public class WhenTestingNotes : IClassFixture<SystemApiFactory>
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ItShouldRejectANoteRecordedBeforeTheTripStarted()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId, TripStatusEnum.Completed)));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/notes",
+            new RecordTripNoteDto(Guid.NewGuid(), "before the off", StartedOn.AddMinutes(-1)));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectANoteRecordedAfterTheTripFinished()
+    {
+        // Arrange
+        Reset();
+        var client = _factory.CreateAuthenticatedClient();
+        var current = await client.GetFromJsonAsync<CurrentUserDto>("/api/users/current");
+        var tripId = Guid.NewGuid();
+        _factory.TripRepository.GetByIdAsync(tripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(Trip(tripId, current!.UserId, TripStatusEnum.Completed)));
+
+        // Act
+        var response = await client.PostAsJsonAsync(
+            $"/api/trips/{tripId:D}/notes",
+            new RecordTripNoteDto(Guid.NewGuid(), "after the off", StartedOn.AddHours(4)));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await _factory.TripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
     private static Trip Trip(
         Guid tripId,
         Guid ownerUserId,

--- a/tests/FishingLogBook.Application.Tests/Trips/Commands/AssociateTripCatchesCommandTests/BaseAssociateTripCatchesCommandTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Commands/AssociateTripCatchesCommandTests/BaseAssociateTripCatchesCommandTest.cs
@@ -1,0 +1,28 @@
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.Trips.Commands;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Commands.AssociateTripCatchesCommandTests;
+
+public class BaseAssociateTripCatchesCommandTest
+{
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid CatchId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    protected readonly ITripCatchService MockTripCatchService = Substitute.For<ITripCatchService>();
+    protected readonly AssociateTripCatchesHandler Sut;
+
+    protected BaseAssociateTripCatchesCommandTest()
+    {
+        Sut = new AssociateTripCatchesHandler(MockTripCatchService, TestMapper.Create());
+    }
+
+    protected static AssociateTripCatchesCommand Command(params Guid[] catchIds)
+    {
+        return new AssociateTripCatchesCommand
+        {
+            TripId = TripId,
+            CatchIds = catchIds.Length == 0 ? [CatchId] : catchIds
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Commands/AssociateTripCatchesCommandTests/WhenTestingHandle.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Commands/AssociateTripCatchesCommandTests/WhenTestingHandle.cs
@@ -1,0 +1,56 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Shared.Dtos;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Commands.AssociateTripCatchesCommandTests;
+
+public class WhenTestingHandle : BaseAssociateTripCatchesCommandTest
+{
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheServiceFails()
+    {
+        // Arrange
+        MockTripCatchService
+            .AssociateAsync(Arg.Any<AssociateTripCatchesArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<TripCatchAssociationDto>(new TripNotFoundError()));
+
+        // Act
+        var response = await Sut.Handle(Command(), CancellationToken.None);
+
+        // Assert
+        response.IsFailure.Should().BeTrue();
+        response.Error.Should().BeOfType<TripNotFoundError>();
+        response.Association.Should().BeNull();
+        await MockTripCatchService.Received(1).AssociateAsync(
+            Arg.Is<AssociateTripCatchesArgs>(args =>
+                args.TripId == TripId
+                && args.CatchIds.SequenceEqual(new[] { CatchId })),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheAssociationWhenTheServiceSucceeds()
+    {
+        // Arrange
+        var otherCatchId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var association = new TripCatchAssociationDto([CatchId], [otherCatchId]);
+        MockTripCatchService
+            .AssociateAsync(Arg.Any<AssociateTripCatchesArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(association));
+
+        // Act
+        var response = await Sut.Handle(Command(CatchId, otherCatchId), CancellationToken.None);
+
+        // Assert
+        response.IsSuccess.Should().BeTrue();
+        response.Association.Should().Be(association);
+        await MockTripCatchService.Received(1).AssociateAsync(
+            Arg.Is<AssociateTripCatchesArgs>(args =>
+                args.TripId == TripId
+                && args.CatchIds.SequenceEqual(new[] { CatchId, otherCatchId })),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Commands/AssociateTripCatchesCommandValidatorTests/BaseAssociateTripCatchesCommandValidatorTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Commands/AssociateTripCatchesCommandValidatorTests/BaseAssociateTripCatchesCommandValidatorTest.cs
@@ -1,0 +1,11 @@
+using FishingLogBook.Application.Trips.Commands;
+
+namespace FishingLogBook.Application.Tests.Trips.Commands.AssociateTripCatchesCommandValidatorTests;
+
+public class BaseAssociateTripCatchesCommandValidatorTest
+{
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid CatchId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    protected readonly AssociateTripCatchesCommandValidator Sut = new();
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Commands/AssociateTripCatchesCommandValidatorTests/WhenTestingValidate.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Commands/AssociateTripCatchesCommandValidatorTests/WhenTestingValidate.cs
@@ -1,0 +1,96 @@
+using FishingLogBook.Application.Trips.Commands;
+using FluentValidation.TestHelper;
+
+namespace FishingLogBook.Application.Tests.Trips.Commands.AssociateTripCatchesCommandValidatorTests;
+
+public class WhenTestingValidate : BaseAssociateTripCatchesCommandValidatorTest
+{
+    [Fact]
+    public void ItShouldRejectAMissingTrip()
+    {
+        // Arrange
+        var command = Command(tripId: Guid.Empty);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.TripId);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnEmptyCatchList()
+    {
+        // Arrange
+        var command = Command(catchIds: []);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.CatchIds);
+    }
+
+    [Fact]
+    public void ItShouldRejectAnEmptyCatchIdenifierInTheList()
+    {
+        // Arrange
+        var command = Command(catchIds: [Guid.Empty]);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor("CatchIds[0]");
+    }
+
+    [Fact]
+    public void ItShouldRejectMoreThanFiftyCatchesInOneRequest()
+    {
+        // Arrange
+        var command = Command(catchIds: [.. Enumerable.Range(0, 51).Select(_ => Guid.NewGuid())]);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(item => item.CatchIds);
+    }
+
+    [Fact]
+    public void ItShouldAcceptExactlyFiftyCatchesInOneRequest()
+    {
+        // Arrange
+        var command = Command(catchIds: [.. Enumerable.Range(0, 50).Select(_ => Guid.NewGuid())]);
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ItShouldAcceptAnOrdinaryRequest()
+    {
+        // Arrange
+        var command = Command();
+
+        // Act
+        var result = Sut.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    private static AssociateTripCatchesCommand Command(
+        Guid? tripId = null,
+        IReadOnlyList<Guid>? catchIds = null)
+    {
+        return new AssociateTripCatchesCommand
+        {
+            TripId = tripId ?? TripId,
+            CatchIds = catchIds ?? [CatchId]
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripCatchServiceTests/BaseTripCatchServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripCatchServiceTests/BaseTripCatchServiceTest.cs
@@ -1,0 +1,79 @@
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Contracts.Repositories;
+using FishingLogBook.Application.Contracts.Services;
+using FishingLogBook.Application.Trips.Services;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripCatchServiceTests;
+
+public class BaseTripCatchServiceTest
+{
+    protected static readonly Guid CurrentUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid CatchId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    protected static readonly Guid OtherCatchId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+    protected static readonly DateTimeOffset CaughtOn = DateTimeOffset.Parse("2026-08-17T09:12:00Z");
+
+    protected readonly ITripRepository MockTripRepository = Substitute.For<ITripRepository>();
+    protected readonly ICatchRepository MockCatchRepository = Substitute.For<ICatchRepository>();
+    protected readonly ICurrentUser MockCurrentUser = Substitute.For<ICurrentUser>();
+    protected readonly TripCatchService Sut;
+
+    protected BaseTripCatchServiceTest()
+    {
+        MockCurrentUser.IsResolved.Returns(true);
+        MockCurrentUser.UserId.Returns(CurrentUserId);
+        MockCatchRepository.AssociateTripAsync(Arg.Any<PersistCatchTripArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok(true));
+        Sut = new TripCatchService(MockTripRepository, MockCatchRepository, MockCurrentUser);
+    }
+
+    protected void GivenTrip(Guid ownerUserId, TripStatusEnum status = TripStatusEnum.Active)
+    {
+        MockTripRepository.GetByIdAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(new Trip
+            {
+                Id = TripId,
+                OwnerUserId = ownerUserId,
+                Status = status,
+                StartedOn = StartedOn,
+                EndedOn = status == TripStatusEnum.Completed ? StartedOn.AddHours(3) : null
+            }));
+    }
+
+    protected void GivenNoTrip()
+    {
+        MockTripRepository.GetByIdAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Trip?>(null));
+    }
+
+    protected void GivenCatch(
+        Guid catchId,
+        Guid userId,
+        DateTimeOffset? caughtOn = null,
+        Guid? tripId = null)
+    {
+        MockCatchRepository.GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(new Catch
+            {
+                Id = catchId,
+                UserId = userId,
+                AnglerUserId = userId,
+                RecordedByUserId = userId,
+                CaughtOn = caughtOn ?? CaughtOn,
+                TripId = tripId
+            }));
+    }
+
+    protected void GivenNoCatch(Guid catchId)
+    {
+        MockCatchRepository.GetByIdAsync(catchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Catch?>(null));
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripCatchServiceTests/WhenTestingAssociate.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripCatchServiceTests/WhenTestingAssociate.cs
@@ -1,0 +1,308 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Enums;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripCatchServiceTests;
+
+public class WhenTestingAssociate : BaseTripCatchServiceTest
+{
+    [Fact]
+    public async Task ItShouldFailWhenTheTripIsUnknown()
+    {
+        // Arrange
+        GivenNoTrip();
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNotFoundError>();
+        await MockCatchRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheTripBelongsToAnotherAngler()
+    {
+        // Arrange
+        GivenTrip(OtherUserId);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNotFoundError>();
+        await MockCatchRepository.DidNotReceive().GetByIdAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheCatchLookupFails()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        MockCatchRepository.GetByIdAsync(CatchId, Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<Catch?>("Failed to load the catch."));
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFailureWhenTheAssociationCallFails()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId);
+        MockCatchRepository.AssociateTripAsync(Arg.Any<PersistCatchTripArgs>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Fail<bool>("Failed to save the catch."));
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchBelongingToAnotherAngler()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, OtherUserId);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AssociatedCatchIds.Should().BeEmpty();
+        result.Value.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchAlreadyAssociatedWithAnotherTrip()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId, tripId: Guid.NewGuid());
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchAlreadyAssociatedWithThisTrip()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId, tripId: TripId);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnUnknownCatch()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenNoCatch(CatchId);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchCaughtBeforeTheTripStarted()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId, caughtOn: StartedOn.AddMinutes(-1));
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchCaughtAfterACompletedTripFinished()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId, TripStatusEnum.Completed);
+        GivenCatch(CatchId, CurrentUserId, caughtOn: StartedOn.AddHours(3).AddMinutes(1));
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectACatchCaughtWellIntoTheFutureOnAnActiveTrip()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId, caughtOn: DateTimeOffset.UtcNow.AddHours(1));
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldIgnoreDuplicateCatchIdsInOneRequest()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId, CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AssociatedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        await MockCatchRepository.Received(1).AssociateTripAsync(
+            Arg.Any<PersistCatchTripArgs>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAcceptACatchCaughtExactlyWhenTheTripStarted()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId, caughtOn: StartedOn);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AssociatedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+    }
+
+    [Fact]
+    public async Task ItShouldAcceptACatchCaughtExactlyWhenACompletedTripFinished()
+    {
+        // Arrange
+        var endedOn = StartedOn.AddHours(3);
+        GivenTrip(CurrentUserId, TripStatusEnum.Completed);
+        GivenCatch(CatchId, CurrentUserId, caughtOn: endedOn);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AssociatedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+    }
+
+    [Fact]
+    public async Task ItShouldAssociateAnEligibleCatchUsingTheTrustedCurrentUser()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockCatchRepository.Received(1).AssociateTripAsync(
+            Arg.Is<PersistCatchTripArgs>(args =>
+                args.CatchId == CatchId
+                && args.TripId == TripId
+                && args.UserId == CurrentUserId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAssociateEligibleCatchesAndRejectIneligibleOnesInOneRequest()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        GivenCatch(CatchId, CurrentUserId);
+        GivenCatch(OtherCatchId, OtherUserId);
+
+        // Act
+        var result = await Sut.AssociateAsync(Args(CatchId, OtherCatchId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AssociatedCatchIds.Should().ContainSingle().Which.Should().Be(CatchId);
+        result.Value.RejectedCatchIds.Should().ContainSingle().Which.Should().Be(OtherCatchId);
+        await MockCatchRepository.Received(1).AssociateTripAsync(
+            Arg.Is<PersistCatchTripArgs>(args => args.CatchId == CatchId),
+            Arg.Any<CancellationToken>());
+        await MockCatchRepository.DidNotReceive().AssociateTripAsync(
+            Arg.Is<PersistCatchTripArgs>(args => args.CatchId == OtherCatchId),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static AssociateTripCatchesArgs Args(params Guid[] catchIds)
+    {
+        return new AssociateTripCatchesArgs
+        {
+            TripId = TripId,
+            CatchIds = catchIds
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/WhenTestingDelete.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/WhenTestingDelete.cs
@@ -1,0 +1,110 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Application.Trips.Errors;
+using FishingLogBook.Domain.Trips;
+using FluentResults;
+using NSubstitute;
+
+namespace FishingLogBook.Application.Tests.Trips.Services.TripNoteServiceTests;
+
+public class WhenTestingDelete : BaseTripNoteServiceTest
+{
+    [Fact]
+    public async Task ItShouldFailWhenTheTripIsUnknown()
+    {
+        // Arrange
+        GivenNoTrip();
+
+        // Act
+        var result = await Sut.DeleteAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteNotFoundError>();
+        await MockTripNoteRepository.DidNotReceive().DeleteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheTripBelongsToAnotherAngler()
+    {
+        // Arrange
+        GivenTrip(OtherUserId);
+        MockTripNoteRepository.GetByIdAsync(NoteId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(StoredNote(TripId)));
+
+        // Act
+        var result = await Sut.DeleteAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteNotFoundError>();
+        await MockTripNoteRepository.DidNotReceive().DeleteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheNoteIsUnknown()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.DeleteAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteNotFoundError>();
+        await MockTripNoteRepository.DidNotReceive().DeleteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheNoteBelongsToAnotherTrip()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        MockTripNoteRepository.GetByIdAsync(NoteId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(StoredNote(Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"))));
+
+        // Act
+        var result = await Sut.DeleteAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteNotFoundError>();
+        await MockTripNoteRepository.DidNotReceive().DeleteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDeleteTheAnglersOwnNote()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+        MockTripNoteRepository.GetByIdAsync(NoteId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<TripNote?>(StoredNote(TripId)));
+
+        // Act
+        var result = await Sut.DeleteAsync(Args(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockTripNoteRepository.Received(1).DeleteAsync(
+            NoteId,
+            Arg.Any<CancellationToken>());
+    }
+
+    private static DeleteTripNoteArgs Args()
+    {
+        return new DeleteTripNoteArgs
+        {
+            TripId = TripId,
+            NoteId = NoteId
+        };
+    }
+}

--- a/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/WhenTestingRecord.cs
+++ b/tests/FishingLogBook.Application.Tests/Trips/Services/TripNoteServiceTests/WhenTestingRecord.cs
@@ -243,14 +243,106 @@ public class WhenTestingRecord : BaseTripNoteServiceTest
             .Should().BeEquivalentTo(["NoteId", "Text", "RecordedOn"]);
     }
 
-    private static RecordTripNoteArgs Args(string text = "water dropped about a foot")
+    [Fact]
+    public async Task ItShouldRejectANoteRecordedBeforeTheTripStarted()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(
+            Args(recordedOn: StartedOn.AddMinutes(-1)),
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteOutsideTripError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectANoteRecordedAfterACompletedTripFinished()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId, TripStatusEnum.Completed);
+
+        // Act
+        var result = await Sut.RecordAsync(
+            Args(recordedOn: StartedOn.AddHours(3).AddMinutes(1)),
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteOutsideTripError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectANoteRecordedInTheFutureOnAnActiveTrip()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(
+            Args(recordedOn: DateTimeOffset.UtcNow.AddHours(1)),
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Should().BeOfType<TripNoteOutsideTripError>();
+        await MockTripNoteRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<TripNote>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAcceptANoteRecordedExactlyWhenTheTripStarted()
+    {
+        // Arrange
+        GivenTrip(CurrentUserId);
+
+        // Act
+        var result = await Sut.RecordAsync(Args(recordedOn: StartedOn), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockTripNoteRepository.Received(1).UpsertAsync(
+            Arg.Is<TripNote>(note => note.RecordedOn == StartedOn),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAcceptANoteRecordedExactlyWhenACompletedTripFinished()
+    {
+        // Arrange
+        var endedOn = StartedOn.AddHours(3);
+        GivenTrip(CurrentUserId, TripStatusEnum.Completed);
+
+        // Act
+        var result = await Sut.RecordAsync(Args(recordedOn: endedOn), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await MockTripNoteRepository.Received(1).UpsertAsync(
+            Arg.Is<TripNote>(note => note.RecordedOn == endedOn),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static RecordTripNoteArgs Args(
+        string text = "water dropped about a foot",
+        DateTimeOffset? recordedOn = null)
     {
         return new RecordTripNoteArgs
         {
             TripId = TripId,
             NoteId = NoteId,
             Text = text,
-            RecordedOn = RecordedOn
+            RecordedOn = recordedOn ?? RecordedOn
         };
     }
 }

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/CatchRepositoryTests/WhenTestingAssociateTrip.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Repositories/CatchRepositoryTests/WhenTestingAssociateTrip.cs
@@ -1,0 +1,181 @@
+using AwesomeAssertions;
+using FishingLogBook.Application.Args;
+using FishingLogBook.Domain.Catches;
+using FishingLogBook.Domain.Enums;
+using FishingLogBook.Domain.Trips;
+using FishingLogBook.Infrastructure.Persistence.Repositories;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Repositories.CatchRepositoryTests;
+
+public class WhenTestingAssociateTrip : BaseCatchRepositoryTest
+{
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+
+    private readonly TripRepository _trips;
+
+    public WhenTestingAssociateTrip(PostgresFixture fixture)
+        : base(fixture)
+    {
+        _trips = new TripRepository(
+            ConnectionFactory,
+            NullLogger<TripRepository>.Instance,
+            TestMapper.Create());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFalseWhenTheCatchIsMissing()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+
+        // Act
+        var result = await Sut.AssociateTripAsync(
+            Args(Guid.NewGuid(), userId, trip.Id),
+            CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldFailWhenTheTripDoesNotExist()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var catchRecord = NewCatch(userId);
+        await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+        var missingTripId = Guid.NewGuid();
+
+        // Act
+        var result = await Sut.AssociateTripAsync(
+            Args(catchRecord.Id, userId, missingTripId),
+            CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors[0].Message.Should().Be("Failed to save the catch.");
+        loaded.Value!.TripId.Should().BeNull();
+        Logger.Records.Should().ContainSingle();
+        Logger.Records[0].Level.Should().Be(LogLevel.Error);
+        Logger.Records[0].Exception.Should().NotBeNull();
+        Logger.Records[0].Message.Should().Contain(catchRecord.Id.ToString("D"));
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFalseWhenAnotherAnglerOwnsTheCatch()
+    {
+        // Arrange
+        var ownerId = await CreateUserAsync();
+        var otherUserId = await CreateUserAsync();
+        var trip = await CreateTripAsync(otherUserId);
+        var catchRecord = NewCatch(ownerId);
+        await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+
+        // Act
+        var result = await Sut.AssociateTripAsync(
+            Args(catchRecord.Id, otherUserId, trip.Id),
+            CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+        loaded.Value!.TripId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFalseWhenTheCatchAlreadyHasATrip()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var first = await CreateTripAsync(userId);
+        var second = await CreateTripAsync(userId);
+        var catchRecord = NewCatch(userId);
+        await Sut.UpsertAsync(
+            WithTrip(catchRecord, first.Id),
+            CancellationToken.None);
+
+        // Act
+        var result = await Sut.AssociateTripAsync(
+            Args(catchRecord.Id, userId, second.Id),
+            CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+        loaded.Value!.TripId.Should().Be(first.Id);
+    }
+
+    [Fact]
+    public async Task ItShouldAssociateAnUnlinkedOwnedCatch()
+    {
+        // Arrange
+        var userId = await CreateUserAsync();
+        var trip = await CreateTripAsync(userId);
+        var catchRecord = NewCatch(userId);
+        await Sut.UpsertAsync(catchRecord, CancellationToken.None);
+
+        // Act
+        var result = await Sut.AssociateTripAsync(
+            Args(catchRecord.Id, userId, trip.Id),
+            CancellationToken.None);
+        var loaded = await Sut.GetByIdAsync(catchRecord.Id, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+        loaded.Value!.TripId.Should().Be(trip.Id);
+    }
+
+    private static PersistCatchTripArgs Args(Guid catchId, Guid userId, Guid tripId)
+    {
+        return new PersistCatchTripArgs
+        {
+            CatchId = catchId,
+            UserId = userId,
+            TripId = tripId
+        };
+    }
+
+    private static Catch WithTrip(Catch seed, Guid tripId)
+    {
+        return new Catch
+        {
+            Id = seed.Id,
+            UserId = seed.UserId,
+            AnglerUserId = seed.AnglerUserId,
+            RecordedByUserId = seed.RecordedByUserId,
+            TripId = tripId,
+            CaughtOn = seed.CaughtOn,
+            Photographs = seed.Photographs
+        };
+    }
+
+    private async Task<Trip> CreateTripAsync(
+        Guid ownerUserId,
+        TripStatusEnum status = TripStatusEnum.Active)
+    {
+        var trip = new Trip
+        {
+            Id = Guid.NewGuid(),
+            OwnerUserId = ownerUserId,
+            Status = status,
+            StartedOn = StartedOn,
+            EndedOn = status == TripStatusEnum.Completed ? StartedOn.AddHours(3) : null
+        };
+        var saved = await _trips.UpsertAsync(trip, CancellationToken.None);
+        if (saved.IsFailed)
+        {
+            throw new InvalidOperationException(saved.Errors[0].Message);
+        }
+
+        return saved.Value;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/CatchSelectorTests/BaseCatchSelectorTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/CatchSelectorTests/BaseCatchSelectorTest.cs
@@ -1,9 +1,12 @@
 using Bunit;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
 using NSubstitute;
@@ -17,7 +20,10 @@ public class BaseCatchSelectorTest
     protected static readonly Guid TroutCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000002");
     protected static readonly DateTimeOffset CaughtOn = DateTimeOffset.Parse("2026-08-27T07:30:00Z");
 
-    protected static BunitContext CreateContext(ICatchStore? catchStore = null, ILoggingService? logging = null)
+    protected static BunitContext CreateContext(
+        ICatchStore? catchStore = null,
+        ILoggingService? logging = null,
+        ITimeService? time = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -26,6 +32,8 @@ public class BaseCatchSelectorTest
         context.Services.AddSingleton(Substitute.For<ICultureService>());
         context.Services.AddSingleton(catchStore ?? Substitute.For<ICatchStore>());
         context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
+        context.Services.AddSingleton(time ?? TestTimeService.WithOffset(TimeSpan.Zero));
+        context.Services.AddSingleton<IMeasurementService>(new MeasurementService());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
     }
@@ -38,13 +46,22 @@ public class BaseCatchSelectorTest
         return store;
     }
 
-    protected static CatchModel Catch(Guid catchId, string? speciesName, DateTimeOffset? caughtOn = null)
+    protected static CatchModel Catch(
+        Guid catchId,
+        string? speciesName,
+        DateTimeOffset? caughtOn = null,
+        decimal? weight = null,
+        decimal? length = null,
+        string? method = null)
     {
         return new CatchModel(
             catchId,
             caughtOn ?? CaughtOn,
             [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg)],
             speciesName,
-            UserId: OwnerUserId);
+            UserId: OwnerUserId,
+            Weight: weight,
+            Length: length,
+            Method: method);
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/CatchSelectorTests/WhenTestingSelect.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/CatchSelectorTests/WhenTestingSelect.cs
@@ -1,71 +1,66 @@
 using AwesomeAssertions;
 using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Enums;
 using FishingLogBook.Web.Features.Catch.Components.CatchSelector;
 using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
 
 namespace FishingLogBook.Web.Tests.Features.Catch.Components.CatchSelectorTests;
 
 public class WhenTestingSelect : BaseCatchSelectorTest
 {
     [Fact]
-    public async Task ItShouldShowTheEmptyLabelAndNoConfirmActionWhenThereIsNothingToSelect()
+    public async Task ItShouldRenderNothingWhenThereIsNothingToSelect()
     {
         // Arrange
         await using var context = CreateContext();
-        var confirmed = new List<IReadOnlyList<Guid>>();
+        var selections = new List<IReadOnlyList<Guid>>();
 
         // Act
         var cut = context.Render<CatchSelector>(parameters => parameters
             .Add(component => component.Catches, Array.Empty<CatchModel>())
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add")
-            .Add(component => component.OnConfirm, ids => confirmed.Add(ids)));
+            .Add(component => component.SelectedChanged, ids => selections.Add(ids)));
 
         // Assert
-        cut.Find("#catch-selector-empty").TextContent.Should().Contain("Nothing to add");
-        cut.FindAll("#catch-selector-confirm").Should().BeEmpty();
-        confirmed.Should().BeEmpty();
+        cut.FindAll(".catch-selector-row").Should().BeEmpty();
+        selections.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task ItShouldKeepConfirmDisabledUntilSomethingIsSelected()
+    public async Task ItShouldNotSelectAnythingUntilTheAnglerChooses()
     {
         // Arrange
         await using var context = CreateContext();
-        var confirmed = new List<IReadOnlyList<Guid>>();
-        var cut = context.Render<CatchSelector>(parameters => parameters
-            .Add(component => component.Catches, new[] { Catch(PikeCatchId, "Pike") })
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add")
-            .Add(component => component.OnConfirm, ids => confirmed.Add(ids)));
+        var selections = new List<IReadOnlyList<Guid>>();
 
         // Act
-        cut.Find("#catch-selector-confirm").Click();
+        var cut = context.Render<CatchSelector>(parameters => parameters
+            .Add(component => component.Catches, new[] { Catch(PikeCatchId, "Pike") })
+            .Add(component => component.SelectedChanged, ids => selections.Add(ids)));
 
         // Assert
-        cut.Find("#catch-selector-confirm").HasAttribute("disabled").Should().BeTrue();
-        confirmed.Should().BeEmpty();
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull();
+        selections.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task ItShouldNotConfirmWhenTheSelectorIsDisabled()
+    public async Task ItShouldNotChangeTheSelectionWhileDisabled()
     {
         // Arrange
         await using var context = CreateContext();
-        var confirmed = new List<IReadOnlyList<Guid>>();
+        var selections = new List<IReadOnlyList<Guid>>();
         var cut = context.Render<CatchSelector>(parameters => parameters
             .Add(component => component.Catches, new[] { Catch(PikeCatchId, "Pike") })
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add")
             .Add(component => component.Disabled, true)
-            .Add(component => component.OnConfirm, ids => confirmed.Add(ids)));
+            .Add(component => component.SelectedChanged, ids => selections.Add(ids)));
 
         // Act
-        cut.Find("#catch-selector-confirm").Click();
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
 
         // Assert
-        confirmed.Should().BeEmpty();
-        cut.Find($"#catch-selector-option-{PikeCatchId:D}").HasAttribute("disabled").Should().BeTrue();
+        selections.Should().BeEmpty();
     }
 
     [Fact]
@@ -73,24 +68,20 @@ public class WhenTestingSelect : BaseCatchSelectorTest
     {
         // Arrange
         await using var context = CreateContext();
-        var confirmed = new List<IReadOnlyList<Guid>>();
+        var selections = new List<IReadOnlyList<Guid>>();
         var cut = context.Render<CatchSelector>(parameters => parameters
-            .Add(
-                component => component.Catches,
-                new[] { Catch(PikeCatchId, "Pike"), Catch(TroutCatchId, "Brown Trout") })
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add")
-            .Add(component => component.OnConfirm, ids => confirmed.Add(ids)));
-        cut.Find($"#catch-selector-option-{TroutCatchId:D}").Change(true);
+            .Add(component => component.Catches, new[] { Catch(PikeCatchId, "Pike") })
+            .Add(component => component.SelectedChanged, ids => selections.Add(ids)));
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
+        selections.Should().ContainSingle();
 
         // Act
         cut.Render(parameters => parameters
-            .Add(component => component.Catches, new[] { Catch(PikeCatchId, "Pike") }));
-        cut.Find("#catch-selector-confirm").Click();
+            .Add(component => component.Catches, new[] { Catch(TroutCatchId, "Brown Trout") })
+            .Add(component => component.SelectedChanged, ids => selections.Add(ids)));
 
         // Assert
-        confirmed.Should().BeEmpty();
-        cut.Find("#catch-selector-confirm").HasAttribute("disabled").Should().BeTrue();
+        selections.Last().Should().BeEmpty();
     }
 
     [Fact]
@@ -98,54 +89,96 @@ public class WhenTestingSelect : BaseCatchSelectorTest
     {
         // Arrange
         await using var context = CreateContext();
-        var confirmed = new List<IReadOnlyList<Guid>>();
+        var selections = new List<IReadOnlyList<Guid>>();
         var cut = context.Render<CatchSelector>(parameters => parameters
-            .Add(
-                component => component.Catches,
-                new[] { Catch(PikeCatchId, "Pike"), Catch(TroutCatchId, "Brown Trout") })
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add")
-            .Add(component => component.OnConfirm, ids => confirmed.Add(ids)));
+            .Add(component => component.Catches, new[] { Catch(PikeCatchId, "Pike") })
+            .Add(component => component.SelectedChanged, ids => selections.Add(ids)));
         cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
-        cut.Find($"#catch-selector-option-{TroutCatchId:D}").Change(true);
 
         // Act
-        cut.Find($"#catch-selector-option-{TroutCatchId:D}").Change(false);
-        cut.Find("#catch-selector-confirm").Click();
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(false);
 
         // Assert
-        confirmed.Should().ContainSingle();
-        confirmed[0].Should().Equal(PikeCatchId);
+        selections.Should().HaveCount(2);
+        selections[0].Should().Equal(PikeCatchId);
+        selections[1].Should().BeEmpty();
     }
 
     [Fact]
-    public async Task ItShouldConfirmEverySelectedCatchAndDescribeThemForTheAngler()
+    public async Task ItShouldReportEverySelectedCatch()
     {
         // Arrange
         await using var context = CreateContext();
-        var confirmed = new List<IReadOnlyList<Guid>>();
+        var selections = new List<IReadOnlyList<Guid>>();
         var cut = context.Render<CatchSelector>(parameters => parameters
-            .Add(
-                component => component.Catches,
-                new[]
-                {
-                    Catch(PikeCatchId, "Pike"),
-                    Catch(TroutCatchId, null, CaughtOn.AddHours(1))
-                })
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add")
-            .Add(component => component.UnknownSpeciesLabel, "Catch recorded")
-            .Add(component => component.OnConfirm, ids => confirmed.Add(ids)));
+            .Add(component => component.Catches, new[]
+            {
+                Catch(PikeCatchId, "Pike"),
+                Catch(TroutCatchId, "Brown Trout")
+            })
+            .Add(component => component.SelectedChanged, ids => selections.Add(ids)));
 
         // Act
         cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
         cut.Find($"#catch-selector-option-{TroutCatchId:D}").Change(true);
-        cut.Find("#catch-selector-confirm").Click();
 
         // Assert
-        confirmed.Should().ContainSingle();
-        confirmed[0].Should().Equal(PikeCatchId, TroutCatchId);
-        cut.Markup.Should().Contain("Pike");
-        cut.Markup.Should().Contain("Catch recorded");
+        selections.Last().Should().Equal(PikeCatchId, TroutCatchId);
+    }
+
+    [Fact]
+    public async Task ItShouldDescribeACatchWithoutRenderingEmptyValues()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var cut = context.Render<CatchSelector>(parameters => parameters
+            .Add(component => component.Catches, new[]
+            {
+                Catch(PikeCatchId, "Pike", weight: 2.5m),
+                Catch(TroutCatchId, null, length: 45m)
+            })
+            .Add(component => component.UnknownSpeciesLabel, "Unnamed catch")
+            .Add(component => component.WeightUnit, WeightUnitEnum.Kg)
+            .Add(component => component.LengthUnit, LengthUnitEnum.Cm));
+
+        // Assert
+        cut.Find($"#catch-selector-species-{PikeCatchId:D}").TextContent.Should().Contain("Pike");
+        cut.Find($"#catch-selector-facts-{PikeCatchId:D}").TextContent.Should().Contain("2.5 kg");
+        cut.Find($"#catch-selector-facts-{PikeCatchId:D}").TextContent.Should().NotContain("cm");
+        cut.Find($"#catch-selector-species-{TroutCatchId:D}").TextContent.Should().Contain("Unnamed catch");
+        cut.Find($"#catch-selector-facts-{TroutCatchId:D}").TextContent.Should().Contain("45 cm");
+        cut.FindAll($"#catch-selector-method-{TroutCatchId:D}").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheMethodWhenTheAnglerRecordedOne()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        // Act
+        var cut = context.Render<CatchSelector>(parameters => parameters
+            .Add(component => component.Catches, new[] { Catch(PikeCatchId, "Pike", method: "Fly") }));
+
+        // Assert
+        cut.Find($"#catch-selector-method-{PikeCatchId:D}").TextContent.Should().Contain("Fly");
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheLocalTimeOfTheCatch()
+    {
+        // Arrange
+        await using var context = CreateContext(time: TestTimeService.WithOffset(TimeSpan.FromHours(2)));
+
+        // Act
+        var cut = context.Render<CatchSelector>(parameters => parameters
+            .Add(component => component.Catches, new[] { Catch(PikeCatchId, "Pike") }));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#catch-selector-facts-{PikeCatchId:D}").TextContent.Should().Contain("09:30"));
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Components/CatchSelectorTests/WhenTestingThumbnails.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Components/CatchSelectorTests/WhenTestingThumbnails.cs
@@ -20,9 +20,7 @@ public class WhenTestingThumbnails : BaseCatchSelectorTest
         // Act
         var cut = context.Render<CatchSelector>(parameters => parameters
             .Add(component => component.Catches, new[] { withoutPhoto })
-            .Add(component => component.OwnerUserId, OwnerUserId)
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add"));
+            .Add(component => component.OwnerUserId, OwnerUserId));
 
         // Assert
         cut.Find(".catch-selector-thumbnail-placeholder").Should().NotBeNull();
@@ -52,9 +50,7 @@ public class WhenTestingThumbnails : BaseCatchSelectorTest
         // Act
         var cut = context.Render<CatchSelector>(parameters => parameters
             .Add(component => component.Catches, new[] { withRemotePhoto })
-            .Add(component => component.OwnerUserId, OwnerUserId)
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add"));
+            .Add(component => component.OwnerUserId, OwnerUserId));
 
         // Assert
         cut.WaitForAssertion(() =>
@@ -84,9 +80,7 @@ public class WhenTestingThumbnails : BaseCatchSelectorTest
         // Act
         var cut = context.Render<CatchSelector>(parameters => parameters
             .Add(component => component.Catches, new[] { withLocalPhoto })
-            .Add(component => component.OwnerUserId, OwnerUserId)
-            .Add(component => component.ConfirmLabel, "Add to this trip")
-            .Add(component => component.EmptyLabel, "Nothing to add"));
+            .Add(component => component.OwnerUserId, OwnerUserId));
 
         // Assert
         cut.WaitForAssertion(() =>

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Clients/TripClientTests/WhenTestingCatches.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Clients/TripClientTests/WhenTestingCatches.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Clients.TripClientTests;
+
+public class WhenTestingCatches : BaseTripClientTest
+{
+    private static readonly Guid PikeCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
+    private static readonly Guid TroutCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000002");
+
+    [Fact]
+    public async Task ItShouldThrowWhenTheServerRejectsTheAssociation()
+    {
+        // Arrange
+        var handler = new RecordingHandler(HttpStatusCode.BadRequest);
+        var client = CreateClient(handler);
+
+        // Act
+        var act = async () => await client.AssociateCatchesAsync(
+            TripId,
+            new AssociateTripCatchesDto([PikeCatchId]),
+            CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be($"https://api.test/api/trips/{TripId:D}/catches");
+    }
+
+    [Fact]
+    public async Task ItShouldThrowWhenTheServerIsUnavailable()
+    {
+        // Arrange
+        var handler = new RecordingHandler(HttpStatusCode.ServiceUnavailable);
+        var client = CreateClient(handler);
+
+        // Act
+        var act = async () => await client.AssociateCatchesAsync(
+            TripId,
+            new AssociateTripCatchesDto([PikeCatchId]),
+            CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task ItShouldReturnNullWhenTheBodyIsMissing()
+    {
+        // Arrange
+        var client = CreateClient(new RecordingHandler(HttpStatusCode.OK, "null"));
+
+        // Act
+        var association = await client.AssociateCatchesAsync(
+            TripId,
+            new AssociateTripCatchesDto([PikeCatchId]),
+            CancellationToken.None);
+
+        // Assert
+        association.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldPostTheCatchIdsToTheTripCatchesRoute()
+    {
+        // Arrange
+        var body = $$"""
+            {
+                "associatedCatchIds": ["{{PikeCatchId:D}}"],
+                "rejectedCatchIds": ["{{TroutCatchId:D}}"]
+            }
+            """;
+        var handler = new RecordingHandler(HttpStatusCode.OK, body);
+        var client = CreateClient(handler);
+
+        // Act
+        var association = await client.AssociateCatchesAsync(
+            TripId,
+            new AssociateTripCatchesDto([PikeCatchId, TroutCatchId]),
+            CancellationToken.None);
+
+        // Assert
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest.RequestUri!.ToString()
+            .Should().Be($"https://api.test/api/trips/{TripId:D}/catches");
+        handler.LastBody.Should().Contain($"\"{PikeCatchId:D}\"");
+        handler.LastBody.Should().Contain($"\"{TroutCatchId:D}\"");
+        association!.AssociatedCatchIds.Should().Equal(PikeCatchId);
+        association.RejectedCatchIds.Should().Equal(TroutCatchId);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripCatchesTests/BaseTripCatchesTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripCatchesTests/BaseTripCatchesTest.cs
@@ -1,8 +1,8 @@
 using Bunit;
 using FishingLogBook.Shared.Constants;
-using FishingLogBook.Web.Features.Catch.Models;
-using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,33 +17,33 @@ public class BaseTripCatchesTest
     protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     protected static readonly Guid PikeCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
     protected static readonly Guid TroutCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000002");
-    protected static readonly Guid TrippedCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000003");
     protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-27T06:00:00Z");
+    protected static readonly DateTimeOffset EndedOn = DateTimeOffset.Parse("2026-08-27T14:00:00Z");
 
-    protected static BunitContext CreateContext(ICatchStore catchStore, ILoggingService? logging = null)
+    protected static BunitContext CreateContext(
+        IModalService modalService,
+        ILoggingService? logging = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
-        context.Services.AddSingleton(catchStore);
+        context.Services.AddSingleton(modalService);
         context.Services.AddSingleton(logging ?? QuietLogging());
         context.Services.AddSingleton(Substitute.For<ICultureService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
     }
 
-    protected static ICatchStore StoreWith(params CatchModel[] catches)
+    protected static IModalService ModalServiceAdding(AddTripCatchesModalResult? result = null)
     {
-        var store = Substitute.For<ICatchStore>();
-        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>()).Returns(catches);
-        store.UpdateTripAsync(
-                Arg.Any<Guid>(),
-                Arg.Any<Guid>(),
-                Arg.Any<Guid?>(),
+        var modalService = Substitute.For<IModalService>();
+        modalService
+            .ShowAsync<AddTripCatchesModal, AddTripCatchesModalModel, AddTripCatchesModalResult>(
+                Arg.Any<AddTripCatchesModalModel>(),
                 Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
-        return store;
+            .Returns(result);
+        return modalService;
     }
 
     protected static ILoggingService QuietLogging()
@@ -54,19 +54,13 @@ public class BaseTripCatchesTest
         return logging;
     }
 
-    protected static CatchModel Catch(Guid catchId, string? speciesName, Guid? tripId = null)
-    {
-        return new CatchModel(
-            catchId,
-            StartedOn.AddMinutes(30),
-            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg)],
-            speciesName,
-            UserId: OwnerUserId,
-            TripId: tripId);
-    }
-
     protected static TripModel Trip()
     {
         return new TripModel(TripId, OwnerUserId, TripConstants.Active, StartedOn);
+    }
+
+    protected static TripModel CompletedTrip()
+    {
+        return new TripModel(TripId, OwnerUserId, TripConstants.Completed, StartedOn, EndedOn);
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripCatchesTests/WhenTestingAddExistingCatches.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripCatchesTests/WhenTestingAddExistingCatches.cs
@@ -1,199 +1,137 @@
 using AwesomeAssertions;
 using Bunit;
-using FishingLogBook.Web.Features.Catch.Models;
-using FishingLogBook.Web.Features.Catch.Offline.Stores;
-using FishingLogBook.Web.Features.Trips.Components.TripCatches;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Tests.TestSupport;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
+using TripCatchesComponent = FishingLogBook.Web.Features.Trips.Components.TripCatches.TripCatches;
 
 namespace FishingLogBook.Web.Tests.Features.Trips.Components.TripCatchesTests;
 
 public class WhenTestingAddExistingCatches : BaseTripCatchesTest
 {
     [Fact]
-    public async Task ItShouldOfferRecordCatchForThisTripWithoutReadingAnyCatches()
+    public async Task ItShouldOfferRecordCatchForThisTripWithoutOpeningThePicker()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        var store = StoreWith();
-        await using var context = CreateContext(store);
+        var modalService = ModalServiceAdding();
+        await using var context = CreateContext(modalService);
 
         // Act
-        var cut = context.Render<TripCatches>(parameters => parameters
-            .Add(component => component.Trip, Trip())
-            .Add(component => component.RecordCatchBaseHref, "/offline/record"));
+        var cut = context.Render<TripCatchesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
 
         // Assert
-        cut.Find("#trip-catches-record").GetAttribute("href")
-            .Should().Be($"/offline/record?tripId={TripId:D}");
-        await store.DidNotReceive().GetMetadataAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        cut.Find("#trip-catches-record").GetAttribute("href").Should().Be($"/catches/record?tripId={TripId:D}");
+        cut.Find("#trip-catches-add").TextContent.Should().Contain("Add catch");
+        cut.Find("#trip-catches-actions").ClassName.Should().Contain("mud-grid");
+        await modalService.DidNotReceive()
+            .ShowAsync<AddTripCatchesModal, AddTripCatchesModalModel, AddTripCatchesModalResult>(
+                Arg.Any<AddTripCatchesModalModel>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ItShouldShowTheFailureWhenTheUnassignedCatchesCannotBeRead()
+    public async Task ItShouldOpenThePickerForThisTripsTimeframe()
     {
         // Arrange
-        using var culture = TestCulture.Use(CultureNames.English);
-        var store = Substitute.For<ICatchStore>();
-        store.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("IndexedDB unavailable."));
-        var logging = QuietLogging();
-        await using var context = CreateContext(store, logging);
-        var cut = context.Render<TripCatches>(parameters => parameters
-            .Add(component => component.Trip, Trip()));
+        var modalService = ModalServiceAdding();
+        await using var context = CreateContext(modalService);
+        var cut = context.Render<TripCatchesComponent>(parameters =>
+            parameters.Add(component => component.Trip, CompletedTrip()));
 
         // Act
-        cut.Find("#trip-catches-add").Click();
+        await cut.Find("#trip-catches-add").ClickAsync();
 
         // Assert
-        cut.WaitForAssertion(() => cut.Find("#trip-catches-failed").Should().NotBeNull());
-        await logging.Received(1).LogErrorAsync(
-            "reading catches that are not on a trip",
-            Arg.Any<InvalidOperationException>(),
-            Arg.Any<CancellationToken>());
-        await store.DidNotReceive().UpdateTripAsync(
-            Arg.Any<Guid>(),
-            Arg.Any<Guid>(),
-            Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
+        await modalService.Received(1)
+            .ShowAsync<AddTripCatchesModal, AddTripCatchesModalModel, AddTripCatchesModalResult>(
+                Arg.Is<AddTripCatchesModalModel>(model =>
+                    model.Scope.TripId == TripId
+                    && model.Scope.OwnerUserId == OwnerUserId
+                    && model.Scope.StartedOn == StartedOn
+                    && model.Scope.EndedOn == EndedOn
+                    && model.Storage == TripStorageEnum.LocalFirst),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ItShouldOnlyOfferCatchesThatAreNotAlreadyOnATrip()
+    public async Task ItShouldAskTheServerForAHistoricalTrip()
     {
         // Arrange
-        using var culture = TestCulture.Use(CultureNames.English);
-        var store = StoreWith(
-            Catch(PikeCatchId, "Pike"),
-            Catch(TrippedCatchId, "Brown Trout", Guid.NewGuid()));
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripCatches>(parameters => parameters
-            .Add(component => component.Trip, Trip()));
+        var modalService = ModalServiceAdding();
+        await using var context = CreateContext(modalService);
+        var cut = context.Render<TripCatchesComponent>(parameters => parameters
+            .Add(component => component.Trip, CompletedTrip())
+            .Add(component => component.CatchStorage, TripStorageEnum.Server));
 
         // Act
-        cut.Find("#trip-catches-add").Click();
+        await cut.Find("#trip-catches-add").ClickAsync();
 
         // Assert
-        cut.WaitForAssertion(() =>
-            cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
-        cut.FindAll($"#catch-selector-option-{TrippedCatchId:D}").Should().BeEmpty();
-        await store.Received(1).GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await modalService.Received(1)
+            .ShowAsync<AddTripCatchesModal, AddTripCatchesModalModel, AddTripCatchesModalResult>(
+                Arg.Is<AddTripCatchesModalModel>(model => model.Storage == TripStorageEnum.Server),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ItShouldSayWhenEveryCatchIsAlreadyOnATrip()
+    public async Task ItShouldNotTellTheParentWhenThePickerWasDismissed()
     {
         // Arrange
-        using var culture = TestCulture.Use(CultureNames.English);
-        var store = StoreWith(Catch(TrippedCatchId, "Brown Trout", Guid.NewGuid()));
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripCatches>(parameters => parameters
-            .Add(component => component.Trip, Trip()));
-
-        // Act
-        cut.Find("#trip-catches-add").Click();
-
-        // Assert
-        cut.WaitForAssertion(() =>
-            cut.Find("#catch-selector-empty").TextContent.Should()
-                .Contain("Every catch is already on a trip."));
-        cut.FindAll("#catch-selector-confirm").Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task ItShouldCloseThePickerWithoutAttachingAnything()
-    {
-        // Arrange
-        using var culture = TestCulture.Use(CultureNames.English);
-        var store = StoreWith(Catch(PikeCatchId, "Pike"));
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripCatches>(parameters => parameters
-            .Add(component => component.Trip, Trip()));
-        cut.Find("#trip-catches-add").Click();
-        cut.WaitForAssertion(() => cut.Find("#trip-catches-cancel").Should().NotBeNull());
-
-        // Act
-        cut.Find("#trip-catches-cancel").Click();
-
-        // Assert
-        cut.FindAll("#trip-catches-picker").Should().BeEmpty();
-        cut.Find("#trip-catches-add").Should().NotBeNull();
-        await store.DidNotReceive().UpdateTripAsync(
-            Arg.Any<Guid>(),
-            Arg.Any<Guid>(),
-            Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ItShouldShowTheFailureWhenAttachingACatchFails()
-    {
-        // Arrange
-        using var culture = TestCulture.Use(CultureNames.English);
-        var store = StoreWith(Catch(PikeCatchId, "Pike"));
-        store.UpdateTripAsync(
-                OwnerUserId,
-                PikeCatchId,
-                TripId,
-                Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("IndexedDB unavailable."));
-        var logging = QuietLogging();
         var attached = 0;
-        await using var context = CreateContext(store, logging);
-        var cut = context.Render<TripCatches>(parameters => parameters
+        await using var context = CreateContext(ModalServiceAdding());
+        var cut = context.Render<TripCatchesComponent>(parameters => parameters
             .Add(component => component.Trip, Trip())
             .Add(component => component.OnCatchesAttached, () => attached++));
-        cut.Find("#trip-catches-add").Click();
-        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
-        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
 
         // Act
-        cut.Find("#catch-selector-confirm").Click();
+        await cut.Find("#trip-catches-add").ClickAsync();
 
         // Assert
-        cut.WaitForAssertion(() => cut.Find("#trip-catches-failed").Should().NotBeNull());
         attached.Should().Be(0);
-        await logging.Received(1).LogErrorAsync(
-            "adding catches to a trip",
-            Arg.Any<InvalidOperationException>(),
-            Arg.Any<CancellationToken>());
+        cut.FindAll("#trip-catches-partial").Should().BeEmpty();
     }
 
     [Fact]
-    public async Task ItShouldAttachEverySelectedCatchToThisTripAndTellTheParent()
+    public async Task ItShouldTellTheParentWhenCatchesWereAdded()
+    {
+        // Arrange
+        var attached = 0;
+        await using var context = CreateContext(ModalServiceAdding(
+            new AddTripCatchesModalResult([PikeCatchId, TroutCatchId], [])));
+        var cut = context.Render<TripCatchesComponent>(parameters => parameters
+            .Add(component => component.Trip, Trip())
+            .Add(component => component.OnCatchesAttached, () => attached++));
+
+        // Act
+        await cut.Find("#trip-catches-add").ClickAsync();
+
+        // Assert
+        attached.Should().Be(1);
+        cut.FindAll("#trip-catches-partial").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldWarnWhenSomeCatchesCouldNotBeAdded()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        var store = StoreWith(Catch(PikeCatchId, "Pike"), Catch(TroutCatchId, "Brown Trout"));
         var attached = 0;
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripCatches>(parameters => parameters
+        await using var context = CreateContext(ModalServiceAdding(
+            new AddTripCatchesModalResult([PikeCatchId], [TroutCatchId])));
+        var cut = context.Render<TripCatchesComponent>(parameters => parameters
             .Add(component => component.Trip, Trip())
             .Add(component => component.OnCatchesAttached, () => attached++));
-        cut.Find("#trip-catches-add").Click();
-        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
-        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
-        cut.Find($"#catch-selector-option-{TroutCatchId:D}").Change(true);
 
         // Act
-        cut.Find("#catch-selector-confirm").Click();
+        await cut.Find("#trip-catches-add").ClickAsync();
 
         // Assert
-        cut.WaitForAssertion(() => attached.Should().Be(1));
-        cut.FindAll("#trip-catches-picker").Should().BeEmpty();
-        await store.Received(1).UpdateTripAsync(
-            OwnerUserId,
-            PikeCatchId,
-            TripId,
-            Arg.Any<CancellationToken>());
-        await store.Received(1).UpdateTripAsync(
-            OwnerUserId,
-            TroutCatchId,
-            TripId,
-            Arg.Any<CancellationToken>());
-        await store.DidNotReceive().SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
-        await store.DidNotReceive().GetAllAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        attached.Should().Be(1);
+        cut.Find("#trip-catches-partial").TextContent.Should().Contain("no longer available");
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripEditorTests/BaseTripEditorTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripEditorTests/BaseTripEditorTest.cs
@@ -50,6 +50,7 @@ public class BaseTripEditorTest
         context.Services.AddSingleton(anglerPreferences ?? QuietAnglerPreferences());
         context.Services.AddSingleton(noteStore ?? Substitute.For<ITripNoteStore>());
         context.Services.AddSingleton(logging ?? QuietLogging());
+        context.Services.AddSingleton(Substitute.For<ITripNoteWriteService>());
         context.Services.AddSingleton(Substitute.For<ITripPhotographStore>());
         context.Services.AddSingleton(Substitute.For<ITripClient>());
         context.Services.AddSingleton(Substitute.For<IPhotographPreparationService>());

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripEditorTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripEditorTests/WhenTestingRender.cs
@@ -89,6 +89,9 @@ public class WhenTestingRender : BaseTripEditorTest
 
         // Assert
         cut.Find("#trip-editor-catches-empty").TextContent.Should().Contain("No catches yet");
+        cut.Find("#trip-catches-actions").ClassName.Should().Contain("mud-grid");
+        cut.Find("#trip-catches-record").Should().NotBeNull();
+        cut.Find("#trip-catches-add").Should().NotBeNull();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/BaseTripNotesTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/BaseTripNotesTest.cs
@@ -42,6 +42,17 @@ public class BaseTripNotesTest
         return modalService;
     }
 
+    protected static IModalService ModalServiceEditing(TripNoteModel edited)
+    {
+        var modalService = ConfirmingModalService();
+        modalService
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                Arg.Any<AddTripNoteModalModel>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AddTripNoteModalResult(edited));
+        return modalService;
+    }
+
     protected static BunitContext CreateContext(
         ITripNoteStore store,
         ITripClient? tripClient = null,

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/BaseTripNotesTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/BaseTripNotesTest.cs
@@ -8,6 +8,7 @@ using FishingLogBook.Web.Features.Trips.Clients;
 using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Tests.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,16 +47,19 @@ public class BaseTripNotesTest
         ITripClient? tripClient = null,
         ILoggingService? logging = null,
         ITimeService? time = null,
-        IModalService? modalService = null)
+        IModalService? modalService = null,
+        ITripNoteWriteService? noteWriter = null)
     {
+        var client = tripClient ?? Substitute.For<ITripClient>();
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
         context.Services.AddSingleton(store);
-        context.Services.AddSingleton(tripClient ?? Substitute.For<ITripClient>());
+        context.Services.AddSingleton(client);
         context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
         context.Services.AddSingleton(time ?? TestTimeService.WithOffset(TimeSpan.Zero));
+        context.Services.AddSingleton(noteWriter ?? new TripNoteWriteService(store, client));
         context.Services.AddSingleton(modalService ?? ConfirmingModalService());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/BaseTripNotesTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/BaseTripNotesTest.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Features.Trips.Offline.Stores;
 using FishingLogBook.Web.Localization;
@@ -26,6 +27,17 @@ public class BaseTripNotesTest
         var modalService = Substitute.For<IModalService>();
         modalService.ConfirmAsync(Arg.Any<ConfirmModalModel>(), Arg.Any<CancellationToken>())
             .Returns(confirm);
+        return modalService;
+    }
+
+    protected static IModalService ModalServiceAdding(TripNoteModel note)
+    {
+        var modalService = ConfirmingModalService();
+        modalService
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                Arg.Any<AddTripNoteModalModel>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AddTripNoteModalResult(note));
         return modalService;
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingAdd.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingAdd.cs
@@ -3,6 +3,7 @@ using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
@@ -165,6 +166,31 @@ public class WhenTestingAdd : BaseTripNotesTest
             .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
                 Arg.Is<AddTripNoteModalModel>(model => model.TripStartedOn == StartedOn),
                 Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAskTheModalToWriteAHistoricalNoteToTheServer()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var modalService = ConfirmingModalService();
+        await using var context = CreateContext(store, modalService: modalService);
+        var cut = context.Render<TripNotesComponent>(parameters => parameters
+            .Add(component => component.Trip, CompletedTrip())
+            .Add(component => component.NoteStorage, TripNoteStorageEnum.Server));
+
+        // Act
+        await cut.Find("#trip-note-start").ClickAsync();
+
+        // Assert
+        await modalService.Received(1)
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                Arg.Is<AddTripNoteModalModel>(model =>
+                    model.TripId == TripId
+                    && model.Storage == TripNoteStorageEnum.Server
+                    && model.TripEndedOn != null),
+                Arg.Any<CancellationToken>());
+        store.ForTripCalls.Should().Be(0);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingAdd.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingAdd.cs
@@ -177,7 +177,7 @@ public class WhenTestingAdd : BaseTripNotesTest
         await using var context = CreateContext(store, modalService: modalService);
         var cut = context.Render<TripNotesComponent>(parameters => parameters
             .Add(component => component.Trip, CompletedTrip())
-            .Add(component => component.NoteStorage, TripNoteStorageEnum.Server));
+            .Add(component => component.NoteStorage, TripStorageEnum.Server));
 
         // Act
         await cut.Find("#trip-note-start").ClickAsync();
@@ -187,7 +187,7 @@ public class WhenTestingAdd : BaseTripNotesTest
             .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
                 Arg.Is<AddTripNoteModalModel>(model =>
                     model.TripId == TripId
-                    && model.Storage == TripNoteStorageEnum.Server
+                    && model.Storage == TripStorageEnum.Server
                     && model.TripEndedOn != null),
                 Arg.Any<CancellationToken>());
         store.ForTripCalls.Should().Be(0);

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingAdd.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingAdd.cs
@@ -1,9 +1,9 @@
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Constants;
-using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Diagnostics.Services;
-using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
 using NSubstitute;
@@ -22,7 +22,8 @@ public class WhenTestingAdd : BaseTripNotesTest
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        var modalService = ConfirmingModalService();
+        await using var context = CreateContext(store, modalService: modalService);
 
         // Act
         var cut = context.Render<TripNotesComponent>(parameters =>
@@ -31,125 +32,54 @@ public class WhenTestingAdd : BaseTripNotesTest
         // Assert
         cut.Find("#trip-notes").Should().NotBeNull();
         cut.Find("#trip-note-start").TextContent.Should().Contain("Add note");
-        cut.FindAll("#trip-note-editor").Should().BeEmpty();
-        store.Count.Should().Be(0);
+        cut.FindAll("#trip-note-text").Should().BeEmpty();
+        await modalService.DidNotReceive()
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                Arg.Any<AddTripNoteModalModel>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ItShouldNotAllowSavingAWhitespaceOnlyNote()
+    public async Task ItShouldOpenTheAddNoteModalForThisTrip()
     {
         // Arrange
         var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        var modalService = ConfirmingModalService();
+        await using var context = CreateContext(store, modalService: modalService);
         var cut = context.Render<TripNotesComponent>(parameters =>
             parameters.Add(component => component.Trip, Trip()));
-        await cut.Find("#trip-note-start").ClickAsync();
 
         // Act
-        cut.Find("#trip-note-text").Input("   \t  ");
+        await cut.Find("#trip-note-start").ClickAsync();
 
         // Assert
-        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
-        await cut.Find("#trip-note-save").ClickAsync();
-        store.Count.Should().Be(0);
+        await modalService.Received(1)
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                Arg.Is<AddTripNoteModalModel>(model =>
+                    model.TripId == TripId
+                    && model.OwnerUserId == OwnerUserId
+                    && model.TripStartedOn == StartedOn),
+                Arg.Any<CancellationToken>());
+        cut.FindAll("#trip-notes-list").Should().BeEmpty();
     }
 
     [Fact]
-    public async Task ItShouldNotAllowSavingANoteOverTheCap()
+    public async Task ItShouldNotChangeTheTripWhenTheModalIsDismissed()
     {
         // Arrange
         var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripNotesComponent>(parameters =>
-            parameters.Add(component => component.Trip, Trip()));
-        await cut.Find("#trip-note-start").ClickAsync();
+        var changed = 0;
+        await using var context = CreateContext(store, modalService: ConfirmingModalService());
+        var cut = context.Render<TripNotesComponent>(parameters => parameters
+            .Add(component => component.Trip, Trip())
+            .Add(component => component.Changed, () => changed++));
 
         // Act
-        cut.Find("#trip-note-text").Input(new string('a', TripConstants.MaxNoteTextLength + 1));
-
-        // Assert
-        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
-        store.Count.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task ItShouldKeepTheTypedTextWhenTheLocalWriteFails()
-    {
-        // Arrange
-        using var culture = TestCulture.Use(CultureNames.English);
-        var store = new MemoryTripNoteStore { FailWrite = true };
-        var logging = Substitute.For<ILoggingService>();
-        await using var context = CreateContext(store, logging: logging);
-        var cut = context.Render<TripNotesComponent>(parameters =>
-            parameters.Add(component => component.Trip, Trip()));
         await cut.Find("#trip-note-start").ClickAsync();
-        cut.Find("#trip-note-text").Input("fish rising near the reeds");
-
-        // Act
-        await cut.Find("#trip-note-save").ClickAsync();
 
         // Assert
-        cut.Find("#trip-note-add-failed").TextContent.Should().Contain("could not be added");
-        cut.Find("#trip-note-text").GetAttribute("value").Should().Be("fish rising near the reeds");
-        store.Count.Should().Be(0);
-        await logging.Received(1).LogErrorAsync(
-            "adding a trip note",
-            Arg.Any<Exception>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ItShouldNeverLogTheNoteText()
-    {
-        // Arrange
-        const string secret = "met Sarah about the lease at the bailiff hut";
-        var store = new MemoryTripNoteStore { FailWrite = true };
-        var logging = Substitute.For<ILoggingService>();
-        await using var context = CreateContext(store, logging: logging);
-        var cut = context.Render<TripNotesComponent>(parameters =>
-            parameters.Add(component => component.Trip, Trip()));
-        await cut.Find("#trip-note-start").ClickAsync();
-        cut.Find("#trip-note-text").Input(secret);
-
-        // Act
-        await cut.Find("#trip-note-save").ClickAsync();
-
-        // Assert
-        await logging.DidNotReceive().LogErrorAsync(
-            Arg.Is<string>(operation => operation.Contains(secret)),
-            Arg.Any<Exception>(),
-            Arg.Any<CancellationToken>());
-        await logging.DidNotReceive().LogErrorAsync(
-            Arg.Any<string>(),
-            Arg.Is<Exception>(exception => exception.Message.Contains(secret)),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ItShouldSaveTheNoteLocallyAndClearTheEditor()
-    {
-        // Arrange
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripNotesComponent>(parameters =>
-            parameters.Add(component => component.Trip, Trip()));
-        await cut.Find("#trip-note-start").ClickAsync();
-        cut.Find("#trip-note-text").Input("  changed to olive nymph  ");
-
-        // Act
-        await cut.Find("#trip-note-save").ClickAsync();
-
-        // Assert
-        store.Count.Should().Be(1);
-        var stored = store.All().Single();
-        stored.Text.Should().Be("changed to olive nymph");
-        stored.TripId.Should().Be(TripId);
-        stored.OwnerUserId.Should().Be(OwnerUserId);
-        stored.SyncStatus.Should().Be(SyncStatus.SavedLocally);
-        stored.RecordedOn.Should().NotBe(default);
-        stored.RecordedOn.Should().NotBe(StartedOn);
-        cut.FindAll("#trip-note-editor").Should().BeEmpty();
-        cut.Find("#trip-note-start").Should().NotBeNull();
+        changed.Should().Be(0);
+        cut.FindAll("#trip-notes-list").Should().BeEmpty();
     }
 
     [Fact]
@@ -157,22 +87,84 @@ public class WhenTestingAdd : BaseTripNotesTest
     {
         // Arrange
         var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        var note = Note(FirstNoteId, "wind picked up", StartedOn.AddHours(2));
+        await using var context = CreateContext(store, modalService: ModalServiceAdding(note));
         var cut = context.Render<TripNotesComponent>(parameters =>
             parameters.Add(component => component.Trip, Trip()));
-        await cut.Find("#trip-note-start").ClickAsync();
-        cut.Find("#trip-note-text").Input("wind picked up");
 
         // Act
-        await cut.Find("#trip-note-save").ClickAsync();
+        await cut.Find("#trip-note-start").ClickAsync();
 
         // Assert
-        var noteId = store.All().Single().Id;
         cut.WaitForAssertion(() =>
         {
-            cut.Find($"#trip-note-{noteId:D}").TextContent.Should().Contain("wind picked up");
-            cut.Find($"#trip-note-time-{noteId:D}").TextContent.Should().MatchRegex(@"^\d{2}:\d{2}$");
+            cut.Find($"#trip-note-{FirstNoteId:D}").TextContent.Should().Contain("wind picked up");
+            cut.Find($"#trip-note-time-{FirstNoteId:D}").TextContent.Should().Be("09:00");
         });
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheNotesInTimeOrderWhenAnEarlierTimeIsChosen()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await store.SaveAsync(
+            Note(SecondNoteId, "wind picked up", StartedOn.AddHours(5)),
+            CancellationToken.None);
+        var backdated = Note(FirstNoteId, "fish rising near the reeds", StartedOn.AddHours(1));
+        await using var context = CreateContext(store, modalService: ModalServiceAdding(backdated));
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-{SecondNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#trip-note-start").ClickAsync();
+
+        // Assert
+        var rendered = cut.FindAll("#trip-notes-list .trip-note-text")
+            .Select(element => element.TextContent.Trim())
+            .ToArray();
+        rendered.Should().Equal("fish rising near the reeds", "wind picked up");
+    }
+
+    [Fact]
+    public async Task ItShouldNotifyTheParentThatTheTripChanged()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var changed = 0;
+        var note = Note(FirstNoteId, "stopped for lunch", StartedOn.AddHours(3));
+        await using var context = CreateContext(store, modalService: ModalServiceAdding(note));
+        var cut = context.Render<TripNotesComponent>(parameters => parameters
+            .Add(component => component.Trip, Trip())
+            .Add(component => component.Changed, () => changed++));
+
+        // Act
+        await cut.Find("#trip-note-start").ClickAsync();
+
+        // Assert
+        changed.Should().Be(1);
+        cut.Find($"#trip-note-{FirstNoteId:D}").TextContent.Should().Contain("stopped for lunch");
+    }
+
+    [Fact]
+    public async Task ItShouldStillOfferNotesOnACompletedTrip()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var modalService = ConfirmingModalService();
+        await using var context = CreateContext(store, modalService: modalService);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, CompletedTrip()));
+
+        // Act
+        await cut.Find("#trip-note-start").ClickAsync();
+
+        // Assert
+        await modalService.Received(1)
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                Arg.Is<AddTripNoteModalModel>(model => model.TripStartedOn == StartedOn),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -197,70 +189,6 @@ public class WhenTestingAdd : BaseTripNotesTest
             .Select(element => element.TextContent.Trim())
             .ToArray();
         rendered.Should().Equal("fish rising near the reeds", "wind picked up");
-    }
-
-    [Fact]
-    public async Task ItShouldAddSeveralNotesInTheOrderTheyWereWritten()
-    {
-        // Arrange
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripNotesComponent>(parameters =>
-            parameters.Add(component => component.Trip, Trip()));
-
-        // Act
-        await cut.Find("#trip-note-start").ClickAsync();
-        cut.Find("#trip-note-text").Input("first");
-        await cut.Find("#trip-note-save").ClickAsync();
-        await cut.Find("#trip-note-start").ClickAsync();
-        cut.Find("#trip-note-text").Input("second");
-        await cut.Find("#trip-note-save").ClickAsync();
-
-        // Assert
-        store.Count.Should().Be(2);
-        var rendered = cut.FindAll("#trip-notes-list .trip-note-text")
-            .Select(element => element.TextContent.Trim())
-            .ToArray();
-        rendered.Should().Equal("first", "second");
-    }
-
-    [Fact]
-    public async Task ItShouldNotifyTheParentThatTheTripChanged()
-    {
-        // Arrange
-        var store = new MemoryTripNoteStore();
-        var changed = 0;
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripNotesComponent>(parameters => parameters
-            .Add(component => component.Trip, Trip())
-            .Add(component => component.Changed, () => changed++));
-        await cut.Find("#trip-note-start").ClickAsync();
-        cut.Find("#trip-note-text").Input("stopped for lunch");
-
-        // Act
-        await cut.Find("#trip-note-save").ClickAsync();
-
-        // Assert
-        changed.Should().Be(1);
-    }
-
-    [Fact]
-    public async Task ItShouldStillOfferNotesOnACompletedTrip()
-    {
-        // Arrange
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
-        var cut = context.Render<TripNotesComponent>(parameters =>
-            parameters.Add(component => component.Trip, CompletedTrip()));
-        await cut.Find("#trip-note-start").ClickAsync();
-        cut.Find("#trip-note-text").Input("a good day, three brownies");
-
-        // Act
-        await cut.Find("#trip-note-save").ClickAsync();
-
-        // Assert
-        store.Count.Should().Be(1);
-        store.All().Single().Text.Should().Be("a good day, three brownies");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingEdit.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingEdit.cs
@@ -1,0 +1,118 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
+using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+using NSubstitute;
+using TripNotesComponent = FishingLogBook.Web.Features.Trips.Components.TripNotes.TripNotes;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Components.TripNotesTests;
+
+public class WhenTestingEdit : BaseTripNotesTest
+{
+    private static readonly Guid FirstNoteId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static readonly Guid SecondNoteId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+    [Fact]
+    public async Task ItShouldOpenTheModalWithTheExistingNote()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var existing = Note(FirstNoteId, "wind picked up", StartedOn.AddHours(2));
+        await store.SaveAsync(existing, CancellationToken.None);
+        var modalService = ConfirmingModalService();
+        await using var context = CreateContext(store, modalService: modalService);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-{FirstNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.InvokeAsync(() => cut.Instance.EditNoteAsync(FirstNoteId, existing.Text, existing.RecordedOn));
+
+        // Assert
+        await modalService.Received(1)
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                Arg.Is<AddTripNoteModalModel>(model =>
+                    model.TripId == TripId
+                    && model.ExistingNote != null
+                    && model.ExistingNote.Id == FirstNoteId
+                    && model.ExistingNote.Text == "wind picked up"
+                    && model.ExistingNote.RecordedOn == existing.RecordedOn),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotChangeTheTripWhenTheEditIsDismissed()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var existing = Note(FirstNoteId, "wind picked up", StartedOn.AddHours(2));
+        await store.SaveAsync(existing, CancellationToken.None);
+        var changed = 0;
+        await using var context = CreateContext(store, modalService: ConfirmingModalService());
+        var cut = context.Render<TripNotesComponent>(parameters => parameters
+            .Add(component => component.Trip, Trip())
+            .Add(component => component.Changed, () => changed++));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-{FirstNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.InvokeAsync(() => cut.Instance.EditNoteAsync(FirstNoteId, existing.Text, existing.RecordedOn));
+
+        // Assert
+        changed.Should().Be(0);
+        cut.Find($"#trip-note-{FirstNoteId:D}").TextContent.Should().Contain("wind picked up");
+    }
+
+    [Fact]
+    public async Task ItShouldReplaceTheNoteTextAndRepositionItWhenRecordedOnChanges()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var early = Note(FirstNoteId, "fish rising near the reeds", StartedOn.AddHours(1));
+        var late = Note(SecondNoteId, "wind picked up", StartedOn.AddHours(5));
+        await store.SaveAsync(early, CancellationToken.None);
+        await store.SaveAsync(late, CancellationToken.None);
+        var movedLater = early with { Text = "moved to the afternoon", RecordedOn = StartedOn.AddHours(6) };
+        var modalService = ModalServiceEditing(movedLater);
+        await using var context = CreateContext(store, modalService: modalService);
+        var cut = context.Render<TripNotesComponent>(parameters =>
+            parameters.Add(component => component.Trip, Trip()));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-{SecondNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.InvokeAsync(() => cut.Instance.EditNoteAsync(FirstNoteId, early.Text, early.RecordedOn));
+        cut.Render(parameters => parameters.Add(component => component.Trip, Trip()));
+
+        // Assert
+        var rendered = cut.FindAll("#trip-notes-list .trip-note-text")
+            .Select(element => element.TextContent.Trim())
+            .ToArray();
+        rendered.Should().Equal("wind picked up", "moved to the afternoon");
+    }
+
+    [Fact]
+    public async Task ItShouldNotifyTheParentThatTheTripChanged()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var existing = Note(FirstNoteId, "wind picked up", StartedOn.AddHours(2));
+        await store.SaveAsync(existing, CancellationToken.None);
+        var edited = existing with { Text = "wind died down" };
+        var changed = 0;
+        await using var context = CreateContext(store, modalService: ModalServiceEditing(edited));
+        var cut = context.Render<TripNotesComponent>(parameters => parameters
+            .Add(component => component.Trip, Trip())
+            .Add(component => component.Changed, () => changed++));
+        cut.WaitForAssertion(() => cut.Find($"#trip-note-{FirstNoteId:D}").Should().NotBeNull());
+
+        // Act
+        await cut.InvokeAsync(() => cut.Instance.EditNoteAsync(FirstNoteId, existing.Text, existing.RecordedOn));
+        cut.Render(parameters => parameters
+            .Add(component => component.Trip, Trip())
+            .Add(component => component.Changed, () => changed++));
+
+        // Assert
+        changed.Should().Be(1);
+        cut.Find($"#trip-note-{FirstNoteId:D}").TextContent.Should().Contain("wind died down");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingRemove.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingRemove.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
 using NSubstitute;
@@ -87,6 +88,56 @@ public class WhenTestingRemove : BaseTripNotesTest
             FirstNoteId,
             Arg.Any<CancellationToken>());
         store.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldNotDeleteAHistoricalNoteWhenTheConfirmationIsCancelled()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var client = Substitute.For<ITripClient>();
+        await using var context = CreateContext(
+            store,
+            tripClient: client,
+            modalService: ConfirmingModalService(confirm: false));
+        var cut = context.Render<TripNotesComponent>(parameters => parameters
+            .Add(component => component.Trip, CompletedTrip())
+            .Add(component => component.NoteStorage, TripNoteStorageEnum.Server));
+
+        // Act
+        await cut.InvokeAsync(() => cut.Instance.RemoveNoteAsync(FirstNoteId));
+
+        // Assert
+        await client.DidNotReceive().DeleteNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        store.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldDeleteAHistoricalNoteOnTheServerAfterConfirmation()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        var client = Substitute.For<ITripClient>();
+        var changed = 0;
+        await using var context = CreateContext(store, tripClient: client);
+        var cut = context.Render<TripNotesComponent>(parameters => parameters
+            .Add(component => component.Trip, CompletedTrip())
+            .Add(component => component.NoteStorage, TripNoteStorageEnum.Server)
+            .Add(component => component.Changed, () => changed++));
+
+        // Act
+        await cut.InvokeAsync(() => cut.Instance.RemoveNoteAsync(FirstNoteId));
+
+        // Assert
+        await client.Received(1).DeleteNoteAsync(
+            TripId,
+            FirstNoteId,
+            Arg.Any<CancellationToken>());
+        store.DeleteCalls.Should().Be(0);
+        changed.Should().Be(1);
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingRemove.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripNotesTests/WhenTestingRemove.cs
@@ -102,7 +102,7 @@ public class WhenTestingRemove : BaseTripNotesTest
             modalService: ConfirmingModalService(confirm: false));
         var cut = context.Render<TripNotesComponent>(parameters => parameters
             .Add(component => component.Trip, CompletedTrip())
-            .Add(component => component.NoteStorage, TripNoteStorageEnum.Server));
+            .Add(component => component.NoteStorage, TripStorageEnum.Server));
 
         // Act
         await cut.InvokeAsync(() => cut.Instance.RemoveNoteAsync(FirstNoteId));
@@ -125,7 +125,7 @@ public class WhenTestingRemove : BaseTripNotesTest
         await using var context = CreateContext(store, tripClient: client);
         var cut = context.Render<TripNotesComponent>(parameters => parameters
             .Add(component => component.Trip, CompletedTrip())
-            .Add(component => component.NoteStorage, TripNoteStorageEnum.Server)
+            .Add(component => component.NoteStorage, TripStorageEnum.Server)
             .Add(component => component.Changed, () => changed++));
 
         // Act

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripTimelineTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripTimelineTests/WhenTestingRender.cs
@@ -287,7 +287,7 @@ public class WhenTestingRender : BaseTripTimelineTest
                 {
                     Item(TripTimelineKindEnum.Note, StartedOn.AddMinutes(15), text: "Windy.", noteId: NoteId)
                 })
-            .Add(component => component.CanDeleteNotes, false)
+            .Add(component => component.CanEditNotes, false)
             .Add(component => component.OnDeleteNote, noteId => deleted.Add(noteId)));
 
         // Assert
@@ -310,7 +310,7 @@ public class WhenTestingRender : BaseTripTimelineTest
                 {
                     Item(TripTimelineKindEnum.Note, StartedOn.AddMinutes(15), text: "Windy.", noteId: NoteId)
                 })
-            .Add(component => component.CanDeleteNotes, true)
+            .Add(component => component.CanEditNotes, true)
             .Add(component => component.OnDeleteNote, noteId => deleted.Add(noteId)));
 
         // Act
@@ -320,6 +320,59 @@ public class WhenTestingRender : BaseTripTimelineTest
         deleted.Should().Equal(NoteId);
         cut.Find($"#trip-timeline-note-remove-{NoteId:D}").GetAttribute("aria-label")
             .Should().Be("Remove note");
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferEditingANoteWhenTheTripCannotBeEdited()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+        var edited = new List<TripTimelineItemModel>();
+
+        // Act
+        var cut = context.Render<TripTimeline>(parameters => parameters
+            .Add(
+                component => component.Items,
+                new[]
+                {
+                    Item(TripTimelineKindEnum.Note, StartedOn.AddMinutes(15), text: "Windy.", noteId: NoteId)
+                })
+            .Add(component => component.CanEditNotes, false)
+            .Add(component => component.OnEditNote, item => edited.Add(item)));
+
+        // Assert
+        cut.Markup.Should().Contain("Windy.");
+        cut.FindAll($"#trip-timeline-note-edit-{NoteId:D}").Should().BeEmpty();
+        edited.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldAskTheParentToEditANote()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+        var edited = new List<TripTimelineItemModel>();
+        var cut = context.Render<TripTimeline>(parameters => parameters
+            .Add(
+                component => component.Items,
+                new[]
+                {
+                    Item(TripTimelineKindEnum.Note, StartedOn.AddMinutes(15), text: "Windy.", noteId: NoteId)
+                })
+            .Add(component => component.CanEditNotes, true)
+            .Add(component => component.OnEditNote, item => edited.Add(item)));
+
+        // Act
+        cut.Find($"#trip-timeline-note-edit-{NoteId:D}").Click();
+
+        // Assert
+        edited.Should().ContainSingle();
+        edited[0].NoteId.Should().Be(NoteId);
+        edited[0].Text.Should().Be("Windy.");
+        cut.Find($"#trip-timeline-note-edit-{NoteId:D}").GetAttribute("aria-label")
+            .Should().Be("Edit note");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripCatchesModalTests/BaseAddTripCatchesModalTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripCatchesModalTests/BaseAddTripCatchesModalTest.cs
@@ -1,0 +1,104 @@
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripCatchesModalTests;
+
+public class BaseAddTripCatchesModalTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid PikeCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
+    protected static readonly Guid TroutCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000002");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+    protected static readonly DateTimeOffset EndedOn = DateTimeOffset.Parse("2026-08-17T16:00:00Z");
+
+    protected static BunitContext CreateContext(
+        ITripCatchService tripCatches,
+        ILoggingService? logging = null)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(tripCatches);
+        context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
+        context.Services.AddSingleton(Substitute.For<ICatchStore>());
+        context.Services.AddSingleton<ITimeService>(TestTimeService.WithOffset(TimeSpan.Zero));
+        context.Services.AddSingleton<IMeasurementService>(new MeasurementService());
+        context.Services.AddSingleton(Substitute.For<ICultureService>());
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+
+    protected static ITripCatchService TripCatchesOffering(params CatchModel[] candidates)
+    {
+        var service = Substitute.For<ITripCatchService>();
+        service.GetEligibleAsync(
+                Arg.Any<TripCatchScopeModel>(),
+                Arg.Any<TripStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns(candidates);
+        service.AssociateAsync(
+                Arg.Any<TripCatchScopeModel>(),
+                Arg.Any<IReadOnlyList<Guid>>(),
+                Arg.Any<TripStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => new TripCatchAssociationModel(
+                call.ArgAt<IReadOnlyList<Guid>>(1),
+                []));
+        return service;
+    }
+
+    protected static async Task<(IRenderedComponent<MudDialogProvider> Cut, IDialogReference Dialog)> ShowModalAsync(
+        BunitContext context,
+        TripStorageEnum storage = TripStorageEnum.LocalFirst,
+        DateTimeOffset? endedOn = null)
+    {
+        var cut = context.Render<MudDialogProvider>();
+        var dialogs = context.Services.GetRequiredService<IDialogService>();
+        var parameters = new DialogParameters<AddTripCatchesModal>
+        {
+            {
+                modal => modal.Model,
+                new AddTripCatchesModalModel(
+                    new TripCatchScopeModel(TripId, OwnerUserId, StartedOn, endedOn ?? EndedOn),
+                    storage)
+            }
+        };
+        var dialog = await dialogs.ShowAsync<AddTripCatchesModal>(
+            parameters,
+            new DialogOptions
+            {
+                CloseButton = true,
+                CloseOnEscapeKey = true,
+                FullWidth = true,
+                MaxWidth = MaxWidth.Small
+            });
+        return (cut, dialog);
+    }
+
+    protected static CatchModel Catch(Guid catchId, string speciesName, DateTimeOffset? caughtOn = null)
+    {
+        return new CatchModel(
+            catchId,
+            caughtOn ?? StartedOn.AddHours(2),
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg)],
+            speciesName,
+            UserId: OwnerUserId);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripCatchesModalTests/WhenTestingAssociate.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripCatchesModalTests/WhenTestingAssociate.cs
@@ -1,0 +1,192 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripCatchesModalTests;
+
+public class WhenTestingAssociate : BaseAddTripCatchesModalTest
+{
+    [Fact]
+    public async Task ItShouldAddNothingWhenTheAnglerCancels()
+    {
+        // Arrange
+        var tripCatches = TripCatchesOffering(Catch(PikeCatchId, "Pike"));
+        await using var context = CreateContext(tripCatches);
+        var (cut, dialog) = await ShowModalAsync(context);
+        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
+
+        // Act
+        await cut.Find("#trip-catches-cancel").ClickAsync();
+
+        // Assert
+        var result = await dialog.Result;
+        result.Should().NotBeNull();
+        result!.Canceled.Should().BeTrue();
+        await tripCatches.DidNotReceive().AssociateAsync(
+            Arg.Any<TripCatchScopeModel>(),
+            Arg.Any<IReadOnlyList<Guid>>(),
+            Arg.Any<TripStorageEnum>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAssociateEverySelectedCatchInOneAction()
+    {
+        // Arrange
+        var tripCatches = TripCatchesOffering(
+            Catch(PikeCatchId, "Pike"),
+            Catch(TroutCatchId, "Brown Trout"));
+        await using var context = CreateContext(tripCatches);
+        var (cut, dialog) = await ShowModalAsync(context);
+        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
+        cut.Find($"#catch-selector-option-{TroutCatchId:D}").Change(true);
+
+        // Act
+        await cut.Find("#trip-catches-confirm").ClickAsync();
+
+        // Assert
+        await tripCatches.Received(1).AssociateAsync(
+            Arg.Is<TripCatchScopeModel>(scope => scope.TripId == TripId),
+            Arg.Is<IReadOnlyList<Guid>>(ids =>
+                ids.Count == 2 && ids.Contains(PikeCatchId) && ids.Contains(TroutCatchId)),
+            TripStorageEnum.LocalFirst,
+            Arg.Any<CancellationToken>());
+        var result = await dialog.Result;
+        result!.Canceled.Should().BeFalse();
+        result.Data.Should().BeOfType<AddTripCatchesModalResult>()
+            .Which.AssociatedCatchIds.Should().Equal(PikeCatchId, TroutCatchId);
+    }
+
+    [Fact]
+    public async Task ItShouldUseTheServerForAHistoricalTrip()
+    {
+        // Arrange
+        var tripCatches = TripCatchesOffering(Catch(PikeCatchId, "Pike"));
+        await using var context = CreateContext(tripCatches);
+        var (cut, _) = await ShowModalAsync(context, TripStorageEnum.Server);
+        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
+
+        // Act
+        await cut.Find("#trip-catches-confirm").ClickAsync();
+
+        // Assert
+        await tripCatches.Received(1).GetEligibleAsync(
+            Arg.Any<TripCatchScopeModel>(),
+            TripStorageEnum.Server,
+            Arg.Any<CancellationToken>());
+        await tripCatches.Received(1).AssociateAsync(
+            Arg.Any<TripCatchScopeModel>(),
+            Arg.Is<IReadOnlyList<Guid>>(ids => ids.Count == 1 && ids[0] == PikeCatchId),
+            TripStorageEnum.Server,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRefreshTheListWhenEverySelectedCatchWasRefused()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var tripCatches = TripCatchesOffering(Catch(PikeCatchId, "Pike"));
+        tripCatches.AssociateAsync(
+                Arg.Any<TripCatchScopeModel>(),
+                Arg.Any<IReadOnlyList<Guid>>(),
+                Arg.Any<TripStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new TripCatchAssociationModel([], [PikeCatchId]));
+        await using var context = CreateContext(tripCatches);
+        var (cut, dialog) = await ShowModalAsync(context, TripStorageEnum.Server);
+        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
+
+        // Act
+        await cut.Find("#trip-catches-confirm").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-catches-rejected").TextContent.Should().Contain("no longer available"));
+        dialog.Result.IsCompleted.Should().BeFalse();
+        await tripCatches.Received(2).GetEligibleAsync(
+            Arg.Any<TripCatchScopeModel>(),
+            Arg.Any<TripStorageEnum>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAskTheAnglerToGoOnlineWhenTheServerCannotBeReached()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var tripCatches = TripCatchesOffering(Catch(PikeCatchId, "Pike"));
+        tripCatches.AssociateAsync(
+                Arg.Any<TripCatchScopeModel>(),
+                Arg.Any<IReadOnlyList<Guid>>(),
+                Arg.Any<TripStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripCatchAssociationModel>(_ => throw new HttpRequestException("offline"));
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(tripCatches, logging);
+        var (cut, dialog) = await ShowModalAsync(context, TripStorageEnum.Server);
+        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
+
+        // Act
+        await cut.Find("#trip-catches-confirm").ClickAsync();
+
+        // Assert
+        cut.Find("#trip-catches-failed").TextContent
+            .Should().Contain("You need to be online to add catches to this trip.");
+        dialog.Result.IsCompleted.Should().BeFalse();
+        await logging.Received(1).LogErrorAsync(
+            "adding catches to a trip",
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheFailureWhenALocalAssociationFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var tripCatches = TripCatchesOffering(Catch(PikeCatchId, "Pike"));
+        tripCatches.AssociateAsync(
+                Arg.Any<TripCatchScopeModel>(),
+                Arg.Any<IReadOnlyList<Guid>>(),
+                Arg.Any<TripStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripCatchAssociationModel>(_ => throw new InvalidOperationException("write failed"));
+        await using var context = CreateContext(tripCatches);
+        var (cut, dialog) = await ShowModalAsync(context);
+        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
+
+        // Act
+        await cut.Find("#trip-catches-confirm").ClickAsync();
+
+        // Assert
+        cut.Find("#trip-catches-failed").TextContent
+            .Should().Contain("could not be added to the trip");
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    private static CatchModel Catch(Guid catchId, string speciesName)
+    {
+        return new CatchModel(
+            catchId,
+            StartedOn.AddHours(2),
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg)],
+            speciesName,
+            UserId: OwnerUserId);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripCatchesModalTests/WhenTestingSelect.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripCatchesModalTests/WhenTestingSelect.cs
@@ -1,0 +1,144 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripCatchesModalTests;
+
+public class WhenTestingSelect : BaseAddTripCatchesModalTest
+{
+    [Fact]
+    public async Task ItShouldShowACleanEmptyStateWhenNothingCanBeAdded()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var tripCatches = TripCatchesOffering();
+        await using var context = CreateContext(tripCatches);
+
+        // Act
+        var (cut, dialog) = await ShowModalAsync(context);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-catches-empty").TextContent.Should().Contain("No catches to add"));
+        cut.Find("#trip-catches-empty").TextContent.Should()
+            .Contain("All catches recorded during this trip are already associated.");
+        cut.FindAll("#catch-selector").Should().BeEmpty();
+        cut.FindAll("#trip-catches-confirm").Should().BeEmpty();
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldOnlyOfferTheCatchesTheTripServiceFoundEligible()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var tripCatches = TripCatchesOffering(
+            Catch(PikeCatchId, "Pike"),
+            Catch(TroutCatchId, "Brown Trout"));
+        await using var context = CreateContext(tripCatches);
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-catches-subtitle").TextContent
+                .Should().Contain("Select catches to add to this trip"));
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull();
+        cut.Find($"#catch-selector-option-{TroutCatchId:D}").Should().NotBeNull();
+        await tripCatches.Received(1).GetEligibleAsync(
+            Arg.Is<TripCatchScopeModel>(scope =>
+                scope.TripId == TripId
+                && scope.OwnerUserId == OwnerUserId
+                && scope.StartedOn == StartedOn
+                && scope.EndedOn == EndedOn),
+            TripStorageEnum.LocalFirst,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheConfirmActionDisabledUntilACatchIsChosen()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(TripCatchesOffering(Catch(PikeCatchId, "Pike")));
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-catches-confirm").HasAttribute("disabled").Should().BeTrue());
+    }
+
+    [Fact]
+    public async Task ItShouldCountTheChosenCatchesOnTheConfirmAction()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(TripCatchesOffering(
+            Catch(PikeCatchId, "Pike"),
+            Catch(TroutCatchId, "Brown Trout")));
+        var (cut, _) = await ShowModalAsync(context);
+        cut.WaitForAssertion(() => cut.Find($"#catch-selector-option-{PikeCatchId:D}").Should().NotBeNull());
+
+        // Act
+        cut.Find($"#catch-selector-option-{PikeCatchId:D}").Change(true);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-catches-confirm").TextContent.Should().Contain("Add 1 catch"));
+        cut.Find($"#catch-selector-option-{TroutCatchId:D}").Change(true);
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-catches-confirm").TextContent.Should().Contain("Add 2 catches"));
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheFailureWhenTheEligibleCatchesCannotBeRead()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var tripCatches = Substitute.For<Web.Features.Trips.Services.ITripCatchService>();
+        tripCatches.GetEligibleAsync(
+                Arg.Any<TripCatchScopeModel>(),
+                Arg.Any<TripStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<Web.Features.Catch.Models.CatchModel>>(
+                _ => throw new InvalidOperationException("read failed"));
+        var logging = Substitute.For<Web.Features.Diagnostics.Services.ILoggingService>();
+        await using var context = CreateContext(tripCatches, logging);
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-catches-load-failed").TextContent.Should().Contain("could not be read"));
+        await logging.Received(1).LogErrorAsync(
+            "reading the catches that can join a trip",
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchCatchPickerCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        await using var context = CreateContext(TripCatchesOffering());
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-catches-empty").TextContent.Should().Contain("Aucune prise à ajouter"));
+        cut.Find("#trip-catches-modal-title").TextContent.Should().Contain("Ajouter des prises");
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/BaseAddTripNoteModalTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/BaseAddTripNoteModalTest.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Html.Dom;
 using Bunit;
 using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
@@ -44,7 +45,7 @@ public class BaseAddTripNoteModalTest
         var writer = Substitute.For<ITripNoteWriteService>();
         writer.AddAsync(
                 Arg.Any<TripNoteDraftModel>(),
-                Arg.Any<TripNoteStorageEnum>(),
+                Arg.Any<TripStorageEnum>(),
                 Arg.Any<CancellationToken>())
             .Returns(call =>
             {
@@ -59,12 +60,36 @@ public class BaseAddTripNoteModalTest
         return writer;
     }
 
+    protected static ITripNoteWriteService WriterThatUpdates()
+    {
+        var writer = WriterThatSaves();
+        writer.UpdateAsync(
+                Arg.Any<TripNoteModel>(),
+                Arg.Any<TripStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<TripNoteModel>(0));
+        return writer;
+    }
+
+    protected static TripNoteModel ExistingNote(
+        string text = "water dropped about a foot",
+        DateTimeOffset? recordedOn = null)
+    {
+        return new TripNoteModel(
+            NoteId,
+            TripId,
+            OwnerUserId,
+            text,
+            recordedOn ?? StartedOn.AddHours(2),
+            SyncStatus.Synchronised);
+    }
+
     protected static ITripNoteWriteService WriterThatCannotReachTheServer()
     {
         var writer = Substitute.For<ITripNoteWriteService>();
         writer.AddAsync(
                 Arg.Any<TripNoteDraftModel>(),
-                Arg.Any<TripNoteStorageEnum>(),
+                Arg.Any<TripStorageEnum>(),
                 Arg.Any<CancellationToken>())
             .Returns<TripNoteModel>(_ => throw new HttpRequestException("offline"));
         return writer;
@@ -75,7 +100,7 @@ public class BaseAddTripNoteModalTest
         var writer = Substitute.For<ITripNoteWriteService>();
         writer.AddAsync(
                 Arg.Any<TripNoteDraftModel>(),
-                Arg.Any<TripNoteStorageEnum>(),
+                Arg.Any<TripStorageEnum>(),
                 Arg.Any<CancellationToken>())
             .Returns<TripNoteModel>(_ => throw new InvalidOperationException("write failed"));
         return writer;
@@ -85,7 +110,8 @@ public class BaseAddTripNoteModalTest
         BunitContext context,
         DateTimeOffset? startedOn = null,
         DateTimeOffset? endedOn = null,
-        TripNoteStorageEnum storage = TripNoteStorageEnum.LocalFirst)
+        TripStorageEnum storage = TripStorageEnum.LocalFirst,
+        TripNoteModel? existingNote = null)
     {
         var cut = context.Render<MudDialogProvider>();
         var dialogs = context.Services.GetRequiredService<IDialogService>();
@@ -98,7 +124,8 @@ public class BaseAddTripNoteModalTest
                     OwnerUserId,
                     startedOn ?? StartedOn,
                     endedOn,
-                    storage)
+                    storage,
+                    existingNote)
             }
         };
         var dialog = await dialogs.ShowAsync<AddTripNoteModal>(

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/BaseAddTripNoteModalTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/BaseAddTripNoteModalTest.cs
@@ -1,0 +1,66 @@
+using Bunit;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripNoteModalTests;
+
+public class BaseAddTripNoteModalTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+
+    protected static BunitContext CreateContext(
+        ITripNoteStore store,
+        ILoggingService? logging = null,
+        ITimeService? time = null)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(store);
+        context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
+        context.Services.AddSingleton(time ?? TestTimeService.WithOffset(TimeSpan.Zero));
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        return context;
+    }
+
+    protected static async Task<(IRenderedComponent<MudDialogProvider> Cut, IDialogReference Dialog)> ShowModalAsync(
+        BunitContext context,
+        DateTimeOffset? startedOn = null)
+    {
+        var cut = context.Render<MudDialogProvider>();
+        var dialogs = context.Services.GetRequiredService<IDialogService>();
+        var parameters = new DialogParameters<AddTripNoteModal>
+        {
+            {
+                modal => modal.Model,
+                new AddTripNoteModalModel(TripId, OwnerUserId, startedOn ?? StartedOn)
+            }
+        };
+        var dialog = await dialogs.ShowAsync<AddTripNoteModal>(
+            parameters,
+            new DialogOptions
+            {
+                CloseButton = true,
+                CloseOnEscapeKey = true,
+                FullWidth = true,
+                MaxWidth = MaxWidth.Small
+            });
+        return (cut, dialog);
+    }
+
+    protected static TimeSpan OffsetPuttingLocalTimeAt(TimeSpan localTimeOfDay)
+    {
+        return localTimeOfDay - DateTimeOffset.UtcNow.UtcDateTime.TimeOfDay;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/BaseAddTripNoteModalTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/BaseAddTripNoteModalTest.cs
@@ -1,8 +1,11 @@
+using AngleSharp.Html.Dom;
 using Bunit;
 using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
-using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Tests.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,10 +19,12 @@ public class BaseAddTripNoteModalTest
 {
     protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid NoteId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
     protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+    protected static readonly DateTimeOffset EndedOn = DateTimeOffset.Parse("2026-08-17T16:00:00Z");
 
     protected static BunitContext CreateContext(
-        ITripNoteStore store,
+        ITripNoteWriteService? writer = null,
         ILoggingService? logging = null,
         ITimeService? time = null)
     {
@@ -27,16 +32,60 @@ public class BaseAddTripNoteModalTest
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
-        context.Services.AddSingleton(store);
+        context.Services.AddSingleton(writer ?? WriterThatSaves());
         context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
         context.Services.AddSingleton(time ?? TestTimeService.WithOffset(TimeSpan.Zero));
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
     }
 
+    protected static ITripNoteWriteService WriterThatSaves()
+    {
+        var writer = Substitute.For<ITripNoteWriteService>();
+        writer.AddAsync(
+                Arg.Any<TripNoteDraftModel>(),
+                Arg.Any<TripNoteStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var draft = call.ArgAt<TripNoteDraftModel>(0);
+                return new TripNoteModel(
+                    NoteId,
+                    draft.TripId,
+                    draft.OwnerUserId,
+                    draft.Text,
+                    draft.RecordedOn);
+            });
+        return writer;
+    }
+
+    protected static ITripNoteWriteService WriterThatCannotReachTheServer()
+    {
+        var writer = Substitute.For<ITripNoteWriteService>();
+        writer.AddAsync(
+                Arg.Any<TripNoteDraftModel>(),
+                Arg.Any<TripNoteStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripNoteModel>(_ => throw new HttpRequestException("offline"));
+        return writer;
+    }
+
+    protected static ITripNoteWriteService WriterThatFails()
+    {
+        var writer = Substitute.For<ITripNoteWriteService>();
+        writer.AddAsync(
+                Arg.Any<TripNoteDraftModel>(),
+                Arg.Any<TripNoteStorageEnum>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripNoteModel>(_ => throw new InvalidOperationException("write failed"));
+        return writer;
+    }
+
     protected static async Task<(IRenderedComponent<MudDialogProvider> Cut, IDialogReference Dialog)> ShowModalAsync(
         BunitContext context,
-        DateTimeOffset? startedOn = null)
+        DateTimeOffset? startedOn = null,
+        DateTimeOffset? endedOn = null,
+        TripNoteStorageEnum storage = TripNoteStorageEnum.LocalFirst)
     {
         var cut = context.Render<MudDialogProvider>();
         var dialogs = context.Services.GetRequiredService<IDialogService>();
@@ -44,7 +93,12 @@ public class BaseAddTripNoteModalTest
         {
             {
                 modal => modal.Model,
-                new AddTripNoteModalModel(TripId, OwnerUserId, startedOn ?? StartedOn)
+                new AddTripNoteModalModel(
+                    TripId,
+                    OwnerUserId,
+                    startedOn ?? StartedOn,
+                    endedOn,
+                    storage)
             }
         };
         var dialog = await dialogs.ShowAsync<AddTripNoteModal>(
@@ -62,5 +116,15 @@ public class BaseAddTripNoteModalTest
     protected static TimeSpan OffsetPuttingLocalTimeAt(TimeSpan localTimeOfDay)
     {
         return localTimeOfDay - DateTimeOffset.UtcNow.UtcDateTime.TimeOfDay;
+    }
+
+    protected static string DateValue(IRenderedComponent<MudDialogProvider> cut)
+    {
+        return ((IHtmlInputElement)cut.Find("#trip-note-date")).Value;
+    }
+
+    protected static string TimeValue(IRenderedComponent<MudDialogProvider> cut)
+    {
+        return ((IHtmlInputElement)cut.Find("#trip-note-time")).Value;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingEdit.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingEdit.cs
@@ -1,0 +1,189 @@
+using AngleSharp.Html.Dom;
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripNoteModalTests;
+
+public class WhenTestingEdit : BaseAddTripNoteModalTest
+{
+    [Fact]
+    public async Task ItShouldOpenOnTheNoteThatIsBeingEdited()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(WriterThatUpdates());
+
+        // Act
+        var (cut, _) = await ShowModalAsync(
+            context,
+            endedOn: EndedOn,
+            existingNote: ExistingNote("water dropped about a foot", StartedOn.AddHours(4)));
+
+        // Assert
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("11:00"));
+        DateValue(cut).Should().Be("2026-08-17");
+        ((IHtmlTextAreaElement)cut.Find("#trip-note-text")).Value
+            .Should().Be("water dropped about a foot");
+        cut.Find("#trip-note-modal-title").TextContent.Should().Contain("Edit note");
+        cut.Find("#trip-note-save").TextContent.Should().Contain("Save");
+    }
+
+    [Fact]
+    public async Task ItShouldShowTheFrenchEditCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        await using var context = CreateContext(WriterThatUpdates());
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context, endedOn: EndedOn, existingNote: ExistingNote());
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-modal-title").TextContent.Should().Contain("Modifier la note"));
+        cut.Find("#trip-note-save").TextContent.Should().Contain("Enregistrer");
+    }
+
+    [Fact]
+    public async Task ItShouldChangeNothingWhenTheAnglerCancels()
+    {
+        // Arrange
+        var writer = WriterThatUpdates();
+        await using var context = CreateContext(writer);
+        var (cut, dialog) = await ShowModalAsync(
+            context,
+            endedOn: EndedOn,
+            existingNote: ExistingNote());
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("09:00"));
+        cut.Find("#trip-note-text").Input("changed my mind");
+
+        // Act
+        await cut.Find("#trip-note-cancel").ClickAsync();
+
+        // Assert
+        var result = await dialog.Result;
+        result!.Canceled.Should().BeTrue();
+        await writer.DidNotReceive().UpdateAsync(
+            Arg.Any<TripNoteModel>(),
+            Arg.Any<TripStorageEnum>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnEditedTimeBeforeTheTripStarted()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var writer = WriterThatUpdates();
+        await using var context = CreateContext(writer);
+        var (cut, dialog) = await ShowModalAsync(
+            context,
+            endedOn: EndedOn,
+            existingNote: ExistingNote());
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("09:00"));
+
+        // Act
+        cut.Find("#trip-note-time").Input("06:30");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-recorded-on-invalid").TextContent
+                .Should().Contain("before the trip started"));
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        dialog.Result.IsCompleted.Should().BeFalse();
+        await writer.DidNotReceive().UpdateAsync(
+            Arg.Any<TripNoteModel>(),
+            Arg.Any<TripStorageEnum>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRejectAnEditedTimeAfterTheTripFinished()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var writer = WriterThatUpdates();
+        await using var context = CreateContext(writer);
+        var (cut, _) = await ShowModalAsync(
+            context,
+            endedOn: EndedOn,
+            existingNote: ExistingNote());
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("09:00"));
+
+        // Act
+        cut.Find("#trip-note-time").Input("17:30");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-recorded-on-invalid").TextContent
+                .Should().Contain("after the trip finished"));
+        await writer.DidNotReceive().UpdateAsync(
+            Arg.Any<TripNoteModel>(),
+            Arg.Any<TripStorageEnum>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSaveTheChangedTextAndTimeOfALocalNote()
+    {
+        // Arrange
+        var writer = WriterThatUpdates();
+        await using var context = CreateContext(writer);
+        var (cut, dialog) = await ShowModalAsync(
+            context,
+            endedOn: EndedOn,
+            existingNote: ExistingNote());
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("09:00"));
+
+        // Act
+        cut.Find("#trip-note-time").Input("11:45");
+        cut.Find("#trip-note-text").Input("  changed to olive nymph  ");
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        await writer.Received(1).UpdateAsync(
+            Arg.Is<TripNoteModel>(note =>
+                note.Id == NoteId
+                && note.TripId == TripId
+                && note.Text == "changed to olive nymph"
+                && note.RecordedOn == DateTimeOffset.Parse("2026-08-17T11:45:00Z")),
+            TripStorageEnum.LocalFirst,
+            Arg.Any<CancellationToken>());
+        var result = await dialog.Result;
+        result!.Canceled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldSendAHistoricalNoteEditThroughTheServer()
+    {
+        // Arrange
+        var writer = WriterThatUpdates();
+        await using var context = CreateContext(writer);
+        var (cut, _) = await ShowModalAsync(
+            context,
+            endedOn: EndedOn,
+            storage: TripStorageEnum.Server,
+            existingNote: ExistingNote());
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("09:00"));
+
+        // Act
+        cut.Find("#trip-note-text").Input("fish started rising beside the reeds");
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        await writer.Received(1).UpdateAsync(
+            Arg.Is<TripNoteModel>(note => note.Text == "fish started rising beside the reeds"),
+            TripStorageEnum.Server,
+            Arg.Any<CancellationToken>());
+        await writer.DidNotReceive().AddAsync(
+            Arg.Any<TripNoteDraftModel>(),
+            Arg.Any<TripStorageEnum>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingRender.cs
@@ -1,9 +1,7 @@
-using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Localization;
-using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
 using FishingLogBook.Web.Tests.TestSupport;
 
 namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripNoteModalTests;
@@ -15,8 +13,7 @@ public class WhenTestingRender : BaseAddTripNoteModalTest
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        await using var context = CreateContext();
 
         // Act
         var (cut, dialog) = await ShowModalAsync(context);
@@ -25,8 +22,8 @@ public class WhenTestingRender : BaseAddTripNoteModalTest
         cut.WaitForAssertion(() =>
             cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue());
         cut.Find("#trip-note-modal-title").TextContent.Should().Contain("Add note");
-        cut.Find("#trip-note-recorded-on").GetAttribute("type").Should().Be("datetime-local");
-        store.Count.Should().Be(0);
+        cut.Find("#trip-note-date").GetAttribute("type").Should().Be("date");
+        cut.Find("#trip-note-time").GetAttribute("type").Should().Be("time");
         dialog.Result.IsCompleted.Should().BeFalse();
     }
 
@@ -35,50 +32,61 @@ public class WhenTestingRender : BaseAddTripNoteModalTest
     {
         // Arrange
         var offset = OffsetPuttingLocalTimeAt(new TimeSpan(23, 59, 0));
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store, time: TestTimeService.WithOffset(offset));
+        await using var context = CreateContext(time: TestTimeService.WithOffset(offset));
 
         // Act
         var (cut, _) = await ShowModalAsync(context);
 
         // Assert
         var tripLocal = TestTimeService.ToDateTimeLocal(StartedOn, offset);
-        cut.WaitForAssertion(() =>
-            RecordedOnValue(cut).Should().Be($"{tripLocal[..11]}23:59"));
+        cut.WaitForAssertion(() => DateValue(cut).Should().Be(tripLocal[..10]));
+        TimeValue(cut).Should().Be("23:59");
     }
 
     [Fact]
-    public async Task ItShouldNotOpenBeforeTheTripStarted()
+    public async Task ItShouldOpenAtTheTripStartWhenTheCurrentTimeWouldFallBeforeIt()
     {
         // Arrange
         var offset = OffsetPuttingLocalTimeAt(TimeSpan.Zero);
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store, time: TestTimeService.WithOffset(offset));
+        await using var context = CreateContext(time: TestTimeService.WithOffset(offset));
 
         // Act
         var (cut, _) = await ShowModalAsync(context);
 
         // Assert
         var tripLocal = TestTimeService.ToDateTimeLocal(StartedOn, offset);
-        cut.WaitForAssertion(() => RecordedOnValue(cut).Should().Be(tripLocal));
+        cut.WaitForAssertion(() => DateValue(cut).Should().Be(tripLocal[..10]));
+        TimeValue(cut).Should().Be(tripLocal[11..16]);
     }
 
     [Fact]
-    public async Task ItShouldStayOnTheTripDateForATripThatStartedOnAnEarlierDay()
+    public async Task ItShouldOpenAtTheEndOfACompletedTripRatherThanNow()
     {
         // Arrange
-        var offset = OffsetPuttingLocalTimeAt(new TimeSpan(23, 59, 0));
-        var startedOn = StartedOn.AddDays(-3);
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store, time: TestTimeService.WithOffset(offset));
+        await using var context = CreateContext();
 
         // Act
-        var (cut, _) = await ShowModalAsync(context, startedOn);
+        var (cut, _) = await ShowModalAsync(context, endedOn: EndedOn);
 
         // Assert
-        var tripLocal = TestTimeService.ToDateTimeLocal(startedOn, offset);
+        cut.WaitForAssertion(() => DateValue(cut).Should().Be("2026-08-17"));
+        TimeValue(cut).Should().Be("16:00");
+        cut.FindAll("#trip-note-recorded-on-invalid").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheDateInsideTheTrip()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context, endedOn: EndedOn);
+
+        // Assert
         cut.WaitForAssertion(() =>
-            RecordedOnValue(cut).Should().Be($"{tripLocal[..11]}23:59"));
+            cut.Find("#trip-note-date").GetAttribute("min").Should().Be("2026-08-17"));
+        cut.Find("#trip-note-date").GetAttribute("max").Should().Be("2026-08-17");
     }
 
     [Fact]
@@ -86,23 +94,36 @@ public class WhenTestingRender : BaseAddTripNoteModalTest
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.French);
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        await using var context = CreateContext();
 
         // Act
         var (cut, _) = await ShowModalAsync(context);
 
         // Assert
         cut.WaitForAssertion(() =>
-            cut.Find("#trip-note-modal").TextContent.Should().Contain("Date et heure de la note"));
+            cut.Find("#trip-note-modal").TextContent.Should().Contain("Heure"));
         cut.Find("#trip-note-modal-title").TextContent.Should().Contain("Ajouter une note");
         cut.Find("#trip-note-save").TextContent.Should().Contain("Ajouter une note");
         cut.Find("#trip-note-modal").TextContent.Should()
             .Contain("Modifiez l'heure pour placer cette note sur la chronologie de la sortie.");
     }
 
-    private static string RecordedOnValue(IRenderedComponent<MudBlazor.MudDialogProvider> cut)
+    [Fact]
+    public async Task ItShouldShowTheFrenchCopyWhenTheTimeFallsOutsideTheTrip()
     {
-        return ((IHtmlInputElement)cut.Find("#trip-note-recorded-on")).Value;
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        await using var context = CreateContext();
+        var (cut, _) = await ShowModalAsync(context, endedOn: EndedOn);
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("16:00"));
+
+        // Act
+        cut.Find("#trip-note-time").Input("06:00");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-recorded-on-invalid").TextContent
+                .Should().Contain("C'est avant le début de la sortie"));
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingRender.cs
@@ -1,0 +1,108 @@
+using AngleSharp.Html.Dom;
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+using FishingLogBook.Web.Tests.TestSupport;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripNoteModalTests;
+
+public class WhenTestingRender : BaseAddTripNoteModalTest
+{
+    [Fact]
+    public async Task ItShouldNotOfferToSaveAnEmptyNote()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+
+        // Act
+        var (cut, dialog) = await ShowModalAsync(context);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue());
+        cut.Find("#trip-note-modal-title").TextContent.Should().Contain("Add note");
+        cut.Find("#trip-note-recorded-on").GetAttribute("type").Should().Be("datetime-local");
+        store.Count.Should().Be(0);
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldOpenOnTheTripDateWithTheCurrentTime()
+    {
+        // Arrange
+        var offset = OffsetPuttingLocalTimeAt(new TimeSpan(23, 59, 0));
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store, time: TestTimeService.WithOffset(offset));
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context);
+
+        // Assert
+        var tripLocal = TestTimeService.ToDateTimeLocal(StartedOn, offset);
+        cut.WaitForAssertion(() =>
+            RecordedOnValue(cut).Should().Be($"{tripLocal[..11]}23:59"));
+    }
+
+    [Fact]
+    public async Task ItShouldNotOpenBeforeTheTripStarted()
+    {
+        // Arrange
+        var offset = OffsetPuttingLocalTimeAt(TimeSpan.Zero);
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store, time: TestTimeService.WithOffset(offset));
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context);
+
+        // Assert
+        var tripLocal = TestTimeService.ToDateTimeLocal(StartedOn, offset);
+        cut.WaitForAssertion(() => RecordedOnValue(cut).Should().Be(tripLocal));
+    }
+
+    [Fact]
+    public async Task ItShouldStayOnTheTripDateForATripThatStartedOnAnEarlierDay()
+    {
+        // Arrange
+        var offset = OffsetPuttingLocalTimeAt(new TimeSpan(23, 59, 0));
+        var startedOn = StartedOn.AddDays(-3);
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store, time: TestTimeService.WithOffset(offset));
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context, startedOn);
+
+        // Assert
+        var tripLocal = TestTimeService.ToDateTimeLocal(startedOn, offset);
+        cut.WaitForAssertion(() =>
+            RecordedOnValue(cut).Should().Be($"{tripLocal[..11]}23:59"));
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchNoteCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+
+        // Act
+        var (cut, _) = await ShowModalAsync(context);
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-modal").TextContent.Should().Contain("Date et heure de la note"));
+        cut.Find("#trip-note-modal-title").TextContent.Should().Contain("Ajouter une note");
+        cut.Find("#trip-note-save").TextContent.Should().Contain("Ajouter une note");
+        cut.Find("#trip-note-modal").TextContent.Should()
+            .Contain("Modifiez l'heure pour placer cette note sur la chronologie de la sortie.");
+    }
+
+    private static string RecordedOnValue(IRenderedComponent<MudBlazor.MudDialogProvider> cut)
+    {
+        return ((IHtmlInputElement)cut.Find("#trip-note-recorded-on")).Value;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingSave.cs
@@ -178,7 +178,7 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
         var (cut, dialog) = await ShowModalAsync(
             context,
             endedOn: EndedOn,
-            storage: TripNoteStorageEnum.Server);
+            storage: TripStorageEnum.Server);
         cut.Find("#trip-note-text").Input("fish started rising beside the reeds");
 
         // Act
@@ -260,7 +260,7 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
                 && draft.OwnerUserId == OwnerUserId
                 && draft.Text == "changed to olive nymph"
                 && draft.RecordedOn == DateTimeOffset.Parse("2026-08-17T11:30:00Z")),
-            TripNoteStorageEnum.LocalFirst,
+            TripStorageEnum.LocalFirst,
             Arg.Any<CancellationToken>());
         var result = await dialog.Result;
         result.Should().NotBeNull();
@@ -278,7 +278,7 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
         var (cut, dialog) = await ShowModalAsync(
             context,
             endedOn: EndedOn,
-            storage: TripNoteStorageEnum.Server);
+            storage: TripStorageEnum.Server);
         cut.WaitForAssertion(() => TimeValue(cut).Should().Be("16:00"));
 
         // Act
@@ -292,7 +292,7 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
                 draft.TripId == TripId
                 && draft.Text == "fish started rising beside the reeds"
                 && draft.RecordedOn == DateTimeOffset.Parse("2026-08-17T11:30:00Z")),
-            TripNoteStorageEnum.Server,
+            TripStorageEnum.Server,
             Arg.Any<CancellationToken>());
         var result = await dialog.Result;
         result.Should().NotBeNull();
@@ -304,7 +304,7 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
     {
         await writer.DidNotReceive().AddAsync(
             Arg.Any<TripNoteDraftModel>(),
-            Arg.Any<TripNoteStorageEnum>(),
+            Arg.Any<TripStorageEnum>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingSave.cs
@@ -1,0 +1,169 @@
+using AngleSharp.Html.Dom;
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripNoteModalTests;
+
+public class WhenTestingSave : BaseAddTripNoteModalTest
+{
+    [Fact]
+    public async Task ItShouldNotSaveAWhitespaceOnlyNote()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var (cut, dialog) = await ShowModalAsync(context);
+
+        // Act
+        cut.Find("#trip-note-text").Input("   \t  ");
+
+        // Assert
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        await cut.Find("#trip-note-save").ClickAsync();
+        store.Count.Should().Be(0);
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldNotSaveANoteOverTheCap()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var (cut, dialog) = await ShowModalAsync(context);
+
+        // Act
+        cut.Find("#trip-note-text").Input(new string('a', TripConstants.MaxNoteTextLength + 1));
+
+        // Assert
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        store.Count.Should().Be(0);
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldNotSaveWhenTheNoteTimeIsCleared()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var (cut, dialog) = await ShowModalAsync(context);
+        cut.Find("#trip-note-text").Input("wind picked up");
+
+        // Act
+        cut.Find("#trip-note-recorded-on").Input(string.Empty);
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        cut.Find("#trip-note-recorded-on-invalid").TextContent
+            .Should().Contain("Enter a valid date and time for this note.");
+        store.Count.Should().Be(0);
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheTypedNoteWhenTheLocalWriteFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = new MemoryTripNoteStore { FailWrite = true };
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(store, logging);
+        var (cut, dialog) = await ShowModalAsync(context);
+        cut.Find("#trip-note-text").Input("fish rising near the reeds");
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        cut.Find("#trip-note-add-failed").TextContent.Should().Contain("could not be added");
+        ((IHtmlTextAreaElement)cut.Find("#trip-note-text")).Value
+            .Should().Be("fish rising near the reeds");
+        store.Count.Should().Be(0);
+        dialog.Result.IsCompleted.Should().BeFalse();
+        await logging.Received(1).LogErrorAsync(
+            "adding a trip note",
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNeverLogTheNoteText()
+    {
+        // Arrange
+        const string secret = "met Sarah about the lease at the bailiff hut";
+        var store = new MemoryTripNoteStore { FailWrite = true };
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(store, logging);
+        var (cut, _) = await ShowModalAsync(context);
+        cut.Find("#trip-note-text").Input(secret);
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Is<string>(operation => operation.Contains(secret)),
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Any<string>(),
+            Arg.Is<Exception>(exception => exception.Message.Contains(secret)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldCloseWithoutSavingWhenCancelled()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var (cut, dialog) = await ShowModalAsync(context);
+        cut.Find("#trip-note-text").Input("changed to olive nymph");
+
+        // Act
+        await cut.Find("#trip-note-cancel").ClickAsync();
+
+        // Assert
+        var result = await dialog.Result;
+        result.Should().NotBeNull();
+        result!.Canceled.Should().BeTrue();
+        store.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ItShouldSaveTheNoteAtTheChosenTime()
+    {
+        // Arrange
+        var store = new MemoryTripNoteStore();
+        await using var context = CreateContext(store);
+        var (cut, dialog) = await ShowModalAsync(context);
+
+        // Act
+        cut.Find("#trip-note-recorded-on").Input("2026-08-17T14:35");
+        cut.Find("#trip-note-text").Input("  changed to olive nymph  ");
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        store.Count.Should().Be(1);
+        var stored = store.All().Single();
+        stored.Text.Should().Be("changed to olive nymph");
+        stored.RecordedOn.Should().Be(DateTimeOffset.Parse("2026-08-17T14:35:00Z"));
+        stored.TripId.Should().Be(TripId);
+        stored.OwnerUserId.Should().Be(OwnerUserId);
+        stored.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        var result = await dialog.Result;
+        result.Should().NotBeNull();
+        result!.Canceled.Should().BeFalse();
+        result.Data.Should().BeOfType<AddTripNoteModalResult>()
+            .Which.Note.Should().Be(stored);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Modals/AddTripNoteModalTests/WhenTestingSave.cs
@@ -2,11 +2,12 @@ using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Constants;
-using FishingLogBook.Web.Common;
 using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Trips.Enums;
 using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
+using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Localization;
-using FishingLogBook.Web.Tests.Features.Trips.Offline.Stores.TripNoteStoreTests;
+using FishingLogBook.Web.Tests.TestSupport;
 using NSubstitute;
 
 namespace FishingLogBook.Web.Tests.Features.Trips.Modals.AddTripNoteModalTests;
@@ -17,8 +18,8 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
     public async Task ItShouldNotSaveAWhitespaceOnlyNote()
     {
         // Arrange
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer);
         var (cut, dialog) = await ShowModalAsync(context);
 
         // Act
@@ -27,7 +28,7 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
         // Assert
         cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
         await cut.Find("#trip-note-save").ClickAsync();
-        store.Count.Should().Be(0);
+        await ShouldNotHaveWrittenAsync(writer);
         dialog.Result.IsCompleted.Should().BeFalse();
     }
 
@@ -35,8 +36,8 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
     public async Task ItShouldNotSaveANoteOverTheCap()
     {
         // Arrange
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer);
         var (cut, dialog) = await ShowModalAsync(context);
 
         // Act
@@ -44,28 +45,102 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
 
         // Assert
         cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
-        store.Count.Should().Be(0);
+        await ShouldNotHaveWrittenAsync(writer);
         dialog.Result.IsCompleted.Should().BeFalse();
     }
 
     [Fact]
-    public async Task ItShouldNotSaveWhenTheNoteTimeIsCleared()
+    public async Task ItShouldNotSaveWhenTheNoteDateIsCleared()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer);
         var (cut, dialog) = await ShowModalAsync(context);
         cut.Find("#trip-note-text").Input("wind picked up");
 
         // Act
-        cut.Find("#trip-note-recorded-on").Input(string.Empty);
-        await cut.Find("#trip-note-save").ClickAsync();
+        cut.Find("#trip-note-date").Input(string.Empty);
 
         // Assert
-        cut.Find("#trip-note-recorded-on-invalid").TextContent
-            .Should().Contain("Enter a valid date and time for this note.");
-        store.Count.Should().Be(0);
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-recorded-on-invalid").TextContent
+                .Should().Contain("Enter a valid date and time for this note."));
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        await ShouldNotHaveWrittenAsync(writer);
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectATimeBeforeTheTripStarted()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var offset = OffsetPuttingLocalTimeAt(new TimeSpan(12, 0, 0));
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer, time: TestTimeService.WithOffset(offset));
+        var startedOn = DateTimeOffset.UtcNow.AddHours(-2);
+        var (cut, dialog) = await ShowModalAsync(context, startedOn);
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("12:00"));
+        cut.Find("#trip-note-text").Input("fish rising near the reeds");
+
+        // Act
+        cut.Find("#trip-note-time").Input("09:00");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-recorded-on-invalid").TextContent
+                .Should().Contain("before the trip started"));
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        await ShouldNotHaveWrittenAsync(writer);
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectATimeInTheFutureOnAnActiveTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var offset = OffsetPuttingLocalTimeAt(new TimeSpan(12, 0, 0));
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer, time: TestTimeService.WithOffset(offset));
+        var startedOn = DateTimeOffset.UtcNow.AddHours(-2);
+        var (cut, dialog) = await ShowModalAsync(context, startedOn);
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("12:00"));
+        cut.Find("#trip-note-text").Input("fish rising near the reeds");
+
+        // Act
+        cut.Find("#trip-note-time").Input("13:30");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-recorded-on-invalid").TextContent
+                .Should().Contain("in the future"));
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        await ShouldNotHaveWrittenAsync(writer);
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldRejectATimeAfterACompletedTripFinished()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer);
+        var (cut, dialog) = await ShowModalAsync(context, endedOn: EndedOn);
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("16:00"));
+        cut.Find("#trip-note-text").Input("a good day, three brownies");
+
+        // Act
+        cut.Find("#trip-note-time").Input("18:30");
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#trip-note-recorded-on-invalid").TextContent
+                .Should().Contain("after the trip finished"));
+        cut.Find("#trip-note-save").HasAttribute("disabled").Should().BeTrue();
+        await ShouldNotHaveWrittenAsync(writer);
         dialog.Result.IsCompleted.Should().BeFalse();
     }
 
@@ -74,9 +149,8 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
-        var store = new MemoryTripNoteStore { FailWrite = true };
         var logging = Substitute.For<ILoggingService>();
-        await using var context = CreateContext(store, logging);
+        await using var context = CreateContext(WriterThatFails(), logging);
         var (cut, dialog) = await ShowModalAsync(context);
         cut.Find("#trip-note-text").Input("fish rising near the reeds");
 
@@ -87,7 +161,34 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
         cut.Find("#trip-note-add-failed").TextContent.Should().Contain("could not be added");
         ((IHtmlTextAreaElement)cut.Find("#trip-note-text")).Value
             .Should().Be("fish rising near the reeds");
-        store.Count.Should().Be(0);
+        dialog.Result.IsCompleted.Should().BeFalse();
+        await logging.Received(1).LogErrorAsync(
+            "adding a trip note",
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAskTheAnglerToGoOnlineWhenAHistoricalTripCannotBeReached()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var logging = Substitute.For<ILoggingService>();
+        await using var context = CreateContext(WriterThatCannotReachTheServer(), logging);
+        var (cut, dialog) = await ShowModalAsync(
+            context,
+            endedOn: EndedOn,
+            storage: TripNoteStorageEnum.Server);
+        cut.Find("#trip-note-text").Input("fish started rising beside the reeds");
+
+        // Act
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        cut.Find("#trip-note-add-failed").TextContent
+            .Should().Contain("You need to be online to add a note to this trip.");
+        ((IHtmlTextAreaElement)cut.Find("#trip-note-text")).Value
+            .Should().Be("fish started rising beside the reeds");
         dialog.Result.IsCompleted.Should().BeFalse();
         await logging.Received(1).LogErrorAsync(
             "adding a trip note",
@@ -100,9 +201,8 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
     {
         // Arrange
         const string secret = "met Sarah about the lease at the bailiff hut";
-        var store = new MemoryTripNoteStore { FailWrite = true };
         var logging = Substitute.For<ILoggingService>();
-        await using var context = CreateContext(store, logging);
+        await using var context = CreateContext(WriterThatFails(), logging);
         var (cut, _) = await ShowModalAsync(context);
         cut.Find("#trip-note-text").Input(secret);
 
@@ -124,8 +224,8 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
     public async Task ItShouldCloseWithoutSavingWhenCancelled()
     {
         // Arrange
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer);
         var (cut, dialog) = await ShowModalAsync(context);
         cut.Find("#trip-note-text").Input("changed to olive nymph");
 
@@ -136,34 +236,75 @@ public class WhenTestingSave : BaseAddTripNoteModalTest
         var result = await dialog.Result;
         result.Should().NotBeNull();
         result!.Canceled.Should().BeTrue();
-        store.Count.Should().Be(0);
+        await ShouldNotHaveWrittenAsync(writer);
     }
 
     [Fact]
-    public async Task ItShouldSaveTheNoteAtTheChosenTime()
+    public async Task ItShouldSaveALocalNoteAtTheChosenTime()
     {
         // Arrange
-        var store = new MemoryTripNoteStore();
-        await using var context = CreateContext(store);
-        var (cut, dialog) = await ShowModalAsync(context);
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer);
+        var (cut, dialog) = await ShowModalAsync(context, endedOn: EndedOn);
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("16:00"));
 
         // Act
-        cut.Find("#trip-note-recorded-on").Input("2026-08-17T14:35");
+        cut.Find("#trip-note-time").Input("11:30");
         cut.Find("#trip-note-text").Input("  changed to olive nymph  ");
         await cut.Find("#trip-note-save").ClickAsync();
 
         // Assert
-        store.Count.Should().Be(1);
-        var stored = store.All().Single();
-        stored.Text.Should().Be("changed to olive nymph");
-        stored.RecordedOn.Should().Be(DateTimeOffset.Parse("2026-08-17T14:35:00Z"));
-        stored.TripId.Should().Be(TripId);
-        stored.OwnerUserId.Should().Be(OwnerUserId);
-        stored.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        await writer.Received(1).AddAsync(
+            Arg.Is<TripNoteDraftModel>(draft =>
+                draft.TripId == TripId
+                && draft.OwnerUserId == OwnerUserId
+                && draft.Text == "changed to olive nymph"
+                && draft.RecordedOn == DateTimeOffset.Parse("2026-08-17T11:30:00Z")),
+            TripNoteStorageEnum.LocalFirst,
+            Arg.Any<CancellationToken>());
         var result = await dialog.Result;
         result.Should().NotBeNull();
         result!.Canceled.Should().BeFalse();
         result.Data.Should().BeOfType<AddTripNoteModalResult>()
-            .Which.Note.Should().Be(stored);
+            .Which.Note.RecordedOn.Should().Be(DateTimeOffset.Parse("2026-08-17T11:30:00Z"));
+    }
+
+    [Fact]
+    public async Task ItShouldSendAHistoricalNoteToTheServerAtTheChosenTime()
+    {
+        // Arrange
+        var writer = WriterThatSaves();
+        await using var context = CreateContext(writer);
+        var (cut, dialog) = await ShowModalAsync(
+            context,
+            endedOn: EndedOn,
+            storage: TripNoteStorageEnum.Server);
+        cut.WaitForAssertion(() => TimeValue(cut).Should().Be("16:00"));
+
+        // Act
+        cut.Find("#trip-note-time").Input("11:30");
+        cut.Find("#trip-note-text").Input("fish started rising beside the reeds");
+        await cut.Find("#trip-note-save").ClickAsync();
+
+        // Assert
+        await writer.Received(1).AddAsync(
+            Arg.Is<TripNoteDraftModel>(draft =>
+                draft.TripId == TripId
+                && draft.Text == "fish started rising beside the reeds"
+                && draft.RecordedOn == DateTimeOffset.Parse("2026-08-17T11:30:00Z")),
+            TripNoteStorageEnum.Server,
+            Arg.Any<CancellationToken>());
+        var result = await dialog.Result;
+        result.Should().NotBeNull();
+        result!.Canceled.Should().BeFalse();
+    }
+
+    private static async Task ShouldNotHaveWrittenAsync(
+        Web.Features.Trips.Services.ITripNoteWriteService writer)
+    {
+        await writer.DidNotReceive().AddAsync(
+            Arg.Any<TripNoteDraftModel>(),
+            Arg.Any<TripNoteStorageEnum>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Stores/TripNoteStoreTests/MemoryTripNoteStore.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Offline/Stores/TripNoteStoreTests/MemoryTripNoteStore.cs
@@ -37,12 +37,15 @@ public sealed class MemoryTripNoteStore : ITripNoteStore
         return Task.CompletedTask;
     }
 
+    public int DeleteCalls { get; private set; }
+
     public Task<bool> DeleteAsync(
         Guid ownerUserId,
         Guid tripId,
         Guid noteId,
         CancellationToken cancellationToken)
     {
+        DeleteCalls++;
         if (!_notes.TryGetValue(noteId, out var note)
             || note.OwnerUserId != ownerUserId
             || note.TripId != tripId)

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/BaseActiveTripTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/BaseActiveTripTest.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Models;
@@ -65,7 +66,9 @@ public class BaseActiveTripTest
         ICatchStore? catchStore = null,
         IAnglerPreferencesProvider? anglerPreferences = null,
         ITripClient? tripClient = null,
-        IModalService? modalService = null)
+        IModalService? modalService = null,
+        ITripNoteWriteService? noteWriter = null,
+        INetworkService? network = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -88,8 +91,17 @@ public class BaseActiveTripTest
         context.Services.AddSingleton<ITripTimelineService>(new TripTimelineService());
         context.Services.AddSingleton<IMeasurementService>(new MeasurementService());
         context.Services.AddSingleton(modalService ?? ConfirmingModalService());
+        context.Services.AddSingleton(noteWriter ?? Substitute.For<ITripNoteWriteService>());
+        context.Services.AddSingleton(network ?? OnlineNetwork());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
+    }
+
+    protected static INetworkService OnlineNetwork(bool isOnline = true)
+    {
+        var network = Substitute.For<INetworkService>();
+        network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(isOnline);
+        return network;
     }
 
     protected static IAnglerPreferencesProvider QuietAnglerPreferences(

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingDiaryComposition.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingDiaryComposition.cs
@@ -139,7 +139,58 @@ public class WhenTestingDiaryComposition : BaseActiveTripTest
         cut.FindAll("#active-trip-add-catch").Should().BeEmpty();
         cut.FindAll("#active-trip-add-photo").Should().BeEmpty();
         cut.FindAll("#active-trip-finish").Should().BeEmpty();
-        cut.FindAll("#trip-note-start").Should().BeEmpty();
         cut.Find("#active-trip-logbook").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldStillOfferAddNoteOnACompletedTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .Returns(StoredCompletedTrip());
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#trip-note-start").Should().NotBeNull());
+        var trigger = cut.Find("#trip-note-start");
+        trigger.ClassName.Should().Contain("mud-fab");
+        trigger.GetAttribute("aria-label").Should().Be("Add note");
+        cut.FindAll("#active-trip-actions").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldStillOfferToRemoveANoteOnACompletedTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var noteId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .Returns(StoredCompletedTrip() with
+            {
+                Notes = [
+                    new TripNoteModel(
+                        noteId,
+                        TripId,
+                        OwnerUserId,
+                        "a good day, three brownies",
+                        StartedOn.AddHours(2))
+                ]
+            });
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#trip-timeline-note-remove-{noteId:D}").Should().NotBeNull());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingDiaryComposition.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingDiaryComposition.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripCatches;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Features.Trips.Offline.Stores;
 using FishingLogBook.Web.Localization;
@@ -33,7 +34,7 @@ public class WhenTestingDiaryComposition : BaseActiveTripTest
     }
 
     [Fact]
-    public async Task ItShouldOfferTheActiveTripActionsWithoutStackingFullWidthButtons()
+    public async Task ItShouldOfferTheActiveTripActionsInThreeEqualColumns()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
@@ -46,10 +47,12 @@ public class WhenTestingDiaryComposition : BaseActiveTripTest
 
         // Assert
         cut.WaitForAssertion(() => cut.Find("#active-trip-actions").Should().NotBeNull());
-        cut.Find("#active-trip-record-catch").Should().NotBeNull();
-        cut.Find("#active-trip-add-catch").Should().NotBeNull();
-        cut.Find("#active-trip-add-photo").Should().NotBeNull();
-        cut.Find("#active-trip-finish").Should().NotBeNull();
+        cut.Find("#active-trip-actions").ClassName.Should().Contain("mud-grid");
+        cut.Find("#active-trip-record-catch").ClassName.Should().Contain("active-trip-action");
+        cut.Find("#active-trip-add-catch").ClassName.Should().Contain("active-trip-action");
+        cut.Find("#active-trip-add-photo").ClassName.Should().Contain("active-trip-action");
+        cut.Find("#active-trip-update").ClassName.Should().Contain("active-trip-action");
+        cut.Find("#active-trip-finish").ClassName.Should().Contain("active-trip-action");
         cut.Find("#active-trip-update").GetAttribute("href").Should().Be($"/trips/{TripId:D}/edit");
     }
 
@@ -93,24 +96,49 @@ public class WhenTestingDiaryComposition : BaseActiveTripTest
     }
 
     [Fact]
-    public async Task ItShouldRevealTheCatchSelectorOnlyWhenAddCatchIsChosen()
+    public async Task ItShouldOpenTheCatchPickerOnlyWhenAddCatchIsChosen()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
         var store = await StoreWithActiveTripAsync();
-        var catchStore = QuietCatchStore(CatchFor(null));
-        await using var context = CreateContext(store, catchStore: catchStore);
+        var modalService = ConfirmingModalService();
+        await using var context = CreateContext(store, modalService: modalService);
         var cut = context.Render<ActiveTripPage>(parameters =>
             parameters.Add(page => page.TripId, TripId));
         cut.WaitForAssertion(() => cut.Find("#active-trip-add-catch").Should().NotBeNull());
-        cut.FindAll("#catch-selector").Should().BeEmpty();
+        await modalService.DidNotReceive()
+            .ShowAsync<AddTripCatchesModal, AddTripCatchesModalModel, AddTripCatchesModalResult>(
+                Arg.Any<AddTripCatchesModalModel>(),
+                Arg.Any<CancellationToken>());
 
         // Act
         await cut.Find("#active-trip-add-catch").ClickAsync();
 
         // Assert
-        cut.WaitForAssertion(() => cut.Find("#catch-selector").Should().NotBeNull());
+        await modalService.Received(1)
+            .ShowAsync<AddTripCatchesModal, AddTripCatchesModalModel, AddTripCatchesModalResult>(
+                Arg.Is<AddTripCatchesModalModel>(model => model.Scope.TripId == TripId),
+                Arg.Any<CancellationToken>());
         cut.FindAll("#trip-catches-record").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldStillOfferAddCatchOnACompletedTrip()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>())
+            .Returns(StoredCompletedTrip());
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-add-catch").Should().NotBeNull());
+        cut.FindAll("#active-trip-finish").Should().BeEmpty();
     }
 
     [Fact]
@@ -134,10 +162,9 @@ public class WhenTestingDiaryComposition : BaseActiveTripTest
         // Assert
         cut.WaitForAssertion(() =>
             cut.Find("#active-trip-status").TextContent.Should().Contain("Finished"));
-        cut.FindAll("#active-trip-actions").Should().BeEmpty();
         cut.FindAll("#active-trip-record-catch").Should().BeEmpty();
-        cut.FindAll("#active-trip-add-catch").Should().BeEmpty();
         cut.FindAll("#active-trip-add-photo").Should().BeEmpty();
+        cut.FindAll("#active-trip-update").Should().BeEmpty();
         cut.FindAll("#active-trip-finish").Should().BeEmpty();
         cut.Find("#active-trip-logbook").Should().NotBeNull();
     }
@@ -161,7 +188,7 @@ public class WhenTestingDiaryComposition : BaseActiveTripTest
         var trigger = cut.Find("#trip-note-start");
         trigger.ClassName.Should().Contain("mud-fab");
         trigger.GetAttribute("aria-label").Should().Be("Add note");
-        cut.FindAll("#active-trip-actions").Should().BeEmpty();
+        cut.FindAll("#active-trip-finish").Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingHistoricalTrip.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingHistoricalTrip.cs
@@ -3,8 +3,11 @@ using Bunit;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Modals.AddTripNote;
 using FishingLogBook.Web.Features.Trips.Models;
 using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using FishingLogBook.Web.Tests.TestSupport;
 using NSubstitute;
@@ -114,7 +117,136 @@ public class WhenTestingHistoricalTrip : BaseActiveTripTest
         cut.Find("#active-trip-place").TextContent.Should().Contain("Lough Corrib");
         cut.Find($"#trip-timeline-catch-{catchId:D}").TextContent.Should().Contain("Pike");
         cut.Markup.Should().Contain("The wind dropped.");
-        cut.FindAll("#trip-note-start").Should().BeEmpty();
         await tripClient.Received(1).GetDetailAsync(TripId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOfferAddNoteOnAnOwnedHistoricalTripWhileOnline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns((TripModel?)null);
+        var tripClient = HistoricalTripClient();
+        await using var context = CreateContext(store, tripClient: tripClient);
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#trip-note-start").Should().NotBeNull());
+        cut.Find("#trip-note-start").GetAttribute("aria-label").Should().Be("Add note");
+        cut.FindAll("#active-trip-actions").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferAddNoteOnAHistoricalTripWhileOffline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns((TripModel?)null);
+        var noteWriter = Substitute.For<ITripNoteWriteService>();
+        await using var context = CreateContext(
+            store,
+            tripClient: HistoricalTripClient(),
+            noteWriter: noteWriter,
+            network: OnlineNetwork(false));
+
+        // Act
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#active-trip-card").Should().NotBeNull());
+        cut.FindAll("#trip-note-start").Should().BeEmpty();
+        await noteWriter.DidNotReceive().AddAsync(
+            Arg.Any<TripNoteDraftModel>(),
+            Arg.Any<TripNoteStorageEnum>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowANewHistoricalNoteAtItsChosenPlaceOnTheTimeline()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var noteId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+        var catchId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+        var store = Substitute.For<ITripStore>();
+        store.GetAsync(OwnerUserId, TripId, Arg.Any<CancellationToken>()).Returns((TripModel?)null);
+        var recordedOn = StartedOn.AddMinutes(30);
+        var tripClient = Substitute.For<ITripClient>();
+        tripClient.GetDetailAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(
+                HistoricalDetail(catchId),
+                HistoricalDetail(catchId) with
+                {
+                    Notes = [new TripNoteDto(noteId, TripId, "fish started rising", recordedOn)]
+                });
+        var modalService = ConfirmingModalService();
+        modalService
+            .ShowAsync<AddTripNoteModal, AddTripNoteModalModel, AddTripNoteModalResult>(
+                Arg.Any<AddTripNoteModalModel>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new AddTripNoteModalResult(
+                new TripNoteModel(noteId, TripId, OwnerUserId, "fish started rising", recordedOn)));
+        await using var context = CreateContext(
+            store,
+            tripClient: tripClient,
+            modalService: modalService);
+        var cut = context.Render<ActiveTripPage>(parameters =>
+            parameters.Add(page => page.TripId, TripId));
+        cut.WaitForAssertion(() => cut.Find("#trip-note-start").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#trip-note-start").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#trip-timeline-note-{noteId:D}").TextContent
+                .Should().Contain("fish started rising"));
+        var rendered = cut.FindAll("[id^=trip-timeline-]")
+            .Select(element => element.Id!)
+            .ToArray();
+        rendered.Should().ContainInOrder(
+            $"trip-timeline-note-{noteId:D}",
+            $"trip-timeline-catch-{catchId:D}");
+        await tripClient.Received(2).GetDetailAsync(TripId, Arg.Any<CancellationToken>());
+    }
+
+    private static TripDetailDto HistoricalDetail(Guid catchId)
+    {
+        return new TripDetailDto(
+            new TripViewDto(
+                TripId,
+                OwnerUserId,
+                TripConstants.Completed,
+                StartedOn,
+                StartedOn.AddHours(5))
+            {
+                PlaceName = "Lough Corrib"
+            })
+        {
+            Catches = [new TripCatchSummaryDto(catchId, StartedOn.AddHours(1)) { SpeciesName = "Pike" }]
+        };
+    }
+
+    private static ITripClient HistoricalTripClient()
+    {
+        var tripClient = Substitute.For<ITripClient>();
+        tripClient.GetDetailAsync(TripId, Arg.Any<CancellationToken>())
+            .Returns(new TripDetailDto(
+                new TripViewDto(
+                    TripId,
+                    OwnerUserId,
+                    TripConstants.Completed,
+                    StartedOn,
+                    StartedOn.AddHours(5))
+                {
+                    PlaceName = "Lough Corrib"
+                }));
+        return tripClient;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingHistoricalTrip.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingHistoricalTrip.cs
@@ -137,7 +137,10 @@ public class WhenTestingHistoricalTrip : BaseActiveTripTest
         // Assert
         cut.WaitForAssertion(() => cut.Find("#trip-note-start").Should().NotBeNull());
         cut.Find("#trip-note-start").GetAttribute("aria-label").Should().Be("Add note");
-        cut.FindAll("#active-trip-actions").Should().BeEmpty();
+        cut.Find("#active-trip-add-catch").Should().NotBeNull();
+        cut.FindAll("#active-trip-record-catch").Should().BeEmpty();
+        cut.FindAll("#active-trip-update").Should().BeEmpty();
+        cut.FindAll("#active-trip-finish").Should().BeEmpty();
     }
 
     [Fact]
@@ -163,7 +166,7 @@ public class WhenTestingHistoricalTrip : BaseActiveTripTest
         cut.FindAll("#trip-note-start").Should().BeEmpty();
         await noteWriter.DidNotReceive().AddAsync(
             Arg.Any<TripNoteDraftModel>(),
-            Arg.Any<TripNoteStorageEnum>(),
+            Arg.Any<TripStorageEnum>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/ActiveTripTests/WhenTestingRender.cs
@@ -131,6 +131,14 @@ public class WhenTestingRender : BaseActiveTripTest
         cut.WaitForAssertion(() =>
             cut.Find("#active-trip-heading").TextContent.Should().Contain("Day with Dad"));
         cut.Find("#active-trip-place").TextContent.Should().Contain("Lough Corrib");
+        cut.Find("#active-trip-facts").ClassName.Should().Contain("mud-grid");
+        cut.Find(".active-trip-fact-place").ClassName.Should().Contain("mud-grid-item-xs-6");
+        cut.Find(".active-trip-fact-started").ClassName.Should().Contain("mud-grid-item-xs-3");
+        cut.Find(".active-trip-fact-elapsed").ClassName.Should().Contain("mud-grid-item-xs-3");
+        cut.Find("#active-trip-stats").ClassName.Should().Contain("mud-grid");
+        cut.Find(".active-trip-stat-catches").ClassName.Should().Contain("mud-grid-item-xs-6");
+        cut.Find(".active-trip-stat-photos").ClassName.Should().Contain("mud-grid-item-xs-3");
+        cut.Find(".active-trip-stat-notes").ClassName.Should().Contain("mud-grid-item-xs-3");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/TripEditTests/BaseTripEditTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/TripEditTests/BaseTripEditTest.cs
@@ -58,6 +58,7 @@ public class BaseTripEditTest
         context.Services.AddSingleton<IMeasurementService>(new MeasurementService());
         context.Services.AddSingleton(Substitute.For<ITripPhotographStore>());
         context.Services.AddSingleton(Substitute.For<ITripNoteStore>());
+        context.Services.AddSingleton(Substitute.For<ITripNoteWriteService>());
         context.Services.AddSingleton(Substitute.For<ITripClient>());
         context.Services.AddSingleton(Substitute.For<IPhotographPreparationService>());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/TripListTests/BaseTripListTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/TripListTests/BaseTripListTest.cs
@@ -99,6 +99,7 @@ public class BaseTripListTest
         Guid? tripId = null,
         string status = TripConstants.Active,
         DateTimeOffset? startedOn = null,
+        string? title = null,
         string? placeName = null,
         IReadOnlyList<TripPhotographModel>? photographs = null,
         IReadOnlyList<TripNoteModel>? notes = null)
@@ -109,6 +110,7 @@ public class BaseTripListTest
             status,
             startedOn ?? StartedOn,
             status == TripConstants.Completed ? (startedOn ?? StartedOn).AddHours(3) : null,
+            Title: title,
             PlaceName: placeName,
             Photographs: photographs,
             Notes: notes);

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/TripListTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Pages/TripListTests/WhenTestingRender.cs
@@ -197,6 +197,56 @@ public class WhenTestingRender : BaseTripListTest
     }
 
     [Fact]
+    public async Task ItShouldShowTheStartedDateWhenTheTripHasNoTitle()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = StoreWith(LocalTrip(placeName: "Ballynahinch"));
+        var client = ClientWith();
+        await using var context = CreateContext(store, client);
+
+        // Act
+        var cut = context.Render<TripListPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#trip-list-date-{LocalTripId:D}").TextContent.Should().Contain("27 Aug 2026"));
+        cut.FindAll($"#trip-list-title-{LocalTripId:D}").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldKeepTheStartedDateWhenTheTripHasATitle()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = StoreWith(LocalTrip(title: "First day of mayfly", placeName: "Lough Corrib"));
+        var client = ClientWith();
+        await using var context = CreateContext(store, client);
+
+        // Act
+        var cut = context.Render<TripListPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find($"#trip-list-date-{LocalTripId:D}").TextContent.Should().Contain("27 Aug 2026"));
+        var heading = cut.Find($"#trip-list-item-{LocalTripId:D} .trip-list-heading-group").TextContent;
+        heading.Should().Contain("27 Aug 2026");
+        heading.Should().Contain("First day of mayfly");
+        heading.IndexOf("27 Aug 2026", StringComparison.Ordinal)
+            .Should().BeLessThan(heading.IndexOf("First day of mayfly", StringComparison.Ordinal));
+        var title = cut.Find($"#trip-list-title-{LocalTripId:D}");
+        var date = cut.Find($"#trip-list-date-{LocalTripId:D}");
+        title.TextContent.Should().Contain("First day of mayfly");
+        title.ClassName.Should().NotContain("mud-text-secondary");
+        date.ClassName.Should().NotContain("mud-text-secondary");
+        title.ClassName.Should().Contain("mud-typography-subtitle1");
+        date.ClassName.Should().Contain("mud-typography-subtitle1");
+        cut.Find($"#trip-list-item-{LocalTripId:D} .trip-list-heading-row").ClassName.Should().Contain("flex-row");
+        cut.Find($"#trip-list-place-{LocalTripId:D}").TextContent.Should().Contain("Lough Corrib");
+        cut.Find($"#trip-list-place-{LocalTripId:D}").ClassName.Should().Contain("mud-text-secondary");
+    }
+
+    [Fact]
     public async Task ItShouldShowFrenchCopy()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripCatchServiceTests/BaseTripCatchServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripCatchServiceTests/BaseTripCatchServiceTest.cs
@@ -1,0 +1,87 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.TripCatchServiceTests;
+
+public class BaseTripCatchServiceTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid OtherTripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab");
+    protected static readonly Guid PikeCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
+    protected static readonly Guid TroutCatchId = Guid.Parse("cccccccc-0000-0000-0000-000000000002");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+    protected static readonly DateTimeOffset EndedOn = DateTimeOffset.Parse("2026-08-17T16:00:00Z");
+
+    protected readonly ICatchStore MockCatchStore = Substitute.For<ICatchStore>();
+    protected readonly ICatchClient MockCatchClient = Substitute.For<ICatchClient>();
+    protected readonly ITripClient MockTripClient = Substitute.For<ITripClient>();
+    protected readonly TripCatchService Sut;
+
+    protected BaseTripCatchServiceTest()
+    {
+        MockCatchStore.GetMetadataAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        MockCatchStore.UpdateTripAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<Guid>(),
+                Arg.Any<Guid?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        MockCatchClient.GetAllAsync(Arg.Any<CancellationToken>()).Returns([]);
+        MockTripClient.AssociateCatchesAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<AssociateTripCatchesDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => new TripCatchAssociationDto(
+                call.ArgAt<AssociateTripCatchesDto>(1).CatchIds,
+                []));
+        Sut = new TripCatchService(MockCatchStore, MockCatchClient, MockTripClient);
+    }
+
+    protected static TripCatchScopeModel CompletedScope()
+    {
+        return new TripCatchScopeModel(TripId, OwnerUserId, StartedOn, EndedOn);
+    }
+
+    protected static TripCatchScopeModel ActiveScope(DateTimeOffset? startedOn = null)
+    {
+        return new TripCatchScopeModel(TripId, OwnerUserId, startedOn ?? StartedOn);
+    }
+
+    protected static CatchModel Catch(
+        Guid catchId,
+        DateTimeOffset caughtOn,
+        Guid? tripId = null,
+        Guid? userId = null)
+    {
+        return new CatchModel(
+            catchId,
+            caughtOn,
+            [new CatchPhotographModel(Guid.NewGuid(), catchId, PhotographContentTypeConstants.Jpeg)],
+            "Pike",
+            UserId: userId ?? OwnerUserId,
+            TripId: tripId);
+    }
+
+    protected static CatchViewDto RemoteCatch(
+        Guid catchId,
+        DateTimeOffset caughtOn,
+        Guid? tripId = null,
+        Guid? userId = null)
+    {
+        return new CatchViewDto(catchId, userId ?? OwnerUserId, caughtOn)
+        {
+            TripId = tripId,
+            SpeciesName = "Pike"
+        };
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripCatchServiceTests/WhenTestingAssociate.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripCatchServiceTests/WhenTestingAssociate.cs
@@ -31,8 +31,72 @@ public class WhenTestingAssociate : BaseTripCatchServiceTest
     }
 
     [Fact]
+    public async Task ItShouldRejectALocalCatchThatIsNotEligible()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns([Catch(PikeCatchId, StartedOn.AddHours(1))]);
+
+        // Act
+        var association = await Sut.AssociateAsync(
+            CompletedScope(),
+            [PikeCatchId, TroutCatchId],
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        association.AssociatedCatchIds.Should().Equal(PikeCatchId);
+        association.RejectedCatchIds.Should().Equal(TroutCatchId);
+        await MockCatchStore.Received(1).UpdateTripAsync(
+            OwnerUserId,
+            PikeCatchId,
+            TripId,
+            Arg.Any<CancellationToken>());
+        await MockCatchStore.DidNotReceive().UpdateTripAsync(
+            Arg.Any<Guid>(),
+            TroutCatchId,
+            Arg.Any<Guid?>(),
+            Arg.Any<CancellationToken>());
+        await MockTripClient.DidNotReceive().AssociateCatchesAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<AssociateTripCatchesDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAssociateADuplicateLocalCatchOnlyOnce()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns([Catch(PikeCatchId, StartedOn.AddHours(1))]);
+
+        // Act
+        var association = await Sut.AssociateAsync(
+            CompletedScope(),
+            [PikeCatchId, PikeCatchId],
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        association.AssociatedCatchIds.Should().Equal(PikeCatchId);
+        await MockCatchStore.Received(1).UpdateTripAsync(
+            OwnerUserId,
+            PikeCatchId,
+            TripId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldAssociateALocalTripThroughTheOfflineStore()
     {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                Catch(PikeCatchId, StartedOn.AddHours(1)),
+                Catch(TroutCatchId, StartedOn.AddHours(2))
+            ]);
+
         // Act
         var association = await Sut.AssociateAsync(
             CompletedScope(),

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripCatchServiceTests/WhenTestingAssociate.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripCatchServiceTests/WhenTestingAssociate.cs
@@ -1,0 +1,140 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Trips.Enums;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.TripCatchServiceTests;
+
+public class WhenTestingAssociate : BaseTripCatchServiceTest
+{
+    [Fact]
+    public async Task ItShouldDoNothingWhenNothingWasSelected()
+    {
+        // Act
+        var association = await Sut.AssociateAsync(
+            CompletedScope(),
+            [],
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        association.AssociatedCatchIds.Should().BeEmpty();
+        await MockCatchStore.DidNotReceive().UpdateTripAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<Guid?>(),
+            Arg.Any<CancellationToken>());
+        await MockTripClient.DidNotReceive().AssociateCatchesAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<AssociateTripCatchesDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAssociateALocalTripThroughTheOfflineStore()
+    {
+        // Act
+        var association = await Sut.AssociateAsync(
+            CompletedScope(),
+            [PikeCatchId, TroutCatchId],
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        association.AssociatedCatchIds.Should().Equal(PikeCatchId, TroutCatchId);
+        association.RejectedCatchIds.Should().BeEmpty();
+        await MockCatchStore.Received(1).UpdateTripAsync(
+            OwnerUserId,
+            PikeCatchId,
+            TripId,
+            Arg.Any<CancellationToken>());
+        await MockCatchStore.Received(1).UpdateTripAsync(
+            OwnerUserId,
+            TroutCatchId,
+            TripId,
+            Arg.Any<CancellationToken>());
+        await MockTripClient.DidNotReceive().AssociateCatchesAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<AssociateTripCatchesDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldAssociateAHistoricalTripInOneAuthenticatedCall()
+    {
+        // Act
+        var association = await Sut.AssociateAsync(
+            CompletedScope(),
+            [PikeCatchId, TroutCatchId],
+            TripStorageEnum.Server,
+            CancellationToken.None);
+
+        // Assert
+        association.AssociatedCatchIds.Should().Equal(PikeCatchId, TroutCatchId);
+        await MockTripClient.Received(1).AssociateCatchesAsync(
+            TripId,
+            Arg.Is<AssociateTripCatchesDto>(request =>
+                request.CatchIds.Count == 2
+                && request.CatchIds.Contains(PikeCatchId)
+                && request.CatchIds.Contains(TroutCatchId)),
+            Arg.Any<CancellationToken>());
+        await MockCatchStore.DidNotReceive().UpdateTripAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<Guid?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportTheCatchesTheServerRefused()
+    {
+        // Arrange
+        MockTripClient.AssociateCatchesAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<AssociateTripCatchesDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new TripCatchAssociationDto([PikeCatchId], [TroutCatchId]));
+
+        // Act
+        var association = await Sut.AssociateAsync(
+            CompletedScope(),
+            [PikeCatchId, TroutCatchId],
+            TripStorageEnum.Server,
+            CancellationToken.None);
+
+        // Assert
+        association.AssociatedCatchIds.Should().Equal(PikeCatchId);
+        association.RejectedCatchIds.Should().Equal(TroutCatchId);
+        await MockCatchStore.DidNotReceive().UpdateTripAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<Guid?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotWriteLocallyWhenTheHistoricalCallFails()
+    {
+        // Arrange
+        MockTripClient.AssociateCatchesAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<AssociateTripCatchesDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripCatchAssociationDto?>(_ => throw new HttpRequestException("offline"));
+
+        // Act
+        var associate = async () => await Sut.AssociateAsync(
+            CompletedScope(),
+            [PikeCatchId],
+            TripStorageEnum.Server,
+            CancellationToken.None);
+
+        // Assert
+        await associate.Should().ThrowAsync<HttpRequestException>();
+        await MockCatchStore.DidNotReceive().UpdateTripAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<Guid?>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripCatchServiceTests/WhenTestingGetEligible.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripCatchServiceTests/WhenTestingGetEligible.cs
@@ -1,0 +1,180 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.Trips.Enums;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.TripCatchServiceTests;
+
+public class WhenTestingGetEligible : BaseTripCatchServiceTest
+{
+    [Fact]
+    public async Task ItShouldOfferACatchRecordedDuringACompletedTripThatIsNotOnATrip()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns([Catch(PikeCatchId, StartedOn.AddHours(3))]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            CompletedScope(),
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Select(candidate => candidate.Id).Should().Equal(PikeCatchId);
+        await MockCatchClient.DidNotReceive().GetAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferACatchFromBeforeTheTripStarted()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns([Catch(PikeCatchId, StartedOn.AddMinutes(-1))]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            CompletedScope(),
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferACatchFromAfterACompletedTripFinished()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns([Catch(PikeCatchId, EndedOn.AddMinutes(1))]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            CompletedScope(),
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldUseNowAsTheUpperBoundOfAnActiveTrip()
+    {
+        // Arrange
+        var startedOn = DateTimeOffset.UtcNow.AddHours(-2);
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                Catch(PikeCatchId, startedOn.AddMinutes(30)),
+                Catch(TroutCatchId, DateTimeOffset.UtcNow.AddHours(1))
+            ]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            ActiveScope(startedOn),
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Select(candidate => candidate.Id).Should().Equal(PikeCatchId);
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferACatchAlreadyOnThisTrip()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns([Catch(PikeCatchId, StartedOn.AddHours(1), tripId: TripId)]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            CompletedScope(),
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferACatchAlreadyOnAnotherTrip()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns([Catch(PikeCatchId, StartedOn.AddHours(1), tripId: OtherTripId)]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            CompletedScope(),
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferACatchBelongingToAnotherAngler()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns([Catch(PikeCatchId, StartedOn.AddHours(1), userId: OtherUserId)]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            CompletedScope(),
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldReadTheServerForAHistoricalTripAndApplyTheSameRules()
+    {
+        // Arrange
+        MockCatchClient.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                RemoteCatch(PikeCatchId, StartedOn.AddHours(2)),
+                RemoteCatch(TroutCatchId, StartedOn.AddHours(3), tripId: OtherTripId),
+                RemoteCatch(Guid.NewGuid(), EndedOn.AddHours(1)),
+                RemoteCatch(Guid.NewGuid(), StartedOn.AddHours(1), userId: OtherUserId)
+            ]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            CompletedScope(),
+            TripStorageEnum.Server,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Select(candidate => candidate.Id).Should().Equal(PikeCatchId);
+        await MockCatchStore.DidNotReceive().GetMetadataAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOrderTheCandidatesByWhenTheyWereCaught()
+    {
+        // Arrange
+        MockCatchStore.GetMetadataAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(
+            [
+                Catch(TroutCatchId, StartedOn.AddHours(4)),
+                Catch(PikeCatchId, StartedOn.AddHours(1))
+            ]);
+
+        // Act
+        var eligible = await Sut.GetEligibleAsync(
+            CompletedScope(),
+            TripStorageEnum.LocalFirst,
+            CancellationToken.None);
+
+        // Assert
+        eligible.Select(candidate => candidate.Id).Should().Equal(PikeCatchId, TroutCatchId);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/BaseTripNoteWriteServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/BaseTripNoteWriteServiceTest.cs
@@ -1,0 +1,45 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Trips.Offline.Stores;
+using FishingLogBook.Web.Features.Trips.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.TripNoteWriteServiceTests;
+
+public class BaseTripNoteWriteServiceTest
+{
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    protected static readonly Guid NoteId = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    protected static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-17T07:00:00Z");
+    protected static readonly DateTimeOffset RecordedOn = DateTimeOffset.Parse("2026-08-17T11:30:00Z");
+
+    protected readonly ITripNoteStore MockNoteStore = Substitute.For<ITripNoteStore>();
+    protected readonly ITripClient MockTripClient = Substitute.For<ITripClient>();
+    protected readonly TripNoteWriteService Sut;
+
+    protected BaseTripNoteWriteServiceTest()
+    {
+        MockNoteStore.SaveAsync(Arg.Any<Web.Features.Trips.Models.TripNoteModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        MockNoteStore.DeleteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<Guid>(),
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => new TripNoteDto(
+                call.ArgAt<RecordTripNoteDto>(1).NoteId,
+                call.ArgAt<Guid>(0),
+                call.ArgAt<RecordTripNoteDto>(1).Text,
+                call.ArgAt<RecordTripNoteDto>(1).RecordedOn)
+            {
+                CreatedByUserId = OwnerUserId
+            });
+        Sut = new TripNoteWriteService(MockNoteStore, MockTripClient);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingAdd.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingAdd.cs
@@ -16,7 +16,7 @@ public class WhenTestingAdd : BaseTripNoteWriteServiceTest
         var draft = new TripNoteDraftModel(TripId, OwnerUserId, "changed to olive nymph", RecordedOn);
 
         // Act
-        var note = await Sut.AddAsync(draft, TripNoteStorageEnum.LocalFirst, CancellationToken.None);
+        var note = await Sut.AddAsync(draft, TripStorageEnum.LocalFirst, CancellationToken.None);
 
         // Assert
         note.TripId.Should().Be(TripId);
@@ -49,7 +49,7 @@ public class WhenTestingAdd : BaseTripNoteWriteServiceTest
             RecordedOn);
 
         // Act
-        var note = await Sut.AddAsync(draft, TripNoteStorageEnum.Server, CancellationToken.None);
+        var note = await Sut.AddAsync(draft, TripStorageEnum.Server, CancellationToken.None);
 
         // Assert
         note.RecordedOn.Should().Be(RecordedOn);
@@ -81,7 +81,7 @@ public class WhenTestingAdd : BaseTripNoteWriteServiceTest
         var draft = new TripNoteDraftModel(TripId, OwnerUserId, "  trimmed by the server  ", RecordedOn);
 
         // Act
-        var note = await Sut.AddAsync(draft, TripNoteStorageEnum.Server, CancellationToken.None);
+        var note = await Sut.AddAsync(draft, TripStorageEnum.Server, CancellationToken.None);
 
         // Assert
         note.Id.Should().Be(NoteId);
@@ -104,7 +104,7 @@ public class WhenTestingAdd : BaseTripNoteWriteServiceTest
 
         // Act
         var add = async () =>
-            await Sut.AddAsync(draft, TripNoteStorageEnum.Server, CancellationToken.None);
+            await Sut.AddAsync(draft, TripStorageEnum.Server, CancellationToken.None);
 
         // Assert
         await add.Should().ThrowAsync<HttpRequestException>();

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingAdd.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingAdd.cs
@@ -1,0 +1,115 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.TripNoteWriteServiceTests;
+
+public class WhenTestingAdd : BaseTripNoteWriteServiceTest
+{
+    [Fact]
+    public async Task ItShouldSaveALocalTripNoteThroughTheOfflineStore()
+    {
+        // Arrange
+        var draft = new TripNoteDraftModel(TripId, OwnerUserId, "changed to olive nymph", RecordedOn);
+
+        // Act
+        var note = await Sut.AddAsync(draft, TripNoteStorageEnum.LocalFirst, CancellationToken.None);
+
+        // Assert
+        note.TripId.Should().Be(TripId);
+        note.OwnerUserId.Should().Be(OwnerUserId);
+        note.Text.Should().Be("changed to olive nymph");
+        note.RecordedOn.Should().Be(RecordedOn);
+        note.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        await MockNoteStore.Received(1).SaveAsync(
+            Arg.Is<TripNoteModel>(saved =>
+                saved.TripId == TripId
+                && saved.OwnerUserId == OwnerUserId
+                && saved.Text == "changed to olive nymph"
+                && saved.RecordedOn == RecordedOn
+                && saved.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+        await MockTripClient.DidNotReceive().RecordNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordTripNoteDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPostAHistoricalTripNoteWithoutTouchingTheOfflineStore()
+    {
+        // Arrange
+        var draft = new TripNoteDraftModel(
+            TripId,
+            OwnerUserId,
+            "fish started rising beside the reeds",
+            RecordedOn);
+
+        // Act
+        var note = await Sut.AddAsync(draft, TripNoteStorageEnum.Server, CancellationToken.None);
+
+        // Assert
+        note.RecordedOn.Should().Be(RecordedOn);
+        note.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        await MockTripClient.Received(1).RecordNoteAsync(
+            TripId,
+            Arg.Is<RecordTripNoteDto>(request =>
+                request.Text == "fish started rising beside the reeds"
+                && request.RecordedOn == RecordedOn
+                && request.NoteId != Guid.Empty),
+            Arg.Any<CancellationToken>());
+        await MockNoteStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripNoteModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldTakeTheStoredIdentityFromTheServerResponse()
+    {
+        // Arrange
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new TripNoteDto(NoteId, TripId, "trimmed by the server", RecordedOn)
+            {
+                CreatedByUserId = OwnerUserId
+            });
+        var draft = new TripNoteDraftModel(TripId, OwnerUserId, "  trimmed by the server  ", RecordedOn);
+
+        // Act
+        var note = await Sut.AddAsync(draft, TripNoteStorageEnum.Server, CancellationToken.None);
+
+        // Assert
+        note.Id.Should().Be(NoteId);
+        note.Text.Should().Be("trimmed by the server");
+        await MockNoteStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripNoteModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotWriteALocalNoteWhenTheHistoricalPostFails()
+    {
+        // Arrange
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripNoteDto?>(_ => throw new HttpRequestException("offline"));
+        var draft = new TripNoteDraftModel(TripId, OwnerUserId, "wind picked up", RecordedOn);
+
+        // Act
+        var add = async () =>
+            await Sut.AddAsync(draft, TripNoteStorageEnum.Server, CancellationToken.None);
+
+        // Assert
+        await add.Should().ThrowAsync<HttpRequestException>();
+        await MockNoteStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripNoteModel>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingRemove.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingRemove.cs
@@ -15,7 +15,7 @@ public class WhenTestingRemove : BaseTripNoteWriteServiceTest
         var removal = new TripNoteRemovalModel(TripId, OwnerUserId, NoteId, SyncStatus.SavedLocally);
 
         // Act
-        await Sut.RemoveAsync(removal, TripNoteStorageEnum.LocalFirst, CancellationToken.None);
+        await Sut.RemoveAsync(removal, TripStorageEnum.LocalFirst, CancellationToken.None);
 
         // Assert
         await MockNoteStore.Received(1).DeleteAsync(
@@ -36,7 +36,7 @@ public class WhenTestingRemove : BaseTripNoteWriteServiceTest
         var removal = new TripNoteRemovalModel(TripId, OwnerUserId, NoteId, SyncStatus.Synchronised);
 
         // Act
-        await Sut.RemoveAsync(removal, TripNoteStorageEnum.LocalFirst, CancellationToken.None);
+        await Sut.RemoveAsync(removal, TripStorageEnum.LocalFirst, CancellationToken.None);
 
         // Assert
         await MockTripClient.Received(1).DeleteNoteAsync(
@@ -57,7 +57,7 @@ public class WhenTestingRemove : BaseTripNoteWriteServiceTest
         var removal = new TripNoteRemovalModel(TripId, OwnerUserId, NoteId);
 
         // Act
-        await Sut.RemoveAsync(removal, TripNoteStorageEnum.Server, CancellationToken.None);
+        await Sut.RemoveAsync(removal, TripStorageEnum.Server, CancellationToken.None);
 
         // Assert
         await MockTripClient.Received(1).DeleteNoteAsync(
@@ -81,7 +81,7 @@ public class WhenTestingRemove : BaseTripNoteWriteServiceTest
 
         // Act
         var remove = async () =>
-            await Sut.RemoveAsync(removal, TripNoteStorageEnum.Server, CancellationToken.None);
+            await Sut.RemoveAsync(removal, TripStorageEnum.Server, CancellationToken.None);
 
         // Assert
         await remove.Should().ThrowAsync<HttpRequestException>();

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingRemove.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingRemove.cs
@@ -1,0 +1,94 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.TripNoteWriteServiceTests;
+
+public class WhenTestingRemove : BaseTripNoteWriteServiceTest
+{
+    [Fact]
+    public async Task ItShouldDeleteALocalOnlyNoteWithoutCallingTheServer()
+    {
+        // Arrange
+        var removal = new TripNoteRemovalModel(TripId, OwnerUserId, NoteId, SyncStatus.SavedLocally);
+
+        // Act
+        await Sut.RemoveAsync(removal, TripNoteStorageEnum.LocalFirst, CancellationToken.None);
+
+        // Assert
+        await MockNoteStore.Received(1).DeleteAsync(
+            OwnerUserId,
+            TripId,
+            NoteId,
+            Arg.Any<CancellationToken>());
+        await MockTripClient.DidNotReceive().DeleteNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDeleteASynchronisedLocalNoteOnTheServerAndOnTheDevice()
+    {
+        // Arrange
+        var removal = new TripNoteRemovalModel(TripId, OwnerUserId, NoteId, SyncStatus.Synchronised);
+
+        // Act
+        await Sut.RemoveAsync(removal, TripNoteStorageEnum.LocalFirst, CancellationToken.None);
+
+        // Assert
+        await MockTripClient.Received(1).DeleteNoteAsync(
+            TripId,
+            NoteId,
+            Arg.Any<CancellationToken>());
+        await MockNoteStore.Received(1).DeleteAsync(
+            OwnerUserId,
+            TripId,
+            NoteId,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldDeleteAHistoricalNoteOnTheServerOnly()
+    {
+        // Arrange
+        var removal = new TripNoteRemovalModel(TripId, OwnerUserId, NoteId);
+
+        // Act
+        await Sut.RemoveAsync(removal, TripNoteStorageEnum.Server, CancellationToken.None);
+
+        // Assert
+        await MockTripClient.Received(1).DeleteNoteAsync(
+            TripId,
+            NoteId,
+            Arg.Any<CancellationToken>());
+        await MockNoteStore.DidNotReceive().DeleteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotDeleteLocallyWhenTheHistoricalDeleteFails()
+    {
+        // Arrange
+        MockTripClient.DeleteNoteAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(_ => throw new HttpRequestException("offline"));
+        var removal = new TripNoteRemovalModel(TripId, OwnerUserId, NoteId);
+
+        // Act
+        var remove = async () =>
+            await Sut.RemoveAsync(removal, TripNoteStorageEnum.Server, CancellationToken.None);
+
+        // Assert
+        await remove.Should().ThrowAsync<HttpRequestException>();
+        await MockNoteStore.DidNotReceive().DeleteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingUpdate.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Services/TripNoteWriteServiceTests/WhenTestingUpdate.cs
@@ -1,0 +1,116 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Services.TripNoteWriteServiceTests;
+
+public class WhenTestingUpdate : BaseTripNoteWriteServiceTest
+{
+    [Fact]
+    public async Task ItShouldKeepALocalOnlyNoteWaitingToSynchronise()
+    {
+        // Arrange
+        var note = Note(SyncStatus.SavedLocally) with { Text = "changed to olive nymph" };
+
+        // Act
+        var updated = await Sut.UpdateAsync(note, TripStorageEnum.LocalFirst, CancellationToken.None);
+
+        // Assert
+        updated.SyncStatus.Should().Be(SyncStatus.SavedLocally);
+        await MockNoteStore.Received(1).SaveAsync(
+            Arg.Is<TripNoteModel>(saved =>
+                saved.Id == NoteId
+                && saved.Text == "changed to olive nymph"
+                && saved.SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
+        await MockTripClient.DidNotReceive().RecordNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordTripNoteDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldQueueAnAlreadySynchronisedLocalNoteForResending()
+    {
+        // Arrange
+        var note = Note(SyncStatus.Synchronised) with { RecordedOn = RecordedOn.AddHours(1) };
+
+        // Act
+        var updated = await Sut.UpdateAsync(note, TripStorageEnum.LocalFirst, CancellationToken.None);
+
+        // Assert
+        updated.SyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
+        await MockNoteStore.Received(1).SaveAsync(
+            Arg.Is<TripNoteModel>(saved =>
+                saved.RecordedOn == RecordedOn.AddHours(1)
+                && saved.SyncStatus == SyncStatus.WaitingToSynchronise),
+            Arg.Any<CancellationToken>());
+        await MockTripClient.DidNotReceive().RecordNoteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordTripNoteDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSendAHistoricalNoteEditToTheServerOnly()
+    {
+        // Arrange
+        var note = Note(SyncStatus.Synchronised) with
+        {
+            Text = "fish started rising beside the reeds",
+            RecordedOn = RecordedOn.AddMinutes(-45)
+        };
+
+        // Act
+        var updated = await Sut.UpdateAsync(note, TripStorageEnum.Server, CancellationToken.None);
+
+        // Assert
+        updated.SyncStatus.Should().Be(SyncStatus.Synchronised);
+        updated.RecordedOn.Should().Be(RecordedOn.AddMinutes(-45));
+        await MockTripClient.Received(1).RecordNoteAsync(
+            TripId,
+            Arg.Is<RecordTripNoteDto>(request =>
+                request.NoteId == NoteId
+                && request.Text == "fish started rising beside the reeds"
+                && request.RecordedOn == RecordedOn.AddMinutes(-45)),
+            Arg.Any<CancellationToken>());
+        await MockNoteStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripNoteModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotWriteLocallyWhenTheHistoricalEditFails()
+    {
+        // Arrange
+        MockTripClient.RecordNoteAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<RecordTripNoteDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns<TripNoteDto?>(_ => throw new HttpRequestException("offline"));
+
+        // Act
+        var update = async () =>
+            await Sut.UpdateAsync(Note(SyncStatus.Synchronised), TripStorageEnum.Server, CancellationToken.None);
+
+        // Assert
+        await update.Should().ThrowAsync<HttpRequestException>();
+        await MockNoteStore.DidNotReceive().SaveAsync(
+            Arg.Any<TripNoteModel>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static TripNoteModel Note(SyncStatus syncStatus)
+    {
+        return new TripNoteModel(
+            NoteId,
+            TripId,
+            OwnerUserId,
+            "water dropped about a foot",
+            RecordedOn,
+            syncStatus);
+    }
+}


### PR DESCRIPTION
## Summary
- Follow-up after [#190](https://github.com/kingkeamo/fishing-logbook/pull/190) / [#179](https://github.com/kingkeamo/fishing-logbook/issues/179): attach existing unlinked catches to a trip in one request, with server ownership and timeframe checks, and a multi-select modal on the diary and editor.
- Add Note is one modal for every owned trip: date and time default inside the trip window, times outside it are refused, and a historical trip that only exists on the server posts the note online rather than orphaning it locally.
- Trip screens: active-trip facts and actions in MudBlazor columns, Record catch / Add catch side by side, list rows show date and title together.
- Self-review follow-up: Testcontainers coverage for `AssociateTripAsync`, HTTP contract tests for `TripClient.AssociateCatchesAsync`, handler mapping through Mapster, API 503 on persistence failure, and the Visual Studio `.http` scratch file now lists every trip route.

Part of #108. Follow-up after #179 — do not auto-close it.

## Test plan
- [ ] Active trip: Record catch and Add catch sit side by side; facts row uses a wider location column.
- [ ] Add existing catches: eligible catches can be multi-selected and attached; already-on-trip / other-angler / outside-window catches are refused.
- [ ] Historical / server-only trip: Add catch requires being online; association hits `POST /api/trips/{id}/catches`.
- [ ] Add note on an active trip, a finished local trip, and a historical server trip; a time outside the trip is refused.
- [ ] Trip list shows date and title on the same row when a trip is named.
- [ ] Phone check of the active-trip card and trip list layout (not covered by Playwright).

## Self review
- Issue/AC: PASS for this follow-up (associate existing catches, notes on any owned trip, layout tidy). Timeline ACs remain with merged #190.
- Architecture/CQRS: PASS. `POST /api/trips/{id}/catches` → handler → `ITripCatchService` → `ICatchRepository`. Handler maps through `IMapper`.
- Rules: PASS after self-review fixes (mapper, Testcontainers SQL, HTTP client contract, handler tests, `.http` sync).
- Security/privacy: PASS. Ownership is `ICurrentUser` vs trip `OwnerUserId`. Ineligible IDs go to `RejectedCatchIds`, not 404. SQL also requires `UserId` and `TripId IS NULL`.
- Database/migrations: N/A. Reuses existing `Catch.TripId`; no new migration.
- Tests/coverage: PASS. Associate SQL, HTTP client, handler, API 503, local ineligible-ID rejection, note timeframe, and modal/bUnit coverage.
- Browser: N/A for authenticated Blazor associate/layout. Playwright is IndexedDB/PWA/shell. Remaining risk is visual layout on a phone.
- Web/UI/localisation: PASS. EN + FR for add-catches and add-note; FR empty-state covered.
- Code smells: PASS for the paths reviewed. Unused leftover add-catch strings removed.
- CI/deployment: PASS. No migration, Terraform, or secret change.

Findings discovered during self-review and fixed on this branch:
1. `CatchRepository.AssociateTripAsync` had no live PostgreSQL coverage.
2. `TripClient.AssociateCatchesAsync` had no HTTP contract tests.
3. Handler tests were missing after switching to `IMapper`.
4. API had no 503 path when association persistence failed.
5. Trip routes were missing from `FishingLogBook.Api.http`.

Remaining deliberate gaps:
- Commit `7df3ead` still has a `Co-authored-by: Cursor` trailer; not amended.
- Repository SQL does not also check trip ownership; the application service is the security boundary.
- Layout on phones is a device check, not Playwright.
