### PR TITLE
FLB#188 | harden catch privacy saves and offline load recovery agains…

### DIFF
--- a/src/FishingLogBook.Web/Features/Catch/Modals/LocationPrivacy/LocationPrivacyModal.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Modals/LocationPrivacy/LocationPrivacyModal.razor
@@ -76,6 +76,13 @@
                     </MudAlert>
                 }
 
+                @if (_queueFailed)
+                {
+                    <MudAlert Severity="Severity.Warning" id="catch-location-privacy-queue-failed">
+                        @Loc["Catch_LocationPrivacyQueueFailed"]
+                    </MudAlert>
+                }
+
                 @if (_saveFailed)
                 {
                     <MudAlert Severity="Severity.Error" id="catch-location-privacy-save-failed">

--- a/src/FishingLogBook.Web/Features/Catch/Modals/LocationPrivacy/LocationPrivacyModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Modals/LocationPrivacy/LocationPrivacyModal.razor.cs
@@ -5,6 +5,7 @@ using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -25,8 +26,6 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
     private bool _missingLocation;
     private bool _saveFailed;
     private bool _savedOnDevice;
-    private bool _restoreCatchSync;
-    private bool _restoreMetadataSync;
 
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = default!;
@@ -42,6 +41,9 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
 
     [Inject]
     private ILocalCatchOwnerService LocalCatchOwner { get; set; } = default!;
+
+    [Inject]
+    private ILoggingService Logging { get; set; } = default!;
 
     [Inject]
     private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
@@ -76,8 +78,12 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
 
             _visibility = _catch.Location.Visibility;
         }
-        catch (Exception)
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("loading catch location privacy", exception, CancellationToken.None);
             _loadFailed = true;
             _catch = null;
         }
@@ -121,6 +127,14 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
         {
             return;
         }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("saving catch location privacy", exception, CancellationToken.None);
+            if (!_savedOnDevice)
+            {
+                _saveFailed = true;
+            }
+        }
         finally
         {
             _isSaving = false;
@@ -133,22 +147,19 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
         {
             var updated = _catch! with
             {
-                Location = _catch.Location! with { Visibility = _visibility },
-                SyncStatus = _catch.SyncStatus == SyncStatus.Synchronised
-                    ? SyncStatus.WaitingToSynchronise
-                    : _catch.SyncStatus,
-                MetadataSyncStatus = _catch.MetadataSyncStatus == SyncStatus.Synchronised
-                    ? SyncStatus.WaitingToSynchronise
-                    : _catch.MetadataSyncStatus
+                Location = _catch.Location! with { Visibility = _visibility }
             };
-            _restoreCatchSync = _catch.SyncStatus == SyncStatus.Synchronised;
-            _restoreMetadataSync = _catch.MetadataSyncStatus == SyncStatus.Synchronised;
             await CatchStore.SaveAsync(updated, _cancellationTokenSource.Token);
             _catch = updated;
             return true;
         }
-        catch (Exception)
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync("saving catch location privacy locally", exception, CancellationToken.None);
             _saveFailed = true;
             return false;
         }
@@ -162,32 +173,60 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
                 CatchId,
                 _visibility,
                 _cancellationTokenSource.Token);
-            await RestoreSynchronisedAfterSuccessfulPropagateAsync();
         }
-        catch (HttpRequestException)
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
-            return;
+            throw;
         }
-        catch (TaskCanceledException)
+        catch (Exception exception) when (IsRecoverablePropagationFailure(exception))
         {
-            return;
+            await Logging.LogErrorAsync(
+                "updating catch location visibility",
+                exception,
+                CancellationToken.None);
+            await PersistWaitingToSynchroniseAsync();
         }
     }
 
-    private async Task RestoreSynchronisedAfterSuccessfulPropagateAsync()
+    private async Task PersistWaitingToSynchroniseAsync()
     {
-        if (_catch is null || (!_restoreCatchSync && !_restoreMetadataSync))
+        if (_catch is null
+            || (_catch.SyncStatus != SyncStatus.Synchronised
+                && _catch.MetadataSyncStatus != SyncStatus.Synchronised))
         {
             return;
         }
 
-        var restored = _catch with
+        try
         {
-            SyncStatus = _restoreCatchSync ? SyncStatus.Synchronised : _catch.SyncStatus,
-            MetadataSyncStatus = _restoreMetadataSync ? SyncStatus.Synchronised : _catch.MetadataSyncStatus
-        };
-        await CatchStore.SaveAsync(restored, _cancellationTokenSource.Token);
-        _catch = restored;
+            var waiting = _catch with
+            {
+                SyncStatus = _catch.SyncStatus == SyncStatus.Synchronised
+                    ? SyncStatus.WaitingToSynchronise
+                    : _catch.SyncStatus,
+                MetadataSyncStatus = _catch.MetadataSyncStatus == SyncStatus.Synchronised
+                    ? SyncStatus.WaitingToSynchronise
+                    : _catch.MetadataSyncStatus
+            };
+            await CatchStore.SaveAsync(waiting, _cancellationTokenSource.Token);
+            _catch = waiting;
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await Logging.LogErrorAsync(
+                "queueing location privacy for synchronisation",
+                exception,
+                CancellationToken.None);
+        }
+    }
+
+    private static bool IsRecoverablePropagationFailure(Exception exception)
+    {
+        return exception is HttpRequestException or TaskCanceledException or TimeoutException;
     }
 
     private void Cancel()

