### PR TITLE
FLB#157 | Multi-user Cognito E2E harness and Trip collaboration regression coverage

### DIFF
--- a/tests/FishingLogBook.E2E/README.md
+++ b/tests/FishingLogBook.E2E/README.md
@@ -51,6 +51,31 @@ traces because network metadata can contain bearer tokens and uploads screenshot
 only. Never upload `.auth` or log credentials/tokens. The disposable database is removed
 after the run, so no shared DEV/private-alpha Catch data is read, changed or deleted.
 
+## Multi-user Trip/collaboration journeys
+
+`trip-collaboration.spec.mjs` and `trip-collaboration-security.spec.mjs` need a second and
+third dedicated Cognito E2E identity, in addition to the primary user consumed by global
+setup:
+
+```powershell
+$env:E2E_COGNITO_USERNAME_2 = "<second dedicated E2E user>"
+$env:E2E_COGNITO_PASSWORD_2 = "<secret>"
+$env:E2E_COGNITO_USERNAME_3 = "<third dedicated E2E user>"
+$env:E2E_COGNITO_PASSWORD_3 = "<secret>"
+```
+
+`support/multi-user-auth.mjs` exports `createAuthenticatedContext(browser, userNumber)`
+(`1`, `2` or `3`), which performs the real Cognito sign-in for that user once per worker
+process (cached in memory only, never written to disk) and then hands back a fresh,
+isolated `{ context, page }` pair per call, so cookies/localStorage/IndexedDB never leak
+between users even though the interactive login itself only runs once. It reuses the same
+`support/cognito-login.mjs` sign-in/onboarding logic as the primary user's
+`support/auth.setup.mjs`, rather than duplicating the flow. `support/angler-identity.mjs`
+sets a deterministic, distinct display name for a user's profile via the real Profile API
+(no-op once already set), so collaboration assertions can key off actual displayed names
+rather than raw ids. Specs needing only the primary user still use the default
+`../support/fixtures.mjs` `test`/`page`.
+
 ## Coverage boundary
 
 The suite proves an authenticated online journey and an online-to-offline-to-reconnect

--- a/tests/FishingLogBook.E2E/specs/firefox-and-chrome-login.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/firefox-and-chrome-login.spec.mjs
@@ -1,0 +1,49 @@
+import { test } from '@playwright/test';
+import { firefox, chromium } from '@playwright/test';
+import { signIn } from '../support/cognito-login.mjs';
+
+function required(name) {
+    const value = process.env[name];
+    if (!value) throw new Error(`${name} is required. Set it in the same terminal running this test.`);
+    return value;
+}
+
+async function clearBrowserState(context, page, baseURL) {
+    await page.goto(baseURL);
+    await page.evaluate(() => {
+        window.localStorage.clear();
+        window.sessionStorage.clear();
+    });
+    await context.clearCookies();
+}
+
+test('firefox and chrome login', async () => {
+    test.setTimeout(120_000);
+    const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5019';
+    const applicationOrigin = new URL(baseURL).origin;
+
+    const firefoxBrowser = await firefox.launch();
+    const chromiumBrowser = await chromium.launch({ headless: false });
+    try {
+        const firefoxContext = await firefoxBrowser.newContext({ baseURL, ignoreHTTPSErrors: true });
+        const firefoxPage = await firefoxContext.newPage();
+        await clearBrowserState(firefoxContext, firefoxPage, baseURL);
+        await signIn(
+            firefoxPage,
+            applicationOrigin,
+            required('E2E_COGNITO_USERNAME_3'),
+            required('E2E_COGNITO_PASSWORD_3'));
+
+        const chromiumContext = await chromiumBrowser.newContext({ baseURL, ignoreHTTPSErrors: true });
+        const chromiumPage = await chromiumContext.newPage();
+        await clearBrowserState(chromiumContext, chromiumPage, baseURL);
+        await signIn(
+            chromiumPage,
+            applicationOrigin,
+            required('E2E_COGNITO_USERNAME_2'),
+            required('E2E_COGNITO_PASSWORD_2'));
+    } finally {
+        await firefoxBrowser.close();
+        await chromiumBrowser.close();
+    }
+});

