### PR TITLE
FLB#199 | add get-only http retry resilience to api clients

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />

--- a/src/FishingLogBook.Web/Configuration/HttpClientResilienceExtensions.cs
+++ b/src/FishingLogBook.Web/Configuration/HttpClientResilienceExtensions.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
+
+namespace FishingLogBook.Web.Configuration;
+
+internal static class HttpClientResilienceExtensions
+{
+    internal const string PipelineName = "get-read-retry";
+    internal const int MaxRetryAttempts = 2;
+    internal static readonly TimeSpan InitialRetryDelay = TimeSpan.FromMilliseconds(200);
+
+    internal static IHttpClientBuilder ConfigureGetReadResilience(this IHttpClientBuilder builder)
+    {
+        builder.AddResilienceHandler(
+            PipelineName,
+            static pipeline =>
+            {
+                var options = new HttpRetryStrategyOptions
+                {
+                    MaxRetryAttempts = MaxRetryAttempts,
+                    Delay = InitialRetryDelay,
+                    BackoffType = DelayBackoffType.Exponential,
+                    UseJitter = true,
+                    ShouldRetryAfterHeader = true
+                };
+                options.DisableForUnsafeHttpMethods();
+
+                var defaultShouldHandle = options.ShouldHandle;
+                options.ShouldHandle = args =>
+                {
+                    if (args.Outcome.Result?.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        return ValueTask.FromResult(false);
+                    }
+
+                    return defaultShouldHandle(args);
+                };
+
+                pipeline.AddRetry(options);
+            });
+
+        return builder;
+    }
+}

--- a/src/FishingLogBook.Web/FishingLogBook.Web.csproj
+++ b/src/FishingLogBook.Web/FishingLogBook.Web.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
     <PackageReference Include="MudBlazor" />
   </ItemGroup>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -135,12 +135,15 @@ public static class ServiceCollectionExtensions
             client.BaseAddress = apiBaseAddress;
         })
             .AddHttpMessageHandler<AuthorizationMessageHandler>()