--- a/src/FishingLogBook.Web/Features/Catch/Modals/LocationPrivacy/LocationPrivacyModal.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Modals/LocationPrivacy/LocationPrivacyModal.razor.cs
@@ -26,6 +26,7 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
     private bool _missingLocation;
     private bool _saveFailed;
     private bool _savedOnDevice;
+    private bool _queueFailed;
 
     [CascadingParameter]
     private IMudDialogInstance MudDialog { get; set; } = default!;
@@ -98,6 +99,7 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
         _visibility = visibility;
         _saveFailed = false;
         _savedOnDevice = false;
+        _queueFailed = false;
     }
 
     private async Task SaveAsync()
@@ -110,6 +112,7 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
         _isSaving = true;
         _saveFailed = false;
         _savedOnDevice = false;
+        _queueFailed = false;
         try
         {
             if (!await TryPersistLocalVisibilityAsync())
@@ -119,7 +122,12 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
 
             _savedOnDevice = true;
             await InvokeAsync(StateHasChanged);
-            await PropagateVisibilityAsync();
+            if (!await PropagateVisibilityAsync())
+            {
+                _queueFailed = true;
+                return;
+            }
+
             await Task.Delay(SavedFeedbackDelay, _cancellationTokenSource.Token);
             MudDialog.Close(DialogResult.Ok(new LocationPrivacyModalResult(true)));
         }
@@ -165,7 +173,7 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
         }
     }
 
-    private async Task PropagateVisibilityAsync()
+    private async Task<bool> PropagateVisibilityAsync()
     {
         try
         {
@@ -173,6 +181,7 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
                 CatchId,
                 _visibility,
                 _cancellationTokenSource.Token);
+            return true;
         }
         catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
@@ -184,17 +193,21 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
                 "updating catch location visibility",
                 exception,
                 CancellationToken.None);
-            await PersistWaitingToSynchroniseAsync();
+            return await PersistWaitingToSynchroniseAsync();
         }
     }
 
-    private async Task PersistWaitingToSynchroniseAsync()
+    private async Task<bool> PersistWaitingToSynchroniseAsync()
     {
-        if (_catch is null
-            || (_catch.SyncStatus != SyncStatus.Synchronised
-                && _catch.MetadataSyncStatus != SyncStatus.Synchronised))
+        if (_catch is null)
         {
-            return;
+            return false;
+        }
+
+        if (_catch.SyncStatus != SyncStatus.Synchronised
+            && _catch.MetadataSyncStatus != SyncStatus.Synchronised)
+        {
+            return true;
         }
 
         try
@@ -210,6 +223,7 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
             };
             await CatchStore.SaveAsync(waiting, _cancellationTokenSource.Token);
             _catch = waiting;
+            return true;
         }
         catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
         {
@@ -221,6 +235,7 @@ public partial class LocationPrivacyModal : ComponentBase, IDisposable
                 "queueing location privacy for synchronisation",
                 exception,
                 CancellationToken.None);
+            return false;
         }
     }
 

--- a/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchEdit/OfflineCatchEdit.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchEdit/OfflineCatchEdit.razor
@@ -9,9 +9,20 @@
 <MudContainer MaxWidth="MaxWidth.Small" Gutters="false">
     <MudStack Spacing="4" AlignItems="AlignItems.Stretch">
         <MudText Typo="Typo.h4" Align="Align.Center" id="offline-catch-edit-title">@Loc["Catch_EditTitle"]</MudText>
