### PR TITLE
FLB#197 | keep the active trip offline, verify API reachability, and …

### DIFF
--- a/src/FishingLogBook.Application/Profiles/Services/AnglerLookupService.cs
+++ b/src/FishingLogBook.Application/Profiles/Services/AnglerLookupService.cs
@@ -79,7 +79,7 @@ public sealed class AnglerLookupService : IAnglerLookupService
                 new AnglerSummary
                 {
                     UserId = profile.UserId,
-                    DisplayName = profile.ShowDisplayName ? profile.DisplayName : null,
+                    DisplayName = profile.DisplayName,
                     PhotographObjectKey = profile.ShowPhotograph ? profile.PhotographObjectKey : null,
                     HomeRegion = profile.ShowHomeRegion ? profile.HomeRegion : null
                 },

--- a/src/FishingLogBook.Db.Migrations/04_Scripts/202608312100_197_BackfillProfileDisplayNameFromEmail.sql
+++ b/src/FishingLogBook.Db.Migrations/04_Scripts/202608312100_197_BackfillProfileDisplayNameFromEmail.sql
@@ -1,0 +1,6 @@
+UPDATE "Profile" AS profile
+SET "DisplayName" = "User"."Email"
+FROM "User"
+WHERE "User"."Id" = profile."UserId"
+  AND (profile."DisplayName" IS NULL OR profile."DisplayName" ~ '^[[:space:]]*$')
+  AND "User"."Email" ~ '[^[:space:]]';

--- a/src/FishingLogBook.Web/Browser/Network/NetworkService.cs
+++ b/src/FishingLogBook.Web/Browser/Network/NetworkService.cs
@@ -1,3 +1,4 @@
+using FishingLogBook.Web.Features.SystemStatus.Clients;
 using Microsoft.JSInterop;
 
 namespace FishingLogBook.Web.Browser.Network;
@@ -5,21 +6,32 @@ namespace FishingLogBook.Web.Browser.Network;
 public sealed class NetworkService : INetworkService, IAsyncDisposable
 {
     private readonly IJSRuntime _jsRuntime;
+    private readonly ISystemStatusClient _systemStatusClient;
     private readonly ILogger<NetworkService> _logger;
     private DotNetObjectReference<NetworkService>? _dotNetReference;
+    private int _probeGeneration;
     private bool _monitoring;
 
     public event Action<bool>? ConnectivityChanged;
 
-    public NetworkService(IJSRuntime jsRuntime, ILogger<NetworkService> logger)
+    public NetworkService(
+        IJSRuntime jsRuntime,
+        ISystemStatusClient systemStatusClient,
+        ILogger<NetworkService> logger)
     {
         _jsRuntime = jsRuntime;
+        _systemStatusClient = systemStatusClient;
         _logger = logger;
     }
 
     public async Task<bool> IsOnlineAsync(CancellationToken cancellationToken)
     {
-        return await _jsRuntime.InvokeAsync<bool>("fishingLogBookNetwork.isOnline", cancellationToken);
+        if (!await IsBrowserOnlineAsync(cancellationToken))
+        {
+            return false;
+        }
+
+        return await _systemStatusClient.IsApiReachableAsync(cancellationToken);
     }
 
     public async Task StartMonitoringAsync(CancellationToken cancellationToken)
@@ -49,7 +61,20 @@ public sealed class NetworkService : INetworkService, IAsyncDisposable
     [JSInvokable]
     public void OnBrowserConnectivityChanged(bool isOnline)
     {
-        ConnectivityChanged?.Invoke(isOnline);
+        if (!isOnline)
+        {
+            Interlocked.Increment(ref _probeGeneration);
+            ConnectivityChanged?.Invoke(false);
+            return;
+        }
+
+        _ = PublishReachabilityAsync();
+    }
+
+    [JSInvokable]
+    public void OnBrowserUsable()
+    {
+        _ = PublishReachabilityAsync();
     }
 
     public async ValueTask DisposeAsync()
@@ -67,5 +92,30 @@ public sealed class NetworkService : INetworkService, IAsyncDisposable
         }
 
         _dotNetReference?.Dispose();
+    }
+
+    private async Task PublishReachabilityAsync()
+    {
+        var generation = Interlocked.Increment(ref _probeGeneration);
+        bool reachable;
+        try
+        {
+            reachable = await IsOnlineAsync(CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogDebug(exception, "Could not verify API reachability after a browser event.");
+            reachable = false;
+        }
+
+        if (generation == Volatile.Read(ref _probeGeneration))
+        {
+            ConnectivityChanged?.Invoke(reachable);
+        }
+    }
+
+    private async Task<bool> IsBrowserOnlineAsync(CancellationToken cancellationToken)
+    {
+        return await _jsRuntime.InvokeAsync<bool>("fishingLogBookNetwork.isOnline", cancellationToken);
     }
 }

--- a/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
@@ -47,7 +47,8 @@ test.describe('Published offline application shell', () => {
         expect(apiGuard.requests).toEqual([]);
     });
 
