### PR TITLE
FLB#205 | mark catch metadata pending when photographs change from Ed…

### DIFF
--- a/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.Photographs.cs
+++ b/src/FishingLogBook.Web/Features/Catch/Pages/CatchEdit/CatchEdit.Photographs.cs
@@ -52,6 +52,7 @@ public partial class CatchEdit
                     photograph.ContentType,
                     photograph.Bytes)
             ],
+            MetadataSyncStatus = SyncStatus.WaitingToSynchronise,
             SyncStatus = PendingOverallStatus(current.SyncStatus)
         };
     }
@@ -140,6 +141,7 @@ public partial class CatchEdit
             Photographs = [.. _catch.Photographs.Select(photograph => photograph.Id == photographId
                 ? photograph with { SyncStatus = SyncStatus.PendingDeletion }
                 : photograph)],
+            MetadataSyncStatus = SyncStatus.WaitingToSynchronise,
             SyncStatus = PendingOverallStatus(_catch.SyncStatus)
         };
 

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchPhotographServiceTests/WhenTestingCreateUpload.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchPhotographServiceTests/WhenTestingCreateUpload.cs
@@ -11,6 +11,36 @@ namespace FishingLogBook.Application.Tests.Catches.Services.CatchPhotographServi
 public class WhenTestingCreateUpload : BaseCatchPhotographServiceTest
 {
     [Fact]
+    public async Task ItShouldReturnNotFoundWhenThePhotographDoesNotExistYet()
+    {
+        // Arrange
+        MockCatchRepository.GetPhotographAsync(
+                Arg.Any<GetCatchPhotographArgs>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<CatchPhotograph?>(null));
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.CreateUploadAsync(
+            new CreateCatchPhotographUploadArgs
+            {
+                CatchId = CatchId,
+                Request = new PhotographUploadRequestDto(PhotographId, "image/jpeg")
+            },
+            CancellationToken.None);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors.Should().ContainSingle()
+            .Which.Should().BeOfType<CatchPhotographNotFoundError>();
+        await MockObjectStorage.DidNotReceive().CreateUploadUrlAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<TimeSpan>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldDeriveTheSameObjectKeyForRepeatedRequests()
     {
         // Arrange

--- a/tests/FishingLogBook.E2E/specs/catch-online.spec.mjs
+++ b/tests/FishingLogBook.E2E/specs/catch-online.spec.mjs
@@ -6,6 +6,38 @@ import {
     testName
 } from '../support/catch-journey.mjs';
 
+test('User adds another photograph from Edit Catch and it persists', async ({ page }) => {
+    const id = await createCatch(page, true);
+    const before = await reloadServerCatches(page);
+    expect(before.find(candidate => candidate.id === id)?.photographs).toHaveLength(1);
+
+    await page.goto('/catches');
+    await page.locator(`#catch-card-menu-${id}`).click();
+    await page.locator(`#catch-card-edit-${id}`).click();
+    await expect(page.locator('#catch-edit-loading')).toBeHidden();
+
+    const uploadUrl = page.waitForResponse(response =>
+        /\/api\/catches\/[0-9a-f-]+\/photographs\/upload-url$/i.test(new URL(response.url()).pathname)
+        && response.request().method() === 'POST'
+        && response.ok());
+    const recorded = page.waitForResponse(response =>
+        /\/api\/catches\/[0-9a-f-]+\/photographs$/i.test(new URL(response.url()).pathname)
+        && response.request().method() === 'POST'
+        && response.ok());
+
+    await page.locator('#catch-edit-photo-gallery input, #catch-edit-photo-gallery').setInputFiles([{
+        name: 'second.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64')
+    }]);
+
+    await uploadUrl;
+    await recorded;
+
+    const after = await reloadServerCatches(page);
+    expect(after.find(candidate => candidate.id === id)?.photographs).toHaveLength(2);
+});
+
 test('@smoke records a catch and retains its catalogue values and photo after reload', async ({ page }) => {
     const id = await createCatch(page, true);
 

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Offline/Synchronisers/CatchSynchroniserTests/WhenTestingSynchronisePending.cs
@@ -598,6 +598,55 @@ public class WhenTestingSynchronisePending : BaseCatchSynchroniserTest
     }
 
     [Fact]
+    public async Task ItShouldUpsertMetadataBeforeUploadingANewPhotographOnASynchronisedCatch()
+    {
+        // Arrange
+        var photographs = new[]
+        {
+            CreatePhotograph(PhotographAId, CatchId, SyncStatus.Synchronised) with
+            {
+                ObjectKey = "catch-photographs/a"
+            },
+            CreatePhotograph(PhotographBId, CatchId, SyncStatus.SavedLocally)
+        };
+        var catchRecord = CreateCatch(
+            catchStatus: SyncStatus.Synchronised,
+            metadataStatus: SyncStatus.WaitingToSynchronise,
+            photographs: photographs) with
+        {
+            SyncStatus = SyncStatus.WaitingToSynchronise
+        };
+        var store = await CreateStoreAsync(catchRecord);
+        var sut = CreateSut(store);
+
+        // Act
+        await sut.SynchronisePendingAsync(CancellationToken.None);
+        var saved = await store.GetAsync(OwnerUserId, CatchId, CancellationToken.None);
+
+        // Assert
+        saved!.MetadataSyncStatus.Should().Be(SyncStatus.Synchronised);
+        saved.Photographs.Should().HaveCount(2);
+        saved.Photographs.Single(item => item.Id == PhotographBId).SyncStatus.Should().Be(SyncStatus.Synchronised);
+        Received.InOrder(() =>
+        {
+            MockCatchClient.UpsertAsync(
+                Arg.Is<CatchDto>(dto =>
+                    dto.Id == CatchId
+                    && dto.Photographs.Count == 2
+                    && dto.Photographs.Any(photo => photo.Id == PhotographBId)),
+                Arg.Any<CancellationToken>());
+            MockCatchClient.CreatePhotographUploadAsync(
+                CatchId,
+                Arg.Is<PhotographUploadRequestDto>(request => request.PhotographId == PhotographBId),
+                Arg.Any<CancellationToken>());
+        });
+        await MockCatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            CatchId,
+            Arg.Is<PhotographUploadRequestDto>(request => request.PhotographId == PhotographAId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldDeleteAPendingDeletionPhotographFromTheServerAndRemoveItLocally()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingPhotographs.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Catch/Pages/CatchEditTests/WhenTestingPhotographs.cs
@@ -140,9 +140,43 @@ public class WhenTestingPhotographs : BaseCatchEditTest
             var call = store.ReceivedCalls().Last();
             var saved = (CatchModel)call.GetArguments()[0]!;
             saved.Photographs.Should().HaveCount(2);
+            saved.MetadataSyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
             saved.SyncStatus.Should().Be(SyncStatus.WaitingToSynchronise);
         });
         await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldMarkMetadataPendingWhenAddingAPhotographToASynchronisedCatch()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        var store = Substitute.For<ICatchStore>();
+        store.GetAsync(OwnerUserId, CatchId, Arg.Any<CancellationToken>())
+            .Returns(StoredCatch(CatchId, SyncStatus.Synchronised, SyncStatus.Synchronised, SyncStatus.Synchronised));
+        store.SaveAsync(Arg.Any<CatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        await using var context = CreateContext(store);
+        var cut = context.Render<CatchEdit>(parameters => parameters.Add(page => page.CatchId, CatchId));
+        cut.WaitForAssertion(() => cut.Find("#catch-edit-photo-camera").Should().NotBeNull());
+
+        // Act
+        cut.FindComponents<InputFile>()[0].UploadFiles(
+            InputFileContent.CreateFromBinary(
+                [0xFF, 0xD8, 0xFF],
+                "photo.jpg",
+                contentType: PhotographContentTypeConstants.Jpeg));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("#catch-edit-photo-unpreparable").Should().BeEmpty());
+        await store.Received(1).SaveAsync(
+            Arg.Is<CatchModel>(catchRecord =>
+                catchRecord.Photographs.Count == 2
+                && catchRecord.MetadataSyncStatus == SyncStatus.WaitingToSynchronise
+                && catchRecord.SyncStatus == SyncStatus.WaitingToSynchronise
+                && catchRecord.Photographs[0].SyncStatus == SyncStatus.Synchronised
+                && catchRecord.Photographs[1].SyncStatus == SyncStatus.SavedLocally),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -257,6 +291,7 @@ public class WhenTestingPhotographs : BaseCatchEditTest
                     == SyncStatus.PendingDeletion
                 && catchRecord.Photographs.Single(item => item.Id == SecondPhotographId).SyncStatus
                     == SyncStatus.Synchronised
+                && catchRecord.MetadataSyncStatus == SyncStatus.WaitingToSynchronise
                 && catchRecord.SyncStatus == SyncStatus.WaitingToSynchronise),
             Arg.Any<CancellationToken>());
         await synchroniser.Received(1).SynchronisePendingAsync(Arg.Any<CancellationToken>());


### PR DESCRIPTION
## Summary

Fixes photograph upload 404 when adding or removing photos from Edit Catch on an already-synchronised catch.

**Root cause:** Edit Catch marked new photographs as `SavedLocally` but left `MetadataSyncStatus` as `Synchronised`. `CatchSynchroniser` skipped the metadata upsert for synchronised catches, then called `POST /api/catches/{catchId}/photographs/upload-url`. The API requires the photograph row to exist in PostgreSQL (created during catch upsert), so upload-url returned 404.

**Fix:** Set `MetadataSyncStatus = WaitingToSynchronise` when photographs are added or removed in `CatchEdit.Photographs.cs`, matching `CatchEditEditor` behaviour so the synchroniser upserts metadata before requesting an upload URL.

## Test plan

- [x] `WhenTestingPhotographs` — metadata marked pending when adding/removing photos on a synchronised catch
- [x] `WhenTestingSynchronisePending` — metadata upsert runs before upload-url on a synchronised catch with a new photo
- [x] `WhenTestingCreateUpload` — upload-url returns not found when the photograph row does not exist yet
- [x] E2E: `User adds another photograph from Edit Catch and it persists`
- [x] Full `dotnet test` suite (2841 passed)

Closes #205