-        @if (_loadFailed)
+        @if (_accessLocked)
         {
-            <MudAlert Severity="Severity.Error" id="offline-catch-edit-load-failed">@Loc["Catch_EditLoadFailed"]</MudAlert>
+            <MudAlert Severity="Severity.Info" id="offline-catch-edit-access-locked">@Loc["OfflineAccess_UnlockFailed"]</MudAlert>
+        }
+        else if (_loadFailed)
+        {
+            <MudAlert Severity="Severity.Error" id="offline-catch-edit-load-failed">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Justify="Justify.SpaceBetween">
+                    <span>@Loc["Catch_EditLoadFailed"]</span>
+                    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Small"
+                               OnClick="RetryLoadAsync" Disabled="_isLoading"
+                               id="offline-catch-edit-load-retry">@Loc["Catch_LoadRetry"]</MudButton>
+                </MudStack>
+            </MudAlert>
         }
         else if (_isLoading)
         {

--- a/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchEdit/OfflineCatchEdit.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchEdit/OfflineCatchEdit.razor.cs
@@ -17,6 +17,7 @@ public partial class OfflineCatchEdit : ComponentBase
     private AnglerPreferencesModel _preferences = AnglerPreferencesModel.Empty;
     private bool _isLoading = true;
     private bool _loadFailed;
+    private bool _accessLocked;
 
     [Parameter]
     public Guid CatchId { get; set; }
@@ -53,12 +54,36 @@ public partial class OfflineCatchEdit : ComponentBase
         }
     }
 