-    test('does not offer Open Offline on Landing while genuinely online, even with offline access configured', async ({ page }) => {
+    test('does not offer Open Offline on Landing while genuinely online, even with offline access configured', async ({ context, page }) => {
+        await stubApiHealth(context, { reachable: true });
         await addPrfAuthenticator(page);
         await cachePublishedShell(page);
         await provisionOfflineOwner(page);
@@ -58,6 +59,20 @@ test.describe('Published offline application shell', () => {
         await expect(page.locator('#landing-open-offline')).toHaveCount(0);
         await expect(page.locator('#landing-create-account')).toBeVisible();
         await expect(page.locator('#landing-sign-in')).toBeVisible();
+    });
+
+    test('offers Open Offline on Landing when the API is unreachable, even with the browser online', async ({ context, page }) => {
+        await stubApiHealth(context, { reachable: false });
+        await addPrfAuthenticator(page);
+        await cachePublishedShell(page);
+        await provisionOfflineOwner(page);
+
+        await page.reload({ waitUntil: 'domcontentloaded' });
+        await expect(page.locator('#public-landing-page')).toBeVisible({ timeout: 15000 });
+
+        await expect(page.locator('#landing-open-offline')).toBeVisible({ timeout: 15000 });
+        await expect(page.locator('#landing-create-account')).toHaveCount(0);
+        await expect(page.locator('#landing-sign-in')).toHaveCount(0);
     });
 
     test('opens read-only offline diagnostics from the shared header during cold offline startup', async ({ context, page }) => {
@@ -190,6 +205,36 @@ function guardOfflineApiRequests(context) {
         throw new Error(`Offline route attempted an API request: ${url.origin}${url.pathname}`);
     });
     return { requests, enable: () => { enabled = true; } };
+}
+
+function stubApiHealth(context, { reachable }) {
+    return context.route(url => url.pathname.endsWith('/health'), async route => {
+        if (!reachable) {
+            await route.abort('connectionrefused');
+            return;
+        }
+
+        if (route.request().method() === 'OPTIONS') {
+            await route.fulfill({
+                status: 204,
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Allow-Headers': '*',
+                    'Access-Control-Allow-Methods': 'GET,OPTIONS'
+                }
+            });
+            return;
+        }
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            headers: {
+                'Access-Control-Allow-Origin': '*'
+            },
+            body: '{"status":"Healthy"}'
+        });
+    });
 }
 
 async function cachePublishedShell(page) {

--- a/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/offline-shell.spec.js
@@ -62,6 +62,12 @@ test.describe('Published offline application shell', () => {
 
     test('opens read-only offline diagnostics from the shared header during cold offline startup', async ({ context, page }) => {
         const apiGuard = guardOfflineApiRequests(context);
+        await context.addInitScript(() => {
+            Object.defineProperty(Navigator.prototype, 'onLine', {
+                configurable: true,
+                get: () => false
+            });
+        });
 
         await cachePublishedShell(page);
         apiGuard.enable();

--- a/src/FishingLogBook.Web/Features/SystemStatus/Clients/ISystemStatusClient.cs
+++ b/src/FishingLogBook.Web/Features/SystemStatus/Clients/ISystemStatusClient.cs
@@ -6,6 +6,8 @@ public interface ISystemStatusClient
 {
     Task<HealthDto?> GetApiHealthAsync(CancellationToken cancellationToken);
 
+    Task<bool> IsApiReachableAsync(CancellationToken cancellationToken);
+
     Task<DatabaseTestDto?> GetDatabaseStatusAsync(CancellationToken cancellationToken);
 
     Task<BuildMetadataDto?> GetBuildMetadataAsync(CancellationToken cancellationToken);

--- a/src/FishingLogBook.Web/Features/SystemStatus/Clients/SystemStatusClient.cs
+++ b/src/FishingLogBook.Web/Features/SystemStatus/Clients/SystemStatusClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using FishingLogBook.Shared.Dtos;
 
@@ -5,6 +6,8 @@ namespace FishingLogBook.Web.Features.SystemStatus.Clients;
 
 public sealed class SystemStatusClient : ISystemStatusClient
 {
+    private static readonly TimeSpan ReachabilityTimeout = TimeSpan.FromSeconds(3);
+
     private readonly HttpClient _httpClient;
 
     public SystemStatusClient(HttpClient httpClient)
@@ -15,6 +18,43 @@ public sealed class SystemStatusClient : ISystemStatusClient
     public async Task<HealthDto?> GetApiHealthAsync(CancellationToken cancellationToken)
     {
         return await _httpClient.GetFromJsonAsync<HealthDto>("health", cancellationToken);
+    }
+
+    public async Task<bool> IsApiReachableAsync(CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(ReachabilityTimeout);
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, "health");
+            request.Headers.CacheControl = new CacheControlHeaderValue
+            {
+                NoCache = true,
+                NoStore = true
+            };
+            request.Headers.Pragma.Add(new NameValueHeaderValue("no-cache"));
+            using var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                timeout.Token);
+            return true;
+        }
+        catch (HttpRequestException exception) when (exception.StatusCode is not null)
+        {
+            return true;
+        }
+        catch (HttpRequestException)
+        {
+            return false;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
     }
 
     public async Task<DatabaseTestDto?> GetDatabaseStatusAsync(CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/ActiveTripBanner/ActiveTripBanner.razor.cs
@@ -27,11 +27,17 @@ public partial class ActiveTripBanner : ComponentBase, IDisposable
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
+    [Parameter]
+    public Guid ViewerUserId { get; set; }
+
+    [Parameter]
+    public string TripBaseHref { get; set; } = "/trips";
+
     private string ViewHref
     {
         get
         {
-            return _trip is null ? "/catches" : $"/trips/{_trip.Id:D}";
+            return TripHref(string.Empty);
         }
     }
 
@@ -47,8 +53,19 @@ public partial class ActiveTripBanner : ComponentBase, IDisposable
     {
         get
         {
-            return _trip is null ? "/catches" : $"/trips/{_trip.Id:D}/edit";
+            return TripHref("/edit");
         }
+    }
+
+    private string TripHref(string suffix)
+    {
+        if (_trip is null)
+        {
+            return "/catches";
+        }
+
+        var root = string.IsNullOrWhiteSpace(TripBaseHref) ? "/trips" : TripBaseHref.TrimEnd('/');
+        return $"{root}/{_trip.Id:D}{suffix}";
     }
 
     protected override async Task OnInitializedAsync()
@@ -62,9 +79,10 @@ public partial class ActiveTripBanner : ComponentBase, IDisposable
         var cancellationToken = _cancellationTokenSource.Token;
         try
         {
-            var viewerUserId = await LocalOwner.GetUserIdAsync(cancellationToken);
-            _viewerUserId = viewerUserId;
-            _trip = await ActiveTrip.GetActiveAsync(viewerUserId, cancellationToken);
+            _viewerUserId = ViewerUserId != Guid.Empty
+                ? ViewerUserId
+                : await LocalOwner.GetUserIdAsync(cancellationToken);
+            _trip = await ActiveTrip.GetActiveAsync(_viewerUserId, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor
@@ -1,5 +1,7 @@
 @inherits LayoutComponentBase
+@using FishingLogBook.Web.Common.Icons
 @using FishingLogBook.Web.Features.OfflineAccess.Enums
+@using FishingLogBook.Web.Features.Trips.Components.ActiveTripBanner
 
 <MudThemeProvider Theme="_theme" IsDarkMode="_isDarkMode" />
 <MudPopoverProvider />
@@ -32,11 +34,21 @@
         <MudNavMenu>
             <MudNavLink Href="/offline/catches" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.MenuBook" id="offline-catches-nav-link">@Loc["Catch_LogbookNav"]</MudNavLink>
             <MudNavLink Href="/offline/record" Icon="@Icons.Material.Filled.AddAPhoto" id="offline-record-nav-link">@Loc["Catch_RecordNav"]</MudNavLink>
+            @if (_activeTrip is not null)
+            {
+                <MudNavLink Href="@($"/offline/trips/{_activeTrip.Id:D}")"
+                            Icon="@FishingLogBookIcons.FishingTrip"
+                            id="offline-trips-nav-link">@Loc["Trip_Nav"]</MudNavLink>
+            }
             <MudNavLink OnClick="Lock" Icon="@Icons.Material.Filled.Lock" id="offline-lock-nav-link">@Loc["OfflineAccess_Lock"]</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
     <MudMainContent>
         <div class="offline-mode-banner" id="offline-mode-banner">@Loc["OfflineAccess_Mode"]</div>
+        @if (OfflineOwnerContext.Owner is { } owner)
+        {
+            <ActiveTripBanner ViewerUserId="owner.UserId" TripBaseHref="/offline/trips" />
+        }
         @if (OfflineReconnect.State is OfflineReconnectStateEnum.ConnectivityRestored
              or OfflineReconnectStateEnum.RecoveringAuthentication
              or OfflineReconnectStateEnum.VerifyingOwner

--- a/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.cs
+++ b/src/FishingLogBook.Web/Layouts/OfflineLayout/OfflineLayout.razor.cs
@@ -1,6 +1,9 @@
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess;
 using FishingLogBook.Web.Features.OfflineAccess.Enums;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
@@ -15,9 +18,12 @@ public partial class OfflineLayout : LayoutComponentBase, IDisposable
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private bool _drawerOpen = true;
     private bool _isDarkMode;
+    private TripModel? _activeTrip;
 
     [Inject] private IOfflineOwnerContextService OfflineOwnerContext { get; set; } = default!;
     [Inject] private IOfflineReconnectService OfflineReconnect { get; set; } = default!;
+    [Inject] private IActiveTripService ActiveTrip { get; set; } = default!;
+    [Inject] private ILoggingService Logging { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
 
@@ -29,7 +35,10 @@ public partial class OfflineLayout : LayoutComponentBase, IDisposable
         }
 
         OfflineReconnect.StateChanged += OnReconnectStateChanged;
+        ActiveTrip.StateChanged += OnActiveTripChanged;
+        await LoadActiveTripAsync();
         await OfflineReconnect.StartAsync(_cancellationTokenSource.Token);
+        StateHasChanged();
     }
 
     private void ToggleDarkMode()
@@ -62,6 +71,43 @@ public partial class OfflineLayout : LayoutComponentBase, IDisposable
         });
     }
 
+    private void OnActiveTripChanged(object? sender, EventArgs args)
+    {
+        if (_cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
+        _ = InvokeAsync(async () =>
+        {
+            await LoadActiveTripAsync();
+            StateHasChanged();
+        });
+    }
+
+    private async Task LoadActiveTripAsync()
+    {
+        try
+        {
+            var owner = OfflineOwnerContext.Owner;
+            if (owner is null)
+            {
+                _activeTrip = null;
+                return;
+            }
+
+            _activeTrip = await ActiveTrip.GetActiveAsync(owner.UserId, _cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            _activeTrip = null;
+            await Logging.LogErrorAsync("resolving the offline active trip", exception, CancellationToken.None);
+        }
+    }
+
     private Task RetryReconnectAsync()
     {
         return OfflineReconnect.AttemptAsync(_cancellationTokenSource.Token);
@@ -83,6 +129,7 @@ public partial class OfflineLayout : LayoutComponentBase, IDisposable
     public void Dispose()
     {
         OfflineReconnect.StateChanged -= OnReconnectStateChanged;
+        ActiveTrip.StateChanged -= OnActiveTripChanged;
         OfflineReconnect.Stop();
         _cancellationTokenSource.Cancel();
         _cancellationTokenSource.Dispose();

--- a/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/bootstrap/service-worker-published.test.js
@@ -376,4 +376,16 @@ describe('published service worker', () => {
         expect(worker.fetch).toHaveBeenCalledOnce();
         expect(worker.cache.match).not.toHaveBeenCalled();
     });
+
+    it('always fetches health from the network without using the cache', async () => {
+        const worker = createWorker({
+            match: async () => new TestResponse('cached-health')
+        });
+
+        const result = await worker.dispatchFetch('https://app.test/health', { mode: 'cors' }).response;
+
+        expect(result.body).toBe('network');
+        expect(worker.fetch).toHaveBeenCalledWith(expect.anything(), { cache: 'no-store' });
+        expect(worker.cache.match).not.toHaveBeenCalled();
+    });
 });

--- a/src/FishingLogBook.Web/wwwroot/js/browser/network.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/network.js
@@ -6,18 +6,28 @@ export function createNetworkApi(targetWindow) {
         startMonitoring: (helper) => {
             if (monitoring) return;
 
-            const notify = () => helper.invokeMethodAsync(
+            const notifyConnectivity = () => helper.invokeMethodAsync(
                 'OnBrowserConnectivityChanged',
                 targetWindow.navigator.onLine);
-            targetWindow.addEventListener('online', notify);
-            targetWindow.addEventListener('offline', notify);
-            monitoring = { notify };
+            const notifyUsable = () => helper.invokeMethodAsync('OnBrowserUsable');
+            const notifyVisible = () => {
+                if (targetWindow.document?.visibilityState === 'visible') {
+                    helper.invokeMethodAsync('OnBrowserUsable');
+                }
+            };
+            targetWindow.addEventListener('online', notifyConnectivity);
+            targetWindow.addEventListener('offline', notifyConnectivity);
+            targetWindow.addEventListener('pageshow', notifyUsable);
+            targetWindow.document?.addEventListener('visibilitychange', notifyVisible);
+            monitoring = { notifyConnectivity, notifyUsable, notifyVisible };
         },
         stopMonitoring: () => {
             if (!monitoring) return;
 
-            targetWindow.removeEventListener('online', monitoring.notify);
-            targetWindow.removeEventListener('offline', monitoring.notify);
+            targetWindow.removeEventListener('online', monitoring.notifyConnectivity);
+            targetWindow.removeEventListener('offline', monitoring.notifyConnectivity);
+            targetWindow.removeEventListener('pageshow', monitoring.notifyUsable);
+            targetWindow.document?.removeEventListener('visibilitychange', monitoring.notifyVisible);
             monitoring = undefined;
         },
         onOnline: (helper) => {

--- a/src/FishingLogBook.Web/wwwroot/js/browser/network.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/network.test.js
@@ -57,6 +57,7 @@ describe('network', () => {
         expect(helper.invokeMethodAsync).toHaveBeenNthCalledWith(2, 'OnBrowserConnectivityChanged', true);
         expect(targetWindow.removeEventListener).toHaveBeenCalledWith('online', handlers.online);
         expect(targetWindow.removeEventListener).toHaveBeenCalledWith('offline', handlers.offline);
+        expect(targetWindow.removeEventListener).toHaveBeenCalledWith('pageshow', handlers.pageshow);
     });
 
     it('registers only one connectivity monitor', () => {
@@ -72,7 +73,40 @@ describe('network', () => {
         api.startMonitoring(helper);
         api.startMonitoring(helper);
 
-        expect(targetWindow.addEventListener).toHaveBeenCalledTimes(2);
+        expect(targetWindow.addEventListener).toHaveBeenCalledTimes(3);
+    });
+
+    it('rechecks usability from startMonitoring when the page resumes or becomes visible', () => {
+        const windowHandlers = {};
+        const documentHandlers = {};
+        const helper = { invokeMethodAsync: vi.fn() };
+        const document = {
+            visibilityState: 'hidden',
+            addEventListener(name, callback) {
+                documentHandlers[name] = callback;
+            },
+            removeEventListener: vi.fn()
+        };
+        const targetWindow = {
+            navigator: { onLine: true },
+            document,
+            addEventListener(name, callback) {
+                windowHandlers[name] = callback;
+            },
+            removeEventListener: vi.fn()
+        };
+        const api = createNetworkApi(targetWindow);
+        api.startMonitoring(helper);
+
+        windowHandlers.pageshow();
+        document.visibilityState = 'visible';
+        documentHandlers.visibilitychange();
+        api.stopMonitoring();
+
+        expect(helper.invokeMethodAsync).toHaveBeenNthCalledWith(1, 'OnBrowserUsable');
+        expect(helper.invokeMethodAsync).toHaveBeenNthCalledWith(2, 'OnBrowserUsable');
+        expect(targetWindow.removeEventListener).toHaveBeenCalledWith('pageshow', windowHandlers.pageshow);
+        expect(document.removeEventListener).toHaveBeenCalledWith('visibilitychange', documentHandlers.visibilitychange);
     });
 
     it('invokes the helper when the page resumes or becomes visible', () => {

--- a/src/FishingLogBook.Web/wwwroot/service-worker.published.js
+++ b/src/FishingLogBook.Web/wwwroot/service-worker.published.js
@@ -104,6 +104,10 @@ async function onFetch(event) {
         return fetch(event.request);
     }
 
+    if (url.pathname.endsWith('/health')) {
+        return fetch(event.request, { cache: 'no-store' });
+    }
+
     const shouldServeIndexHtml = event.request.mode === 'navigate'
         && !manifestUrlList.some(manifestUrl => manifestUrl === event.request.url);
 

--- a/tests/FishingLogBook.Application.Tests/Profiles/Services/AnglerLookupServiceTests/WhenTestingDescribe.cs
+++ b/tests/FishingLogBook.Application.Tests/Profiles/Services/AnglerLookupServiceTests/WhenTestingDescribe.cs
@@ -55,7 +55,7 @@ public class WhenTestingDescribe : BaseAnglerLookupServiceTest
     }
 
     [Fact]
-    public async Task ItShouldHideEveryFieldTheAnglerKeepsPrivate()
+    public async Task ItShouldHidePhotographAndHomeRegionTheAnglerKeepsPrivate()
     {
         // Arrange
         MockProfileRepository.GetByUserIdsAsync(
@@ -80,12 +80,69 @@ public class WhenTestingDescribe : BaseAnglerLookupServiceTest
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value[MatchedUserId].DisplayName.Should().BeNull();
+        result.Value[MatchedUserId].DisplayName.Should().Be("John Connolly");
         result.Value[MatchedUserId].PhotographUrl.Should().BeNull();
         result.Value[MatchedUserId].HomeRegion.Should().BeNull();
         await MockObjectStorage.DidNotReceive().CreateDownloadUrlAsync(
             Arg.Any<string>(),
             Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReturnTheStoredDisplayNameEvenWhenShowDisplayNameIsFalse()
+    {
+        // Arrange
+        MockProfileRepository.GetByUserIdsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<Profile>>(
+            [
+                new Profile
+                {
+                    UserId = MatchedUserId,
+                    DisplayName = "John Connolly",
+                    ShowDisplayName = false
+                }
+            ]));
+
+        // Act
+        var result = await Sut.DescribeAsync([MatchedUserId], CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value[MatchedUserId].DisplayName.Should().Be("John Connolly");
+        await MockProfileRepository.Received(1).GetByUserIdsAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(userIds =>
+                userIds.Count == 1 && userIds.Contains(MatchedUserId)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLeaveDisplayNameEmptyWhenTheProfileHasNoStoredName()
+    {
+        // Arrange
+        MockProfileRepository.GetByUserIdsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<IReadOnlyList<Profile>>(
+            [
+                new Profile
+                {
+                    UserId = MatchedUserId,
+                    DisplayName = null,
+                    ShowDisplayName = true
+                }
+            ]));
+
+        // Act
+        var result = await Sut.DescribeAsync([MatchedUserId], CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value[MatchedUserId].DisplayName.Should().BeNull();
+        await MockProfileRepository.Received(1).GetByUserIdsAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(userIds => userIds.Contains(MatchedUserId)),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/FishingLogBook.Infrastructure.Tests/Repositories/Migrations/SchemaTests/WhenTestingBackfillProfileDisplayName.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Repositories/Migrations/SchemaTests/WhenTestingBackfillProfileDisplayName.cs
@@ -1,0 +1,173 @@
+using AwesomeAssertions;
+using Dapper;
+using FishingLogBook.Db.Migrations;
+using FishingLogBook.Infrastructure.Persistence;
+using FishingLogBook.Infrastructure.Persistence.Repositories;
+using FishingLogBook.Infrastructure.Tests.Repositories.TestSupport;
+using FishingLogBook.Tests.Common.Builders;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FishingLogBook.Infrastructure.Tests.Repositories.Migrations.SchemaTests;
+
+[Collection(PostgresCollection.Name)]
+public class WhenTestingBackfillProfileDisplayName
+{
+    private readonly PostgresFixture _fixture;
+
+    public WhenTestingBackfillProfileDisplayName(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ItShouldBackfillANullDisplayNameFromTheAccountEmail()
+    {
+        // Arrange
+        var email = $"{Guid.NewGuid():N}@example.test";
+        var userId = await CreateUserAsync(email);
+        await InsertProfileAsync(userId, displayName: null, showDisplayName: false);
+
+        // Act
+        await RunBackfillAsync();
+
+        // Assert
+        var profile = await LoadProfileAsync(userId);
+        profile.DisplayName.Should().Be(email);
+        profile.ShowDisplayName.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldBackfillAWhitespaceDisplayNameFromTheAccountEmail()
+    {
+        // Arrange
+        var email = $"{Guid.NewGuid():N}@example.test";
+        var userId = await CreateUserAsync(email);
+        await InsertProfileAsync(userId, displayName: " \t\n ", showDisplayName: true);
+
+        // Act
+        await RunBackfillAsync();
+
+        // Assert
+        var profile = await LoadProfileAsync(userId);
+        profile.DisplayName.Should().Be(email);
+        profile.ShowDisplayName.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldBackfillABlankDisplayNameFromTheAccountEmail()
+    {
+        // Arrange
+        var email = $"{Guid.NewGuid():N}@example.test";
+        var userId = await CreateUserAsync(email);
+        await InsertProfileAsync(userId, displayName: "   ", showDisplayName: false);
+
+        // Act
+        await RunBackfillAsync();
+
+        // Assert
+        var profile = await LoadProfileAsync(userId);
+        profile.DisplayName.Should().Be(email);
+        profile.ShowDisplayName.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldNotOverwriteAnExistingDisplayName()
+    {
+        // Arrange
+        var email = $"{Guid.NewGuid():N}@example.test";
+        var userId = await CreateUserAsync(email);
+        await InsertProfileAsync(userId, displayName: "Pat Connolly", showDisplayName: false);
+
+        // Act
+        await RunBackfillAsync();
+
+        // Assert
+        var profile = await LoadProfileAsync(userId);
+        profile.DisplayName.Should().Be("Pat Connolly");
+        profile.ShowDisplayName.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldNotAlterShowDisplayNameWhenBackfilling()
+    {
+        // Arrange
+        var hiddenEmail = $"{Guid.NewGuid():N}@example.test";
+        var visibleEmail = $"{Guid.NewGuid():N}@example.test";
+        var hiddenUserId = await CreateUserAsync(hiddenEmail);
+        var visibleUserId = await CreateUserAsync(visibleEmail);
+        await InsertProfileAsync(hiddenUserId, displayName: null, showDisplayName: false);
+        await InsertProfileAsync(visibleUserId, displayName: string.Empty, showDisplayName: true);
+
+        // Act
+        await RunBackfillAsync();
+
+        // Assert
+        var hidden = await LoadProfileAsync(hiddenUserId);
+        var visible = await LoadProfileAsync(visibleUserId);
+        hidden.DisplayName.Should().Be(hiddenEmail);
+        hidden.ShowDisplayName.Should().BeFalse();
+        visible.DisplayName.Should().Be(visibleEmail);
+        visible.ShowDisplayName.Should().BeTrue();
+    }
+
+    private async Task RunBackfillAsync()
+    {
+        var connectionFactory = new NpgsqlConnectionFactory(_fixture.ConnectionString);
+        await using var connection = await connectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        await connection.ExecuteAsync(BackfillSql());
+    }
+
+    private async Task<Guid> CreateUserAsync(string email)
+    {
+        var connectionFactory = new NpgsqlConnectionFactory(_fixture.ConnectionString);
+        var users = new UserIdentityRepository(connectionFactory, NullLogger<UserIdentityRepository>.Instance);
+        var user = new UserBuilder().WithEmail(email).Build();
+        var identity = new UserIdentityBuilder().ForUser(user).Build();
+        var created = await users.CreateAsync(user, identity, CancellationToken.None);
+        created.IsSuccess.Should().BeTrue();
+        return created.Value;
+    }
+
+    private async Task InsertProfileAsync(Guid userId, string? displayName, bool showDisplayName)
+    {
+        var connectionFactory = new NpgsqlConnectionFactory(_fixture.ConnectionString);
+        await using var connection = await connectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        await connection.ExecuteAsync(
+            """
+            INSERT INTO "Profile" ("UserId", "DisplayName", "ShowDisplayName")
+            VALUES (@UserId, @DisplayName, @ShowDisplayName);
+            """,
+            new { UserId = userId, DisplayName = displayName, ShowDisplayName = showDisplayName });
+    }
+
+    private async Task<ProfileRow> LoadProfileAsync(Guid userId)
+    {
+        var connectionFactory = new NpgsqlConnectionFactory(_fixture.ConnectionString);
+        await using var connection = await connectionFactory.CreateOpenConnectionAsync(CancellationToken.None);
+        return await connection.QuerySingleAsync<ProfileRow>(
+            """
+            SELECT "DisplayName", "ShowDisplayName"
+            FROM "Profile"
+            WHERE "UserId" = @UserId;
+            """,
+            new { UserId = userId });
+    }
+
+    private static string BackfillSql()
+    {
+        var assembly = typeof(MigrationService).Assembly;
+        var resourceName = assembly.GetManifestResourceNames()
+            .Single(name => name.Contains("197_BackfillProfileDisplayNameFromEmail", StringComparison.Ordinal));
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded migration '{resourceName}' was not found.");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    private sealed class ProfileRow
+    {
+        public string? DisplayName { get; init; }
+
+        public bool ShowDisplayName { get; init; }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Network/NetworkServiceTests/BaseNetworkServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Network/NetworkServiceTests/BaseNetworkServiceTest.cs
@@ -1,0 +1,20 @@
+using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Features.SystemStatus.Clients;
+using FishingLogBook.Web.Tests.Browser.Network.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Network.NetworkServiceTests;
+
+public class BaseNetworkServiceTest
+{
+    protected static NetworkService CreateService(
+        FakeNetworkJsRuntime jsRuntime,
+        ISystemStatusClient? systemStatus = null)
+    {
+        return new NetworkService(
+            jsRuntime,
+            systemStatus ?? Substitute.For<ISystemStatusClient>(),
+            NullLogger<NetworkService>.Instance);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Network/NetworkServiceTests/WhenTestingIsOnline.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Network/NetworkServiceTests/WhenTestingIsOnline.cs
@@ -1,0 +1,146 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.SystemStatus.Clients;
+using FishingLogBook.Web.Tests.Browser.Network.TestSupport;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Browser.Network.NetworkServiceTests;
+
+public class WhenTestingIsOnline : BaseNetworkServiceTest
+{
+    [Fact]
+    public async Task ItShouldBeOfflineImmediatelyWhenTheBrowserIsOffline()
+    {
+        // Arrange
+        var jsRuntime = new FakeNetworkJsRuntime { BrowserOnline = false };
+        var systemStatus = Substitute.For<ISystemStatusClient>();
+        var sut = CreateService(jsRuntime, systemStatus);
+
+        // Act
+        var online = await sut.IsOnlineAsync(CancellationToken.None);
+
+        // Assert
+        online.Should().BeFalse();
+        await systemStatus.DidNotReceive().IsApiReachableAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldBeOnlineWhenTheBrowserIsOnlineAndTheApiResponds()
+    {
+        // Arrange
+        var jsRuntime = new FakeNetworkJsRuntime { BrowserOnline = true };
+        var systemStatus = Substitute.For<ISystemStatusClient>();
+        systemStatus.IsApiReachableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        var sut = CreateService(jsRuntime, systemStatus);
+
+        // Act
+        var online = await sut.IsOnlineAsync(CancellationToken.None);
+
+        // Assert
+        online.Should().BeTrue();
+        await systemStatus.Received(1).IsApiReachableAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldBeOfflineWhenTheBrowserIsOnlineButTheApiIsUnreachable()
+    {
+        // Arrange
+        var jsRuntime = new FakeNetworkJsRuntime { BrowserOnline = true };
+        var systemStatus = Substitute.For<ISystemStatusClient>();
+        systemStatus.IsApiReachableAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var sut = CreateService(jsRuntime, systemStatus);
+
+        // Act
+        var online = await sut.IsOnlineAsync(CancellationToken.None);
+
+        // Assert
+        online.Should().BeFalse();
+        await systemStatus.Received(1).IsApiReachableAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRethrowWhenTheCallerCancelsTheHealthProbe()
+    {
+        // Arrange
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+        var jsRuntime = new FakeNetworkJsRuntime { BrowserOnline = true };
+        var systemStatus = Substitute.For<ISystemStatusClient>();
+        systemStatus.IsApiReachableAsync(Arg.Any<CancellationToken>())
+            .Returns<bool>(_ => throw new OperationCanceledException(cancelled.Token));
+        var sut = CreateService(jsRuntime, systemStatus);
+
+        // Act
+        var act = () => sut.IsOnlineAsync(cancelled.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task ItShouldPublishOfflineImmediatelyWhenTheBrowserGoesOffline()
+    {
+        // Arrange
+        var systemStatus = Substitute.For<ISystemStatusClient>();
+        var sut = CreateService(new FakeNetworkJsRuntime(), systemStatus);
+        bool? published = null;
+        sut.ConnectivityChanged += isOnline => published = isOnline;
+
+        // Act
+        sut.OnBrowserConnectivityChanged(false);
+
+        // Assert
+        published.Should().BeFalse();
+        await systemStatus.DidNotReceive().IsApiReachableAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPublishAfterVerifyingTheApiWhenTheBrowserComesOnline()
+    {
+        // Arrange
+        var jsRuntime = new FakeNetworkJsRuntime { BrowserOnline = true };
+        var systemStatus = Substitute.For<ISystemStatusClient>();
+        systemStatus.IsApiReachableAsync(Arg.Any<CancellationToken>()).Returns(true);
+        var sut = CreateService(jsRuntime, systemStatus);
+        bool? published = null;
+        sut.ConnectivityChanged += isOnline => published = isOnline;
+
+        // Act
+        sut.OnBrowserConnectivityChanged(true);
+        await WaitForAsync(() => published is not null);
+
+        // Assert
+        published.Should().BeTrue();
+        await systemStatus.Received(1).IsApiReachableAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReverifyReachabilityWhenThePageBecomesUsable()
+    {
+        // Arrange
+        var jsRuntime = new FakeNetworkJsRuntime { BrowserOnline = true };
+        var systemStatus = Substitute.For<ISystemStatusClient>();
+        systemStatus.IsApiReachableAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var sut = CreateService(jsRuntime, systemStatus);
+        bool? published = null;
+        sut.ConnectivityChanged += isOnline => published = isOnline;
+
+        // Act
+        sut.OnBrowserUsable();
+        await WaitForAsync(() => published is not null);
+
+        // Assert
+        published.Should().BeFalse();
+        await systemStatus.Received(1).IsApiReachableAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        var expiry = DateTime.UtcNow.AddSeconds(2);
+        while (!condition() && DateTime.UtcNow < expiry)
+        {
+            await Task.Delay(10);
+        }
+
+        condition().Should().BeTrue();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Browser/Network/TestSupport/FakeNetworkJsRuntime.cs
+++ b/tests/FishingLogBook.Web.Tests/Browser/Network/TestSupport/FakeNetworkJsRuntime.cs
@@ -1,0 +1,26 @@
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Tests.Browser.Network.TestSupport;
+
+public sealed class FakeNetworkJsRuntime : IJSRuntime
+{
+    public bool BrowserOnline { get; set; } = true;
+
+    public string? LastIdentifier { get; private set; }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+        return InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+    {
+        LastIdentifier = identifier;
+        if (identifier == "fishingLogBookNetwork.isOnline")
+        {
+            return new ValueTask<TValue>((TValue)(object)BrowserOnline);
+        }
+
+        return default;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/OfflineArchitectureTests/WhenTestingDependencies.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/OfflineAccess/OfflineArchitectureTests/WhenTestingDependencies.cs
@@ -64,6 +64,8 @@ public class WhenTestingDependencies : BaseOfflineArchitectureTest
         // Assert
         directOnlineDependencies.Should().BeEmpty();
         injectedTypes.Should().Contain(type => type.Name == "IOfflineReconnectService");
+        injectedTypes.Should().Contain(type => type.Name == "IActiveTripService");
+        injectedTypes.Should().Contain(type => type.Name == "ILoggingService");
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Clients/SystemStatusClientTests/BaseSystemStatusClientTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Clients/SystemStatusClientTests/BaseSystemStatusClientTest.cs
@@ -6,9 +6,14 @@ namespace FishingLogBook.Web.Tests.Features.SystemStatus.Clients.SystemStatusCli
 
 public class BaseSystemStatusClientTest
 {
-    protected static SystemStatusClient CreateClient(RecordingHandler handler)
+    protected static SystemStatusClient CreateClient(HttpMessageHandler handler)
     {
         return new SystemStatusClient(new HttpClient(handler) { BaseAddress = new Uri("https://api.test/") });
+    }
+
+    protected static SystemStatusClient CreateClient(RecordingHandler handler)
+    {
+        return CreateClient((HttpMessageHandler)handler);
     }
 
     protected sealed class RecordingHandler(HttpStatusCode statusCode, string responseBody) : HttpMessageHandler

--- a/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Clients/SystemStatusClientTests/WhenTestingIsApiReachable.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/SystemStatus/Clients/SystemStatusClientTests/WhenTestingIsApiReachable.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+
+namespace FishingLogBook.Web.Tests.Features.SystemStatus.Clients.SystemStatusClientTests;
+
+public class WhenTestingIsApiReachable : BaseSystemStatusClientTest
+{
+    [Fact]
+    public async Task ItShouldTreatAnyHttpResponseAsReachableWithoutUsingCache()
+    {
+        // Arrange
+        var handler = new RecordingHandler(HttpStatusCode.InternalServerError, "{}");
+
+        // Act
+        var reachable = await CreateClient(handler).IsApiReachableAsync(CancellationToken.None);
+
+        // Assert
+        reachable.Should().BeTrue();
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Get);
+        handler.LastRequest.RequestUri!.PathAndQuery.Should().Be("/health");
+        handler.LastRequest.Headers.CacheControl.Should().BeEquivalentTo(new CacheControlHeaderValue
+        {
+            NoCache = true,
+            NoStore = true
+        });
+        handler.LastRequest.Headers.Pragma.ToString().Should().Be("no-cache");
+    }
+
+    [Fact]
+    public async Task ItShouldTreatAClientErrorResponseAsReachable()
+    {
+        // Arrange
+        var handler = new RecordingHandler(HttpStatusCode.NotFound, "{}");
+
+        // Act
+        var reachable = await CreateClient(handler).IsApiReachableAsync(CancellationToken.None);
+
+        // Assert
+        reachable.Should().BeTrue();
+        handler.LastRequest!.RequestUri!.PathAndQuery.Should().Be("/health");
+    }
+
+    [Fact]
+    public async Task ItShouldTreatAnHttpFailureWithAStatusCodeAsReachable()
+    {
+        // Arrange
+        var handler = new ThrowingHandler(new HttpRequestException("bad gateway", null, HttpStatusCode.BadGateway));
+
+        // Act
+        var reachable = await CreateClient(handler).IsApiReachableAsync(CancellationToken.None);
+
+        // Assert
+        reachable.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldTreatANetworkFailureWithoutAStatusCodeAsUnreachable()
+    {
+        // Arrange
+        var handler = new ThrowingHandler(new HttpRequestException("connection refused"));
+
+        // Act
+        var reachable = await CreateClient(handler).IsApiReachableAsync(CancellationToken.None);
+
+        // Assert
+        reachable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldTreatATimeoutAsUnreachable()
+    {
+        // Arrange
+        var handler = new ThrowingHandler(new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout."));
+
+        // Act
+        var reachable = await CreateClient(handler).IsApiReachableAsync(CancellationToken.None);
+
+        // Assert
+        reachable.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldRethrowWhenTheCallerCancels()
+    {
+        // Arrange
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+        var handler = new HangingHandler();
+
+        // Act
+        var act = () => CreateClient(handler).IsApiReachableAsync(cancelled.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromException<HttpResponseMessage>(exception);
+        }
+    }
+
+    private sealed class HangingHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken);
+            throw new InvalidOperationException("The health probe should have been cancelled.");
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/ActiveTripBannerTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/ActiveTripBannerTests/WhenTestingRender.cs
@@ -213,6 +213,30 @@ public class WhenTestingRender
     }
 
     [Fact]
+    public async Task ItShouldSkipTheOnlineOwnerLookupWhenViewerUserIdIsProvided()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var owner = Substitute.For<ILocalCatchOwnerService>();
+        var activeTrip = ActiveTripService(ActiveTrip());
+        await using var context = CreateContext(activeTrip, owner);
+
+        // Act
+        var cut = context.Render<ActiveTripBanner>(parameters => parameters
+            .Add(banner => banner.ViewerUserId, OwnerUserId)
+            .Add(banner => banner.TripBaseHref, "/offline/trips"));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#active-trip-banner-view").GetAttribute("href")
+                .Should().Be($"/offline/trips/{TripId:D}"));
+        cut.Find("#active-trip-banner-update").GetAttribute("href")
+            .Should().Be($"/offline/trips/{TripId:D}/edit");
+        await activeTrip.Received(1).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await owner.DidNotReceive().GetUserIdAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldKeepTheUpdateActionOnTheAnglersOwnTrip()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/BaseOfflineLayoutTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/BaseOfflineLayoutTest.cs
@@ -1,6 +1,9 @@
 using Bunit;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Models;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Features.Trips.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
@@ -10,9 +13,14 @@ namespace FishingLogBook.Web.Tests.Layouts.OfflineLayoutTests;
 
 public class BaseOfflineLayoutTest
 {
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
     protected static BunitContext CreateContext(
         out OfflineOwnerContextService owner,
-        IOfflineReconnectService? reconnect = null)
+        IOfflineReconnectService? reconnect = null,
+        IActiveTripService? activeTrip = null,
+        ILocalCatchOwnerService? localOwner = null,
+        ILoggingService? logging = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -21,9 +29,20 @@ public class BaseOfflineLayoutTest
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         context.Services.AddSingleton(Substitute.For<ICultureService>());
         owner = new OfflineOwnerContextService();
-        owner.Unlock(new OfflineOwnerModel(Guid.Parse("11111111-1111-1111-1111-111111111111"), 1));
+        owner.Unlock(new OfflineOwnerModel(OwnerUserId, 1));
         context.Services.AddSingleton<IOfflineOwnerContextService>(owner);
         context.Services.AddSingleton(reconnect ?? Substitute.For<IOfflineReconnectService>());
+        context.Services.AddSingleton(activeTrip ?? NoActiveTrip());
+        context.Services.AddSingleton(localOwner ?? Substitute.For<ILocalCatchOwnerService>());
+        context.Services.AddSingleton(logging ?? Substitute.For<ILoggingService>());
         return context;
+    }
+
+    protected static IActiveTripService NoActiveTrip()
+    {
+        var activeTrip = Substitute.For<IActiveTripService>();
+        activeTrip.GetActiveAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((FishingLogBook.Web.Features.Trips.Models.TripModel?)null);
+        return activeTrip;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/WhenTestingActiveTrip.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/WhenTestingActiveTrip.cs
@@ -1,0 +1,99 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Features.Trips.Models;
+using FishingLogBook.Web.Features.Trips.Services;
+using FishingLogBook.Web.Layouts.OfflineLayout;
+using Microsoft.AspNetCore.Components;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Layouts.OfflineLayoutTests;
+
+public class WhenTestingActiveTrip : BaseOfflineLayoutTest
+{
+    private static readonly Guid TripId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly DateTimeOffset StartedOn = DateTimeOffset.Parse("2026-08-26T05:32:00Z");
+
+    [Fact]
+    public async Task ItShouldKeepTheActiveTripOutOfOfflineNavigationWhenNoneIsStored()
+    {
+        // Arrange
+        var activeTrip = NoActiveTrip();
+        await using var context = CreateContext(out _, activeTrip: activeTrip);
+
+        // Act
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+        await Task.Yield();
+
+        // Assert
+        cut.FindAll("#offline-trips-nav-link").Should().BeEmpty();
+        cut.FindAll("#active-trip-banner").Should().BeEmpty();
+        await activeTrip.Received(2).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldExposeTheLocalActiveTripInOfflineNavigationAndTheBanner()
+    {
+        // Arrange
+        var activeTrip = Substitute.For<IActiveTripService>();
+        activeTrip.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(new TripModel(TripId, OwnerUserId, TripConstants.Active, StartedOn));
+        var localOwner = Substitute.For<ILocalCatchOwnerService>();
+        await using var context = CreateContext(out _, activeTrip: activeTrip, localOwner: localOwner);
+
+        // Act
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#offline-trips-nav-link").GetAttribute("href")
+                .Should().Be($"/offline/trips/{TripId:D}");
+            cut.Find("#active-trip-banner").Should().NotBeNull();
+            cut.Find("#active-trip-banner-view").GetAttribute("href")
+                .Should().Be($"/offline/trips/{TripId:D}");
+            cut.Find("#active-trip-banner-update").GetAttribute("href")
+                .Should().Be($"/offline/trips/{TripId:D}/edit");
+        });
+        await activeTrip.Received(2).GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>());
+        await localOwner.DidNotReceive().GetUserIdAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldHideOfflineTripEditWhenTheStoredTripIsNotOwnedByTheViewer()
+    {
+        // Arrange
+        var otherOwner = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var activeTrip = Substitute.For<IActiveTripService>();
+        activeTrip.GetActiveAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(new TripModel(
+                TripId,
+                otherOwner,
+                TripConstants.Active,
+                StartedOn,
+                ParticipantUserIds: [OwnerUserId],
+                Origin: TripOriginEnum.Server));
+        await using var context = CreateContext(out _, activeTrip: activeTrip);
+
+        // Act
+        var cut = context.Render<OfflineLayout>(parameters => parameters.Add(
+            layout => layout.Body,
+            (RenderFragment)(_ => { })));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#offline-trips-nav-link").GetAttribute("href")
+                .Should().Be($"/offline/trips/{TripId:D}");
+            cut.Find("#active-trip-banner-view").GetAttribute("href")
+                .Should().Be($"/offline/trips/{TripId:D}");
+            cut.FindAll("#active-trip-banner-update").Should().BeEmpty();
+        });
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/OfflineLayoutTests/WhenTestingRender.cs
@@ -31,6 +31,7 @@ public class WhenTestingRender : BaseOfflineLayoutTest
         cut.Find("#offline-catches-nav-link").Should().NotBeNull();
         cut.Find("#offline-record-nav-link").Should().NotBeNull();
         cut.Find("#offline-lock-nav-link").Should().NotBeNull();
+        cut.FindAll("#offline-trips-nav-link").Should().BeEmpty();
         cut.FindAll("#profile-nav-link").Should().BeEmpty();
         cut.FindAll("#app-update-banner").Should().BeEmpty();
         cut.FindAll("#user-menu-button").Should().BeEmpty();


### PR DESCRIPTION
…use stored collabo## Summary
- Keep the active trip visible in the offline shell from local IndexedDB, including `/offline/trips/{TripId}` navigation and owner-only edit.
- Backfill blank `Profile.DisplayName` from `User.Email`, and return that stored name for private trip collaboration even when `ShowDisplayName` is false. Public/search visibility is unchanged.
- Treat the browser as offline immediately when `navigator.onLine` is false; when the browser is online, verify the existing `GET /health` so an unreachable API does not look connected.

Closes #197

## Test plan
- [ ] Start a trip, lose API connectivity, confirm the offline shell still shows the in-progress banner and Trips nav to `/offline/trips/{id}`
- [ ] Confirm collaborator names on a shared trip use stored DisplayName when `ShowDisplayName` is false
- [ ] Confirm public profile / angler search still hide DisplayName when `ShowDisplayName` is false
- [ ] Confirm a blank/whitespace DisplayName is backfilled from account email and existing names are not overwritten
- [ ] Confirm browser offline goes offline immediately; online with a failing `/health` (timeout/DNS) enters the offline-capable state; any HTTP response counts as reachable
- [ ] Apply DbUp migrations after merge (`dotnet run --project src/FishingLogBook.Db.Migrations.App -- --run`)

## Self review
- Issue/AC: PASS for the three agreed phone-testing bugs. New-user DisplayName default / onboarding UX is a follow-up, not this PR.
- Architecture/CQRS: PASS. No collaboration DTO/SQL expansion, no `GetSummariesByUserIdsAsync`.
- Rules: PASS. Bug 2 stayed on the backfill migration plus `DescribeAsync`.
- Security/privacy: PASS. Public/search still honour `ShowDisplayName`. Private trip collaboration uses stored DisplayName. Photograph/home region still gated.
- Database/migrations: PASS. Idempotent `04_Scripts` backfill; `ShowDisplayName` is not written.
- Tests/coverage: PASS for backfill, DescribeAsync, public/search privacy, offline banner/nav, and `/health` reachability.
- Browser: PASS / N/A for authenticated offline Blazor UI (bUnit covers banner/nav; Playwright has no Cognito host). Bug 3 cold-offline `/health` is covered by `offline-shell.spec.js` with `navigator.onLine` stubbed.
- Web/UI/localisation: PASS / N/A. No new user-visible strings. Offline trips nav reuses `Trip_Nav`.
- Code smells: PASS. Offline layout and banner both read `IActiveTripService`; accepted to keep the banner reusable.
- CI/deployment: PASS. Migration apply required after merge. No Terraform.

Findings discovered during self-review:
1. `BTRIM` does not treat tab/newline as blank — fixed with `[[:space:]]`.
2. Cold-offline diagnostics Playwright still saw `navigator.onLine === true` and probed `/health` — stubbed.
3. New profiles can still be created with null DisplayName — follow-up ticket, not this PR.

Fixes made:
1. Whitespace-aware backfill SQL and tests.
2. `navigator.onLine = false` on the cold-offline diagnostics spec.
3. Offline active-trip `GetActiveAsync` assertion matches layout + banner.

Remaining deliberate gaps:
- Onboarding/profile DisplayName-or-email UX and server default for new users.
- Offline reconnect from a trip still returns to `/catches`.rator names