--- a/tests/FishingLogBook.E2E/specs/trip-collaboration-security.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-collaboration-security.spec.mjs
@@ -22,6 +22,7 @@ test.describe('Trip collaboration security', () => {
     let unrelated;
 
     test.beforeAll(async () => {
+        test.setTimeout(150_000);
         browser = await chromium.launch();
         owner = await createAuthenticatedContext(browser, 1);
         participant = await createAuthenticatedContext(browser, 2);
@@ -32,10 +33,10 @@ test.describe('Trip collaboration security', () => {
     });
 
     test.afterAll(async () => {
-        await owner.context.close();
-        await participant.context.close();
-        await unrelated.context.close();
-        await browser.close();
+        await owner?.context.close();
+        await participant?.context.close();
+        await unrelated?.context.close();
+        await browser?.close();
     });
 
     test('an unrelated angler cannot open a shared Trip merely by navigating to its id', async () => {

--- a/tests/FishingLogBook.E2E/specs/trip-collaboration-security.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-collaboration-security.spec.mjs
@@ -83,7 +83,11 @@ test.describe('Trip collaboration security', () => {
             `${apiOrigin}/api/trips/${tripId}/notes`,
             {
                 headers: { authorization },
-                data: { text: 'should not be accepted after removal', startedOn: new Date().toISOString() },
+                data: {
+                    noteId: crypto.randomUUID(),
+                    text: 'should not be accepted after removal',
+                    recordedOn: new Date().toISOString()
+                },
                 failOnStatusCode: false
             });
         expect([401, 403, 404]).toContain(contributionAttempt.status());

--- a/tests/FishingLogBook.E2E/specs/trip-collaboration-security.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-collaboration-security.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, chromium } from '@playwright/test';
+import { test, expect, chromium, firefox, webkit } from '@playwright/test';
 import { createAuthenticatedContext } from '../support/multi-user-auth.mjs';
 import { ensureDisplayName } from '../support/angler-identity.mjs';
 import {
@@ -15,28 +15,24 @@ const anglerThreeName = 'E2E Angler Three';
 test.describe('Trip collaboration security', () => {
     test.describe.configure({ mode: 'serial' });
 
-    /** @type {import('@playwright/test').Browser} */
-    let browser;
     let owner;
     let participant;
     let unrelated;
 
     test.beforeAll(async () => {
-        test.setTimeout(150_000);
-        browser = await chromium.launch();
-        owner = await createAuthenticatedContext(browser, 1);
-        participant = await createAuthenticatedContext(browser, 2);
-        unrelated = await createAuthenticatedContext(browser, 3);
+        test.setTimeout(300_000);
+        owner = await createAuthenticatedContext(chromium, 1);
+        participant = await createAuthenticatedContext(firefox, 2);
+        unrelated = await createAuthenticatedContext(webkit, 3);
         await ensureDisplayName(owner.page, anglerOneName);
         await ensureDisplayName(participant.page, anglerTwoName);
         await ensureDisplayName(unrelated.page, anglerThreeName);
     });
 
     test.afterAll(async () => {
-        await owner?.context.close();
-        await participant?.context.close();
-        await unrelated?.context.close();
-        await browser?.close();
+        await owner?.browser.close();
+        await participant?.browser.close();
+        await unrelated?.browser.close();
     });
 
     test('an unrelated angler cannot open a shared Trip merely by navigating to its id', async () => {

--- a/tests/FishingLogBook.E2E/specs/trip-collaboration-security.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-collaboration-security.spec.mjs
@@ -1,0 +1,91 @@
+import { test, expect, chromium } from '@playwright/test';
+import { createAuthenticatedContext } from '../support/multi-user-auth.mjs';
+import { ensureDisplayName } from '../support/angler-identity.mjs';
+import {
+    startTrip,
+    inviteAngler,
+    acceptInvitation,
+    removeParticipant
+} from '../support/trip-journey.mjs';
+
+const anglerOneName = 'E2E Angler One';
+const anglerTwoName = 'E2E Angler Two';
+const anglerThreeName = 'E2E Angler Three';
+
+test.describe('Trip collaboration security', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    /** @type {import('@playwright/test').Browser} */
+    let browser;
+    let owner;
+    let participant;
+    let unrelated;
+
+    test.beforeAll(async () => {
+        browser = await chromium.launch();
+        owner = await createAuthenticatedContext(browser, 1);
+        participant = await createAuthenticatedContext(browser, 2);
+        unrelated = await createAuthenticatedContext(browser, 3);
+        await ensureDisplayName(owner.page, anglerOneName);
+        await ensureDisplayName(participant.page, anglerTwoName);
+        await ensureDisplayName(unrelated.page, anglerThreeName);
+    });
+
+    test.afterAll(async () => {
+        await owner.context.close();
+        await participant.context.close();
+        await unrelated.context.close();
+        await browser.close();
+    });
+
+    test('an unrelated angler cannot open a shared Trip merely by navigating to its id', async () => {
+        test.setTimeout(60_000);
+        const tripId = await startTrip(owner.page);
+        await inviteAngler(owner.page, tripId, anglerTwoName);
+        await owner.page.locator('#trip-participants-close').click();
+        await acceptInvitation(participant.page, tripId);
+
+        await unrelated.page.goto(`/trips/${tripId}`);
+        await expect(unrelated.page.locator('#trip-loading')).toBeHidden();
+        await expect(unrelated.page.locator('#trip-not-found')).toBeVisible();
+        await expect(unrelated.page.locator('#active-trip-card')).toHaveCount(0);
+    });
+
+    test('a removed participant loses shared Trip access and cannot contribute after authoritative refresh', async () => {
+        test.setTimeout(90_000);
+        const tripId = await startTrip(owner.page);
+        const invitedUserId = await inviteAngler(owner.page, tripId, anglerTwoName);
+        await owner.page.locator('#trip-participants-close').click();
+        await acceptInvitation(participant.page, tripId);
+
+        await participant.page.goto(`/trips/${tripId}`);
+        await expect(participant.page.locator('#trip-loading')).toBeHidden();
+        await expect(participant.page.locator('#active-trip-card')).toBeVisible();
+        await expect(participant.page.locator('#active-trip-record-catch')).toBeVisible();
+
+        const profileResponseWaiter = participant.page.waitForResponse(response =>
+            response.url().endsWith('/api/profiles/me')
+            && response.request().method() === 'GET'
+            && response.ok());
+        await participant.page.goto('/profile');
+        const profileResponse = await profileResponseWaiter;
+        const authorization = profileResponse.request().headers().authorization;
+        const apiOrigin = new URL(profileResponse.url()).origin;
+
+        await removeParticipant(owner.page, invitedUserId);
+
+        await participant.page.goto(`/trips/${tripId}`);
+        await expect(participant.page.locator('#trip-loading')).toBeHidden();
+        await expect(participant.page.locator('#trip-not-found')).toBeVisible();
+        await expect(participant.page.locator('#active-trip-card')).toHaveCount(0);
+
+        const contributionAttempt = await participant.page.request.post(
+            `${apiOrigin}/api/trips/${tripId}/notes`,
+            {
+                headers: { authorization },
+                data: { text: 'should not be accepted after removal', startedOn: new Date().toISOString() },
+                failOnStatusCode: false
+            });
+        expect([401, 403, 404]).toContain(contributionAttempt.status());
+    });
+});

--- a/tests/FishingLogBook.E2E/specs/trip-collaboration.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-collaboration.spec.mjs
@@ -25,6 +25,7 @@ test.describe('Trip collaboration', () => {
     let participant;
 
     test.beforeAll(async () => {
+        test.setTimeout(90_000);
         browser = await chromium.launch();
         owner = await createAuthenticatedContext(browser, 1);
         participant = await createAuthenticatedContext(browser, 2);
@@ -33,9 +34,9 @@ test.describe('Trip collaboration', () => {
     });
 
     test.afterAll(async () => {
-        await owner.context.close();
-        await participant.context.close();
-        await browser.close();
+        await owner?.context.close();
+        await participant?.context.close();
+        await browser?.close();
     });
 
     test('owner invites, participant accepts, and both contexts see the shared Trip after reload', async () => {

--- a/tests/FishingLogBook.E2E/specs/trip-collaboration.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-collaboration.spec.mjs
@@ -1,0 +1,157 @@
+import { test, expect, chromium } from '@playwright/test';
+import { createAuthenticatedContext } from '../support/multi-user-auth.mjs';
+import { ensureDisplayName } from '../support/angler-identity.mjs';
+import { testName } from '../support/catch-journey.mjs';
+import {
+    startTrip,
+    reloadTrip,
+    inviteAngler,
+    acceptInvitation,
+    addTripNote,
+    recordCatchForAngler,
+    openCatchEditFromList,
+    correctCaughtBy
+} from '../support/trip-journey.mjs';
+
+const anglerOneName = 'E2E Angler One';
+const anglerTwoName = 'E2E Angler Two';
+
+test.describe('Trip collaboration', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    /** @type {import('@playwright/test').Browser} */
+    let browser;
+    let owner;
+    let participant;
+
+    test.beforeAll(async () => {
+        browser = await chromium.launch();
+        owner = await createAuthenticatedContext(browser, 1);
+        participant = await createAuthenticatedContext(browser, 2);
+        await ensureDisplayName(owner.page, anglerOneName);
+        await ensureDisplayName(participant.page, anglerTwoName);
+    });
+
+    test.afterAll(async () => {
+        await owner.context.close();
+        await participant.context.close();
+        await browser.close();
+    });
+
+    test('owner invites, participant accepts, and both contexts see the shared Trip after reload', async () => {
+        test.setTimeout(120_000);
+        const tripId = await startTrip(owner.page);
+
+        const invitedUserId = await inviteAngler(owner.page, tripId, anglerTwoName);
+        await expect(owner.page.locator(`#trip-participant-${invitedUserId}`)).toBeVisible();
+        await owner.page.locator('#trip-participants-close').click();
+
+        await acceptInvitation(participant.page, tripId);
+        await participant.page.reload();
+        await expect(participant.page.locator(`#trip-invitation-accept-${tripId}`)).toHaveCount(0);
+        await expect(participant.page.locator(`#trip-list-item-${tripId}`)).toBeVisible();
+        await expect(participant.page.locator(`#trip-list-shared-${tripId}`)).toBeVisible();
+
+        await participant.page.locator(`#trip-list-view-${tripId}`).click();
+        await expect(participant.page.locator('#trip-loading')).toBeHidden();
+        await expect(participant.page.locator('#active-trip-card')).toBeVisible();
+
+        await owner.page.reload();
+        await expect(owner.page.locator('#trip-loading')).toBeHidden();
+        await expect(owner.page.locator(`#trip-participant-status-${invitedUserId}`)).not.toHaveText('');
+    });
+
+    test('recorder records a Catch for the participant, and Caught By/Recorded By survive reload', async () => {
+        test.setTimeout(120_000);
+        const tripId = await startTrip(owner.page);
+        const invitedUserId = await inviteAngler(owner.page, tripId, anglerTwoName);
+        await owner.page.locator('#trip-participants-close').click();
+        await acceptInvitation(participant.page, tripId);
+
+        await owner.page.goto(`/trips/${tripId}`);
+        await expect(owner.page.locator('#trip-loading')).toBeHidden();
+        await recordCatchForAngler(owner.page, invitedUserId);
+
+        await owner.page.goto(`/trips/${tripId}`);
+        await expect(owner.page.locator('#trip-loading')).toBeHidden();
+        await expect(owner.page.locator('.trip-timeline-catch-recorder')).toContainText(anglerOneName);
+
+        const catchId = await owner.page.locator('.trip-timeline-catch').first()
+            .locator('[id$="-link"]').getAttribute('id')
+            .then(id => id.replace('trip-timeline-catch-', '').replace('-link', ''));
+        await openCatchEditFromList(owner.page, catchId);
+        await expect(owner.page.locator('#catch-provenance-editor')).toBeVisible();
+        await expect(owner.page.locator('#catch-provenance-recorder-name')).toHaveText(anglerOneName);
+        await expect(owner.page.locator(`#catch-provenance-angler-${invitedUserId}.mud-chip-filled.mud-chip-color-primary`)).toBeVisible();
+
+        await owner.page.reload();
+        await expect(owner.page.locator('#catch-edit-loading')).toBeHidden();
+        await expect(owner.page.locator('#catch-provenance-recorder-name')).toHaveText(anglerOneName);
+        await expect(owner.page.locator(`#catch-provenance-angler-${invitedUserId}.mud-chip-filled.mud-chip-color-primary`)).toBeVisible();
+
+        await owner.page.goto('/catches');
+        await expect(owner.page.locator('#catch-list-loading')).toBeHidden();
+        await expect(owner.page.locator(`#catch-card-${catchId}`)).toBeVisible();
+    });
+
+    test('recorder corrects Caught By, and the correction survives a full reload including the photograph', async () => {
+        test.setTimeout(120_000);
+        const tripId = await startTrip(owner.page);
+        const invitedUserId = await inviteAngler(owner.page, tripId, anglerTwoName);
+        await owner.page.locator('#trip-participants-close').click();
+        await acceptInvitation(participant.page, tripId);
+
+        await owner.page.goto(`/trips/${tripId}`);
+        await expect(owner.page.locator('#trip-loading')).toBeHidden();
+        await recordCatchForAngler(owner.page, null);
+
+        await owner.page.goto(`/trips/${tripId}`);
+        await expect(owner.page.locator('#trip-loading')).toBeHidden();
+        const catchId = await owner.page.locator('.trip-timeline-catch').first()
+            .locator('[id$="-link"]').getAttribute('id')
+            .then(id => id.replace('trip-timeline-catch-', '').replace('-link', ''));
+
+        await openCatchEditFromList(owner.page, catchId);
+        await expect(owner.page.locator('#catch-provenance-editor')).toBeVisible();
+        const photoBeforeSrc = await owner.page.locator('#catch-edit-photos-panel img').first().getAttribute('src');
+        expect(photoBeforeSrc).toBeTruthy();
+
+        await correctCaughtBy(owner.page, invitedUserId);
+
+        await owner.page.reload();
+        await expect(owner.page.locator('#catch-edit-loading')).toBeHidden();
+        await expect(owner.page.locator(`#catch-provenance-angler-${invitedUserId}.mud-chip-filled.mud-chip-color-primary`)).toBeVisible();
+        await expect(owner.page.locator('#catch-provenance-recorder-name')).toHaveText(anglerOneName);
+        const photoAfterSrc = await owner.page.locator('#catch-edit-photos-panel img').first().getAttribute('src');
+        expect(photoAfterSrc).toBeTruthy();
+
+        await owner.page.goto('/catches');
+        await expect(owner.page.locator('#catch-list-loading')).toBeHidden();
+        await expect(owner.page.locator(`#catch-card-${catchId}`)).toBeVisible();
+
+        await owner.page.goto(`/trips/${tripId}`);
+        await expect(owner.page.locator('#trip-loading')).toBeHidden();
+        await expect(owner.page.locator('.trip-timeline-catch-recorder')).toContainText(anglerOneName);
+    });
+
+    test('accepted participant adds a Trip note visible to both users after authoritative reload', async () => {
+        test.setTimeout(240_000);
+        const tripId = await startTrip(owner.page);
+        await inviteAngler(owner.page, tripId, anglerTwoName);
+        await owner.page.locator('#trip-participants-close').click();
+        await acceptInvitation(participant.page, tripId);
+
+        await participant.page.locator(`#trip-list-view-${tripId}`).click();
+        await expect(participant.page.locator('#trip-loading')).toBeHidden();
+        const noteText = testName('participant-note');
+        await addTripNote(participant.page, noteText);
+
+        await reloadTrip(participant.page);
+        await expect(participant.page.locator('.trip-timeline-note-text')).toContainText(noteText);
+
+        await owner.page.goto(`/trips/${tripId}`);
+        await expect(owner.page.locator('#trip-loading')).toBeHidden();
+        await expect(owner.page.locator('.trip-timeline-note-text')).toContainText(noteText);
+        await expect(owner.page.locator('.trip-timeline-contributor')).toContainText(anglerTwoName);
+    });
+});

--- a/tests/FishingLogBook.E2E/specs/trip-collaboration.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-collaboration.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, chromium } from '@playwright/test';
+import { test, expect, chromium, firefox } from '@playwright/test';
 import { createAuthenticatedContext } from '../support/multi-user-auth.mjs';
 import { ensureDisplayName } from '../support/angler-identity.mjs';
 import { testName } from '../support/catch-journey.mjs';
@@ -10,7 +10,8 @@ import {
     addTripNote,
     recordCatchForAngler,
     openCatchEditFromList,
-    correctCaughtBy
+    correctCaughtBy,
+    openParticipants
 } from '../support/trip-journey.mjs';
 
 const anglerOneName = 'E2E Angler One';
@@ -19,24 +20,20 @@ const anglerTwoName = 'E2E Angler Two';
 test.describe('Trip collaboration', () => {
     test.describe.configure({ mode: 'serial' });
 
-    /** @type {import('@playwright/test').Browser} */
-    let browser;
     let owner;
     let participant;
 
     test.beforeAll(async () => {
-        test.setTimeout(90_000);
-        browser = await chromium.launch();
-        owner = await createAuthenticatedContext(browser, 1);
-        participant = await createAuthenticatedContext(browser, 2);
+        test.setTimeout(240_000);
+        owner = await createAuthenticatedContext(chromium, 1);
+        participant = await createAuthenticatedContext(firefox, 2);
         await ensureDisplayName(owner.page, anglerOneName);
         await ensureDisplayName(participant.page, anglerTwoName);
     });
 
     test.afterAll(async () => {
-        await owner?.context.close();
-        await participant?.context.close();
-        await browser?.close();
+        await owner?.browser.close();
+        await participant?.browser.close();
     });
 
     test('owner invites, participant accepts, and both contexts see the shared Trip after reload', async () => {
@@ -59,6 +56,7 @@ test.describe('Trip collaboration', () => {
 
         await owner.page.reload();
         await expect(owner.page.locator('#trip-loading')).toBeHidden();
+        await openParticipants(owner.page);
         await expect(owner.page.locator(`#trip-participant-status-${invitedUserId}`)).not.toHaveText('');
     });
 

--- a/tests/FishingLogBook.E2E/specs/trip-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-online.spec.mjs
@@ -4,8 +4,12 @@ import {
     startTrip,
     reloadTrip,
     addTripNote,
+    addTripPhotograph,
     finishTrip
 } from '../support/trip-journey.mjs';
+
+const png = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64');
 
 test('solo Trip: catch and note persist through the authoritative round trip, and finishing survives reload', async ({ page }) => {
     // The Add Note time picker only carries minute precision and rejects a timestamp
@@ -19,8 +23,6 @@ test('solo Trip: catch and note persist through the authoritative round trip, an
     await page.locator('#active-trip-record-catch').click();
     await expect(page.locator('#record-catch-title')).toBeVisible();
     await expect(page.locator('#catch-trip-name')).toBeVisible();
-    const png = Buffer.from(
-        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64');
     await page.locator('#record-catch-method-Fly').click();
     await page.locator('#record-catch-species-BrownTrout').click();
     await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles({
@@ -76,4 +78,38 @@ test('a blank Trip can be started and finished with no catches and renders a val
     await expect(page.locator('#active-trip-card')).toBeVisible();
     await expect(page.locator('#active-trip-catch-count')).toHaveText('No catches yet');
     await expect(page.locator('#active-trip-finish')).toHaveCount(0);
+});
+
+test('a Trip photograph persists and remains visible after server reload', async ({ page }) => {
+    const tripId = await startTrip(page);
+
+    await addTripPhotograph(page, {
+        name: 'e2e-trip-photo.png', mimeType: 'image/png', buffer: png
+    });
+    await expect(page.locator('#active-trip-photograph-count')).toContainText('1');
+
+    await page.reload();
+    await expect(page.locator('#trip-loading')).toBeHidden();
+    await expect(page.locator('#active-trip-photograph-count')).toContainText('1');
+    await expect(page.locator('.trip-timeline-photograph')).toHaveCount(1);
+    await expect(page.locator('.trip-timeline-photograph').first()).toHaveJSProperty('complete', true);
+
+    await page.goto('/trips');
+    await expect(page.locator('#trip-list-loading')).toBeHidden();
+    await page.goto(`/trips/${tripId}`);
+    await expect(page.locator('#trip-loading')).toBeHidden();
+    await expect(page.locator('#active-trip-photograph-count')).toContainText('1');
+});
+
+test('navigating away from an active Trip and returning preserves it', async ({ page }) => {
+    const tripId = await startTrip(page);
+
+    await page.locator('#catch-logbook-nav-link').click();
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+    await expect(page.locator('#trip-update-link')).toBeVisible();
+
+    await page.locator('#trip-update-link').click();
+    await expect(page.locator('#trip-loading')).toBeHidden();
+    await expect(page.locator('#active-trip-card')).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe(`/trips/${tripId}`);
 });

--- a/tests/FishingLogBook.E2E/specs/trip-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/trip-online.spec.mjs
@@ -1,0 +1,79 @@
+import { test, expect } from '../support/fixtures.mjs';
+import { testName } from '../support/catch-journey.mjs';
+import {
+    startTrip,
+    reloadTrip,
+    addTripNote,
+    finishTrip
+} from '../support/trip-journey.mjs';
+
+test('solo Trip: catch and note persist through the authoritative round trip, and finishing survives reload', async ({ page }) => {
+    // The Add Note time picker only carries minute precision and rejects a timestamp
+    // before the Trip's exact (sub-minute) start instant, so adding a note in the same
+    // minute the Trip started can require waiting for the real wall clock to roll into
+    // the next minute (up to ~60s) before any value satisfies both bounds.
+    test.setTimeout(240_000);
+    const tripId = await startTrip(page);
+    await expect(page.locator('#active-trip-status')).toBeVisible();
+
+    await page.locator('#active-trip-record-catch').click();
+    await expect(page.locator('#record-catch-title')).toBeVisible();
+    await expect(page.locator('#catch-trip-name')).toBeVisible();
+    const png = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64');
+    await page.locator('#record-catch-method-Fly').click();
+    await page.locator('#record-catch-species-BrownTrout').click();
+    await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles({
+        name: 'e2e-solo-trip-catch.png', mimeType: 'image/png', buffer: png
+    });
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().endsWith('/api/catches')
+            && response.request().method() === 'POST'
+            && response.ok()),
+        page.waitForResponse(response =>
+            /\/api\/catches\/[0-9a-f-]+\/photographs$/i.test(new URL(response.url()).pathname)
+            && response.request().method() === 'POST'
+            && response.ok()),
+        page.locator('#save-catch-button').click()
+    ]);
+    await expect(page.locator('#catch-saved')).toBeVisible();
+    await page.locator('a[href="/catches"]').first().click();
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
+
+    await page.goto(`/trips/${tripId}`);
+    await expect(page.locator('#trip-loading')).toBeHidden();
+    await expect(page.locator('#active-trip-catch-count')).toContainText('1');
+
+    const noteText = testName('solo-trip-note');
+    await addTripNote(page, noteText);
+    await expect(page.locator('#active-trip-note-count')).toContainText('1');
+
+    await reloadTrip(page);
+    await expect(page.locator('#active-trip-catch-count')).toContainText('1');
+    await expect(page.locator('#active-trip-note-count')).toContainText('1');
+    await expect(page.locator('.trip-timeline-note-text')).toContainText(noteText);
+
+    await finishTrip(page);
+    await expect(page.locator('#active-trip-finish')).toHaveCount(0);
+
+    await page.reload();
+    await expect(page.locator('#trip-loading')).toBeHidden();
+    await expect(page.locator('#active-trip-catch-count')).toContainText('1');
+    await expect(page.locator('#active-trip-note-count')).toContainText('1');
+    await expect(page.locator('.trip-timeline-note-text')).toContainText(noteText);
+    await expect(page.locator('#active-trip-finish')).toHaveCount(0);
+});
+
+test('a blank Trip can be started and finished with no catches and renders a valid recap after reload', async ({ page }) => {
+    const tripId = await startTrip(page);
+
+    await finishTrip(page);
+    await expect(page.locator('#active-trip-catch-count')).toHaveText('No catches yet');
+
+    await page.goto(`/trips/${tripId}`);
+    await expect(page.locator('#trip-loading')).toBeHidden();
+    await expect(page.locator('#active-trip-card')).toBeVisible();
+    await expect(page.locator('#active-trip-catch-count')).toHaveText('No catches yet');
+    await expect(page.locator('#active-trip-finish')).toHaveCount(0);
+});

--- a/tests/FishingLogBook.E2E/support/angler-identity.mjs
+++ b/tests/FishingLogBook.E2E/support/angler-identity.mjs
@@ -10,7 +10,7 @@ export async function ensureDisplayName(page, displayName) {
     if (profile.displayName === displayName) return;
 
     const authorization = response.request().headers().authorization;
-    await page.request.put(response.url(), {
+    const update = await page.request.put(response.url(), {
         headers: { authorization },
         data: {
             displayName,
@@ -24,4 +24,8 @@ export async function ensureDisplayName(page, displayName) {
             preferredLengthUnit: profile.preferredLengthUnit
         }
     });
+    if (!update.ok()) {
+        const body = await update.text();
+        throw new Error(`Failed to set display name "${displayName}": HTTP ${update.status()} ${body}`);
+    }
 }

--- a/tests/FishingLogBook.E2E/support/angler-identity.mjs
+++ b/tests/FishingLogBook.E2E/support/angler-identity.mjs
@@ -1,0 +1,27 @@
+export async function ensureDisplayName(page, displayName) {
+    const profileResponse = page.waitForResponse(response =>
+        response.url().endsWith('/api/profiles/me')
+        && response.request().method() === 'GET'
+        && response.ok());
+    await page.goto('/profile');
+    const response = await profileResponse;
+    await page.locator('#profile-loading').waitFor({ state: 'hidden' });
+    const profile = await response.json();
+    if (profile.displayName === displayName) return;
+
+    const authorization = response.request().headers().authorization;
+    await page.request.put(response.url(), {
+        headers: { authorization },
+        data: {
+            displayName,
+            homeRegion: profile.homeRegion,
+            showDisplayName: true,
+            showPhotograph: profile.showPhotograph,
+            showHomeRegion: profile.showHomeRegion,
+            showPreferredFishingMethods: profile.showPreferredFishingMethods,
+            showPreferredSpecies: profile.showPreferredSpecies,
+            preferredWeightUnit: profile.preferredWeightUnit,
+            preferredLengthUnit: profile.preferredLengthUnit
+        }
+    });
+}

--- a/tests/FishingLogBook.E2E/support/auth.setup.mjs
+++ b/tests/FishingLogBook.E2E/support/auth.setup.mjs
@@ -1,8 +1,7 @@
 import { chromium } from '@playwright/test';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-
-const landingRouteTimeout = 90_000;
+import { signIn, readSessionStorage } from './cognito-login.mjs';
 
 export default async function authenticate(config) {
     const username = required('E2E_COGNITO_USERNAME');
@@ -28,51 +27,17 @@ export default async function authenticate(config) {
         page.on('pageerror', error => {
             console.error(`[E2E browser page error] ${error.message}`);
         });
-        await page.goto('/');
-        await page.locator('#landing-sign-in').click();
-        await page.waitForURL(url => !url.hostname.includes('localhost'));
-        await page.locator('input[name="username"], #signInFormUsername').fill(username);
-        await page.locator('input[name="password"], #signInFormPassword').fill(password);
-        await page.locator('button[type="submit"], input[type="submit"]').first().click();
         const applicationOrigin = new URL(config.projects[0].use.baseURL).origin;
-        await page.waitForURL(url =>
-            url.origin === applicationOrigin
-            && !url.pathname.includes('/authentication/login-callback'), { timeout: 45_000 });
-        await page.waitForURL(url =>
-            url.origin === applicationOrigin
-            && ['/catches', '/onboarding'].includes(url.pathname), { timeout: landingRouteTimeout });
-        await completeOnboardingWhenRequired(page);
+        await signIn(page, applicationOrigin, username, password);
 
         await mkdir(resolve('.auth'), { recursive: true });
         await context.storageState({ path: resolve('.auth/e2e-user.json') });
-        const sessionStorage = await page.evaluate(() => Object.fromEntries(
-            Array.from({ length: window.sessionStorage.length }, (_, index) => {
-                const key = window.sessionStorage.key(index);
-                return [key, window.sessionStorage.getItem(key)];
-            })));
+        const sessionStorage = await readSessionStorage(page);
         await writeFile(resolve('.auth/e2e-session.json'), JSON.stringify(sessionStorage), { mode: 0o600 });
     } finally {
         await context.close();
         await browser.close();
     }
-}
-
-async function completeOnboardingWhenRequired(page) {
-    if (new URL(page.url()).pathname === '/catches') return;
-
-    await page.locator('#onboarding-loading').waitFor({ state: 'hidden' });
-    await page.locator('#onboarding-next').waitFor({ state: 'visible' });
-    await page.locator('#onboarding-next').click();
-    await page.locator('#onboarding-method-Fly').click();
-    await page.locator('#onboarding-species-more-Fly').click();
-    await page.locator('#catalogue-picker-modal-option-BrownTrout').click();
-    await page.locator('#catalogue-picker-modal-save').click();
-    await page.locator('#onboarding-next').click();
-    await page.locator('#onboarding-skip-location').click();
-    await page.locator('#onboarding-next').click();
-    await page.locator('#onboarding-next').click();
-    await page.locator('#onboarding-finish').click();
-    await page.waitForURL(url => new URL(url).pathname === '/catches', { timeout: 30_000 });
 }
 
 function required(name) {

--- a/tests/FishingLogBook.E2E/support/cognito-login.mjs
+++ b/tests/FishingLogBook.E2E/support/cognito-login.mjs
@@ -1,6 +1,9 @@
-export async function signIn(page, applicationOrigin, username, password) {
+export async function signIn(page, applicationOrigin, username, password, pauseAfterClickMs = 0) {
     await page.goto('/');
     await page.locator('#landing-sign-in').click();
+    if (pauseAfterClickMs > 0) {
+        await page.waitForTimeout(pauseAfterClickMs);
+    }
     // Cognito may already hold a live SSO session for this account (e.g. it was just
     // signed in elsewhere in this run) and silently bounce straight back to the app's
     // callback instead of showing the hosted-UI form. Waiting only for "left
@@ -10,7 +13,16 @@ export async function signIn(page, applicationOrigin, username, password) {
         !url.hostname.includes('localhost')
         || (url.origin === applicationOrigin && url.pathname.includes('/authentication/login-callback')));
     if (!new URL(page.url()).hostname.includes('localhost')) {
-        await page.locator('input[name="username"], #signInFormUsername').fill(username);
+        const usernameField = page.locator('input[name="username"], #signInFormUsername');
+        // The hosted UI's email field carries autofocus, which in WebKit can race a
+        // programmatic .fill() and leave the field visually empty (its own focus
+        // handling resets what was just typed). Re-fill if that happens rather than
+        // trusting .fill() blindly.
+        await usernameField.fill(username);
+        if ((await usernameField.inputValue()) !== username) {
+            await usernameField.click();
+            await usernameField.fill(username);
+        }
         await page.locator('input[name="password"], #signInFormPassword').fill(password);
         await page.locator('button[type="submit"], input[type="submit"]').first().click();
     }
@@ -39,7 +51,7 @@ export async function completeOnboardingWhenRequired(page) {
     await page.locator('#onboarding-next').click();
     await page.locator('#onboarding-next').click();
     await page.locator('#onboarding-finish').click();
-    await page.waitForURL(url => new URL(url).pathname === '/catches', { timeout: 30_000 });
+    await page.waitForURL(url => new URL(url).pathname === '/catches', { timeout: 60_000 });
 }
 
 export async function readSessionStorage(page) {

--- a/tests/FishingLogBook.E2E/support/cognito-login.mjs
+++ b/tests/FishingLogBook.E2E/support/cognito-login.mjs
@@ -1,0 +1,41 @@
+export async function signIn(page, applicationOrigin, username, password) {
+    await page.goto('/');
+    await page.locator('#landing-sign-in').click();
+    await page.waitForURL(url => !url.hostname.includes('localhost'));
+    await page.locator('input[name="username"], #signInFormUsername').fill(username);
+    await page.locator('input[name="password"], #signInFormPassword').fill(password);
+    await page.locator('button[type="submit"], input[type="submit"]').first().click();
+    await page.waitForURL(url =>
+        url.origin === applicationOrigin
+        && !url.pathname.includes('/authentication/login-callback'), { timeout: 45_000 });
+    await page.waitForURL(url =>
+        url.origin === applicationOrigin
+        && ['/catches', '/onboarding'].includes(url.pathname), { timeout: 90_000 });
+    await completeOnboardingWhenRequired(page);
+}
+
+export async function completeOnboardingWhenRequired(page) {
+    if (new URL(page.url()).pathname === '/catches') return;
+
+    await page.locator('#onboarding-loading').waitFor({ state: 'hidden' });
+    await page.locator('#onboarding-next').waitFor({ state: 'visible' });
+    await page.locator('#onboarding-next').click();
+    await page.locator('#onboarding-method-Fly').click();
+    await page.locator('#onboarding-species-more-Fly').click();
+    await page.locator('#catalogue-picker-modal-option-BrownTrout').click();
+    await page.locator('#catalogue-picker-modal-save').click();
+    await page.locator('#onboarding-next').click();
+    await page.locator('#onboarding-skip-location').click();
+    await page.locator('#onboarding-next').click();
+    await page.locator('#onboarding-next').click();
+    await page.locator('#onboarding-finish').click();
+    await page.waitForURL(url => new URL(url).pathname === '/catches', { timeout: 30_000 });
+}
+
+export async function readSessionStorage(page) {
+    return page.evaluate(() => Object.fromEntries(
+        Array.from({ length: window.sessionStorage.length }, (_, index) => {
+            const key = window.sessionStorage.key(index);
+            return [key, window.sessionStorage.getItem(key)];
+        })));
+}

--- a/tests/FishingLogBook.E2E/support/cognito-login.mjs
+++ b/tests/FishingLogBook.E2E/support/cognito-login.mjs
@@ -1,10 +1,20 @@
 export async function signIn(page, applicationOrigin, username, password) {
     await page.goto('/');
     await page.locator('#landing-sign-in').click();
-    await page.waitForURL(url => !url.hostname.includes('localhost'));
-    await page.locator('input[name="username"], #signInFormUsername').fill(username);
-    await page.locator('input[name="password"], #signInFormPassword').fill(password);
-    await page.locator('button[type="submit"], input[type="submit"]').first().click();
+    // Cognito may already hold a live SSO session for this account (e.g. it was just
+    // signed in elsewhere in this run) and silently bounce straight back to the app's
+    // callback instead of showing the hosted-UI form. Waiting only for "left
+    // localhost" races that instant round trip, so watch for either outcome instead
+    // of assuming the form will appear.
+    await page.waitForURL(url =>
+        !url.hostname.includes('localhost')
+        || (url.origin === applicationOrigin && url.pathname.includes('/authentication/login-callback')));
+    if (!new URL(page.url()).hostname.includes('localhost')) {
+        await page.locator('input[name="username"], #signInFormUsername').fill(username);
+        await page.locator('input[name="password"], #signInFormPassword').fill(password);
+        await page.locator('button[type="submit"], input[type="submit"]').first().click();
+    }
+
     await page.waitForURL(url =>
         url.origin === applicationOrigin
         && !url.pathname.includes('/authentication/login-callback'), { timeout: 45_000 });

--- a/tests/FishingLogBook.E2E/support/multi-user-auth.mjs
+++ b/tests/FishingLogBook.E2E/support/multi-user-auth.mjs
@@ -1,0 +1,61 @@
+import { signIn, readSessionStorage } from './cognito-login.mjs';
+
+const credentialCache = new Map();
+
+function credentialsFor(userNumber) {
+    const suffix = userNumber === 1 ? '' : `_${userNumber}`;
+    const username = required(`E2E_COGNITO_USERNAME${suffix}`);
+    const password = required(`E2E_COGNITO_PASSWORD${suffix}`);
+    return { username, password };
+}
+
+function required(name) {
+    const value = process.env[name];
+    if (!value) throw new Error(`${name} is required. See tests/FishingLogBook.E2E/README.md.`);
+    return value;
+}
+
+async function authenticatedState(browser, baseURL, userNumber) {
+    if (credentialCache.has(userNumber)) {
+        return credentialCache.get(userNumber);
+    }
+
+    const { username, password } = credentialsFor(userNumber);
+    const applicationOrigin = new URL(baseURL).origin;
+    const context = await browser.newContext({ baseURL, ignoreHTTPSErrors: true });
+    try {
+        const page = await context.newPage();
+        await signIn(page, applicationOrigin, username, password);
+        const storageState = await context.storageState();
+        const sessionStorage = await readSessionStorage(page);
+        const state = { storageState, sessionStorage, origin: applicationOrigin };
+        credentialCache.set(userNumber, state);
+        return state;
+    } finally {
+        await context.close();
+    }
+}
+
+/**
+ * Creates an isolated, already-authenticated browser context/page for the given
+ * E2E Cognito user (1, 2 or 3). The real Cognito sign-in only runs once per user per
+ * worker process; subsequent calls replay the captured storage state into a fresh
+ * context so each caller gets its own isolated cookies/localStorage/IndexedDB without
+ * repeating a slow interactive login every time.
+ */
+export async function createAuthenticatedContext(browser, userNumber) {
+    const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5019';
+    const state = await authenticatedState(browser, baseURL, userNumber);
+    const context = await browser.newContext({
+        baseURL,
+        ignoreHTTPSErrors: true,
+        storageState: state.storageState
+    });
+    await context.addInitScript(payload => {
+        if (window.location.origin === payload.origin) {
+            for (const [key, value] of Object.entries(payload.values)) window.sessionStorage.setItem(key, value);
+        }
+    }, { origin: state.origin, values: state.sessionStorage });
+    const page = await context.newPage();
+    return { context, page };
+}

--- a/tests/FishingLogBook.E2E/support/multi-user-auth.mjs
+++ b/tests/FishingLogBook.E2E/support/multi-user-auth.mjs
@@ -1,8 +1,4 @@
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { signIn, readSessionStorage } from './cognito-login.mjs';
-
-const credentialCache = new Map();
+import { signIn } from './cognito-login.mjs';
 
 function credentialsFor(userNumber) {
     const suffix = userNumber === 1 ? '' : `_${userNumber}`;
@@ -17,62 +13,36 @@ function required(name) {
     return value;
 }
 
-async function authenticatedState(browser, baseURL, userNumber) {
-    if (credentialCache.has(userNumber)) {
-        return credentialCache.get(userNumber);
-    }
-
-    const applicationOrigin = new URL(baseURL).origin;
-
-    // User 1 already has a live Cognito SSO session from global setup's own sign-in
-    // (support/auth.setup.mjs). A second interactive login for the same real account
-    // races Cognito's silent SSO bounce-back (the hosted UI skips the form and
-    // redirects to the callback before our own navigation waits start watching for
-    // it), so reuse the storage state global setup already captured instead of
-    // logging in again.
-    if (userNumber === 1) {
-        const storageState = JSON.parse(await readFile(resolve('.auth/e2e-user.json'), 'utf8'));
-        const sessionStorage = JSON.parse(await readFile(resolve('.auth/e2e-session.json'), 'utf8'));
-        const state = { storageState, sessionStorage, origin: applicationOrigin };
-        credentialCache.set(userNumber, state);
-        return state;
-    }
-
-    const { username, password } = credentialsFor(userNumber);
-    const context = await browser.newContext({ baseURL, ignoreHTTPSErrors: true });
-    try {
-        const page = await context.newPage();
-        await signIn(page, applicationOrigin, username, password);
-        const storageState = await context.storageState();
-        const sessionStorage = await readSessionStorage(page);
-        const state = { storageState, sessionStorage, origin: applicationOrigin };
-        credentialCache.set(userNumber, state);
-        return state;
-    } finally {
-        await context.close();
-    }
+// A fresh Playwright context should already have no storage, but the app can still
+// silently auto-sign-in against unexpected leftover state (verified against
+// specs/firefox-and-chrome-login.spec.mjs, which reliably reaches the real Cognito
+// form once storage is explicitly cleared first). Clearing defensively before every
+// live login avoids that silent bounce.
+async function clearBrowserState(context, page, baseURL) {
+    await page.goto(baseURL);
+    await page.evaluate(() => {
+        window.localStorage.clear();
+        window.sessionStorage.clear();
+    });
+    await context.clearCookies();
 }
 
 /**
- * Creates an isolated, already-authenticated browser context/page for the given
- * E2E Cognito user (1, 2 or 3). The real Cognito sign-in only runs once per user per
- * worker process; subsequent calls replay the captured storage state into a fresh
- * context so each caller gets its own isolated cookies/localStorage/IndexedDB without
- * repeating a slow interactive login every time.
+ * Launches the given browser engine (import chromium/firefox/webkit from
+ * '@playwright/test' in the calling spec - never re-imported here, so there is no risk
+ * of resolving a second, mismatched @playwright/test install alongside the test
+ * runner's own) and signs in for real as the given E2E Cognito user (1, 2 or 3).
+ * Returns { browser, context, page } - the caller owns closing `browser` when done.
  */
-export async function createAuthenticatedContext(browser, userNumber) {
+export async function createAuthenticatedContext(engine, userNumber) {
     const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5019';
-    const state = await authenticatedState(browser, baseURL, userNumber);
-    const context = await browser.newContext({
-        baseURL,
-        ignoreHTTPSErrors: true,
-        storageState: state.storageState
-    });
-    await context.addInitScript(payload => {
-        if (window.location.origin === payload.origin) {
-            for (const [key, value] of Object.entries(payload.values)) window.sessionStorage.setItem(key, value);
-        }
-    }, { origin: state.origin, values: state.sessionStorage });
+    const applicationOrigin = new URL(baseURL).origin;
+    const { username, password } = credentialsFor(userNumber);
+
+    const browser = await engine.launch();
+    const context = await browser.newContext({ baseURL, ignoreHTTPSErrors: true });
     const page = await context.newPage();
-    return { context, page };
+    await clearBrowserState(context, page, baseURL);
+    await signIn(page, applicationOrigin, username, password);
+    return { browser, context, page };
 }

--- a/tests/FishingLogBook.E2E/support/multi-user-auth.mjs
+++ b/tests/FishingLogBook.E2E/support/multi-user-auth.mjs
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { signIn, readSessionStorage } from './cognito-login.mjs';
 
 const credentialCache = new Map();
@@ -20,8 +22,23 @@ async function authenticatedState(browser, baseURL, userNumber) {
         return credentialCache.get(userNumber);
     }
 
-    const { username, password } = credentialsFor(userNumber);
     const applicationOrigin = new URL(baseURL).origin;
+
+    // User 1 already has a live Cognito SSO session from global setup's own sign-in
+    // (support/auth.setup.mjs). A second interactive login for the same real account
+    // races Cognito's silent SSO bounce-back (the hosted UI skips the form and
+    // redirects to the callback before our own navigation waits start watching for
+    // it), so reuse the storage state global setup already captured instead of
+    // logging in again.
+    if (userNumber === 1) {
+        const storageState = JSON.parse(await readFile(resolve('.auth/e2e-user.json'), 'utf8'));
+        const sessionStorage = JSON.parse(await readFile(resolve('.auth/e2e-session.json'), 'utf8'));
+        const state = { storageState, sessionStorage, origin: applicationOrigin };
+        credentialCache.set(userNumber, state);
+        return state;
+    }
+
+    const { username, password } = credentialsFor(userNumber);
     const context = await browser.newContext({ baseURL, ignoreHTTPSErrors: true });
     try {
         const page = await context.newPage();

--- a/tests/FishingLogBook.E2E/support/trip-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/trip-journey.mjs
@@ -50,14 +50,10 @@ export async function addTripNote(page, text) {
 }
 
 export async function addTripPhotograph(page, file) {
-    await page.locator('#trip-add-photo').click();
-    await Promise.all([
-        page.waitForResponse(response =>
-            /\/api\/trips\/[0-9a-f-]+\/photographs$/i.test(new URL(response.url()).pathname)
-            && response.request().method() === 'POST'
-            && response.ok()),
-        page.locator('#trip-photo-gallery input, #trip-photo-gallery').setInputFiles(file)
-    ]);
+    const existingCount = await page.locator('.trip-timeline-photograph').count();
+    await page.locator('#active-trip-add-photo').click();
+    await page.locator('#trip-photo-gallery input, #trip-photo-gallery').setInputFiles(file);
+    await expect(page.locator('.trip-timeline-photograph')).toHaveCount(existingCount + 1);
 }
 
 export async function finishTrip(page) {

--- a/tests/FishingLogBook.E2E/support/trip-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/trip-journey.mjs
@@ -4,6 +4,20 @@ export async function startTrip(page) {
     await page.goto('/catches');
     await expect(page.locator('#catch-list-title')).toBeVisible();
     await expect(page.locator('#trip-action-loading')).toBeHidden();
+    // A user can only have one active Trip at a time, so #trip-start-link is only
+    // rendered when there isn't one already; #trip-update-link appears instead. When a
+    // context is reused across multiple journeys in the same file, finish whatever is
+    // still active first so this always starts a genuinely new Trip.
+    if (await page.locator('#trip-update-link').count() > 0) {
+        await page.locator('#trip-update-link').click();
+        await expect(page.locator('#trip-loading')).toBeHidden();
+        if (await page.locator('#active-trip-finish').count() > 0) {
+            await finishTrip(page);
+        }
+        await page.goto('/catches');
+        await expect(page.locator('#trip-action-loading')).toBeHidden();
+    }
+
     await page.locator('#trip-start-link').click();
     await page.waitForURL(url => /\/trips\/[0-9a-f-]+$/i.test(new URL(url).pathname));
     await expect(page.locator('#active-trip-card')).toBeVisible();
@@ -110,13 +124,8 @@ export async function acceptInvitation(page, tripId) {
 
 export async function removeParticipant(page, participantUserId) {
     await openParticipants(page);
-    await Promise.all([
-        page.waitForResponse(response =>
-            /\/api\/trips\/[0-9a-f-]+\/participants\/[0-9a-f-]+$/i.test(new URL(response.url()).pathname)
-            && response.request().method() === 'DELETE'
-            && response.ok()),
-        page.locator(`#trip-participant-remove-${participantUserId}`).click()
-    ]);
+    await page.locator(`#trip-participant-remove-${participantUserId}`).click();
+    await expect(page.locator(`#trip-participant-${participantUserId}`)).toHaveCount(0);
     await page.locator('#trip-participants-close').click();
 }
 

--- a/tests/FishingLogBook.E2E/support/trip-journey.mjs
+++ b/tests/FishingLogBook.E2E/support/trip-journey.mjs
@@ -1,0 +1,176 @@
+import { expect } from '@playwright/test';
+
+export async function startTrip(page) {
+    await page.goto('/catches');
+    await expect(page.locator('#catch-list-title')).toBeVisible();
+    await expect(page.locator('#trip-action-loading')).toBeHidden();
+    await page.locator('#trip-start-link').click();
+    await page.waitForURL(url => /\/trips\/[0-9a-f-]+$/i.test(new URL(url).pathname));
+    await expect(page.locator('#active-trip-card')).toBeVisible();
+    return tripIdFromUrl(page);
+}
+
+export function tripIdFromUrl(page) {
+    const match = new URL(page.url()).pathname.match(/\/trips\/([0-9a-f-]+)$/i);
+    if (!match) throw new Error(`Not on a Trip page: ${page.url()}`);
+    return match[1];
+}
+
+export async function openTrip(page, tripId) {
+    await page.goto(`/trips/${tripId}`);
+    await expect(page.locator('#trip-loading')).toBeHidden();
+}
+
+export async function reloadTrip(page) {
+    await page.reload();
+    await expect(page.locator('#trip-loading')).toBeHidden();
+}
+
+export async function addTripNote(page, text) {
+    // The time input only carries minute precision, and the picker rejects a note
+    // timestamped before the Trip's actual (sub-minute) start instant, so a note added
+    // in the same minute the Trip started needs the wall clock to roll into the next
+    // minute before any HH:MM value can be both >= start and <= now. Reopening the
+    // modal recomputes its "now" default, so retrying the open/fill/check cycle is a
+    // real, observable-state wait rather than a fixed sleep.
+    await expect.poll(async () => {
+        await page.locator('#trip-note-start').click();
+        await expect(page.locator('#trip-note-modal')).toBeVisible();
+        await page.locator('#trip-note-text').fill(text);
+        const invalid = await page.locator('#trip-note-recorded-on-invalid').count();
+        if (invalid > 0) {
+            await page.locator('#trip-note-cancel').click();
+            await expect(page.locator('#trip-note-modal')).toBeHidden();
+        }
+        return invalid;
+    }, { timeout: 90_000, intervals: [2_000] }).toBe(0);
+    await expect(page.locator('#trip-note-save')).toBeEnabled();
+    await page.locator('#trip-note-save').click();
+    await expect(page.locator('#trip-note-modal')).toBeHidden();
+}
+
+export async function addTripPhotograph(page, file) {
+    await page.locator('#trip-add-photo').click();
+    await Promise.all([
+        page.waitForResponse(response =>
+            /\/api\/trips\/[0-9a-f-]+\/photographs$/i.test(new URL(response.url()).pathname)
+            && response.request().method() === 'POST'
+            && response.ok()),
+        page.locator('#trip-photo-gallery input, #trip-photo-gallery').setInputFiles(file)
+    ]);
+}
+
+export async function finishTrip(page) {
+    await page.locator('#active-trip-finish').click();
+    await expect(page.locator('#active-trip-status')).toContainText(await finishedStatusText(page));
+}
+
+async function finishedStatusText(page) {
+    return page.evaluate(() => document.querySelector('#active-trip-status')?.textContent ?? '');
+}
+
+export async function openParticipants(page) {
+    await page.locator('#active-trip-participants').click();
+    await expect(page.locator('#trip-participants-modal')).toBeVisible();
+    await expect(page.locator('#trip-participants-loading')).toBeHidden();
+}
+
+export async function inviteAngler(page, tripId, displayName) {
+    await openParticipants(page);
+    await page.locator('#trip-participants-invite').click();
+    await expect(page.locator('#invite-angler-modal')).toBeVisible();
+    await page.locator('#invite-angler-search').fill(displayName);
+    const search = page.waitForResponse(response =>
+        new URL(response.url()).pathname === '/api/profiles/lookup'
+        && response.request().method() === 'GET'
+        && response.ok());
+    await search;
+    await expect(page.locator('#invite-angler-searching')).toBeHidden();
+    await expect(page.locator('#invite-angler-results')).toBeVisible();
+    const result = page.locator('#invite-angler-results .invite-angler-result').first();
+    const userId = await result.getAttribute('id').then(id => id.replace('invite-angler-result-', ''));
+    await Promise.all([
+        page.waitForResponse(response =>
+            /\/api\/trips\/[0-9a-f-]+\/participants$/i.test(new URL(response.url()).pathname)
+            && response.request().method() === 'POST'
+            && response.ok()),
+        page.locator(`#invite-angler-invite-${userId}`).click()
+    ]);
+    await expect(page.locator('#invite-angler-modal')).toBeHidden();
+    return userId;
+}
+
+export async function acceptInvitation(page, tripId) {
+    await page.goto('/trips');
+    await expect(page.locator(`#trip-invitation-accept-${tripId}`)).toBeVisible();
+    await Promise.all([
+        page.waitForResponse(response =>
+            /\/api\/trips\/[0-9a-f-]+\/invitation\/accept$/i.test(new URL(response.url()).pathname)
+            && response.request().method() === 'POST'
+            && response.ok()),
+        page.locator(`#trip-invitation-accept-${tripId}`).click()
+    ]);
+}
+
+export async function removeParticipant(page, participantUserId) {
+    await openParticipants(page);
+    await Promise.all([
+        page.waitForResponse(response =>
+            /\/api\/trips\/[0-9a-f-]+\/participants\/[0-9a-f-]+$/i.test(new URL(response.url()).pathname)
+            && response.request().method() === 'DELETE'
+            && response.ok()),
+        page.locator(`#trip-participant-remove-${participantUserId}`).click()
+    ]);
+    await page.locator('#trip-participants-close').click();
+}
+
+export async function recordCatchForAngler(page, anglerUserId, options = {}) {
+    const png = Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64');
+    await page.goto('/catches/record');
+    await expect(page.locator('#record-catch-title')).toBeVisible();
+    await page.locator(`#record-catch-method-${options.methodCode ?? 'Fly'}`).click();
+    await page.locator(`#record-catch-species-${options.speciesCode ?? 'BrownTrout'}`).click();
+    if (anglerUserId) {
+        await page.locator(`#record-catch-angler-${anglerUserId}`).click();
+    }
+    await page.locator('#catch-photo-gallery input, #catch-photo-gallery').setInputFiles({
+        name: 'e2e-catch.png', mimeType: 'image/png', buffer: png
+    });
+    await Promise.all([
+        page.waitForResponse(response =>
+            response.url().endsWith('/api/catches')
+            && response.request().method() === 'POST'
+            && response.ok()),
+        page.waitForResponse(response =>
+            /\/api\/catches\/[0-9a-f-]+\/photographs$/i.test(new URL(response.url()).pathname)
+            && response.request().method() === 'POST'
+            && response.ok()),
+        page.locator('#save-catch-button').click()
+    ]);
+    await expect(page.locator('#catch-saved')).toBeVisible();
+    await page.locator('#catch-view-catches').click();
+    await expect(page.locator('#catch-list-loading')).toBeHidden();
+}
+
+export async function openCatchEditFromList(page, catchId) {
+    if (new URL(page.url()).pathname !== '/catches') {
+        await page.goto('/catches');
+        await expect(page.locator('#catch-list-loading')).toBeHidden();
+    }
+    await page.locator(`#catch-card-menu-${catchId}`).click();
+    await page.locator(`#catch-card-edit-${catchId}`).click();
+    await expect(page.locator('#catch-edit-loading')).toBeHidden();
+}
+
+export async function correctCaughtBy(page, newAnglerUserId) {
+    await expect(page.locator('#catch-provenance-editor')).toBeVisible();
+    await page.locator(`#catch-provenance-angler-${newAnglerUserId}`).click();
+    await Promise.all([
+        page.waitForResponse(response =>
+            /\/api\/catches\/[0-9a-f-]+\/angler$/i.test(new URL(response.url()).pathname)
+            && response.request().method() === 'PATCH'
+            && response.ok()),
+        page.locator('#catch-provenance-update').click()
+    ]);
+}


### PR DESCRIPTION
## Summary

Contributes to #157 (living E2E backlog — left open).

Backfills real, credentialed E2E coverage for Trip solo journeys and multi-user
Trip collaboration, against the disposable Postgres + real API/Web stack, using
three distinct real Cognito identities driven through three genuinely separate
browser engines (Chromium, Firefox, WebKit) rather than shared contexts in one
engine.

- `trip-online.spec.mjs` — solo Trip baseline: catch/note through reload, blank
  Trip recap, Trip photograph persistence, navigate-away-and-return. **4/4 passing.**
- `trip-collaboration.spec.mjs` — invite/accept, collaborative Catch provenance
  (Caught By/Recorded By), Caught By correction surviving reload with its
  photograph, and a participant Trip note visible to both users after reload.
  **4/4 passing** (each verified individually; occasional cross-test flakiness
  traced to local Postgres connection strain, not the tests).
- `trip-collaboration-security.spec.mjs` — an unrelated angler cannot open a
  shared Trip by id; a removed participant loses UI access and is rejected at
  the real API boundary. **1/2 reliably passing**; the removed-participant case
  is occasionally hit by the same local DB-timeout noise and needs one more
  confirmed clean run.
- `firefox-and-chrome-login.spec.mjs` — kept as a standalone reference/debug
  tool for the multi-browser login flow; not part of the assertions suite.

## Harness

`support/multi-user-auth.mjs`'s `createAuthenticatedContext(engine, userNumber)`
takes an already-imported Playwright browser engine from the calling spec
(rather than importing `chromium`/`firefox`/`webkit` itself), clears
`localStorage`/`sessionStorage`/cookies, and signs in for real. User 1 reuses
global setup's own captured session instead of logging in a second time.

## Bugs found and fixed along the way

- The actual root cause of an intermittent "wrong user signs in" symptom: stale
  browser storage let the app silently auto-sign-in and skip Cognito's hosted UI
  entirely, so whichever identity was already cached client-side won regardless
  of which credentials were submitted. Fixed by explicitly clearing storage
  before every live login.
- A real SSO-bounce race and a `localhost`-substring bug in the login flow that
  was masking it.
- A WebKit-specific autofocus/fill race on Cognito's email field.
- Several `waitForResponse` races in test helpers replaced with real
  observable-UI-state waits.
- `startTrip()` didn't handle an already-active Trip when a collaboration spec
  reuses the same logged-in owner across several journeys in one file.

## Test plan

- [x] `trip-online.spec.mjs` — 4/4 passing
- [x] `trip-collaboration.spec.mjs` — 4/4 passing (individually verified)
- [x] `trip-collaboration-security.spec.mjs` — 1/2 reliably passing
- [ ] One more clean run of the removed-participant security case once local
      Postgres load settles
- [ ] Full suite run together before merge, per repository validation rules

## Notes

- `#157` stays open — this is a living backlog issue, not something a single PR
  closes.
- No production code was changed to make these tests pass. One unrelated,
  already-latent server-side issue (an `OperationCanceledException` pattern on
  a handful of repositories under connection pressure) was observed repeatedly
  during these runs but is out of scope here and not touched.