-    protected override async Task OnParametersSetAsync()
+    protected override Task OnParametersSetAsync()
     {
+        return LoadAsync();
+    }
+
+    private async Task RetryLoadAsync()
+    {
+        if (_isLoading || _accessLocked)
+        {
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _loadFailed = false;
+        _accessLocked = false;
+        _catch = null;
         try
         {
-            var owner = OfflineOwnerContext.Owner
-                ?? throw new InvalidOperationException("Offline access is locked.");
+            var owner = OfflineOwnerContext.Owner;
+            if (owner is null)
+            {
+                _accessLocked = true;
+                return;
+            }
+
             _catch = await CatchStore.GetAsync(owner.UserId, CatchId, CancellationToken.None);
             if (_catch is null || _catch.UserId != owner.UserId)
             {
@@ -73,6 +98,7 @@ public partial class OfflineCatchEdit : ComponentBase
         {
             await Logging.LogErrorAsync("loading a catch for offline editing", exception, CancellationToken.None);
             _loadFailed = true;
+            _catch = null;
         }
         finally
         {

--- a/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor
@@ -43,9 +43,20 @@
             </MudStack>
         </MudStack>
 
-        @if (_loadFailed)
+        @if (_accessLocked)
         {
-            <MudAlert Severity="Severity.Error" id="offline-catch-list-load-failed">@Loc["Catch_LoadFailed"]</MudAlert>
+            <MudAlert Severity="Severity.Info" id="offline-catch-list-access-locked">@Loc["OfflineAccess_UnlockFailed"]</MudAlert>
+        }
+        else if (_loadFailed)
+        {
+            <MudAlert Severity="Severity.Error" id="offline-catch-list-load-failed">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Justify="Justify.SpaceBetween">
+                    <span>@Loc["Catch_LoadFailed"]</span>
+                    <MudButton Variant="Variant.Filled" Color="Color.Error" Size="Size.Small"
+                               OnClick="RetryLoadAsync" Disabled="_isLoading"
+                               id="offline-catch-list-load-retry">@Loc["Catch_LoadRetry"]</MudButton>
+                </MudStack>
+            </MudAlert>
         }
         else if (_isLoading)
         {

--- a/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/OfflineCatchList/OfflineCatchList.razor.cs
@@ -22,6 +22,7 @@ public partial class OfflineCatchList : ComponentBase
     private LengthUnitEnum _lengthUnit = LengthUnitEnum.Cm;
     private bool _isLoading = true;
     private bool _loadFailed;
+    private bool _accessLocked;
     private TripModel? _activeTrip;
     private bool _isStartingTrip;
 
@@ -41,12 +42,36 @@ public partial class OfflineCatchList : ComponentBase
         }
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
+        return LoadAsync();
+    }
+
+    private async Task RetryLoadAsync()
+    {
+        if (_isLoading || _accessLocked)
+        {
+            return;
+        }
+
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _loadFailed = false;
+        _accessLocked = false;
         try
         {
-            var owner = OfflineOwnerContext.Owner
-                ?? throw new InvalidOperationException("Offline access is locked.");
+            var owner = OfflineOwnerContext.Owner;
+            if (owner is null)
+            {
+                _accessLocked = true;
+                _catches = [];
+                return;
+            }
+
             _ownerUserId = owner.UserId;
             _catches = LocalCatchVisibility.ForOwner(
                 await CatchStore.GetAllAsync(owner.UserId, CancellationToken.None),
@@ -63,6 +88,7 @@ public partial class OfflineCatchList : ComponentBase
         {
             await Logging.LogErrorAsync("loading offline catches", exception, CancellationToken.None);
             _loadFailed = true;
+            _catches = [];
         }
         finally
         {

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor.cs
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor.cs
@@ -40,6 +40,9 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
     private ILoggingService Logging { get; set; } = default!;
 
     [Inject]
+    private ISnackbar Snackbar { get; set; } = default!;
+
+    [Inject]
     private IJSRuntime JsRuntime { get; set; } = default!;
 
     [Inject]
@@ -113,6 +116,7 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
                 "logbook synchronisation",
                 exception,
                 CancellationToken.None);
+            Snackbar.Add(Loc["App_LogbookSyncFailed"], Severity.Warning);
         }
 
         try

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -971,6 +971,9 @@
   <data name="Onboarding_OfflineAccessStep" xml:space="preserve"><value>Accès hors ligne</value></data>
   <data name="Onboarding_OfflineAccessOptional" xml:space="preserve"><value>L’accès hors ligne est facultatif. Choisissez Ouvrir mon carnet pour continuer sans le configurer.</value></data>
   <data name="OfflineAccess_OpenOffline" xml:space="preserve"><value>Ouvrir hors ligne</value></data>
+  <data name="App_LogbookSyncFailed" xml:space="preserve">
+    <value>Vos données sont toujours enregistrées sur cet appareil. La synchronisation peut réessayer.</value>
+  </data>
   <data name="OfflineAccess_UnlockFailed" xml:space="preserve"><value>Impossible d’ouvrir l’accès hors ligne. Réessayez ou connectez-vous lorsque vous avez une connexion.</value></data>
   <data name="OfflineAccess_Mode" xml:space="preserve"><value>Mode hors ligne</value></data>
   <data name="OfflineReconnect_Reconnecting" xml:space="preserve"><value>Vérification de votre connexion…</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -690,6 +690,9 @@
   <data name="Catch_LocationPrivacySavedPendingSync" xml:space="preserve">
     <value>Confidentialité enregistrée sur cet appareil. Elle sera mise à jour lorsque la synchronisation sera disponible.</value>
   </data>
+  <data name="Catch_LocationPrivacyQueueFailed" xml:space="preserve">
+    <value>Enregistré sur cet appareil, mais la mise à jour serveur n'a pas pu être mise en file d'attente. Veuillez réessayer.</value>
+  </data>
   <data name="Profile_Nav" xml:space="preserve">
     <value>Profil</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -828,6 +828,9 @@
   <data name="App_UnhandledErrorSnackbar" xml:space="preserve">
     <value>Something went wrong. Please try again.</value>
   </data>
+  <data name="App_LogbookSyncFailed" xml:space="preserve">
+    <value>Your data is still saved on this device. Synchronisation can retry.</value>
+  </data>
   <data name="Action_TryAgain" xml:space="preserve">
     <value>Try again</value>
   </data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -690,6 +690,9 @@
   <data name="Catch_LocationPrivacySavedPendingSync" xml:space="preserve">
     <value>Privacy saved on this device. It will update when synchronisation is available.</value>
   </data>
+  <data name="Catch_LocationPrivacyQueueFailed" xml:space="preserve">
+    <value>Saved on this device, but we couldn't queue the server update. Please try again.</value>
+  </data>
   <data name="Profile_Nav" xml:space="preserve">
     <value>Profile</value>
   </data>

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/BaseLocationPrivacyModalTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/BaseLocationPrivacyModalTest.cs
@@ -8,6 +8,7 @@ using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
@@ -24,7 +25,8 @@ public class BaseLocationPrivacyModalTest
     protected static BunitContext CreateContext(
         ICatchStore store,
         ICatchClient? client = null,
-        ILocalCatchOwnerService? owner = null)
+        ILocalCatchOwnerService? owner = null,
+        ILoggingService? logging = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -33,8 +35,17 @@ public class BaseLocationPrivacyModalTest
         context.Services.AddSingleton(store);
         context.Services.AddSingleton(client ?? Substitute.For<ICatchClient>());
         context.Services.AddSingleton(owner ?? SignedInOwner());
+        context.Services.AddSingleton(logging ?? QuietLogging());
         context.Services.AddTransient<MudBlazor.MudLocalizer, FishingLogBookMudLocalizer>();
         return context;
+    }
+
+    protected static ILoggingService QuietLogging()
+    {
+        var logging = Substitute.For<ILoggingService>();
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<Exception>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return logging;
     }
 
     protected static async Task<(IRenderedComponent<MudDialogProvider> Cut, IDialogReference Dialog)> ShowModalAsync(

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingRender.cs
@@ -7,6 +7,7 @@ using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -127,7 +128,8 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
         var store = Substitute.For<ICatchStore>();
         store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("IndexedDB failed."));
-        await using var context = CreateContext(store);
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, logging: logging);
 
         // Act
         var (cut, dialog) = await ShowModalAsync(context, catchId);
@@ -138,6 +140,10 @@ public class WhenTestingRender : BaseLocationPrivacyModalTest
                 .Should()
                 .Contain("This catch could not be loaded"));
         await store.Received(1).GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "loading catch location privacy",
+            Arg.Any<InvalidOperationException>(),
+            CancellationToken.None);
         dialog.Result.IsCompleted.Should().BeFalse();
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingSave.cs
@@ -477,7 +477,7 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
     }
 
     [Fact]
-    public async Task ItShouldStillCloseWhenQueueingVisibilityFailsWithTimeout()
+    public async Task ItShouldStayOpenWhenQueueingVisibilityFailsWithTimeout()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
@@ -511,7 +511,16 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         await cut.Find("#catch-location-privacy-save").ClickAsync();
 
         // Assert
-        cut.WaitForAssertion(() => cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty());
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#catch-location-privacy-queue-failed").TextContent
+                .Should()
+                .Contain("Saved on this device, but we couldn't queue the server update");
+            cut.Find("#catch-location-privacy-saved").TextContent
+                .Should()
+                .Contain("Location privacy saved on this device");
+        });
+        cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty();
         await logging.Received(1).LogErrorAsync(
             "updating catch location visibility",
             Arg.Any<HttpRequestException>(),
@@ -520,8 +529,26 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
             "queueing location privacy for synchronisation",
             Arg.Any<TimeoutException>(),
             CancellationToken.None);
