### PR TITLE
FLB#200 | store email as DisplayName when the field is left blank

### DIFF
--- a/src/FishingLogBook.Application/Profiles/Services/ProfileService.cs
+++ b/src/FishingLogBook.Application/Profiles/Services/ProfileService.cs
@@ -21,17 +21,20 @@ public sealed class ProfileService : IProfileService
     private readonly IObjectStorage _objectStorage;
     private readonly IProfilePhotographObjectKeyBuilder _objectKeyBuilder;
     private readonly IFishingPreferenceService _fishingPreferenceService;
+    private readonly ICurrentUser _currentUser;
 
     public ProfileService(
         IProfileRepository profileRepository,
         IObjectStorage objectStorage,
         IProfilePhotographObjectKeyBuilder objectKeyBuilder,
-        IFishingPreferenceService fishingPreferenceService)
+        IFishingPreferenceService fishingPreferenceService,
+        ICurrentUser currentUser)
     {
         _profileRepository = profileRepository;
         _objectStorage = objectStorage;
         _objectKeyBuilder = objectKeyBuilder;
         _fishingPreferenceService = fishingPreferenceService;
+        _currentUser = currentUser;
     }
 
     public bool IsObjectStorageConfigured => _objectStorage.IsConfigured;
@@ -153,7 +156,13 @@ public sealed class ProfileService : IProfileService
             return Result.Ok(profile);
         }
 
-        return await _profileRepository.UpsertAsync(CreateDefault(userId), cancellationToken);
+        return await _profileRepository.UpsertAsync(
+            new Profile
+            {
+                UserId = userId,
+                DisplayName = TrimOrNull(_currentUser.Email)
+            },
+            cancellationToken);
     }
 
     private async Task<ProfileDto> ToOwnDtoAsync(Profile profile, CancellationToken cancellationToken)
@@ -233,12 +242,12 @@ public sealed class ProfileService : IProfileService
         return new Profile { UserId = userId };
     }
 
-    private static Profile ApplyUpdate(Profile current, UpdateProfileArgs args)
+    private Profile ApplyUpdate(Profile current, UpdateProfileArgs args)
     {
         return new Profile
         {
             UserId = args.UserId,
-            DisplayName = TrimOrNull(args.DisplayName),
+            DisplayName = ResolveDisplayName(args.DisplayName, current.DisplayName),
             PhotographId = current.PhotographId,
             PhotographObjectKey = current.PhotographObjectKey,
             PhotographContentType = current.PhotographContentType,
@@ -252,6 +261,23 @@ public sealed class ProfileService : IProfileService
             ShowPreferredSpecies = args.ShowPreferredSpecies,
             OnboardingCompletedOn = current.OnboardingCompletedOn
         };
+    }
+
+    private string? ResolveDisplayName(string? submitted, string? current)
+    {
+        var trimmedSubmitted = TrimOrNull(submitted);
+        if (trimmedSubmitted is not null)
+        {
+            return trimmedSubmitted;
+        }
+
+        var trimmedCurrent = TrimOrNull(current);
+        if (trimmedCurrent is not null)
+        {
+            return trimmedCurrent;
+        }
+
+        return TrimOrNull(_currentUser.Email);
     }
 
     private static string? TrimOrNull(string? value)

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor
@@ -23,6 +23,20 @@
                             <MudStack Spacing="2" Class="py-4">
                                 <MudText Typo="Typo.h4">@Loc["Onboarding_WelcomeTitle"]</MudText>
                                 <MudText>@Loc["Onboarding_WelcomeBody"]</MudText>
+                                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                                    <MudTextField @bind-Value="_displayName"
+                                                  Label="@Loc["Profile_DisplayName"]"
+                                                  Variant="Variant.Outlined"
+                                                  Immediate="true"
+                                                  Class="flex-grow-1"
+                                                  id="onboarding-display-name" />
+                                    <MudTooltip Text="@Loc["Onboarding_DisplayNameHelp"]">
+                                        <MudIconButton Icon="@Icons.Material.Filled.Info"
+                                                       Size="Size.Small"
+                                                       aria-label="@Loc["Onboarding_DisplayNameHelp"]"
+                                                       id="onboarding-display-name-help" />
+                                    </MudTooltip>
+                                </MudStack>
                             </MudStack>
                         </MudStep>
                         <MudStep Title="@Loc["Onboarding_PreferencesStep"]">