-            .AddHttpMessageHandler<CorrelationDelegatingHandler>();
+            .AddHttpMessageHandler<CorrelationDelegatingHandler>()
+            .ConfigureGetReadResilience();
 
         services.AddHttpClient(HttpClientNames.Anonymous, client =>
         {
             client.BaseAddress = apiBaseAddress;
-        }).AddHttpMessageHandler<CorrelationDelegatingHandler>();
+        })
+            .AddHttpMessageHandler<CorrelationDelegatingHandler>()
+            .ConfigureGetReadResilience();
     }
 
     private static AuthorizationMessageHandler CreateApiAuthorizationMessageHandler(

--- a/tests/FishingLogBook.Web.Tests/Configuration/HttpClientResilienceTests/BaseHttpClientResilienceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Configuration/HttpClientResilienceTests/BaseHttpClientResilienceTest.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Diagnostics.Http;
+using FishingLogBook.Web.Features.Diagnostics.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FishingLogBook.Web.Tests.Configuration.HttpClientResilienceTests;
+
+public class BaseHttpClientResilienceTest
+{
+    protected static (HttpClient Client, TestPrimaryHandler Handler) CreateResilientClient(
+        Func<int, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseFactory,
+        bool includeCorrelationHandler = false)
+    {
+        var primary = new TestPrimaryHandler(responseFactory);
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        if (includeCorrelationHandler)
+        {
+            services.AddScoped<CorrelationContext>();
+            services.AddTransient<CorrelationDelegatingHandler>();
+        }
+
+        var builder = services.AddHttpClient(HttpClientNames.Anonymous, client =>
+            {
+                client.BaseAddress = new Uri("https://api.test/");
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => primary);
+
+        if (includeCorrelationHandler)
+        {
+            builder.AddHttpMessageHandler<CorrelationDelegatingHandler>();
+        }
+
+        builder.ConfigureGetReadResilience();
+
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        return (factory.CreateClient(HttpClientNames.Anonymous), primary);
+    }
+
+    protected static HttpResponseMessage CreateResponse(
+        HttpRequestMessage request,
+        HttpStatusCode statusCode)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            RequestMessage = request
+        };
+    }
+
+    protected sealed class TestPrimaryHandler : HttpMessageHandler
+    {
+        private readonly Func<int, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responseFactory;
+        private int _invocationCount;
+
+        public TestPrimaryHandler(
+            Func<int, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public int InvocationCount => _invocationCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var attempt = Interlocked.Increment(ref _invocationCount);
+            return _responseFactory(attempt, request, cancellationToken);
+        }
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Configuration/HttpClientResilienceTests/WhenTestingGetReadRetry.cs
+++ b/tests/FishingLogBook.Web.Tests/Configuration/HttpClientResilienceTests/WhenTestingGetReadRetry.cs
@@ -1,0 +1,228 @@
+using System.Net;
+using AwesomeAssertions;
+using FishingLogBook.Shared.Diagnostics;
+using FishingLogBook.Web.Configuration;
+using FishingLogBook.Web.Features.Diagnostics.Http;
+using FishingLogBook.Web.Features.Diagnostics.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FishingLogBook.Web.Tests.Configuration.HttpClientResilienceTests;
+
+public class WhenTestingGetReadRetry : BaseHttpClientResilienceTest
+{
+    [Fact]
+    public async Task ItShouldRetryGetRequestsAfterTransientNetworkFailures()
+    {
+        // Arrange
+        var (client, handler) = CreateResilientClient((attempt, request, _) =>
+        {
+            if (attempt == 1)
+            {
+                throw new HttpRequestException("connection reset");
+            }
+
+            return Task.FromResult(CreateResponse(request, HttpStatusCode.OK));
+        });
+
+        // Act
+        using var response = await client.GetAsync("api/catches", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        handler.InvocationCount.Should().Be(2);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    public async Task ItShouldRetryGetRequestsAfterTransientServerErrors(HttpStatusCode statusCode)
+    {
+        // Arrange
+        var (client, handler) = CreateResilientClient((attempt, request, _) =>
+            Task.FromResult(CreateResponse(
+                request,
+                attempt <= HttpClientResilienceExtensions.MaxRetryAttempts
+                    ? statusCode
+                    : HttpStatusCode.OK)));
+
+        // Act
+        using var response = await client.GetAsync("api/catches", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        handler.InvocationCount.Should().Be(HttpClientResilienceExtensions.MaxRetryAttempts + 1);
+    }
+
+    [Fact]
+    public async Task ItShouldRetryGetRequestsAfterRequestTimeout()
+    {
+        // Arrange
+        var (client, handler) = CreateResilientClient((attempt, request, _) =>
+            Task.FromResult(CreateResponse(
+                request,
+                attempt == 1 ? HttpStatusCode.RequestTimeout : HttpStatusCode.OK)));
+
+        // Act
+        using var response = await client.GetAsync("api/catches", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        handler.InvocationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ItShouldRetryGetRequestsAfterTooManyRequests()
+    {
+        // Arrange
+        var (client, handler) = CreateResilientClient((attempt, request, _) =>
+            Task.FromResult(CreateResponse(
+                request,
+                attempt == 1 ? HttpStatusCode.TooManyRequests : HttpStatusCode.OK)));
+
+        // Act
+        using var response = await client.GetAsync("api/catches", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        handler.InvocationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ItShouldNotRetryGetRequestsThatReturnNotFound()
+    {
+        // Arrange
+        var (client, handler) = CreateResilientClient((attempt, request, _) =>
+            Task.FromResult(CreateResponse(request, HttpStatusCode.NotFound)));
+
+        // Act
+        using var response = await client.GetAsync("api/catches/00000000-0000-0000-0000-000000000001", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        handler.InvocationCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("PATCH")]
+    [InlineData("DELETE")]
+    public async Task ItShouldNotRetryUnsafeHttpMethodsAfterTransientFailures(string methodName)
+    {
+        // Arrange
+        var method = new HttpMethod(methodName);
+        var (client, handler) = CreateResilientClient((attempt, request, _) =>
+            Task.FromResult(CreateResponse(request, HttpStatusCode.ServiceUnavailable)));
+
+        using var request = new HttpRequestMessage(method, "api/catches")
+        {
+            Content = method == HttpMethod.Post || method == HttpMethod.Put || method == HttpMethod.Patch
+                ? new StringContent("{}")
+                : null
+        };
+
+        // Act
+        using var response = await client.SendAsync(request, CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        handler.InvocationCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldStopRetryingWhenCancellationIsRequested()
+    {
+        // Arrange
+        using var cancellation = new CancellationTokenSource();
+        var (client, handler) = CreateResilientClient(async (attempt, request, _) =>
+        {
+            if (attempt == 1)
+            {
+                await cancellation.CancelAsync();
+                return CreateResponse(request, HttpStatusCode.InternalServerError);
+            }
+
+            return CreateResponse(request, HttpStatusCode.OK);
+        });
+
+        // Act
+        Func<Task> act = async () =>
+        {
+            using var response = await client.GetAsync("api/catches", cancellation.Token);
+            response.EnsureSuccessStatusCode();
+        };
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        handler.InvocationCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ItShouldKeepCorrelationHeadersAcrossGetRetries()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddScoped<CorrelationContext>();
+        services.AddTransient<CorrelationDelegatingHandler>();
+
+        var primary = new CorrelationCapturingHandler((attempt, request, _) =>
+            Task.FromResult(CreateResponse(
+                request,
+                attempt == 1 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.OK)));
+
+        services.AddHttpClient(HttpClientNames.Anonymous, client =>
+            {
+                client.BaseAddress = new Uri("https://api.test/");
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => primary)
+            .AddHttpMessageHandler<CorrelationDelegatingHandler>()
+            .ConfigureGetReadResilience();
+
+        await using var provider = services.BuildServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient(HttpClientNames.Anonymous);
+
+        // Act
+        using var response = await client.GetAsync("api/catches", CancellationToken.None);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        primary.InvocationCount.Should().Be(2);
+        primary.CorrelationIds.Should().HaveCount(2);
+        primary.CorrelationIds.Should().OnlyContain(id => !string.IsNullOrWhiteSpace(id));
+        primary.CorrelationIds.Distinct().Should().ContainSingle();
+    }
+
+    private sealed class CorrelationCapturingHandler : HttpMessageHandler
+    {
+        private readonly Func<int, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responseFactory;
+        private int _invocationCount;
+
+        public CorrelationCapturingHandler(
+            Func<int, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public int InvocationCount => _invocationCount;
+
+        public IReadOnlyList<string> CorrelationIds => _correlationIds;
+
+        private readonly List<string> _correlationIds = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var attempt = Interlocked.Increment(ref _invocationCount);
+            if (request.Headers.TryGetValues(CorrelationHeaders.CorrelationId, out var values))
+            {
+                _correlationIds.Add(values.Single());
+            }
+
+            return await _responseFactory(attempt, request, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds centralized GET-only HTTP retry resilience to the Blazor Web app using `Microsoft.Extensions.Http.Resilience`.

**Approach:** A custom retry-only `AddResilienceHandler` pipeline (`get-read-retry`) configured in `RegisterHttpClients()` — not the full standard handler, to avoid circuit breakers, hedging, and long default timeouts.

**Policy:**
- **2 retries** (3 attempts total), **200ms** initial delay, exponential backoff with jitter
- **429:** respects server `Retry-After` via `ShouldRetryAfterHeader`
- **Retried (GET only):** `HttpRequestException`, HTTP 408, 429, 5xx
- **Not retried:** POST, PUT, PATCH, DELETE (`DisableForUnsafeHttpMethods()`), HTTP 404 (explicit exclusion)

**Clients:** `FishingLogBook.Api` and `FishingLogBook.Anonymous` — handler order preserved: auth → correlation → resilience.

No explicit 404 retry opt-in was added; existing GET 404 semantics are intentional across clients and sync.

## Test plan

- [x] GET + transient network failure — retried, succeeds on later attempt
- [x] GET + HTTP 5xx — retried per bounded policy
- [x] GET + HTTP 408 — retried
- [x] GET + HTTP 429 — retried
- [x] GET + HTTP 404 — not retried
- [x] POST / PUT / PATCH / DELETE — not retried after transient failure
- [x] Cancellation — stops retries
- [x] Correlation header present and consistent across GET retry attempts
- [x] Full `dotnet test` suite (2853 passed)

Closes #199