-        await store.Received(2).SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
-        await ShouldHaveClosedAsSaved(dialog);
+        Received.InOrder(() =>
+        {
+            store.SaveAsync(
+                Arg.Is<CatchModel>(catchRecord =>
+                    catchRecord.Id == catchId
+                    && catchRecord.Location != null
+                    && catchRecord.Location.Visibility == LocationDefaults.Public
+                    && catchRecord.SyncStatus == SyncStatus.Synchronised
+                    && catchRecord.MetadataSyncStatus == SyncStatus.Synchronised),
+                Arg.Any<CancellationToken>());
+            store.SaveAsync(
+                Arg.Is<CatchModel>(catchRecord =>
+                    catchRecord.Id == catchId
+                    && catchRecord.Location != null
+                    && catchRecord.Location.Visibility == LocationDefaults.Public
+                    && catchRecord.SyncStatus == SyncStatus.WaitingToSynchronise
+                    && catchRecord.MetadataSyncStatus == SyncStatus.WaitingToSynchronise),
+                Arg.Any<CancellationToken>());
+        });
+        dialog.Result.IsCompleted.Should().BeFalse();
     }
 
     private static CatchClient CreateCatchClient(UnsynchronisedCatchHandler apiHandler)

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingSave.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Modals/LocationPrivacyModalTests/WhenTestingSave.cs
@@ -11,6 +11,7 @@ using FishingLogBook.Web.Features.Catch.Models;
 using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Catch.Offline.Stores;
 using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Localization;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -237,22 +238,37 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
         cut.WaitForAssertion(() =>
             cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty());
         cut.Markup.Should().NotContain("Location privacy could not be saved");
-        await store.Received(1).SaveAsync(
-            Arg.Is<CatchModel>(catchRecord =>
-                catchRecord.Id == catchId
-                && catchRecord.Location != null
-                && catchRecord.Location.Visibility == LocationDefaults.Private
-                && catchRecord.Location.Latitude == 53.2707
-                && catchRecord.Location.Longitude == -9.0568
-                && catchRecord.Location.AccuracyMetres == 12
-                && catchRecord.Location.CapturedOn == capturedOn
-                && catchRecord.Location.Source == LocationDefaults.DeviceGps
-                && catchRecord.Location.ConsentVersion == LocationDefaults.ConsentVersion
-                && catchRecord.SyncStatus == SyncStatus.WaitingToSynchronise
-                && catchRecord.MetadataSyncStatus == SyncStatus.WaitingToSynchronise
-                && catchRecord.Photographs.All(
-                    photograph => photograph.SyncStatus == SyncStatus.Synchronised)),
-            Arg.Any<CancellationToken>());
+        Received.InOrder(() =>
+        {
+            store.SaveAsync(
+                Arg.Is<CatchModel>(catchRecord =>
+                    catchRecord.Id == catchId
+                    && catchRecord.Location != null
+                    && catchRecord.Location.Visibility == LocationDefaults.Private
+                    && catchRecord.SyncStatus == SyncStatus.Synchronised
+                    && catchRecord.MetadataSyncStatus == SyncStatus.Synchronised),
+                Arg.Any<CancellationToken>());
+            client.UpdateLocationVisibilityAsync(
+                catchId,
+                LocationDefaults.Private,
+                Arg.Any<CancellationToken>());
+            store.SaveAsync(
+                Arg.Is<CatchModel>(catchRecord =>
+                    catchRecord.Id == catchId
+                    && catchRecord.Location != null
+                    && catchRecord.Location.Visibility == LocationDefaults.Private
+                    && catchRecord.Location.Latitude == 53.2707
+                    && catchRecord.Location.Longitude == -9.0568
+                    && catchRecord.Location.AccuracyMetres == 12
+                    && catchRecord.Location.CapturedOn == capturedOn
+                    && catchRecord.Location.Source == LocationDefaults.DeviceGps
+                    && catchRecord.Location.ConsentVersion == LocationDefaults.ConsentVersion
+                    && catchRecord.SyncStatus == SyncStatus.WaitingToSynchronise
+                    && catchRecord.MetadataSyncStatus == SyncStatus.WaitingToSynchronise
+                    && catchRecord.Photographs.All(
+                        photograph => photograph.SyncStatus == SyncStatus.Synchronised)),
+                Arg.Any<CancellationToken>());
+        });
         await client.Received(1).UpdateLocationVisibilityAsync(
             catchId,
             LocationDefaults.Private,
@@ -380,7 +396,7 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
     }
 
     [Fact]
