### PR TITLE
FLB#192 | prefer IPv4 for Cognito JWT metadata fetch

### DIFF
--- a/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
+++ b/src/FishingLogBook.Api/Authentication/AuthenticationExtensions.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using System.Security.Claims;
 using FishingLogBook.Api.Configuration;
 using FishingLogBook.Shared.Constants;
@@ -21,12 +23,15 @@ public static class AuthenticationExtensions
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer();
         services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
-            .Configure<AuthConfig>(ConfigureJwtBearer);
+            .Configure<AuthConfig, ILoggerFactory>(ConfigureJwtBearer);
         services.AddAuthorization();
         return services;
     }
 
-    private static void ConfigureJwtBearer(JwtBearerOptions options, AuthConfig authConfig)
+    private static void ConfigureJwtBearer(
+        JwtBearerOptions options,
+        AuthConfig authConfig,
+        ILoggerFactory loggerFactory)
     {
         authConfig.EnsureRequired();
         options.MapInboundClaims = false;
@@ -44,6 +49,71 @@ public static class AuthenticationExtensions
         options.Authority = authConfig.Authority;
         options.RequireHttpsMetadata = true;
         options.MetadataAddress = $"{authConfig.Authority.TrimEnd('/')}/.well-known/openid-configuration";
+        options.BackchannelHttpHandler = CreateBackchannelHandler(
+            loggerFactory.CreateLogger(typeof(AuthenticationExtensions)));
+    }
+
+    private static HttpMessageHandler CreateBackchannelHandler(ILogger logger)
+    {
+        return new SocketsHttpHandler
+        {
+            ConnectCallback = (context, cancellationToken) =>
+                ConnectBackchannelAsync(context.DnsEndPoint, cancellationToken, logger)
+        };
+    }
+
+    private static async ValueTask<Stream> ConnectBackchannelAsync(
+        DnsEndPoint endPoint,
+        CancellationToken cancellationToken,
+        ILogger logger)
+    {
+        try
+        {
+            return await ConnectSocketAsync(AddressFamily.InterNetwork, endPoint, cancellationToken);
+        }
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+        {
+            logger.LogDebug(exception, "JWT metadata IPv4 connection was cancelled.");
+            throw;
+        }
+        catch (SocketException socketException)
+        {
+            logger.LogWarning(socketException, "JWT metadata IPv4 connection failed; trying IPv6.");
+            try
+            {
+                return await ConnectSocketAsync(AddressFamily.InterNetworkV6, endPoint, cancellationToken);
+            }
+            catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
+            {
+                logger.LogDebug(exception, "JWT metadata IPv6 connection was cancelled.");
+                throw;
+            }
+            catch (SocketException ipv6Exception)
+            {
+                logger.LogError(ipv6Exception, "Failed to open an IPv6 connection for JWT metadata.");
+                throw;
+            }
+        }
+    }
+
+    private static async ValueTask<Stream> ConnectSocketAsync(
+        AddressFamily addressFamily,
+        DnsEndPoint endPoint,
+        CancellationToken cancellationToken)
+    {
+        Socket? socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp);
+        try
+        {
+            socket.NoDelay = true;
+            await socket.ConnectAsync(endPoint, cancellationToken);
+            var stream = new NetworkStream(socket, ownsSocket: true);
+            socket = null;
+            return stream;
+        }
+        finally
+        {
+            socket?.Dispose();
+        }
     }
 
     private static TokenValidationParameters CreateValidationParameters(AuthConfig authConfig)

--- a/tests/FishingLogBook.Api.Tests/AuthenticationExtensionsTests/BaseAuthenticationExtensionsTest.cs
+++ b/tests/FishingLogBook.Api.Tests/AuthenticationExtensionsTests/BaseAuthenticationExtensionsTest.cs
@@ -1,0 +1,31 @@
+using FishingLogBook.Api.Authentication;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Tests.Common.TestSupport;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace FishingLogBook.Api.Tests.AuthenticationExtensionsTests;
+
+public class BaseAuthenticationExtensionsTest
+{
+    protected static JwtBearerOptions CreateConfiguredJwtBearerOptions()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:Authority"] = TestJwt.Issuer,
+                ["Auth:ClientId"] = TestJwt.ClientId,
+                ["Auth:ApiScope"] = TestAuthConstants.ApiScope,
+                ["Auth:ApiResource"] = TestAuthConstants.ApiResource
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddFishingLogBookJwtBearer(configuration);
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(JwtBearerDefaults.AuthenticationScheme);
+    }
+}