--- a/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
+++ b/src/FishingLogBook.Web/Features/Onboarding/Pages/Onboarding/Onboarding.razor.cs
@@ -22,6 +22,7 @@ public partial class Onboarding : ComponentBase, IDisposable
     private bool _locationHandled;
     private bool _offlineAccessReady;
     private string? _preferenceValidationMessage;
+    private string? _displayName;
     private WeightUnitEnum _weightUnit = WeightUnitEnum.Kg;
     private LengthUnitEnum _lengthUnit = LengthUnitEnum.Cm;
     private FishingCatalogueDto _catalogue = new([], []);
@@ -51,6 +52,7 @@ public partial class Onboarding : ComponentBase, IDisposable
         _profile = await profileTask;
         _catalogue = await catalogueTask;
         ApplyPreferences(await preferencesTask);
+        _displayName = _profile.DisplayName;
         _weightUnit = _profile.PreferredWeightUnit;
         _lengthUnit = _profile.PreferredLengthUnit;
         _isLoading = false;
@@ -110,7 +112,7 @@ public partial class Onboarding : ComponentBase, IDisposable
         try
         {
             _profile = await ProfileClient.UpdateOwnAsync(new UpdateProfileDto(
-                _profile.DisplayName,
+                _displayName,
                 _profile.HomeRegion,
                 _profile.ShowDisplayName,
                 _profile.ShowPhotograph,
@@ -119,6 +121,7 @@ public partial class Onboarding : ComponentBase, IDisposable
                 _profile.ShowPreferredSpecies,
                 _weightUnit,
                 _lengthUnit), _cancellationTokenSource.Token);
+            _displayName = _profile.DisplayName;
             var preferences = await FishingPreferenceClient.UpdatePreferencesAsync(
                 BuildFishingPreferencesUpdate(),
                 _cancellationTokenSource.Token);

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -831,6 +831,7 @@
   <data name="Onboarding_WelcomeStep" xml:space="preserve"><value>Bienvenue</value></data>
   <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>Bienvenue dans Catch But Don’t Forget</value></data>
   <data name="Onboarding_WelcomeBody" xml:space="preserve"><value>Catch · Release · Remember. Configurez votre carnet de pêche privé, utilisable hors ligne, en une minute environ.</value></data>
+  <data name="Onboarding_DisplayNameHelp" xml:space="preserve"><value>Les autres pêcheurs pourront voir ce nom. S’il est laissé vide, votre adresse e-mail sera utilisée.</value></data>
   <data name="Onboarding_PreferencesStep" xml:space="preserve"><value>Préférences</value></data>
   <data name="Onboarding_PreferencesTitle" xml:space="preserve"><value>Définissez vos préférences de pêche</value></data>
   <data name="Onboarding_PreferencesBody" xml:space="preserve"><value>Choisissez votre type de pêche, les espèces recherchées et vos unités de mesure. Vous pourrez les modifier dans votre profil.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -831,6 +831,7 @@
   <data name="Onboarding_WelcomeStep" xml:space="preserve"><value>Welcome</value></data>
   <data name="Onboarding_WelcomeTitle" xml:space="preserve"><value>Welcome to Catch But Don’t Forget</value></data>
   <data name="Onboarding_WelcomeBody" xml:space="preserve"><value>Catch · Release · Remember. Set up your private, offline-friendly fishing logbook in about a minute.</value></data>
+  <data name="Onboarding_DisplayNameHelp" xml:space="preserve"><value>Other anglers may see this name. If left blank, your email address will be used.</value></data>
   <data name="Onboarding_PreferencesStep" xml:space="preserve"><value>Preferences</value></data>
   <data name="Onboarding_PreferencesTitle" xml:space="preserve"><value>Set your fishing preferences</value></data>
   <data name="Onboarding_PreferencesBody" xml:space="preserve"><value>Choose what you fish for and the measurements you use. You can change these later in Profile.</value></data>

--- a/tests/FishingLogBook.Api.Tests/ProfileEndpointsTests/WhenTestingUpdateOwn.cs
+++ b/tests/FishingLogBook.Api.Tests/ProfileEndpointsTests/WhenTestingUpdateOwn.cs
@@ -187,6 +187,117 @@ public class WhenTestingUpdateOwn : IClassFixture<SystemApiFactory>
             Arg.Any<CancellationToken>());
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ItShouldStoreTheAuthenticatedEmailWhenDisplayNameIsBlank(string? displayName)
+    {
+        // Arrange
+        var subject = Guid.NewGuid().ToString("N");
+        _factory.ProfileRepository.ClearReceivedCalls();
+        _factory.ProfileRepository
+            .GetByUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(null));
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: subject));
+        var own = await client.GetFromJsonAsync<ProfileDto>("/api/profiles/me");
+        own.Should().NotBeNull();
+        _factory.ProfileRepository.ClearReceivedCalls();
+        _factory.ProfileRepository
+            .GetByUserIdAsync(own!.UserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(null));
+
+        // Act
+        var response = await client.PutAsJsonAsync(
+            "/api/profiles/me",
+            ValidRequest() with { DisplayName = displayName });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ProfileDto>();
+        body.Should().NotBeNull();
+        body!.DisplayName.Should().Be(TestJwt.Email);
+        body.ShowDisplayName.Should().BeTrue();
+        await _factory.ProfileRepository.Received(1).UpsertAsync(
+            Arg.Is<Profile>(profile =>
+                profile.UserId == own.UserId
+                && profile.DisplayName == TestJwt.Email
+                && profile.ShowDisplayName),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepAnExistingDisplayNameWhenTheSubmittedValueIsBlank()
+    {
+        // Arrange
+        var subject = Guid.NewGuid().ToString("N");
+        var existing = new Profile { UserId = Guid.NewGuid(), DisplayName = "Eamonn" };
+        _factory.ProfileRepository.ClearReceivedCalls();
+        _factory.ProfileRepository
+            .GetByUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(null));
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: subject));
+        var own = await client.GetFromJsonAsync<ProfileDto>("/api/profiles/me");
+        own.Should().NotBeNull();
+        existing = new Profile { UserId = own!.UserId, DisplayName = "Eamonn", ShowDisplayName = true };
+        _factory.ProfileRepository.ClearReceivedCalls();
+        _factory.ProfileRepository
+            .GetByUserIdAsync(own.UserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(existing));
+
+        // Act
+        var response = await client.PutAsJsonAsync(
+            "/api/profiles/me",
+            ValidRequest() with { DisplayName = "  " });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ProfileDto>();
+        body.Should().NotBeNull();
+        body!.DisplayName.Should().Be("Eamonn");
+        await _factory.ProfileRepository.Received(1).UpsertAsync(
+            Arg.Is<Profile>(profile =>
+                profile.UserId == own.UserId
+                && profile.DisplayName == "Eamonn"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepShowDisplayNameFalseWhenStoringTheEmailFallback()
+    {
+        // Arrange
+        var subject = Guid.NewGuid().ToString("N");
+        _factory.ProfileRepository.ClearReceivedCalls();
+        _factory.ProfileRepository
+            .GetByUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(null));
+        var client = _factory.CreateAuthenticatedClient(TestJwt.CreateAccessToken(subject: subject));
+        var own = await client.GetFromJsonAsync<ProfileDto>("/api/profiles/me");
+        own.Should().NotBeNull();
+        _factory.ProfileRepository.ClearReceivedCalls();
+        _factory.ProfileRepository
+            .GetByUserIdAsync(own!.UserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(null));
+
+        // Act
+        var response = await client.PutAsJsonAsync(
+            "/api/profiles/me",
+            ValidRequest() with { DisplayName = null, ShowDisplayName = false });
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<ProfileDto>();
+        body.Should().NotBeNull();
+        body!.DisplayName.Should().Be(TestJwt.Email);
+        body.ShowDisplayName.Should().BeFalse();
+        await _factory.ProfileRepository.Received(1).UpsertAsync(
+            Arg.Is<Profile>(profile =>
+                profile.UserId == own.UserId
+                && profile.DisplayName == TestJwt.Email
+                && !profile.ShowDisplayName),
+            Arg.Any<CancellationToken>());
+    }
+
     private static UpdateProfileDto ValidRequest()
     {
         return new UpdateProfileDto(

--- a/tests/FishingLogBook.Application.Tests/Profiles/Services/ProfileServiceTests/BaseProfileServiceTest.cs
+++ b/tests/FishingLogBook.Application.Tests/Profiles/Services/ProfileServiceTests/BaseProfileServiceTest.cs
@@ -11,15 +11,19 @@ namespace FishingLogBook.Application.Tests.Profiles.Services.ProfileServiceTests
 
 public class BaseProfileServiceTest
 {
+    protected const string CurrentUserEmail = "angler@example.test";
+
     protected readonly IProfileRepository MockProfileRepository = Substitute.For<IProfileRepository>();
     protected readonly IObjectStorage MockObjectStorage = Substitute.For<IObjectStorage>();
     protected readonly IProfilePhotographObjectKeyBuilder MockObjectKeyBuilder =
         Substitute.For<IProfilePhotographObjectKeyBuilder>();
     protected readonly IFishingPreferenceService MockFishingPreferenceService = Substitute.For<IFishingPreferenceService>();
+    protected readonly ICurrentUser MockCurrentUser = Substitute.For<ICurrentUser>();
     protected readonly ProfileService Sut;
 
     protected BaseProfileServiceTest()
     {
+        MockCurrentUser.Email.Returns(CurrentUserEmail);
         MockObjectStorage.IsConfigured.Returns(true);
         MockObjectKeyBuilder.Build(Arg.Any<Guid>(), Arg.Any<Guid>())
             .Returns(call => $"profiles/{call.ArgAt<Guid>(0):D}/{call.ArgAt<Guid>(1):D}");
@@ -30,6 +34,7 @@ public class BaseProfileServiceTest
             MockProfileRepository,
             MockObjectStorage,
             MockObjectKeyBuilder,
-            MockFishingPreferenceService);
+            MockFishingPreferenceService,
+            MockCurrentUser);
     }
 }

--- a/tests/FishingLogBook.Application.Tests/Profiles/Services/ProfileServiceTests/WhenTestingCreatePhotographUpload.cs
+++ b/tests/FishingLogBook.Application.Tests/Profiles/Services/ProfileServiceTests/WhenTestingCreatePhotographUpload.cs
@@ -57,7 +57,8 @@ public class WhenTestingCreatePhotographUpload : BaseProfileServiceTest
         result.IsFailed.Should().BeTrue();
         result.Errors[0].Message.Should().Be("Failed to load angler profile.");
         await MockProfileRepository.Received(1).UpsertAsync(
-            Arg.Is<Profile>(profile => profile.UserId == userId && profile.DisplayName == null),
+            Arg.Is<Profile>(profile =>
+                profile.UserId == userId && profile.DisplayName == CurrentUserEmail),
             Arg.Any<CancellationToken>());
         await MockObjectStorage.DidNotReceive().CreateUploadUrlAsync(
             Arg.Any<string>(),
@@ -92,7 +93,8 @@ public class WhenTestingCreatePhotographUpload : BaseProfileServiceTest
         result.Value.ObjectKey.Should().Be(objectKey);
         result.Value.UploadUrl.Should().Be("https://storage.test/upload");
         await MockProfileRepository.Received(1).UpsertAsync(
-            Arg.Is<Profile>(profile => profile.UserId == userId),
+            Arg.Is<Profile>(profile =>
+                profile.UserId == userId && profile.DisplayName == CurrentUserEmail),
             Arg.Any<CancellationToken>());
         await MockObjectStorage.Received(1).CreateUploadUrlAsync(
             objectKey,

--- a/tests/FishingLogBook.Application.Tests/Profiles/Services/ProfileServiceTests/WhenTestingGetPublic.cs
+++ b/tests/FishingLogBook.Application.Tests/Profiles/Services/ProfileServiceTests/WhenTestingGetPublic.cs
@@ -159,6 +159,26 @@ public class WhenTestingGetPublic : BaseProfileServiceTest
     }
 
     [Fact]
+    public async Task ItShouldOmitAnEmailFallbackDisplayNameWhenShowDisplayNameIsFalse()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        StubVisibleProfile(userId, profile => profile.WithDisplayName("angler@example.test").HideDisplayName());
+
+        // Act
+        var result = await Sut.GetPublicAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.DisplayName.Should().BeNull();
+        result.Value.HomeRegion.Should().Be("Westmeath");
+        await MockProfileRepository.Received(1).GetByUserIdAsync(userId, Arg.Any<CancellationToken>());
+        await MockProfileRepository.DidNotReceive().UpsertAsync(
+            Arg.Any<Profile>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldOmitPhotographWhenShowPhotographIsFalse()
     {
         // Arrange

--- a/tests/FishingLogBook.Application.Tests/Profiles/Services/ProfileServiceTests/WhenTestingUpdateOwn.cs
+++ b/tests/FishingLogBook.Application.Tests/Profiles/Services/ProfileServiceTests/WhenTestingUpdateOwn.cs
@@ -209,14 +209,109 @@ public class WhenTestingUpdateOwn : BaseProfileServiceTest
             Arg.Any<CancellationToken>());
     }
 
-    private static UpdateProfileArgs ValidArgs(Guid userId)
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ItShouldStoreTheAuthenticatedEmailWhenDisplayNameIsBlank(string? displayName)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var args = ValidArgs(userId, displayName);
+        MockProfileRepository
+            .GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(null));
+        MockProfileRepository
+            .UpsertAsync(Arg.Any<Profile>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(call.ArgAt<Profile>(0)));
+
+        // Act
+        var result = await Sut.UpdateOwnAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.DisplayName.Should().Be(CurrentUserEmail);
+        result.Value.ShowDisplayName.Should().BeTrue();
+        await MockProfileRepository.Received(1).UpsertAsync(
+            Arg.Is<Profile>(profile =>
+                profile.UserId == userId
+                && profile.DisplayName == CurrentUserEmail
+                && profile.ShowDisplayName),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ItShouldKeepAnExistingNonBlankDisplayNameWhenTheSubmittedValueIsBlank(string? displayName)
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var existing = new ProfileBuilder()
+            .WithUserId(userId)
+            .WithDisplayName("Eamonn")
+            .Build();
+        var args = ValidArgs(userId, displayName);
+        MockProfileRepository
+            .GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(existing));
+        MockProfileRepository
+            .UpsertAsync(Arg.Any<Profile>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(call.ArgAt<Profile>(0)));
+
+        // Act
+        var result = await Sut.UpdateOwnAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.DisplayName.Should().Be("Eamonn");
+        await MockProfileRepository.Received(1).UpsertAsync(
+            Arg.Is<Profile>(profile =>
+                profile.UserId == userId
+                && profile.DisplayName == "Eamonn"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotChangeShowDisplayNameWhenStoringTheEmailFallback()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var args = ValidArgs(userId, displayName: null, showDisplayName: false);
+        MockProfileRepository
+            .GetByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<Profile?>(null));
+        MockProfileRepository
+            .UpsertAsync(Arg.Any<Profile>(), Arg.Any<CancellationToken>())
+            .Returns(call => Result.Ok(call.ArgAt<Profile>(0)));
+
+        // Act
+        var result = await Sut.UpdateOwnAsync(args, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.DisplayName.Should().Be(CurrentUserEmail);
+        result.Value.ShowDisplayName.Should().BeFalse();
+        await MockProfileRepository.Received(1).UpsertAsync(
+            Arg.Is<Profile>(profile =>
+                profile.UserId == userId
+                && profile.DisplayName == CurrentUserEmail
+                && !profile.ShowDisplayName),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static UpdateProfileArgs ValidArgs(
+        Guid userId,
+        string? displayName = "Eamonn",
+        bool showDisplayName = true)
     {
         return new UpdateProfileArgs
         {
             UserId = userId,
-            DisplayName = "Eamonn",
+            DisplayName = displayName,
             HomeRegion = "Westmeath",
-            ShowDisplayName = true,
+            ShowDisplayName = showDisplayName,
             ShowPhotograph = false,
             ShowHomeRegion = true,
             ShowPreferredFishingMethods = true,

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/BaseOnboardingTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/BaseOnboardingTest.cs
@@ -1,0 +1,100 @@
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Install;
+using FishingLogBook.Web.Browser.Location;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Onboarding.Services;
+using FishingLogBook.Web.Features.Profile.Clients;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+using OnboardingPage = FishingLogBook.Web.Features.Onboarding.Pages.Onboarding.Onboarding;
+
+namespace FishingLogBook.Web.Tests.Features.Onboarding.Pages.OnboardingTests;
+
+public class BaseOnboardingTest
+{
+    protected static readonly Guid FlyMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    protected static readonly Guid SpinningMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000002");
+    protected static readonly Guid BrownTroutSpeciesId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
+
+    protected static async Task MoveToPreferencesAsync(IRenderedComponent<OnboardingPage> cut)
+    {
+        cut.WaitForAssertion(() => cut.Find("#onboarding-next"));
+        await cut.Find("#onboarding-next").ClickAsync();
+        cut.WaitForAssertion(() => cut.Find("#onboarding-method-chips"));
+    }
+
+    protected static FishingPreferencesDto ValidPreferences()
+    {
+        return new FishingPreferencesDto(
+        [
+            new FishingMethodPreferenceDto(
+                FlyMethodId,
+                "Fly",
+                "Fly",
+                true,
+                [new FishingSpeciesPreferenceDto(BrownTroutSpeciesId, "BrownTrout", "Brown Trout", true)])
+        ]);
+    }
+
+    protected static Fixture CreateFixture(
+        FishingPreferencesDto savedPreferences,
+        bool isCompleted = false,
+        InstallState? installState = null,
+        InstallResult installResult = InstallResult.Unavailable)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        context.Services.AddSingleton(Substitute.For<IModalService>());
+
+        var onboarding = Substitute.For<IOnboardingService>();
+        onboarding.IsCompletedAsync(Arg.Any<CancellationToken>()).Returns(isCompleted);
+        context.Services.AddSingleton(onboarding);
+
+        var profileDto = new ProfileDto(
+            Guid.NewGuid(), null, null, null, null, null, true, false, false, false, false);
+        var profile = Substitute.For<IProfileClient>();
+        profile.GetOwnAsync(Arg.Any<CancellationToken>()).Returns(profileDto);
+        profile.UpdateOwnAsync(Arg.Any<UpdateProfileDto>(), Arg.Any<CancellationToken>()).Returns(profileDto);
+        context.Services.AddSingleton(profile);
+
+        var preferences = Substitute.For<IFishingPreferenceClient>();
+        preferences.GetCatalogueAsync(Arg.Any<CancellationToken>()).Returns(new FishingCatalogueDto(
+            [
+                new FishingMethodDto(FlyMethodId, "Fly", "Fly"),
+                new FishingMethodDto(SpinningMethodId, "Spinning", "Spinning")
+            ],
+            [new SpeciesDto(BrownTroutSpeciesId, "BrownTrout", "Brown Trout")]));
+        preferences.GetPreferencesAsync(Arg.Any<CancellationToken>()).Returns(savedPreferences);
+        preferences.UpdatePreferencesAsync(
+                Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>())
+            .Returns(savedPreferences);
+        context.Services.AddSingleton(preferences);
+
+        var install = Substitute.For<IInstallService>();
+        install.GetStateAsync(Arg.Any<CancellationToken>())
+            .Returns(installState ?? InstallState.Unknown);
+        install.PromptAsync(Arg.Any<CancellationToken>()).Returns(installResult);
+        context.Services.AddSingleton(install);
+        context.Services.AddSingleton(Substitute.For<ILocationService>());
+        context.Services.AddSingleton(Substitute.For<ILoggingService>());
+        context.AddAuthorization().SetAuthorized("tester@example.test");
+        return new Fixture(context, onboarding, profile, preferences, install);
+    }
+
+    protected sealed record Fixture(
+        BunitContext Context,
+        IOnboardingService Onboarding,
+        IProfileClient Profile,
+        IFishingPreferenceClient Preferences,
+        IInstallService Install) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => Context.DisposeAsync();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingDisplayName.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingDisplayName.cs
@@ -1,0 +1,91 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using OnboardingPage = FishingLogBook.Web.Features.Onboarding.Pages.Onboarding.Onboarding;
+
+namespace FishingLogBook.Web.Tests.Features.Onboarding.Pages.OnboardingTests;
+
+public class WhenTestingDisplayName : BaseOnboardingTest
+{
+    [Fact]
+    public async Task ItShouldRenderTheDisplayNameHelpOnTheWelcomeStep()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(ValidPreferences());
+
+        // Act
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#onboarding-display-name").Should().NotBeNull();
+            cut.Find("#onboarding-display-name-help").GetAttribute("aria-label")
+                .Should().Be("Other anglers may see this name. If left blank, your email address will be used.");
+        });
+        await fixture.Profile.DidNotReceive().UpdateOwnAsync(
+            Arg.Any<UpdateProfileDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLocaliseTheDisplayNameHelp()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        await using var fixture = CreateFixture(ValidPreferences());
+
+        // Act
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#onboarding-display-name-help").GetAttribute("aria-label")
+                .Should().Be("Les autres pêcheurs pourront voir ce nom. S’il est laissé vide, votre adresse e-mail sera utilisée."));
+    }
+
+    [Fact]
+    public async Task ItShouldSendTheEnteredDisplayNameWhenPreferencesAreSaved()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(ValidPreferences());
+        var cut = fixture.Context.Render<OnboardingPage>();
+        cut.WaitForAssertion(() => cut.Find("#onboarding-display-name"));
+        cut.Find("#onboarding-display-name").Input("River Eamonn");
+
+        // Act
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#onboarding-allow-location").Should().NotBeNull());
+        await fixture.Profile.Received(1).UpdateOwnAsync(
+            Arg.Is<UpdateProfileDto>(profile => profile.DisplayName == "River Eamonn"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSendABlankDisplayNameRatherThanApplyingTheEmailFallbackInTheUi()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var fixture = CreateFixture(ValidPreferences());
+        var cut = fixture.Context.Render<OnboardingPage>();
+
+        // Act
+        await MoveToPreferencesAsync(cut);
+        await cut.Find("#onboarding-next").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#onboarding-allow-location").Should().NotBeNull());
+        await fixture.Profile.Received(1).UpdateOwnAsync(
+            Arg.Is<UpdateProfileDto>(profile =>
+                string.IsNullOrWhiteSpace(profile.DisplayName)
+                && profile.DisplayName != "tester@example.test"),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Onboarding/Pages/OnboardingTests/WhenTestingPreferences.cs
@@ -16,12 +16,8 @@ using OnboardingPage = FishingLogBook.Web.Features.Onboarding.Pages.Onboarding.O
 
 namespace FishingLogBook.Web.Tests.Features.Onboarding.Pages.OnboardingTests;
 
-public class WhenTestingPreferences
+public class WhenTestingPreferences : BaseOnboardingTest
 {
-    private static readonly Guid FlyMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
-    private static readonly Guid SpinningMethodId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000002");
-    private static readonly Guid BrownTroutSpeciesId = Guid.Parse("cccccccc-0000-0000-0000-000000000001");
-
     [Fact]
     public async Task ItShouldUseTheReusableMultiSelectWithExistingMethodsSelected()
     {
@@ -348,31 +344,11 @@ public class WhenTestingPreferences
         return context;
     }
 
-    private static async Task MoveToPreferencesAsync(IRenderedComponent<OnboardingPage> cut)
-    {
-        cut.WaitForAssertion(() => cut.Find("#onboarding-next"));
-        await cut.Find("#onboarding-next").ClickAsync();
-        cut.WaitForAssertion(() => cut.Find("#onboarding-method-chips"));
-    }
-
     private static FishingPreferencesDto PreferencesWithoutSpecies(string methodName = "Fly")
     {
         return new FishingPreferencesDto(
         [
             new FishingMethodPreferenceDto(FlyMethodId, "Fly", methodName, true, [])
-        ]);
-    }
-
-    private static FishingPreferencesDto ValidPreferences()
-    {
-        return new FishingPreferencesDto(
-        [
-            new FishingMethodPreferenceDto(
-                FlyMethodId,
-                "Fly",
-                "Fly",
-                true,
-                [new FishingSpeciesPreferenceDto(BrownTroutSpeciesId, "BrownTrout", "Brown Trout", true)])
         ]);
     }
 
@@ -390,62 +366,5 @@ public class WhenTestingPreferences
                 false,
                 spinningHasSpecies ? [species] : [])
         ]);
-    }
-
-    private static Fixture CreateFixture(
-        FishingPreferencesDto savedPreferences,
-        bool isCompleted = false,
-        InstallState? installState = null,
-        InstallResult installResult = InstallResult.Unavailable)
-    {
-        var context = new BunitContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        context.Services.AddMudServices();
-        context.Services.AddLocalization();
-        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
-        context.Services.AddSingleton(Substitute.For<IModalService>());
-
-        var onboarding = Substitute.For<IOnboardingService>();
-        onboarding.IsCompletedAsync(Arg.Any<CancellationToken>()).Returns(isCompleted);
-        context.Services.AddSingleton(onboarding);
-
-        var profileDto = new ProfileDto(
-            Guid.NewGuid(), null, null, null, null, null, true, false, false, false, false);
-        var profile = Substitute.For<IProfileClient>();
-        profile.GetOwnAsync(Arg.Any<CancellationToken>()).Returns(profileDto);
-        profile.UpdateOwnAsync(Arg.Any<UpdateProfileDto>(), Arg.Any<CancellationToken>()).Returns(profileDto);
-        context.Services.AddSingleton(profile);
-
-        var preferences = Substitute.For<IFishingPreferenceClient>();
-        preferences.GetCatalogueAsync(Arg.Any<CancellationToken>()).Returns(new FishingCatalogueDto(
-            [
-                new FishingMethodDto(FlyMethodId, "Fly", "Fly"),
-                new FishingMethodDto(SpinningMethodId, "Spinning", "Spinning")
-            ],
-            [new SpeciesDto(BrownTroutSpeciesId, "BrownTrout", "Brown Trout")]));
-        preferences.GetPreferencesAsync(Arg.Any<CancellationToken>()).Returns(savedPreferences);
-        preferences.UpdatePreferencesAsync(
-                Arg.Any<UpdateFishingPreferencesDto>(), Arg.Any<CancellationToken>())
-            .Returns(savedPreferences);
-        context.Services.AddSingleton(preferences);
-
-        var install = Substitute.For<IInstallService>();
-        install.GetStateAsync(Arg.Any<CancellationToken>())
-            .Returns(installState ?? InstallState.Unknown);
-        install.PromptAsync(Arg.Any<CancellationToken>()).Returns(installResult);
-        context.Services.AddSingleton(install);
-        context.Services.AddSingleton(Substitute.For<ILocationService>());
-        context.Services.AddSingleton(Substitute.For<ILoggingService>());
-        context.AddAuthorization().SetAuthorized("tester@example.test");
-        return new Fixture(context, onboarding, preferences, install);
-    }
-
-    private sealed record Fixture(
-        BunitContext Context,
-        IOnboardingService Onboarding,
-        IFishingPreferenceClient Preferences,
-        IInstallService Install) : IAsyncDisposable
-    {
-        public ValueTask DisposeAsync() => Context.DisposeAsync();
     }
 }


### PR DESCRIPTION
## Summary
- Persist the signed-in user's email as `DisplayName` when a profile is created or updated with a null, empty, or whitespace name.
- Keep an existing non-blank `DisplayName` if the submitted value is blank; do not change `ShowDisplayName`.
- Add a Display Name field on onboarding Welcome, with a compact info tooltip explaining that other anglers may see the name and that email is the fallback if it is left blank.

Closes #200

## Test plan
- [ ] Leave Display Name blank during onboarding, complete preferences save, and confirm the stored profile uses the account email.
- [ ] Enter a display name during onboarding and confirm that value is stored.
- [ ] Confirm `Show display name to other anglers` off still hides the stored name (including an email fallback) on the public profile.
- [ ] Confirm trip collaboration still shows stored collaborator names from #197 / PR #198.

## Self review
- Issue/AC: PASS. Blank/whitespace DisplayName stores email; supplied name is kept; existing non-blank name is not replaced; ShowDisplayName is unchanged; onboarding shows the info icon/help; fallback lives in `ProfileService`, not the UI.
- Architecture/CQRS: PASS. Endpoint → handler → `IProfileService` is unchanged. Fallback uses `ICurrentUser.Email`. `DescribeAsync` / public search gating from PR #198 is untouched.
- Rules: PASS. Feature folder, localisation EN/FR, `WhenTesting` layout, `Received(n)` on service/API tests.
- Security/privacy: PASS. Email is stored as DisplayName only. Public profile still omits DisplayName when `ShowDisplayName` is false.
- Database/migrations: N/A. No schema change. No migration apply after merge.
- Tests/coverage: PASS. Application, API, and onboarding bUnit coverage as specified.
- Browser: N/A. Authenticated onboarding is Cognito/OIDC; covered by bUnit plus API/application tests.
- Web/UI/localisation: PASS. EN/FR help text; ids `onboarding-display-name` and `onboarding-display-name-help`.
- Code smells: PASS. Small `ResolveDisplayName` helper; no onboarding redesign.
- CI/deployment: PASS. No Terraform, secrets, or migration apply after merge.

Remaining deliberate gaps:
- Playwright does not cover authenticated onboarding.
- Profile page does not get the same info icon; the ticket asked for onboarding only.