-    public async Task ItShouldRestoreSynchronisedWhenTheServerAcceptsTheVisibility()
+    public async Task ItShouldKeepSynchronisedWhenTheServerAcceptsTheVisibility()
     {
         // Arrange
         using var culture = TestCulture.Use(CultureNames.English);
@@ -413,22 +429,98 @@ public class WhenTestingSave : BaseLocationPrivacyModalTest
                     catchRecord.Id == catchId
                     && catchRecord.Location != null
                     && catchRecord.Location.Visibility == LocationDefaults.Public
-                    && catchRecord.SyncStatus == SyncStatus.WaitingToSynchronise
-                    && catchRecord.MetadataSyncStatus == SyncStatus.WaitingToSynchronise),
+                    && catchRecord.SyncStatus == SyncStatus.Synchronised
+                    && catchRecord.MetadataSyncStatus == SyncStatus.Synchronised),
                 Arg.Any<CancellationToken>());
             client.UpdateLocationVisibilityAsync(
                 catchId,
                 LocationDefaults.Public,
                 Arg.Any<CancellationToken>());
-            store.SaveAsync(
-                Arg.Is<CatchModel>(catchRecord =>
-                    catchRecord.Id == catchId
-                    && catchRecord.Location != null
-                    && catchRecord.Location.Visibility == LocationDefaults.Public
-                    && catchRecord.SyncStatus == SyncStatus.Synchronised
-                    && catchRecord.MetadataSyncStatus == SyncStatus.Synchronised),
-                Arg.Any<CancellationToken>());
         });
