### PR TITLE
FLB#201 | add a read-only catch view so trip collaborators can see ot…

### DIFF
--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchView/CatchView.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchView/CatchView.razor
@@ -1,0 +1,111 @@
+@page "/catches/{CatchId:guid}"
+@using Microsoft.AspNetCore.Authorization
+@using FishingLogBook.Web.Features.Photographs.Components.PhotographCarousel
+@attribute [Authorize]
+
+<PageTitle>@Loc["Catch_ViewPageTitle"]</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Gutters="false" Class="catch-view-container">
+    <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
+        <MudText Typo="Typo.h4" Align="Align.Center" id="catch-view-title">@Loc["Catch_ViewTitle"]</MudText>
+
+        @if (_loadFailed)
+        {
+            <MudAlert Severity="Severity.Error" id="catch-view-load-failed">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Justify="Justify.SpaceBetween">
+                    <span>@Loc["Catch_ViewLoadFailed"]</span>
+                    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Small"
+                               OnClick="RetryLoadAsync" Disabled="_isLoading"
+                               id="catch-view-load-retry">@Loc["Catch_LoadRetry"]</MudButton>
+                </MudStack>
+            </MudAlert>
+        }
+        else if (_isLoading)
+        {
+            <MudProgressCircular Indeterminate="true" Color="Color.Primary" Class="align-self-center" id="catch-view-loading" />
+        }
+        else if (_catch is not null)
+        {
+            <MudPaper Class="pa-4" Elevation="2" id="catch-view-details">
+                <MudStack Spacing="4">
+                    <PhotographCarousel Photographs="CarouselPhotographs"
+                                        IdPrefix="catch-view" />
+
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_EditSpecies"]</MudText>
+                        <MudText Typo="Typo.h6" id="catch-view-species">@SpeciesLabel</MudText>
+                    </MudStack>
+
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_EditCaughtOn"]</MudText>
+                        <MudText Typo="Typo.body1" id="catch-view-caught-on">@CaughtOnLabel</MudText>
+                    </MudStack>
+
+                    @if (WeightLabel is not null)
+                    {
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_EditWeight"]</MudText>
+                            <MudText Typo="Typo.body1" id="catch-view-weight">@WeightLabel</MudText>
+                        </MudStack>
+                    }
+
+                    @if (LengthLabel is not null)
+                    {
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_EditLength"]</MudText>
+                            <MudText Typo="Typo.body1" id="catch-view-length">@LengthLabel</MudText>
+                        </MudStack>
+                    }
+
+                    @if (HasMethod)
+                    {
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_EditMethod"]</MudText>
+                            <MudText Typo="Typo.body1" id="catch-view-method">@_catch.Method</MudText>
+                        </MudStack>
+                    }
+
+                    @if (HasBaitOrLure)
+                    {
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_EditBaitOrLure"]</MudText>
+                            <MudText Typo="Typo.body1" id="catch-view-bait">@_catch.BaitOrLure</MudText>
+                        </MudStack>
+                    }
+
+                    @if (HasNotes)
+                    {
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_EditNotes"]</MudText>
+                            <MudText Typo="Typo.body1" id="catch-view-notes">@_catch.Notes</MudText>
+                        </MudStack>
+                    }
+
+                    @if (HasAnglerName)
+                    {
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_CaughtByLabel"]</MudText>
+                            <MudText Typo="Typo.body1" id="catch-view-caught-by">@_catch.AnglerName</MudText>
+                        </MudStack>
+                    }
+
+                    @if (HasRecordedByName)
+                    {
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_RecordedByLabel"]</MudText>
+                            <MudText Typo="Typo.body1" id="catch-view-recorded-by">@_catch.RecordedByName</MudText>
+                        </MudStack>
+                    }
+
+                    @if (LocationLabel is not null)
+                    {
+                        <MudStack Spacing="0">
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">@Loc["Catch_ViewLocation"]</MudText>
+                            <MudText Typo="Typo.body1" id="catch-view-location">@LocationLabel</MudText>
+                        </MudStack>
+                    }
+                </MudStack>
+            </MudPaper>
+        }
+    </MudStack>
+</MudContainer>

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchView/CatchView.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchView/CatchView.razor.cs
@@ -1,0 +1,244 @@
+using System.Globalization;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Photographs.Models;
+using FishingLogBook.Web.Features.Profile.Models;
+using FishingLogBook.Web.Features.Profile.Providers;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Catch.Pages.CatchView;
+
+public partial class CatchView : ComponentBase, IDisposable
+{
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+    private CatchViewDto? _catch;
+    private string? _caughtOnLabel;
+    private WeightUnitEnum _weightUnit = WeightUnitEnum.Kg;
+    private LengthUnitEnum _lengthUnit = LengthUnitEnum.Cm;
+    private bool _isLoading = true;
+    private bool _loadFailed;
+
+    [Parameter]
+    public Guid CatchId { get; set; }
+
+    [Inject]
+    private ICatchClient CatchClient { get; set; } = default!;
+
+    [Inject]
+    private IAnglerPreferencesProvider AnglerPreferences { get; set; } = default!;
+
+    [Inject]
+    private IMeasurementService Measurement { get; set; } = default!;
+
+    [Inject]
+    private ITimeService Time { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private IReadOnlyList<PhotographCarouselItemModel> CarouselPhotographs =>
+        _catch is null
+            ? []
+            : _catch.Photographs
+                .Select(photograph => new PhotographCarouselItemModel(
+                    photograph.Id,
+                    photograph.ContentType,
+                    RemoteUrl: photograph.Url))
+                .ToArray();
+
+    private string SpeciesLabel => string.IsNullOrWhiteSpace(_catch?.SpeciesName)
+        ? Loc["Catch_UnknownSpecies"]
+        : _catch.SpeciesName;
+
+    private string CaughtOnLabel => _caughtOnLabel
+        ?? _catch?.CaughtOn.ToString("g", CultureInfo.CurrentCulture)
+        ?? string.Empty;
+
+    private string? WeightLabel
+    {
+        get
+        {
+            var weight = Measurement.ToDisplayWeight(_catch?.Weight, _weightUnit);
+            return weight is null
+                ? null
+                : $"{weight.Value.ToString("0.##", CultureInfo.CurrentCulture)} {WeightUnitLabel}";
+        }
+    }
+
+    private string? LengthLabel
+    {
+        get
+        {
+            var length = Measurement.ToDisplayLength(_catch?.Length, _lengthUnit);
+            return length is null
+                ? null
+                : $"{length.Value.ToString("0.##", CultureInfo.CurrentCulture)} {LengthUnitLabel}";
+        }
+    }
+
+    private string WeightUnitLabel => _weightUnit == WeightUnitEnum.Lb
+        ? Loc["Catch_WeightUnitShort_Lb"]
+        : Loc["Catch_WeightUnitShort_Kg"];
+
+    private string LengthUnitLabel => _lengthUnit == LengthUnitEnum.In
+        ? Loc["Catch_LengthUnitShort_In"]
+        : Loc["Catch_LengthUnitShort_Cm"];
+
+    private bool HasMethod => !string.IsNullOrWhiteSpace(_catch?.Method);
+
+    private bool HasBaitOrLure => !string.IsNullOrWhiteSpace(_catch?.BaitOrLure);
+
+    private bool HasNotes => !string.IsNullOrWhiteSpace(_catch?.Notes);
+
+    private bool HasAnglerName => !string.IsNullOrWhiteSpace(_catch?.AnglerName);
+
+    private bool HasRecordedByName =>
+        !string.IsNullOrWhiteSpace(_catch?.RecordedByName)
+        && _catch.RecordedByUserId != _catch.AnglerUserId;
+
+    private string? LocationLabel
+    {
+        get
+        {
+            var location = _catch?.Location;
+            if (location is null)
+            {
+                return null;
+            }
+
+            if (location.Latitude is { } latitude && location.Longitude is { } longitude)
+            {
+                return FormatCoordinates(latitude, longitude);
+            }
+
+            if (location.ApproximateLatitude is { } approximateLatitude
+                && location.ApproximateLongitude is { } approximateLongitude)
+            {
+                return FormatCoordinates(approximateLatitude, approximateLongitude);
+            }
+
+            return string.IsNullOrWhiteSpace(location.FishingVenueName)
+                ? null
+                : location.FishingVenueName;
+        }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task RetryLoadAsync()
+    {
+        if (_isLoading)
+        {
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _loadFailed = false;
+        _catch = null;
+        _caughtOnLabel = null;
+        try
+        {
+            var catchRecord = await CatchClient.GetAsync(CatchId, _cancellationTokenSource.Token);
+            if (catchRecord is null)
+            {
+                _loadFailed = true;
+                return;
+            }
+
+            _catch = catchRecord;
+            await LoadPreferencesAsync();
+            await RememberCaughtOnAsync(catchRecord.CaughtOn);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("loading a catch", exception, CancellationToken.None);
+            _loadFailed = true;
+            _catch = null;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task LoadPreferencesAsync()
+    {
+        try
+        {
+            var preferences = await AnglerPreferences.GetAsync(_cancellationTokenSource.Token);
+            ApplyPreferences(preferences);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("loading catch view preferences", exception, CancellationToken.None);
+            ApplyPreferences(AnglerPreferencesModel.Empty);
+        }
+    }
+
+    private void ApplyPreferences(AnglerPreferencesModel preferences)
+    {
+        _weightUnit = preferences.WeightUnit;
+        _lengthUnit = preferences.LengthUnit;
+    }
+
+    private async Task RememberCaughtOnAsync(DateTimeOffset caughtOn)
+    {
+        try
+        {
+            var localValue = await Time.ToDateTimeLocalValueAsync(caughtOn, _cancellationTokenSource.Token);
+            _caughtOnLabel = DateTime.TryParseExact(
+                localValue,
+                "yyyy-MM-ddTHH:mm",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var parsed)
+                ? parsed.ToString("g", CultureInfo.CurrentCulture)
+                : caughtOn.ToString("g", CultureInfo.CurrentCulture);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("reading a catch view time", exception, CancellationToken.None);
+            _caughtOnLabel = caughtOn.ToString("g", CultureInfo.CurrentCulture);
+        }
+    }
+
+    private static string FormatCoordinates(double latitude, double longitude)
+    {
+        return $"{latitude.ToString("0.#####", CultureInfo.CurrentCulture)}, {longitude.ToString("0.#####", CultureInfo.CurrentCulture)}";
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchView/CatchView.razor.css
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchView/CatchView.razor.css
@@ -1,0 +1,3 @@
+.catch-view-container {
+    padding-top: 1rem;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripTimeline/TripTimeline.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripTimeline/TripTimeline.razor.cs
@@ -268,7 +268,20 @@ public partial class TripTimeline : ComponentBase, IDisposable
 
     private string? CatchHref(TripTimelineItemModel item)
     {
-        return item.CatchId is { } catchId ? $"{CatchBaseHref}/{catchId:D}/edit" : null;
+        if (item.CatchId is not { } catchId)
+        {
+            return null;
+        }
+
+        return CanEditCatch(item)
+            ? $"{CatchBaseHref}/{catchId:D}/edit"
+            : $"/catches/{catchId:D}";
+    }
+
+    private bool CanEditCatch(TripTimelineItemModel item)
+    {
+        return item.ContributedByUserId == ViewerUserId
+            || item.RecordedByUserId == ViewerUserId;
     }
 
     private static DateTime? ParseLocalValue(string value)

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -621,6 +621,18 @@
   <data name="Catch_EditLoadOfflineFailed" xml:space="preserve">
     <value>Cette prise n'est pas encore enregistrée sur cet appareil. Connectez-vous à Internet et réessayez.</value>
   </data>
+  <data name="Catch_ViewPageTitle" xml:space="preserve">
+    <value>FishingLogBook - Prise</value>
+  </data>
+  <data name="Catch_ViewTitle" xml:space="preserve">
+    <value>Prise</value>
+  </data>
+  <data name="Catch_ViewLoadFailed" xml:space="preserve">
+    <value>Cette prise n'a pas pu être chargée.</value>
+  </data>
+  <data name="Catch_ViewLocation" xml:space="preserve">
+    <value>Lieu</value>
+  </data>
   <data name="Catch_LocationPrivacyPageTitle" xml:space="preserve">
     <value>FishingLogBook - Confidentialité de la localisation</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -621,6 +621,18 @@
   <data name="Catch_EditLoadOfflineFailed" xml:space="preserve">
     <value>This catch isn't saved on this device yet. Connect to the internet and try again.</value>
   </data>
+  <data name="Catch_ViewPageTitle" xml:space="preserve">
+    <value>FishingLogBook - Catch</value>
+  </data>
+  <data name="Catch_ViewTitle" xml:space="preserve">
+    <value>Catch</value>
+  </data>
+  <data name="Catch_ViewLoadFailed" xml:space="preserve">
+    <value>This catch could not be loaded.</value>
+  </data>
+  <data name="Catch_ViewLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
   <data name="Catch_LocationPrivacyPageTitle" xml:space="preserve">
     <value>FishingLogBook - Location privacy</value>
   </data>

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchViewTests/BaseCatchViewTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchViewTests/BaseCatchViewTest.cs
@@ -1,0 +1,112 @@
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Time;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Profile.Models;
+using FishingLogBook.Web.Features.Profile.Providers;
+using FishingLogBook.Web.Localization;
+using FishingLogBook.Web.Tests.TestSupport;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchViewTests;
+
+public class BaseCatchViewTest
+{
+    protected static readonly Guid CatchId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    protected static readonly Guid PhotographId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+    protected static readonly Guid OwnerUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid AnglerUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected static readonly Guid RecorderUserId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    protected static readonly DateTimeOffset CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z");
+
+    protected static BunitContext CreateContext(
+        ICatchClient catchClient,
+        IAnglerPreferencesProvider? preferences = null,
+        ITimeService? time = null,
+        ILoggingService? logging = null)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(catchClient);
+        context.Services.AddSingleton(preferences ?? QuietPreferences());
+        context.Services.AddSingleton(time ?? TestTimeService.WithOffset(TimeSpan.Zero));
+        context.Services.AddSingleton(logging ?? QuietLogging());
+        context.Services.AddSingleton<IMeasurementService>(new MeasurementService());
+        context.Services.AddSingleton(Substitute.For<ICultureService>());
+        context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
+        var authorization = context.AddAuthorization();
+        authorization.SetAuthorized("tester@example.test");
+        return context;
+    }
+
+    protected static IAnglerPreferencesProvider QuietPreferences(
+        WeightUnitEnum weightUnit = WeightUnitEnum.Kg,
+        LengthUnitEnum lengthUnit = LengthUnitEnum.Cm)
+    {
+        var provider = Substitute.For<IAnglerPreferencesProvider>();
+        provider.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(new AnglerPreferencesModel(
+                new FishingCatalogueDto([], []),
+                new FishingPreferencesDto([]),
+                weightUnit,
+                lengthUnit));
+        return provider;
+    }
+
+    protected static ILoggingService QuietLogging()
+    {
+        var logging = Substitute.For<ILoggingService>();
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return logging;
+    }
+
+    protected static ICatchClient ClientReturning(CatchViewDto? catchRecord)
+    {
+        var client = Substitute.For<ICatchClient>();
+        client.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(catchRecord);
+        return client;
+    }
+
+    protected static CatchViewDto ViewDto(
+        string? speciesName = "Brown Trout",
+        decimal? weight = 1.02m,
+        decimal? length = 48m,
+        string? method = "Fly",
+        string? baitOrLure = "Mayfly",
+        string? notes = "Took on the drift.",
+        string? anglerName = "Mark",
+        string? recordedByName = "Eamonn",
+        CatchLocationExposureDto? location = null,
+        IReadOnlyList<CatchPhotographViewDto>? photographs = null)
+    {
+        return new CatchViewDto(CatchId, OwnerUserId, CaughtOn, location)
+        {
+            AnglerUserId = AnglerUserId,
+            AnglerName = anglerName,
+            RecordedByUserId = RecorderUserId,
+            RecordedByName = recordedByName,
+            SpeciesName = speciesName,
+            Weight = weight,
+            Length = length,
+            Method = method,
+            BaitOrLure = baitOrLure,
+            Notes = notes,
+            Photographs = photographs ??
+            [
+                new CatchPhotographViewDto(
+                    PhotographId,
+                    PhotographContentTypeConstants.Jpeg,
+                    "https://storage.test/catch.jpg")
+            ]
+        };
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchViewTests/WhenTestingLoad.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchViewTests/WhenTestingLoad.cs
@@ -1,0 +1,160 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Pages.CatchView;
+using FishingLogBook.Web.Features.Profile.Providers;
+using FishingLogBook.Web.Localization;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchViewTests;
+
+public class WhenTestingLoad : BaseCatchViewTest
+{
+    [Fact]
+    public async Task ItShouldShowLoadFailureWhenTheClientFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAsync(CatchId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("offline"));
+        var preferences = QuietPreferences();
+        var logging = QuietLogging();
+        await using var context = CreateContext(catchClient, preferences, logging: logging);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-view-load-failed").TextContent.Should().Contain("This catch could not be loaded."));
+        cut.FindAll("#catch-view-details").Should().BeEmpty();
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+        await preferences.DidNotReceive().GetAsync(Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "loading a catch",
+            Arg.Any<HttpRequestException>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowLoadFailureWhenTheCatchIsMissing()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchClient = ClientReturning(null);
+        var preferences = QuietPreferences();
+        var logging = QuietLogging();
+        await using var context = CreateContext(catchClient, preferences, logging: logging);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-view-load-failed").TextContent.Should().Contain("This catch could not be loaded."));
+        cut.Find("#catch-view-load-retry").Should().NotBeNull();
+        cut.FindAll("#catch-view-details").Should().BeEmpty();
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+        await preferences.DidNotReceive().GetAsync(Arg.Any<CancellationToken>());
+        await logging.DidNotReceive().LogErrorAsync(
+            Arg.Any<string>(),
+            Arg.Any<Exception>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchLoadFailureCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var catchClient = ClientReturning(null);
+        await using var context = CreateContext(catchClient);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-view-load-failed").TextContent.Should()
+                .Contain("Cette prise n'a pas pu être chargée."));
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowLoadingUntilTheCatchIsLoaded()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var loadStarted = new TaskCompletionSource();
+        var loadContinue = new TaskCompletionSource<CatchViewDto?>();
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAsync(CatchId, Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                loadStarted.TrySetResult();
+                return await loadContinue.Task;
+            });
+        await using var context = CreateContext(catchClient);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+        await loadStarted.Task;
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-view-loading").Should().NotBeNull();
+            cut.FindAll("#catch-view-details").Should().BeEmpty();
+        });
+        loadContinue.SetResult(ViewDto());
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-view-species").TextContent.Should().Contain("Brown Trout");
+            cut.FindAll("#catch-view-loading").Should().BeEmpty();
+        });
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRetryLoadingTheCatch()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchClient = Substitute.For<ICatchClient>();
+        catchClient.GetAsync(CatchId, Arg.Any<CancellationToken>())
+            .Returns((CatchViewDto?)null, ViewDto());
+        await using var context = CreateContext(catchClient);
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-view-load-retry").Should().NotBeNull());
+
+        // Act
+        cut.Find("#catch-view-load-retry").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-view-species").TextContent.Should().Contain("Brown Trout"));
+        await catchClient.Received(2).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldLoadTheCatchFromGetAsync()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchClient = ClientReturning(ViewDto());
+        var preferences = QuietPreferences();
+        await using var context = CreateContext(catchClient, preferences);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-view-details").Should().NotBeNull());
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+        await preferences.Received(1).GetAsync(Arg.Any<CancellationToken>());
+        await catchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchViewTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchViewTests/WhenTestingRender.cs
@@ -1,0 +1,164 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Catch.Pages.CatchView;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.CatchViewTests;
+
+public class WhenTestingRender : BaseCatchViewTest
+{
+    [Fact]
+    public void ItShouldRequireAnAuthenticatedUser()
+    {
+        // Arrange
+        // Act
+        var authorize = typeof(CatchView)
+            .GetCustomAttributes(inherit: true)
+            .OfType<AuthorizeAttribute>()
+            .SingleOrDefault();
+
+        // Assert
+        authorize.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldNotOfferEditOrSaveControls()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchClient = ClientReturning(ViewDto());
+        await using var context = CreateContext(catchClient);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-view-details").Should().NotBeNull());
+        cut.FindAll("#catch-view-save").Should().BeEmpty();
+        cut.FindAll("#catch-edit-save").Should().BeEmpty();
+        cut.FindAll("#catch-view-photo-remove").Should().BeEmpty();
+        cut.Markup.Should().NotContain("Save details");
+        cut.Markup.Should().NotContain("Edit catch");
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+        await catchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await catchClient.DidNotReceive().DeletePhotographAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+        await catchClient.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+        await catchClient.DidNotReceive().CorrectAnglerAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<Guid>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldOmitLocationWhenTheApiHidesIt()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchClient = ClientReturning(ViewDto(
+            location: new CatchLocationExposureDto
+            {
+                Visibility = "Private",
+                Mode = "None"
+            }));
+        await using var context = CreateContext(catchClient);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-view-details").Should().NotBeNull());
+        cut.FindAll("#catch-view-location").Should().BeEmpty();
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRenderApproximateLocationWithoutExactCoordinates()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchClient = ClientReturning(ViewDto(
+            location: new CatchLocationExposureDto
+            {
+                Visibility = "Approximate",
+                Mode = "Approximate",
+                ApproximateLatitude = 53.25,
+                ApproximateLongitude = -7.75
+            }));
+        await using var context = CreateContext(catchClient);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#catch-view-location").TextContent.Should().Contain("53.25").And.Contain("-7.75"));
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRenderCatchDetails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchClient = ClientReturning(ViewDto(
+            location: new CatchLocationExposureDto
+            {
+                Visibility = "Public",
+                Mode = "Exact",
+                Latitude = 53.5,
+                Longitude = -7.9
+            }));
+        await using var context = CreateContext(catchClient);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-view-details").Should().NotBeNull());
+        cut.Find("#catch-view-title").TextContent.Should().Contain("Catch");
+        cut.Find("#catch-view-species").TextContent.Should().Contain("Brown Trout");
+        cut.Find("#catch-view-caught-on").TextContent.Should().Contain("17/08/2026").And.Contain("08:00");
+        cut.Find("#catch-view-weight").TextContent.Should().Contain("1.02").And.Contain("kg");
+        cut.Find("#catch-view-length").TextContent.Should().Contain("48").And.Contain("cm");
+        cut.Find("#catch-view-method").TextContent.Should().Contain("Fly");
+        cut.Find("#catch-view-bait").TextContent.Should().Contain("Mayfly");
+        cut.Find("#catch-view-notes").TextContent.Should().Contain("Took on the drift.");
+        cut.Find("#catch-view-caught-by").TextContent.Should().Contain("Mark");
+        cut.Find("#catch-view-recorded-by").TextContent.Should().Contain("Eamonn");
+        cut.Find("#catch-view-location").TextContent.Should().Contain("53.5").And.Contain("-7.9");
+        cut.Find("#catch-view-photo").GetAttribute("src").Should().Be("https://storage.test/catch.jpg");
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowFrenchCopy()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var catchClient = ClientReturning(ViewDto());
+        await using var context = CreateContext(catchClient);
+
+        // Act
+        var cut = context.Render<CatchView>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-view-title").TextContent.Should().Contain("Prise");
+            cut.Find("#catch-view-species").TextContent.Should().Contain("Brown Trout");
+        });
+        cut.Markup.Should().Contain("Espèce");
+        cut.Markup.Should().Contain("Attrapé par");
+        await catchClient.Received(1).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripTimelineTests/BaseTripTimelineTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripTimelineTests/BaseTripTimelineTest.cs
@@ -86,7 +86,9 @@ public class BaseTripTimelineTest
         Guid? photographId = null,
         string? photographUrl = null,
         decimal? weight = null,
-        decimal? length = null)
+        decimal? length = null,
+        Guid contributedByUserId = default,
+        Guid recordedByUserId = default)
     {
         return new TripTimelineItemModel(kind, occurredOn)
         {
@@ -98,7 +100,9 @@ public class BaseTripTimelineTest
             PhotographUrl = photographUrl,
             ContentType = PhotographContentTypeConstants.Jpeg,
             Weight = weight,
-            Length = length
+            Length = length,
+            ContributedByUserId = contributedByUserId,
+            RecordedByUserId = recordedByUserId
         };
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripTimelineTests/WhenTestingCatchRouting.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripTimelineTests/WhenTestingCatchRouting.cs
@@ -1,0 +1,94 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Trips.Components.TripTimeline;
+using FishingLogBook.Web.Features.Trips.Enums;
+using FishingLogBook.Web.Localization;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Components.TripTimelineTests;
+
+public class WhenTestingCatchRouting : BaseTripTimelineTest
+{
+    private static readonly Guid OtherUserId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public async Task ItShouldRouteTheViewersOwnCatchToEdit()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var cut = context.Render<TripTimeline>(parameters => parameters
+            .Add(
+                component => component.Items,
+                [
+                    Item(
+                        TripTimelineKindEnum.Catch,
+                        StartedOn.AddMinutes(30),
+                        "Pike",
+                        catchId: CatchId,
+                        contributedByUserId: OwnerUserId,
+                        recordedByUserId: OwnerUserId)
+                ])
+            .Add(component => component.ViewerUserId, OwnerUserId));
+
+        // Assert
+        cut.Find($"#trip-timeline-catch-{CatchId:D}-link").GetAttribute("href")
+            .Should().Be($"/catches/{CatchId:D}/edit");
+    }
+
+    [Fact]
+    public async Task ItShouldRouteACatchRecordedByTheViewerToEdit()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var cut = context.Render<TripTimeline>(parameters => parameters
+            .Add(
+                component => component.Items,
+                [
+                    Item(
+                        TripTimelineKindEnum.Catch,
+                        StartedOn.AddMinutes(30),
+                        "Pike",
+                        catchId: CatchId,
+                        contributedByUserId: OtherUserId,
+                        recordedByUserId: OwnerUserId)
+                ])
+            .Add(component => component.ViewerUserId, OwnerUserId));
+
+        // Assert
+        cut.Find($"#trip-timeline-catch-{CatchId:D}-link").GetAttribute("href")
+            .Should().Be($"/catches/{CatchId:D}/edit");
+    }
+
+    [Fact]
+    public async Task ItShouldRouteAnotherParticipantsCatchToTheReadOnlyView()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext();
+
+        // Act
+        var cut = context.Render<TripTimeline>(parameters => parameters
+            .Add(
+                component => component.Items,
+                [
+                    Item(
+                        TripTimelineKindEnum.Catch,
+                        StartedOn.AddMinutes(30),
+                        "Pike",
+                        catchId: CatchId,
+                        contributedByUserId: OtherUserId,
+                        recordedByUserId: OtherUserId)
+                ])
+            .Add(component => component.ViewerUserId, OwnerUserId)
+            .Add(component => component.CatchBaseHref, "/offline/catches"));
+
+        // Assert
+        cut.Find($"#trip-timeline-catch-{CatchId:D}-link").GetAttribute("href")
+            .Should().Be($"/catches/{CatchId:D}");
+    }
+}


### PR DESCRIPTION
Closes #201

## Summary
- Add an authenticated read-only catch page at `/catches/{CatchId}` that loads `CatchViewDto` from `ICatchClient.GetAsync` (`GET /api/catches/{catchId}`) and does not copy another participant’s catch into IndexedDB.
- Route TripTimeline catches the viewer caught or recorded to `/edit`, and every other participant’s catch to the read-only page. No extra API call is used for routing.
- Leave CatchEdit permissions, the write API, and logbook `/edit` links unchanged. Location is shown only as the GET DTO already exposes it.

## Test plan
- [ ] On a shared trip, tap a catch you caught or recorded → `/catches/{id}/edit`
- [ ] Tap a catch another participant caught and recorded → `/catches/{id}` (no edit/save/delete)
- [ ] Confirm photographs, species, time, measurements, method, bait, notes, angler, recorder, and any exposed location render
- [ ] Confirm a missing/failed load shows the read-only error state
- [ ] Confirm your own logbook catch cards still go to `/edit`

## Self review
- Issue/AC: PASS — dedicated view page, GET-only load, timeline routing, CatchEdit/write API untouched, location consumed from DTO
- Architecture/CQRS: PASS — Web-only; existing GET endpoint
- Rules: PASS — feature folder, three-file page, EN+FR, `WhenTesting` tests
- Security/privacy: PASS — `[Authorize]`; no privacy logic recreated in Blazor; no edit/save/delete
- Database/migrations: N/A
- Tests/coverage: PASS — timeline routing, load/render/error, no write calls; existing CatchEdit and CatchCard `/edit` tests still green
- Browser: N/A — authenticated Blazor; Playwright suite is IndexedDB/PWA, not Cognito. Remaining risk is real-browser layout. A testing-infrastructure ticket would be needed for authenticated Playwright
- Web/UI/localisation: PASS
- Code smells: PASS
- CI/deployment: PASS — no migration, Terraform, or env changes

Findings discovered during self-review:
1. GitHub MCP `issue_read` failed during implementation; reviewed against the issue text in chat
2. One Chromium `offline-shell` Playwright test timed out, then passed on retry — unrelated flake

Fixes made:
1. None required (no BLOCKER / SHOULD FIX)

Remaining deliberate gaps:
- Catch list `/edit` links left as-is (own logbook catches)
- Playwright omitted for this authenticated page
- Venue-only location still shows nothing if the API does not send a venue name (existing GET behaviour)