--- a/tests/FishingLogBook.Api.Tests/AuthenticationExtensionsTests/WhenTestingAddFishingLogBookJwtBearer.cs
+++ b/tests/FishingLogBook.Api.Tests/AuthenticationExtensionsTests/WhenTestingAddFishingLogBookJwtBearer.cs
@@ -1,0 +1,49 @@
+using AwesomeAssertions;
+using FishingLogBook.Api.Tests.TestSupport;
+using FishingLogBook.Tests.Common.TestSupport;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+namespace FishingLogBook.Api.Tests.AuthenticationExtensionsTests;
+
+public class WhenTestingAddFishingLogBookJwtBearer : BaseAuthenticationExtensionsTest
+{
+    [Fact]
+    public void ItShouldConfigureASocketsHttpHandlerConnectCallback()
+    {
+        // Arrange
+        var options = CreateConfiguredJwtBearerOptions();
+
+        // Act
+        var handler = options.BackchannelHttpHandler as SocketsHttpHandler;
+
+        // Assert
+        handler.Should().NotBeNull();
+        handler!.ConnectCallback.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ItShouldKeepTheJwtTokenValidationParameters()
+    {
+        // Arrange
+        var options = CreateConfiguredJwtBearerOptions();
+
+        // Act
+        var parameters = options.TokenValidationParameters;
+
+        // Assert
+        options.Authority.Should().Be(TestJwt.Issuer);
+        options.RequireHttpsMetadata.Should().BeTrue();
+        options.MetadataAddress.Should().Be(
+            $"{TestJwt.Issuer.TrimEnd('/')}/.well-known/openid-configuration");
+        options.BackchannelTimeout.Should().Be(TimeSpan.FromMinutes(1));
+        options.MapInboundClaims.Should().BeFalse();
+        options.IncludeErrorDetails.Should().BeFalse();
+        parameters.ValidateIssuer.Should().BeTrue();
+        parameters.ValidIssuer.Should().Be(TestJwt.Issuer);
+        parameters.ValidateAudience.Should().BeTrue();
+        parameters.ValidAudience.Should().Be(TestAuthConstants.ApiResource);
+        parameters.ValidateLifetime.Should().BeTrue();
+        parameters.ValidateIssuerSigningKey.Should().BeTrue();
+        parameters.ClockSkew.Should().Be(TimeSpan.FromSeconds(30));
+    }
+}


### PR DESCRIPTION
Closes #192

## Summary
Local JwtBearer Cognito discovery/JWKS was hanging on IPv6 (~60s then 401). Fly is IPv4 and was already 200.

JwtBearer now uses a `SocketsHttpHandler` backchannel that connects **IPv4 first**, then **IPv6** if IPv4 throws `SocketException`. Token validation rules are unchanged. No JWT warmup, no `InternalsVisibleTo`.

## What changed
- `AuthenticationExtensions`: `BackchannelHttpHandler` with IPv4-then-IPv6 `ConnectCallback`
- Distinct logs: IPv4 cancelled (debug), IPv4 failed trying IPv6 (warning), IPv6 cancelled (debug), IPv6 failed (error)
- Tests: handler is a `SocketsHttpHandler` with a connect callback; existing JWT validation parameters still set

## Manual check
Local signed-in `GET https://localhost:7256/api/profiles/me` returned **200 in ~2–3s** after this change (was ~60s 401).

## Out of scope
Bearer-missing handler, login-callback/`RedirectToLogin`, JWT warmup, service worker / PWA banner, disabling IPv6 on the machine.

## Test coverage (deliberate)
IPv4-first and IPv6 fallback are **not** exercised in CI. Public tests only assert the handler is wired. Loopback `HttpClient` coverage was considered and left out of this PR.

## Deployment
No migration, Terraform, or secret changes.

Self review:
- Issue/AC: PASS for behaviour (IPv4 first, IPv6 fallback, distinct logs, validation unchanged). Local 200 verified. Fly still IPv4-first. Cancel/IPv6-fail paths implemented, not automated.
- Architecture/CQRS: PASS — API JWT backchannel only; no CQRS/layering change
- Rules: PASS — private helpers, no `InternalsVisibleTo`, catches log then rethrow, distinct IPv4/IPv6 messages
- Security/privacy: PASS — JWT validation rules unchanged (`aud`, `token_use`, `client_id`, scope, JWKS)
- Database/migrations: N/A
- Tests/coverage: SHOULD FIX deferred — connect fallback not covered without internals or a loopback harness; user asked to leave tests as they are for this PR
- Browser: N/A — not a UI feature; Playwright cannot prove API socket family
- Web/UI/localisation: N/A
- Code smells: PASS — IPv4 then IPv6 in one method; socket helper shared; no silent catch
- CI/deployment: PASS — no extra apply/config

Findings discovered during self-review:
1. SHOULD FIX (deferred): IPv4/IPv6 connect and log lines are not asserted in tests.

Fixes made:
1. Removed `InternalsVisibleTo` on the API project and tests that reached private connect helpers.

Remaining deliberate gaps:
- No CI test that IPv4 is tried first or that IPv6 runs after `SocketException`
- Hosted Dev 200 after deploy still assumed from IPv4-first (Fly already used IPv4)