+        await store.Received(1).SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
+        await ShouldHaveClosedAsSaved(dialog);
+    }
+
+    [Fact]
+    public async Task ItShouldLogWhenTheLocalSaveFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId));
+        var exception = new InvalidOperationException("IndexedDB failed.");
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(exception);
+        var client = Substitute.For<ICatchClient>();
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, client, logging: logging);
+        var (cut, dialog) = await ShowModalAsync(context, catchId);
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-public").Should().NotBeNull());
+        await cut.Find("#catch-location-privacy-public").ClickAsync();
+
+        // Act
+        await cut.Find("#catch-location-privacy-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-save-failed").Should().NotBeNull());
+        await logging.Received(1).LogErrorAsync(
+            "saving catch location privacy locally",
+            exception,
+            CancellationToken.None);
+        await client.DidNotReceive().UpdateLocationVisibilityAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+        dialog.Result.IsCompleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldStillCloseWhenQueueingVisibilityFailsWithTimeout()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var catchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, catchId, Arg.Any<CancellationToken>())
+            .Returns(LocatedCatch(catchId, LocationDefaults.Private) with
+            {
+                SyncStatus = SyncStatus.Synchronised,
+                MetadataSyncStatus = SyncStatus.Synchronised
+            });
+        var saves = 0;
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                saves += 1;
+                return saves == 1
+                    ? Task.CompletedTask
+                    : throw new TimeoutException("write timed out after 5000ms.");
+            });
+        var client = Substitute.For<ICatchClient>();
+        client.UpdateLocationVisibilityAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException());
+        var logging = QuietLogging();
+        await using var context = CreateContext(store, client, logging: logging);
+        var (cut, dialog) = await ShowModalAsync(context, catchId);
+        cut.WaitForAssertion(() => cut.Find("#catch-location-privacy-public").Should().NotBeNull());
+        await cut.Find("#catch-location-privacy-public").ClickAsync();
+
+        // Act
+        await cut.Find("#catch-location-privacy-save").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-location-privacy-save-failed").Should().BeEmpty());
+        await logging.Received(1).LogErrorAsync(
+            "updating catch location visibility",
+            Arg.Any<HttpRequestException>(),
+            CancellationToken.None);
+        await logging.Received(1).LogErrorAsync(
+            "queueing location privacy for synchronisation",
+            Arg.Any<TimeoutException>(),
+            CancellationToken.None);
+        await store.Received(2).SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>());
         await ShouldHaveClosedAsSaved(dialog);
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchEditTests/WhenTestingLoad.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchEditTests/WhenTestingLoad.cs
@@ -1,0 +1,89 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Pages.OfflineCatchEdit;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.OfflineCatchEditTests;
+
+public class WhenTestingLoad : BaseOfflineCatchEditTest
+{
+    [Fact]
+    public async Task ItShouldShowRetryWhenTheStoreFailsWhileUnlocked()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("single-read timed out after 5000ms."));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<OfflineCatchEdit>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#offline-catch-edit-load-failed").Should().NotBeNull();
+            cut.Find("#offline-catch-edit-load-retry").TextContent.Should().Contain("Try again");
+        });
+        cut.FindAll("#offline-catch-edit-access-locked").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldReloadWhenRetryIsPressedAfterAStoreFailure()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var reads = 0;
+        var recovered = Catch(OwnerUserId);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                reads += 1;
+                return reads == 1
+                    ? throw new TimeoutException("single-read timed out after 5000ms.")
+                    : recovered;
+            });
+        await using var context = CreateContext(store);
+        var cut = context.Render<OfflineCatchEdit>(parameters => parameters.Add(page => page.CatchId, CatchId));
+        cut.WaitForAssertion(() => cut.Find("#offline-catch-edit-load-retry").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#offline-catch-edit-load-retry").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#offline-catch-edit-photo-sections").Should().NotBeNull());
+        cut.FindAll("#offline-catch-edit-load-failed").Should().BeEmpty();
+        await store.Received(2).GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowUnlockGuidanceWithoutRetryWhenAccessIsLocked()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        await using var context = CreateContext(store);
+        var owner = context.Services.GetRequiredService<IOfflineOwnerContextService>();
+        owner.Lock();
+
+        // Act
+        var cut = context.Render<OfflineCatchEdit>(parameters => parameters.Add(page => page.CatchId, CatchId));
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#offline-catch-edit-access-locked").TextContent
+                .Should()
+                .Contain("Offline access could not be opened"));
+        cut.FindAll("#offline-catch-edit-load-retry").Should().BeEmpty();
+        cut.FindAll("#offline-catch-edit-load-failed").Should().BeEmpty();
+        await store.DidNotReceive().GetAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchListTests/WhenTestingRetry.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/OfflineCatchListTests/WhenTestingRetry.cs
@@ -1,0 +1,90 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Catch.Models;
+using FishingLogBook.Web.Features.Catch.Offline.Stores;
+using FishingLogBook.Web.Features.Catch.Pages.OfflineCatchList;
+using FishingLogBook.Web.Features.OfflineAccess.Models;
+using FishingLogBook.Web.Features.OfflineAccess.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FishingLogBook.Web.Tests.Features.Catch.Pages.OfflineCatchListTests;
+
+public class WhenTestingRetry : BaseOfflineCatchListTest
+{
+    [Fact]
+    public async Task ItShouldShowRetryWhenTheStoreFailsWhileUnlocked()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TimeoutException("read timed out after 5000ms."));
+        await using var context = CreateContext(store);
+
+        // Act
+        var cut = context.Render<OfflineCatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#offline-catch-list-load-failed").Should().NotBeNull();
+            cut.Find("#offline-catch-list-load-retry").TextContent.Should().Contain("Try again");
+        });
+        cut.FindAll("#offline-catch-list-access-locked").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldReloadWhenRetryIsPressedAfterAStoreFailure()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var reads = 0;
+        var store = Substitute.For<ICatchStore>();
+        store.GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                reads += 1;
+                return reads == 1
+                    ? throw new TimeoutException("read timed out after 5000ms.")
+                    : Task.FromResult<IReadOnlyList<CatchModel>>([Catch(OwnerUserId, "Recovered Trout")]);
+            });
+        await using var context = CreateContext(store);
+        var cut = context.Render<OfflineCatchList>();
+        cut.WaitForAssertion(() => cut.Find("#offline-catch-list-load-retry").Should().NotBeNull());
+
+        // Act
+        await cut.Find("#offline-catch-list-load-retry").ClickAsync();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#offline-catch-list").TextContent.Should().Contain("Recovered Trout"));
+        cut.FindAll("#offline-catch-list-load-failed").Should().BeEmpty();
+        await store.Received(2).GetAllAsync(OwnerUserId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowUnlockGuidanceWithoutRetryWhenAccessIsLocked()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        await using var context = CreateContext(store);
+        var owner = context.Services.GetRequiredService<IOfflineOwnerContextService>();
+        owner.Lock();
+
+        // Act
+        var cut = context.Render<OfflineCatchList>();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+            cut.Find("#offline-catch-list-access-locked").TextContent
+                .Should()
+                .Contain("Offline access could not be opened"));
+        cut.FindAll("#offline-catch-list-load-retry").Should().BeEmpty();
+        cut.FindAll("#offline-catch-list-load-failed").Should().BeEmpty();
+        await store.DidNotReceive().GetAllAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
@@ -1,3 +1,4 @@
+using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Web.Common.Offline.Synchronisers;
 using FishingLogBook.Web.Features.Catch.Offline;
@@ -7,7 +8,6 @@ using FishingLogBook.Web.Layouts.MainLayout;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
-using AwesomeAssertions;
 using MudBlazor;
 using NSubstitute;
 

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingSynchronisation.cs
@@ -4,8 +4,11 @@ using FishingLogBook.Web.Features.Catch.Offline;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Synchronisers;
 using FishingLogBook.Web.Layouts.MainLayout;
+using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
+using AwesomeAssertions;
+using MudBlazor;
 using NSubstitute;
 
 namespace FishingLogBook.Web.Tests.Layouts.MainLayoutTests;
@@ -187,6 +190,38 @@ public class WhenTestingSynchronisation : BaseMainLayoutTest
             "logbook synchronisation",
             Arg.Is<Exception>(exception => exception.Message == "boom"),
             CancellationToken.None);
+        await diagnosticSynchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldShowALocalisedSnackbarWhenLogbookSynchronisationFails()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var logbookSynchroniser = Substitute.For<ILogbookSynchroniser>();
+        logbookSynchroniser.SynchronisePendingAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("sync failed")));
+        var diagnosticSynchroniser = Substitute.For<IDiagnosticSynchroniser>();
+        await using var context = CreateContext(
+            isAuthenticated: true,
+            logbookSynchroniser,
+            diagnosticSynchroniser);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/catches");
+        var logging = context.Services.GetRequiredService<ILoggingService>();
+        var snackbar = context.Services.GetRequiredService<ISnackbar>();
+
+        // Act
+        context.Render<MainLayout>();
+        await Task.Delay(20);
+
+        // Assert
+        await logging.Received(1).LogErrorAsync(
+            "logbook synchronisation",
+            Arg.Is<Exception>(exception => exception.Message == "sync failed"),
+            CancellationToken.None);
+        snackbar.ShownSnackbars.Should().ContainSingle(
+            message => message.Message.Contains("still saved on this device")
+                && message.Severity == Severity.Warning);
         await diagnosticSynchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary

Release-hardening for catch privacy saves, offline load recovery, and background sync feedback.

- **Location privacy:** successful PATCH for an already-synchronised catch now uses **one** local IndexedDB write and leaves `SyncStatus`/`MetadataSyncStatus` as `Synchronised`. Previously the modal wrote locally, flipped to `WaitingToSynchronise` before PATCH, then wrote again on success to restore `Synchronised` — an unnecessary double-write exposed by production timeout failures (not proven to be the sole root cause).
- **PATCH failure:** visibility is persisted locally first; only on recoverable network/API failure is the catch marked `WaitingToSynchronise` so the existing synchroniser can retry.
- **Storage timeouts:** recoverable `TimeoutException` from IndexedDB is logged and contained in Catch UI — failed/retry UI where appropriate, no escape to the global Blazor error UI. If local persistence already succeeded, the angler is not told their data was lost.
- **Offline catch list/edit:** retryable store failures show `Catch_LoadRetry`; locked `OfflineOwnerContext` shows unlock guidance instead of a misleading retry.
- **Background sync:** `MainLayout` logs logbook sync failures and shows a localised snackbar that data remains saved on this device and sync can retry.

Closes #188  
Closes #165

## What caused the unnecessary privacy double-write

For synchronised catches, `LocationPrivacyModal` was:

1. Saving locally with `WaitingToSynchronise`
2. PATCHing the API
3. On 204, saving again to restore `Synchronised`

Steps 1 and 3 were redundant when PATCH succeeded. This PR removes the pre-PATCH status flip and the post-success restore write.

## Test plan

- [x] `dotnet format`, `dotnet build`, `dotnet test`
- [x] `npm test`, `npm run test:browser`
- [ ] Location privacy on a synchronised catch: successful save → one local write, status stays synchronised
- [ ] Location privacy with API offline: local choice kept, catch queued for sync
- [ ] Offline catch list/edit with unlocked access + store failure: retry shown and works
- [ ] Offline catch list/edit with locked access: unlock guidance shown, no retry
- [ ] Background sync failure: snackbar appears, data not implied lost

## Remaining risk

- IndexedDB timeouts under heavy device load may still occur; this PR contains them in UI and removes the privacy double-write weakness. It does not increase the global 5000ms timeout.
- Playwright offline-shell tests on webkit remain skipped (pre-existing harness limitation); bUnit covers the new Blazor behaviour.