### PR TITLE
FLB#214 | Select import photos and extract historical metadata

### DIFF
--- a/docs/import/historical-photo-import-device-validation.md
+++ b/docs/import/historical-photo-import-device-validation.md
@@ -1,0 +1,31 @@
+# Historical Photo Import Device Validation
+
+**Issue:** #214  
+**Status:** Pending physical-device execution
+
+Record the device model, operating-system version, browser version and whether the PWA was installed for every run. Use test photographs with known EXIF values and compare the parsed result with an independent metadata reader.
+
+## Android installed PWA
+
+- [ ] Select 1, 10 and 20 photographs; confirm order is retained.
+- [ ] Confirm multi-select cancellation and system Back behavior.
+- [ ] Test JPEG, PNG and WebP supplied by the native picker.
+- [ ] Select HEIC-origin photos and record the actual supplied MIME type/transcoding behavior.
+- [ ] Verify EXIF original/digitized date, explicit offset, offset-less wall clock and GPS retention.
+- [ ] Verify orientations 1–8 display correctly after sanitisation.
+- [ ] Remove, replace and cancel selections; confirm previews disappear and no stale preview is shown.
+- [ ] Observe responsiveness and browser/PWA memory pressure at 20 photographs.
+
+## iPhone Home Screen PWA
+
+- [ ] Select 1, 10 and 20 photographs; confirm order is retained.
+- [ ] Record Photos limited/full permission and picker behavior.
+- [ ] Confirm multi-select cancellation and navigation-away behavior.
+- [ ] Test JPEG, PNG and WebP where the picker supplies them.
+- [ ] Select HEIC-origin photos and record conversion, MIME type and metadata retention.
+- [ ] Verify EXIF original/digitized date, explicit offset, offset-less wall clock and GPS retention.
+- [ ] Verify orientations 1–8 display correctly after sanitisation.
+- [ ] Remove, replace and cancel selections; confirm previews disappear and no stale preview is shown.
+- [ ] Observe responsiveness, Home Screen PWA termination and memory pressure at 20 photographs.
+
+Native-picker behavior is not proven by automated CI. A missing or stripped timestamp/GPS value is a supported per-photo metadata-unavailable outcome, not an Import failure.

--- a/src/FishingLogBook.Web/BrowserTests/harness/import-photo-blob-registry.html
+++ b/src/FishingLogBook.Web/BrowserTests/harness/import-photo-blob-registry.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Import photo blob registry harness</title>
+</head>
+<body>
+    <p id="status">loading</p>
+    <script type="module">
+        import { clear, getBytes, register, remove } from '../../wwwroot/js/import/photo-blob-registry.js';
+
+        window.importPhotoHarness = {
+            async registerTestImage(red) {
+                const canvas = document.createElement('canvas');
+                canvas.width = 4;
+                canvas.height = 2;
+                const context = canvas.getContext('2d');
+                context.fillStyle = red ? '#ff0000' : '#0000ff';
+                context.fillRect(0, 0, canvas.width, canvas.height);
+                const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+                return register(new Uint8Array(await blob.arrayBuffer()), 'image/png');
+            },
+            async readLength(token) {
+                return (await getBytes(token)).length;
+            },
+            remove,
+            clear
+        };
+
+        document.getElementById('status').textContent = 'ready';
+    </script>
+</body>
+</html>

--- a/src/FishingLogBook.Web/BrowserTests/import-photo-blob-registry.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/import-photo-blob-registry.spec.js
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+
+const harness = '/src/FishingLogBook.Web/BrowserTests/harness/import-photo-blob-registry.html';
+
+test.describe('Import photo blob registry', () => {
+    test('stores sanitised bytes and releases thumbnail object URLs', async ({ page }) => {
+        await page.goto(harness);
+        await expect(page.locator('#status')).toHaveText('ready');
+
+        const result = await page.evaluate(async () => {
+            const registration = await window.importPhotoHarness.registerTestImage(true);
+            const response = await fetch(registration.thumbnailUrl);
+            const thumbnailType = response.headers.get('content-type');
+            const storedLength = await window.importPhotoHarness.readLength(registration.token);
+            const removed = window.importPhotoHarness.remove(registration.token);
+            let missingAfterRemoval = false;
+            try {
+                await window.importPhotoHarness.readLength(registration.token);
+            } catch {
+                missingAfterRemoval = true;
+            }
+
+            return { registration, thumbnailType, storedLength, removed, missingAfterRemoval };
+        });
+
+        expect(result.registration.token).not.toBe('photo.png');
+        expect(result.registration.thumbnailUrl).toMatch(/^blob:/);
+        expect(result.thumbnailType).toBe('image/jpeg');
+        expect(result.storedLength).toBeGreaterThan(0);
+        expect(result.removed).toBe(true);
+        expect(result.missingAfterRemoval).toBe(true);
+    });
+
+    test('keeps sequential registrations distinct and clears all entries', async ({ page }) => {
+        await page.goto(harness);
+        await expect(page.locator('#status')).toHaveText('ready');
+
+        const result = await page.evaluate(async () => {
+            const first = await window.importPhotoHarness.registerTestImage(true);
+            const second = await window.importPhotoHarness.registerTestImage(false);
+            window.importPhotoHarness.clear();
+            const missing = [];
+            for (const registration of [first, second]) {
+                try {
+                    await window.importPhotoHarness.readLength(registration.token);
+                    missing.push(false);
+                } catch {
+                    missing.push(true);
+                }
+            }
+
+            return { first, second, missing };
+        });
+
+        expect(result.first.token).not.toBe(result.second.token);
+        expect(result.first.thumbnailUrl).not.toBe(result.second.thumbnailUrl);
+        expect(result.missing).toEqual([true, true]);
+    });
+});

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportPhotographPicker/ImportPhotographPicker.razor
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportPhotographPicker/ImportPhotographPicker.razor
@@ -1,0 +1,6 @@
+@using Microsoft.AspNetCore.Components.Forms
+
+<InputFile id="@Id"
+           accept="image/*"
+           multiple
+           OnChange="OnSelectedAsync" />

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportPhotographPicker/ImportPhotographPicker.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportPhotographPicker/ImportPhotographPicker.razor.cs
@@ -1,0 +1,72 @@
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace FishingLogBook.Web.Features.Import.Components.ImportPhotographPicker;
+
+public partial class ImportPhotographPicker : ComponentBase, IAsyncDisposable
+{
+    private CancellationTokenSource? _selectionCancellation;
+    private Task _selectionTask = Task.CompletedTask;
+
+    [Parameter, EditorRequired]
+    public string Id { get; set; } = default!;
+
+    [Parameter]
+    public EventCallback<IReadOnlyList<ImportSelectedPhotoModel>> PhotosPrepared { get; set; }
+
+    [Parameter]
+    public EventCallback SelectionLimitExceeded { get; set; }
+
+    [Inject]
+    private IImportPhotoPreparationService Preparation { get; set; } = default!;
+
+    private async Task OnSelectedAsync(InputFileChangeEventArgs args)
+    {
+        await CancelSelectionAsync();
+        var files = args.GetMultipleFiles(ImportPhotoPreparationService.MaxPhotographs + 1);
+        if (files.Count > ImportPhotoPreparationService.MaxPhotographs)
+        {
+            await SelectionLimitExceeded.InvokeAsync();
+            return;
+        }
+
+        _selectionCancellation = new CancellationTokenSource();
+        _selectionTask = PrepareAsync(files, _selectionCancellation.Token);
+        await _selectionTask;
+    }
+
+    private async Task PrepareAsync(
+        IReadOnlyList<IBrowserFile> files,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var photos = await Preparation.PrepareSelectionAsync(files, cancellationToken);
+            await PhotosPrepared.InvokeAsync(photos);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task CancelSelectionAsync()
+    {
+        if (_selectionCancellation is null)
+        {
+            return;
+        }
+
+        await _selectionCancellation.CancelAsync();
+        await _selectionTask;
+        _selectionCancellation.Dispose();
+        _selectionCancellation = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await CancelSelectionAsync();
+        await Preparation.ClearAsync(CancellationToken.None);
+    }
+}

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportPhotoPreparationStatusEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportPhotoPreparationStatusEnum.cs
@@ -1,0 +1,11 @@
+namespace FishingLogBook.Web.Features.Import.Enums;
+
+public enum ImportPhotoPreparationStatusEnum
+{
+    Pending,
+    Ready,
+    UnsupportedType,
+    TooLarge,
+    PreparationFailed,
+    Cancelled
+}

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportPhotoBlobRegistrationModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportPhotoBlobRegistrationModel.cs
@@ -1,0 +1,3 @@
+namespace FishingLogBook.Web.Features.Import.Models;
+
+public sealed record ImportPhotoBlobRegistrationModel(string Token, string ThumbnailUrl);

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportSelectedPhotoModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportSelectedPhotoModel.cs
@@ -9,7 +9,7 @@ public sealed class ImportSelectedPhotoModel
         int selectionIndex,
         string contentType,
         long byteSize,
-        string blobToken,
+        string? blobToken,
         string? fileName = null,
         string? thumbnailUrl = null)
     {
@@ -42,7 +42,7 @@ public sealed class ImportSelectedPhotoModel
 
     public long ByteSize { get; }
 
-    public string BlobToken { get; }
+    public string? BlobToken { get; private set; }
 
     public string? ThumbnailUrl { get; private set; }
 
@@ -59,6 +59,28 @@ public sealed class ImportSelectedPhotoModel
     public string? Fingerprint { get; private set; }
 
     public bool IsRemoved { get; private set; }
+
+    public ImportPhotoPreparationStatusEnum PreparationStatus { get; private set; }
+
+    public bool IsReady
+    {
+        get
+        {
+            return PreparationStatus == ImportPhotoPreparationStatusEnum.Ready
+                && !string.IsNullOrWhiteSpace(BlobToken)
+                && !string.IsNullOrWhiteSpace(ThumbnailUrl);
+        }
+    }
+
+    public void SetPreparation(
+        ImportPhotoPreparationStatusEnum status,
+        string? blobToken = null,
+        string? thumbnailUrl = null)
+    {
+        PreparationStatus = status;
+        BlobToken = blobToken;
+        ThumbnailUrl = thumbnailUrl;
+    }
 
     public void SetMetadata(
         ImportMetadataStatusEnum status,

--- a/src/FishingLogBook.Web/Features/Import/Services/IImportPhotoBlobRegistryService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/IImportPhotoBlobRegistryService.cs
@@ -1,0 +1,17 @@
+using FishingLogBook.Web.Features.Import.Models;
+
+namespace FishingLogBook.Web.Features.Import.Services;
+
+public interface IImportPhotoBlobRegistryService
+{
+    Task<ImportPhotoBlobRegistrationModel> RegisterAsync(
+        byte[] bytes,
+        string contentType,
+        CancellationToken cancellationToken);
+
+    Task<byte[]> GetBytesAsync(string token, CancellationToken cancellationToken);
+
+    Task RemoveAsync(string token, CancellationToken cancellationToken);
+
+    Task ClearAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Import/Services/IImportPhotoPreparationService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/IImportPhotoPreparationService.cs
@@ -1,0 +1,15 @@
+using FishingLogBook.Web.Features.Import.Models;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace FishingLogBook.Web.Features.Import.Services;
+
+public interface IImportPhotoPreparationService
+{
+    Task<IReadOnlyList<ImportSelectedPhotoModel>> PrepareSelectionAsync(
+        IReadOnlyList<IBrowserFile> files,
+        CancellationToken cancellationToken);
+
+    Task RemoveAsync(ImportSelectedPhotoModel photo, CancellationToken cancellationToken);
+
+    Task ClearAsync(CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPhotoBlobRegistryService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPhotoBlobRegistryService.cs
@@ -20,6 +20,7 @@ public sealed class ImportPhotoBlobRegistryService : IImportPhotoBlobRegistrySer
         CancellationToken cancellationToken)
     {
         var module = await GetModuleAsync(cancellationToken);
+        // Complete one registration atomically so cancellation cleanup cannot race a late JavaScript registry entry.
         return await module.InvokeAsync<ImportPhotoBlobRegistrationModel>(
             "register",
             CancellationToken.None,

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPhotoBlobRegistryService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPhotoBlobRegistryService.cs
@@ -1,0 +1,72 @@
+using FishingLogBook.Web.Features.Import.Models;
+using Microsoft.JSInterop;
+
+namespace FishingLogBook.Web.Features.Import.Services;
+
+public sealed class ImportPhotoBlobRegistryService : IImportPhotoBlobRegistryService, IAsyncDisposable
+{
+    private const string ModulePath = "./js/import/photo-blob-registry.js";
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public ImportPhotoBlobRegistryService(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task<ImportPhotoBlobRegistrationModel> RegisterAsync(
+        byte[] bytes,
+        string contentType,
+        CancellationToken cancellationToken)
+    {
+        var module = await GetModuleAsync(cancellationToken);
+        return await module.InvokeAsync<ImportPhotoBlobRegistrationModel>(
+            "register",
+            CancellationToken.None,
+            bytes,
+            contentType);
+    }
+
+    public async Task<byte[]> GetBytesAsync(string token, CancellationToken cancellationToken)
+    {
+        var module = await GetModuleAsync(cancellationToken);
+        return await module.InvokeAsync<byte[]>("getBytes", cancellationToken, token);
+    }
+
+    public async Task RemoveAsync(string token, CancellationToken cancellationToken)
+    {
+        var module = await GetModuleAsync(cancellationToken);
+        await module.InvokeVoidAsync("remove", cancellationToken, token);
+    }
+
+    public async Task ClearAsync(CancellationToken cancellationToken)
+    {
+        if (_module is not null)
+        {
+            await _module.InvokeVoidAsync("clear", cancellationToken);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _module.InvokeVoidAsync("clear");
+            await _module.DisposeAsync();
+        }
+        catch (JSDisconnectedException)
+        {
+        }
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync(CancellationToken cancellationToken)
+    {
+        _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>("import", cancellationToken, ModulePath);
+        return _module;
+    }
+}

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPhotoPreparationService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPhotoPreparationService.cs
@@ -1,0 +1,247 @@
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Photographs.Enums;
+using FishingLogBook.Web.Features.Photographs.Models;
+using FishingLogBook.Web.Features.Photographs.Services;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace FishingLogBook.Web.Features.Import.Services;
+
+public sealed class ImportPhotoPreparationService : IImportPhotoPreparationService
+{
+    public const int MaxPhotographs = 20;
+    public const long MaxPhotographBytes = PhotographPreparationService.MaxPhotographBytes;
+
+    private readonly IPhotographMetadataService _metadata;
+    private readonly IImportPhotoBlobRegistryService _registry;
+    private readonly ILoggingService _logging;
+
+    public ImportPhotoPreparationService(
+        IPhotographMetadataService metadata,
+        IImportPhotoBlobRegistryService registry,
+        ILoggingService logging)
+    {
+        _metadata = metadata;
+        _registry = registry;
+        _logging = logging;
+    }
+
+    public async Task<IReadOnlyList<ImportSelectedPhotoModel>> PrepareSelectionAsync(
+        IReadOnlyList<IBrowserFile> files,
+        CancellationToken cancellationToken)
+    {
+        if (files.Count > MaxPhotographs)
+        {
+            throw new ArgumentOutOfRangeException(nameof(files), $"At most {MaxPhotographs} photographs may be selected.");
+        }
+
+        await _registry.ClearAsync(cancellationToken);
+        var prepared = new List<ImportSelectedPhotoModel>(files.Count);
+        try
+        {
+            for (var index = 0; index < files.Count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                prepared.Add(await PrepareAsync(files[index], index, cancellationToken));
+            }
+
+            return prepared;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            foreach (var photo in prepared)
+            {
+                photo.SetPreparation(ImportPhotoPreparationStatusEnum.Cancelled);
+            }
+
+            await ClearWithoutCancellationAsync();
+            throw;
+        }
+    }
+
+    public async Task RemoveAsync(ImportSelectedPhotoModel photo, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(photo.BlobToken))
+        {
+            await _registry.RemoveAsync(photo.BlobToken, cancellationToken);
+        }
+
+        photo.Remove();
+    }
+
+    public Task ClearAsync(CancellationToken cancellationToken)
+    {
+        return _registry.ClearAsync(cancellationToken);
+    }
+
+    private async Task<ImportSelectedPhotoModel> PrepareAsync(
+        IBrowserFile file,
+        int selectionIndex,
+        CancellationToken cancellationToken)
+    {
+        var photo = NewPhoto(file, selectionIndex);
+        if (!PhotographContentTypeConstants.IsAllowed(file.ContentType))
+        {
+            photo.SetPreparation(ImportPhotoPreparationStatusEnum.UnsupportedType);
+            return photo;
+        }
+
+        if (file.Size > MaxPhotographBytes)
+        {
+            photo.SetPreparation(ImportPhotoPreparationStatusEnum.TooLarge);
+            return photo;
+        }
+
+        try
+        {
+            var original = await ReadBytesAsync(file, cancellationToken);
+            var historical = await ReadMetadataAsync(original, file);
+            if (historical is null)
+            {
+                photo.SetMetadata(
+                    ImportMetadataStatusEnum.Failed,
+                    ImportTimestampModel.Missing(),
+                    new ImportLocationModel(null, null, false),
+                    "metadata-unavailable");
+            }
+            else
+            {
+                photo.SetMetadata(
+                    historical.CapturedOnWasPresent || historical.HasCoordinates
+                        ? ImportMetadataStatusEnum.Available
+                        : ImportMetadataStatusEnum.Unavailable,
+                    MapTimestamp(historical),
+                    MapLocation(historical));
+            }
+
+            var sanitised = _metadata.Sanitise(original, file.ContentType);
+            if (sanitised is null)
+            {
+                photo.SetPreparation(ImportPhotoPreparationStatusEnum.PreparationFailed);
+                return photo;
+            }
+
+            var registration = await _registry.RegisterAsync(sanitised, file.ContentType, cancellationToken);
+            photo.SetPreparation(
+                ImportPhotoPreparationStatusEnum.Ready,
+                registration.Token,
+                registration.ThumbnailUrl);
+            return photo;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            photo.SetPreparation(ImportPhotoPreparationStatusEnum.Cancelled);
+            throw;
+        }
+        catch (Exception exception)
+        {
+            await LogSafelyAsync(exception);
+            photo.SetPreparation(ImportPhotoPreparationStatusEnum.PreparationFailed);
+            return photo;
+        }
+    }
+
+    private static ImportSelectedPhotoModel NewPhoto(IBrowserFile file, int selectionIndex)
+    {
+        return new ImportSelectedPhotoModel(
+            Guid.NewGuid(),
+            selectionIndex,
+            file.ContentType,
+            file.Size,
+            null,
+            file.Name);
+    }
+
+    private static async Task<byte[]> ReadBytesAsync(IBrowserFile file, CancellationToken cancellationToken)
+    {
+        await using var stream = file.OpenReadStream(MaxPhotographBytes, cancellationToken);
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, cancellationToken);
+        return buffer.ToArray();
+    }
+
+    private async Task<PhotographHistoricalMetadataModel?> ReadMetadataAsync(
+        byte[] original,
+        IBrowserFile file)
+    {
+        try
+        {
+            return _metadata.ReadHistorical(
+                original,
+                file.ContentType,
+                file.LastModified,
+                DateTimeOffset.UtcNow);
+        }
+        catch (Exception exception)
+        {
+            await LogSafelyAsync(exception);
+            return null;
+        }
+    }
+
+    private static ImportTimestampModel MapTimestamp(PhotographHistoricalMetadataModel metadata)
+    {
+        if (metadata.CapturedOnWasMalformed)
+        {
+            return ImportTimestampModel.Unusable(ToImportSource(metadata.CapturedOnSource));
+        }
+
+        if (metadata.CapturedOnSource == PhotographCapturedOnSourceEnum.FileLastModified
+            && metadata.ExplicitInstant is { } fallback)
+        {
+            return ImportTimestampModel.FromWeakFallback(fallback);
+        }
+
+        if (metadata.ExplicitInstant is { } instant)
+        {
+            return ImportTimestampModel.FromExplicitInstant(instant, ToImportSource(metadata.CapturedOnSource));
+        }
+
+        if (metadata.LocalWallClock is { } wallClock)
+        {
+            return ImportTimestampModel.FromLocalWallClock(wallClock, ToImportSource(metadata.CapturedOnSource));
+        }
+
+        return ImportTimestampModel.Missing();
+    }
+
+    private static ImportTimestampSourceEnum ToImportSource(PhotographCapturedOnSourceEnum source)
+    {
+        return source switch
+        {
+            PhotographCapturedOnSourceEnum.ExifOriginal => ImportTimestampSourceEnum.ExifOriginal,
+            PhotographCapturedOnSourceEnum.ExifDigitized => ImportTimestampSourceEnum.ExifDigitized,
+            PhotographCapturedOnSourceEnum.FileLastModified => ImportTimestampSourceEnum.FileLastModified,
+            _ => ImportTimestampSourceEnum.None
+        };
+    }
+
+    private static ImportLocationModel MapLocation(PhotographHistoricalMetadataModel metadata)
+    {
+        return metadata.HasCoordinates
+            ? new ImportLocationModel(metadata.Latitude, metadata.Longitude, true)
+            : new ImportLocationModel(null, null, false);
+    }
+
+    private Task LogSafelyAsync(Exception exception)
+    {
+        return _logging.LogErrorAsync(
+            "preparing a historical photograph",
+            $"A historical photograph could not be prepared ({exception.GetType().Name}).",
+            CancellationToken.None);
+    }
+
+    private async Task ClearWithoutCancellationAsync()
+    {
+        try
+        {
+            await _registry.ClearAsync(CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            await LogSafelyAsync(exception);
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Photographs/Models/PhotographHistoricalMetadataModel.cs
+++ b/src/FishingLogBook.Web/Features/Photographs/Models/PhotographHistoricalMetadataModel.cs
@@ -1,0 +1,21 @@
+using FishingLogBook.Web.Features.Photographs.Enums;
+
+namespace FishingLogBook.Web.Features.Photographs.Models;
+
+public sealed record PhotographHistoricalMetadataModel(
+    DateTimeOffset? ExplicitInstant,
+    DateTime? LocalWallClock,
+    PhotographCapturedOnSourceEnum CapturedOnSource,
+    bool CapturedOnWasPresent,
+    bool CapturedOnWasMalformed,
+    double? Latitude,
+    double? Longitude)
+{
+    public bool HasCoordinates
+    {
+        get
+        {
+            return Latitude.HasValue && Longitude.HasValue;
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Photographs/Services/IPhotographMetadataService.cs
+++ b/src/FishingLogBook.Web/Features/Photographs/Services/IPhotographMetadataService.cs
@@ -11,5 +11,11 @@ public interface IPhotographMetadataService
         DateTimeOffset now,
         CancellationToken cancellationToken);
 
+    PhotographHistoricalMetadataModel ReadHistorical(
+        byte[] bytes,
+        string contentType,
+        DateTimeOffset? fileLastModified,
+        DateTimeOffset now);
+
     byte[]? Sanitise(byte[] bytes, string contentType);
 }

--- a/src/FishingLogBook.Web/Features/Photographs/Services/PhotographMetadataService.cs
+++ b/src/FishingLogBook.Web/Features/Photographs/Services/PhotographMetadataService.cs
@@ -93,6 +93,105 @@ public sealed class PhotographMetadataService : IPhotographMetadataService
                 : PhotographCapturedOnSourceEnum.FileLastModified);
     }
 
+    public PhotographHistoricalMetadataModel ReadHistorical(
+        byte[] bytes,
+        string contentType,
+        DateTimeOffset? fileLastModified,
+        DateTimeOffset now)
+    {
+        var tiffOffset = FindTiffOffset(bytes, contentType);
+        var values = tiffOffset < 0 ? null : ReadExifValues(bytes, tiffOffset);
+        var original = ParseHistoricalCapture(values?.Original, now);
+        if (original is not null)
+        {
+            return ToHistoricalMetadata(original.Value, PhotographCapturedOnSourceEnum.ExifOriginal, values);
+        }
+
+        var digitized = ParseHistoricalCapture(values?.Digitized, now);
+        if (digitized is not null)
+        {
+            return ToHistoricalMetadata(digitized.Value, PhotographCapturedOnSourceEnum.ExifDigitized, values);
+        }
+
+        var exifWasPresent = values?.Original is not null || values?.Digitized is not null;
+        if (exifWasPresent)
+        {
+            var malformedSource = values?.Original is not null
+                ? PhotographCapturedOnSourceEnum.ExifOriginal
+                : PhotographCapturedOnSourceEnum.ExifDigitized;
+            return new PhotographHistoricalMetadataModel(
+                null,
+                null,
+                malformedSource,
+                true,
+                true,
+                values?.Latitude,
+                values?.Longitude);
+        }
+
+        var fallback = PlausibleFileTimestamp(fileLastModified, now);
+        return new PhotographHistoricalMetadataModel(
+            fallback,
+            null,
+            fallback is null
+                ? PhotographCapturedOnSourceEnum.None
+                : PhotographCapturedOnSourceEnum.FileLastModified,
+            false,
+            false,
+            values?.Latitude,
+            values?.Longitude);
+    }
+
+    private static HistoricalCapture? ParseHistoricalCapture(ExifCapture? capture, DateTimeOffset now)
+    {
+        if (capture is not { } candidate)
+        {
+            return null;
+        }
+
+        if (candidate.OffsetText is not null)
+        {
+            return DateTimeOffset.TryParseExact(
+                    candidate.WallClockText + candidate.OffsetText,
+                    ExifWallClockWithOffsetFormat,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var withOffset)
+                && IsPlausibleCapture(withOffset, now)
+                    ? new HistoricalCapture(withOffset, null)
+                    : null;
+        }
+
+        if (!DateTime.TryParseExact(
+                candidate.WallClockText,
+                ExifWallClockFormat,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var wallClock)
+            || wallClock.Year < EarliestPlausibleCaptureYear
+            || wallClock > now.DateTime + MaxCaptureFutureSkew)
+        {
+            return null;
+        }
+
+        return new HistoricalCapture(null, DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified));
+    }
+
+    private static PhotographHistoricalMetadataModel ToHistoricalMetadata(
+        HistoricalCapture capture,
+        PhotographCapturedOnSourceEnum source,
+        ExifValues? values)
+    {
+        return new PhotographHistoricalMetadataModel(
+            capture.ExplicitInstant,
+            capture.LocalWallClock,
+            source,
+            true,
+            false,
+            values?.Latitude,
+            values?.Longitude);
+    }
+
     private static DateTimeOffset? PlausibleFileTimestamp(
         DateTimeOffset? fileLastModified,
         DateTimeOffset now)
@@ -1021,4 +1120,6 @@ public sealed class PhotographMetadataService : IPhotographMetadataService
     private readonly record struct ExifCapture(string WallClockText, string? OffsetText);
 
     private readonly record struct CaptureResult(DateTimeOffset? CapturedOn, bool UsedDigitized);
+
+    private readonly record struct HistoricalCapture(DateTimeOffset? ExplicitInstant, DateTime? LocalWallClock);
 }

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Diagnostics.Storage;
 using FishingLogBook.Web.Features.Diagnostics.Storage.Stores;
 using FishingLogBook.Web.Features.Diagnostics.Synchronisers;
+using FishingLogBook.Web.Features.Import.Services;
 using FishingLogBook.Web.Features.OfflineAccess.Clients;
 using FishingLogBook.Web.Features.OfflineAccess.Services;
 using FishingLogBook.Web.Features.Onboarding.Services;
@@ -110,6 +111,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICatchDateGroupingService, CatchDateGroupingService>();
         services.AddScoped<IPhotographMetadataService, PhotographMetadataService>();
         services.AddScoped<IPhotographPreparationService, PhotographPreparationService>();
+        services.AddScoped<IImportPhotoBlobRegistryService, ImportPhotoBlobRegistryService>();
+        services.AddScoped<IImportPhotoPreparationService, ImportPhotoPreparationService>();
         services.AddScoped<ICatchPhotographProposalService, CatchPhotographProposalService>();
         services.AddSingleton<DiagnosticStatusModel>();
         services.AddScoped<ILoggingService, LoggingService>();

--- a/src/FishingLogBook.Web/wwwroot/js/import/photo-blob-registry.js
+++ b/src/FishingLogBook.Web/wwwroot/js/import/photo-blob-registry.js
@@ -1,0 +1,73 @@
+const entries = new Map();
+const maximumThumbnailDimension = 512;
+
+export async function register(bytes, contentType) {
+    const token = crypto.randomUUID();
+    const blob = new Blob([bytes], { type: contentType });
+    const thumbnail = await createThumbnail(blob);
+    const thumbnailUrl = URL.createObjectURL(thumbnail);
+    entries.set(token, { blob, thumbnailUrl });
+    return { token, thumbnailUrl };
+}
+
+export async function getBytes(token) {
+    const entry = requireEntry(token);
+    return new Uint8Array(await entry.blob.arrayBuffer());
+}
+
+export function remove(token) {
+    const entry = entries.get(token);
+    if (!entry) {
+        return false;
+    }
+
+    URL.revokeObjectURL(entry.thumbnailUrl);
+    entries.delete(token);
+    return true;
+}
+
+export function clear() {
+    for (const entry of entries.values()) {
+        URL.revokeObjectURL(entry.thumbnailUrl);
+    }
+
+    entries.clear();
+}
+
+async function createThumbnail(blob) {
+    const bitmap = await createImageBitmap(blob, { imageOrientation: 'from-image' });
+    try {
+        const scale = Math.min(1, maximumThumbnailDimension / Math.max(bitmap.width, bitmap.height));
+        const width = Math.max(1, Math.round(bitmap.width * scale));
+        const height = Math.max(1, Math.round(bitmap.height * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        canvas.getContext('2d').drawImage(bitmap, 0, 0, width, height);
+        return await canvasToBlob(canvas);
+    } finally {
+        bitmap.close();
+    }
+}
+
+function canvasToBlob(canvas) {
+    return new Promise((resolve, reject) => {
+        canvas.toBlob(blob => {
+            if (blob) {
+                resolve(blob);
+                return;
+            }
+
+            reject(new Error('thumbnail-creation-failed'));
+        }, 'image/jpeg', 0.82);
+    });
+}
+
+function requireEntry(token) {
+    const entry = entries.get(token);
+    if (!entry) {
+        throw new Error('import-photo-not-found');
+    }
+
+    return entry;
+}

--- a/src/FishingLogBook.Web/wwwroot/js/import/photo-blob-registry.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/import/photo-blob-registry.test.js
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clear, getBytes, register, remove } from './photo-blob-registry.js';
+
+const createdUrls = [];
+
+beforeEach(() => {
+    clear();
+    createdUrls.length = 0;
+    let nextToken = 0;
+    vi.stubGlobal('crypto', { randomUUID: () => `token-${++nextToken}` });
+    vi.stubGlobal('createImageBitmap', vi.fn(async () => ({
+        width: 1200,
+        height: 600,
+        close: vi.fn()
+    })));
+    URL.createObjectURL = vi.fn(() => {
+        const url = `blob:thumbnail-${createdUrls.length + 1}`;
+        createdUrls.push(url);
+        return url;
+    });
+    URL.revokeObjectURL = vi.fn();
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({ drawImage: vi.fn() }));
+    HTMLCanvasElement.prototype.toBlob = vi.fn(callback => callback(new Blob([[9]], { type: 'image/jpeg' })));
+});
+
+describe('Import photo blob registry', () => {
+    it('registers opaque tokens and creates bounded object URL thumbnails', async () => {
+        const first = await register(new Uint8Array([1, 2, 3]), 'image/jpeg');
+        const second = await register(new Uint8Array([4, 5]), 'image/png');
+
+        expect(first).toEqual({ token: 'token-1', thumbnailUrl: 'blob:thumbnail-1' });
+        expect(second).toEqual({ token: 'token-2', thumbnailUrl: 'blob:thumbnail-2' });
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(2);
+        expect(createImageBitmap).toHaveBeenCalledTimes(2);
+    });
+
+    it('retrieves the sanitised bytes by opaque token', async () => {
+        const registration = await register(new Uint8Array([1, 2, 3]), 'image/jpeg');
+
+        const bytes = await getBytes(registration.token);
+
+        expect([...bytes]).toEqual([1, 2, 3]);
+    });
+
+    it('deletes one blob and revokes only its thumbnail URL', async () => {
+        const first = await register(new Uint8Array([1]), 'image/jpeg');
+        const second = await register(new Uint8Array([2]), 'image/jpeg');
+
+        expect(remove(first.token)).toBe(true);
+
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith(first.thumbnailUrl);
+        expect([...await getBytes(second.token)]).toEqual([2]);
+        await expect(getBytes(first.token)).rejects.toThrow('import-photo-not-found');
+    });
+
+    it('clears every blob and revokes every thumbnail URL', async () => {
+        const first = await register(new Uint8Array([1]), 'image/jpeg');
+        const second = await register(new Uint8Array([2]), 'image/jpeg');
+
+        clear();
+
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith(first.thumbnailUrl);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith(second.thumbnailUrl);
+        await expect(getBytes(first.token)).rejects.toThrow('import-photo-not-found');
+        await expect(getBytes(second.token)).rejects.toThrow('import-photo-not-found');
+    });
+
+    it('closes each decoded bitmap after creating its thumbnail', async () => {
+        const close = vi.fn();
+        createImageBitmap.mockResolvedValueOnce({ width: 100, height: 200, close });
+
+        await register(new Uint8Array([1]), 'image/jpeg');
+
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retain an entry when thumbnail creation fails', async () => {
+        HTMLCanvasElement.prototype.toBlob = vi.fn(callback => callback(null));
+
+        await expect(register(new Uint8Array([1]), 'image/jpeg'))
+            .rejects.toThrow('thumbnail-creation-failed');
+
+        await expect(getBytes('token-1')).rejects.toThrow('import-photo-not-found');
+        expect(URL.createObjectURL).not.toHaveBeenCalled();
+    });
+});

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportPhotographPickerTests/BaseImportPhotographPickerTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportPhotographPickerTests/BaseImportPhotographPickerTest.cs
@@ -1,0 +1,15 @@
+using Bunit;
+using FishingLogBook.Web.Features.Import.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Components.ImportPhotographPickerTests;
+
+public class BaseImportPhotographPickerTest
+{
+    protected static BunitContext CreateContext(IImportPhotoPreparationService preparation)
+    {
+        var context = new BunitContext();
+        context.Services.AddSingleton(preparation);
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportPhotographPickerTests/WhenTestingSelection.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportPhotographPickerTests/WhenTestingSelection.cs
@@ -1,0 +1,87 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Import.Components.ImportPhotographPicker;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+using Microsoft.AspNetCore.Components.Forms;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Components.ImportPhotographPickerTests;
+
+public class WhenTestingSelection : BaseImportPhotographPickerTest
+{
+    [Fact]
+    public async Task ItShouldRejectMoreThanTwentyFilesWithoutStartingPreparation()
+    {
+        // Arrange
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(preparation);
+        var exceeded = false;
+        var cut = context.Render<ImportPhotographPicker>(parameters => parameters
+            .Add(component => component.Id, "import-picker")
+            .Add(component => component.SelectionLimitExceeded, () => exceeded = true));
+        var files = Enumerable.Range(0, ImportPhotoPreparationService.MaxPhotographs + 1)
+            .Select(index => InputFileContent.CreateFromBinary(
+                [(byte)index],
+                $"{index}.jpg",
+                contentType: "image/jpeg"))
+            .ToArray();
+
+        // Act
+        cut.FindComponent<InputFile>().UploadFiles(files);
+
+        // Assert
+        exceeded.Should().BeTrue();
+        await preparation.DidNotReceive().PrepareSelectionAsync(
+            Arg.Any<IReadOnlyList<IBrowserFile>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPrepareMultipleFilesInBrowserSelectionOrder()
+    {
+        // Arrange
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        preparation.PrepareSelectionAsync(
+                Arg.Any<IReadOnlyList<IBrowserFile>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.ArgAt<IReadOnlyList<IBrowserFile>>(0)
+                .Select((file, index) => new ImportSelectedPhotoModel(
+                    Guid.NewGuid(), index, file.ContentType, file.Size, $"token-{index}", file.Name))
+                .ToArray());
+        await using var context = CreateContext(preparation);
+        IReadOnlyList<ImportSelectedPhotoModel>? selected = null;
+        var cut = context.Render<ImportPhotographPicker>(parameters => parameters
+            .Add(component => component.Id, "import-picker")
+            .Add(component => component.PhotosPrepared, photos => selected = photos));
+
+        // Act
+        cut.FindComponent<InputFile>().UploadFiles(
+            InputFileContent.CreateFromBinary([1], "first.jpg", contentType: "image/jpeg"),
+            InputFileContent.CreateFromBinary([2], "second.jpg", contentType: "image/jpeg"));
+
+        // Assert
+        selected!.Select(photo => photo.FileName).Should().Equal("first.jpg", "second.jpg");
+        await preparation.Received(1).PrepareSelectionAsync(
+            Arg.Is<IReadOnlyList<IBrowserFile>>(files =>
+                files.Count == 2 && files[0].Name == "first.jpg" && files[1].Name == "second.jpg"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldClearTransientResourcesWhenDisposed()
+    {
+        // Arrange
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        preparation.ClearAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        await using var context = CreateContext(preparation);
+        var cut = context.Render<ImportPhotographPicker>(parameters => parameters
+            .Add(component => component.Id, "import-picker"));
+
+        // Act
+        await cut.Instance.DisposeAsync();
+
+        // Assert
+        await preparation.Received(1).ClearAsync(CancellationToken.None);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/BaseImportPhotoPreparationServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/BaseImportPhotoPreparationServiceTest.cs
@@ -1,0 +1,51 @@
+using FishingLogBook.Web.Features.Diagnostics.Services;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+using FishingLogBook.Web.Features.Photographs.Models;
+using FishingLogBook.Web.Features.Photographs.Services;
+using FishingLogBook.Web.Tests.Features.Photographs.Services.PhotographPreparationServiceTests;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportPhotoPreparationServiceTests;
+
+public class BaseImportPhotoPreparationServiceTest : BasePhotographPreparationServiceTest
+{
+    protected static readonly byte[] OriginalBytes = [1, 2, 3];
+    protected static readonly byte[] SanitisedBytes = [4, 5, 6];
+
+    protected static TestContext CreateContext(PhotographHistoricalMetadataModel? historical = null)
+    {
+        var metadata = Substitute.For<IPhotographMetadataService>();
+        metadata.ReadHistorical(
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset>())
+            .Returns(historical ?? MissingMetadata());
+        metadata.Sanitise(Arg.Any<byte[]>(), Arg.Any<string>()).Returns(SanitisedBytes);
+
+        var registry = Substitute.For<IImportPhotoBlobRegistryService>();
+        registry.RegisterAsync(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(call => new ImportPhotoBlobRegistrationModel(
+                $"token-{call.ArgAt<byte[]>(0)[0]}",
+                $"blob:thumbnail-{call.ArgAt<byte[]>(0)[0]}"));
+        registry.ClearAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        registry.RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        var logging = Substitute.For<ILoggingService>();
+        logging.LogErrorAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        return new TestContext(new ImportPhotoPreparationService(metadata, registry, logging), metadata, registry, logging);
+    }
+
+    protected static PhotographHistoricalMetadataModel MissingMetadata()
+    {
+        return new PhotographHistoricalMetadataModel(null, null, 0, false, false, null, null);
+    }
+
+    protected sealed record TestContext(
+        ImportPhotoPreparationService Sut,
+        IPhotographMetadataService Metadata,
+        IImportPhotoBlobRegistryService Registry,
+        ILoggingService Logging);
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/WhenTestingPrepareSelectionAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/WhenTestingPrepareSelectionAsync.cs
@@ -172,20 +172,21 @@ public class WhenTestingPrepareSelectionAsync : BaseImportPhotoPreparationServic
         // Arrange
         var context = CreateContext();
         using var cancellation = new CancellationTokenSource();
-        context.Registry.RegisterAsync(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                cancellation.Cancel();
-                return new ImportPhotoBlobRegistrationModel("token", "blob:thumbnail");
-            });
+        var registry = new CancellingBlobRegistry(cancellation);
+        var sut = new ImportPhotoPreparationService(context.Metadata, registry, context.Logging);
         var files = new[] { File([1]), File([2]) };
 
         // Act
-        var act = () => context.Sut.PrepareSelectionAsync(files, cancellation.Token);
+        var act = () => sut.PrepareSelectionAsync(files, cancellation.Token);
 
         // Assert
         await act.Should().ThrowAsync<OperationCanceledException>();
-        await context.Registry.Received(2).ClearAsync(Arg.Any<CancellationToken>());
+        registry.RegistrationCount.Should().Be(1);
+        registry.ClearCount.Should().Be(2);
+        registry.ActiveEntries.Should().BeEmpty();
+        registry.ActiveThumbnailUrls.Should().BeEmpty();
+        context.Metadata.Received(1).ReadHistorical(
+            Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset>());
     }
 
     [Fact]
@@ -205,5 +206,49 @@ public class WhenTestingPrepareSelectionAsync : BaseImportPhotoPreparationServic
         await context.Registry.Received(1).RemoveAsync(
             Arg.Is<string>(token => token == photo.BlobToken),
             Arg.Any<CancellationToken>());
+    }
+
+    private sealed class CancellingBlobRegistry(CancellationTokenSource cancellation)
+        : IImportPhotoBlobRegistryService
+    {
+        private readonly Dictionary<string, string> _entries = [];
+
+        public int RegistrationCount { get; private set; }
+
+        public int ClearCount { get; private set; }
+
+        public IReadOnlyDictionary<string, string> ActiveEntries => _entries;
+
+        public IReadOnlyCollection<string> ActiveThumbnailUrls => _entries.Values;
+
+        public Task<ImportPhotoBlobRegistrationModel> RegisterAsync(
+            byte[] bytes,
+            string contentType,
+            CancellationToken cancellationToken)
+        {
+            RegistrationCount++;
+            var registration = new ImportPhotoBlobRegistrationModel(
+                $"token-{RegistrationCount}",
+                $"blob:thumbnail-{RegistrationCount}");
+            _entries.Add(registration.Token, registration.ThumbnailUrl);
+            cancellation.Cancel();
+            return Task.FromResult(registration);
+        }
+
+        public Task<byte[]> GetBytesAsync(string token, CancellationToken cancellationToken) =>
+            Task.FromResult(Array.Empty<byte>());
+
+        public Task RemoveAsync(string token, CancellationToken cancellationToken)
+        {
+            _entries.Remove(token);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken)
+        {
+            ClearCount++;
+            _entries.Clear();
+            return Task.CompletedTask;
+        }
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/WhenTestingPrepareSelectionAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/WhenTestingPrepareSelectionAsync.cs
@@ -1,0 +1,209 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+using FishingLogBook.Web.Features.Photographs.Enums;
+using FishingLogBook.Web.Features.Photographs.Models;
+using Microsoft.AspNetCore.Components.Forms;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportPhotoPreparationServiceTests;
+
+public class WhenTestingPrepareSelectionAsync : BaseImportPhotoPreparationServiceTest
+{
+    [Fact]
+    public async Task ItShouldRejectMoreThanTheConfiguredMaximum()
+    {
+        // Arrange
+        var context = CreateContext();
+        var files = Enumerable.Range(0, ImportPhotoPreparationService.MaxPhotographs + 1)
+            .Select(_ => File(OriginalBytes))
+            .ToArray();
+
+        // Act
+        var act = () => context.Sut.PrepareSelectionAsync(files, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+        await context.Registry.DidNotReceive().ClearAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRetainUnsupportedAndOversizedFilesAsFailures()
+    {
+        // Arrange
+        var context = CreateContext();
+        var oversized = Substitute.For<IBrowserFile>();
+        oversized.Name.Returns("large.jpg");
+        oversized.ContentType.Returns(PhotographContentTypeConstants.Jpeg);
+        oversized.Size.Returns(ImportPhotoPreparationService.MaxPhotographBytes + 1);
+        IBrowserFile[] files = [File(OriginalBytes, "image/heic"), oversized];
+
+        // Act
+        var result = await context.Sut.PrepareSelectionAsync(files, CancellationToken.None);
+
+        // Assert
+        result.Select(photo => photo.PreparationStatus).Should().Equal(
+            ImportPhotoPreparationStatusEnum.UnsupportedType,
+            ImportPhotoPreparationStatusEnum.TooLarge);
+        result.Should().OnlyContain(photo => !photo.IsReady);
+        context.Metadata.DidNotReceive().ReadHistorical(
+            Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset>());
+    }
+
+    [Fact]
+    public async Task ItShouldMapExplicitOffsetGpsAndSanitisedBlobInSelectionOrder()
+    {
+        // Arrange
+        var historical = new PhotographHistoricalMetadataModel(
+            DateTimeOffset.Parse("2025-06-14T09:30:00+01:00"),
+            null,
+            PhotographCapturedOnSourceEnum.ExifOriginal,
+            true,
+            false,
+            53.3498,
+            -6.2603);
+        var context = CreateContext(historical);
+        var files = new[]
+        {
+            File([1], name: "first.jpg"),
+            File([2], name: "second.jpg")
+        };
+
+        // Act
+        var result = await context.Sut.PrepareSelectionAsync(files, CancellationToken.None);
+
+        // Assert
+        result.Select(photo => photo.SelectionIndex).Should().Equal(0, 1);
+        result.Select(photo => photo.FileName).Should().Equal("first.jpg", "second.jpg");
+        result.Should().OnlyContain(photo => photo.IsReady);
+        result[0].Timestamp.State.Should().Be(ImportTimestampStateEnum.ExplicitInstant);
+        result[0].Location.HasCanonicalCoordinates.Should().BeTrue();
+        await context.Registry.Received(2).RegisterAsync(
+            Arg.Is<byte[]>(bytes => bytes.SequenceEqual(SanitisedBytes)),
+            PhotographContentTypeConstants.Jpeg,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldMapAmbiguousWeakMalformedAndMissingTimestamps()
+    {
+        // Arrange
+        var variants = new[]
+        {
+            new PhotographHistoricalMetadataModel(null, new DateTime(2025, 6, 14, 9, 30, 0), PhotographCapturedOnSourceEnum.ExifOriginal, true, false, null, null),
+            new PhotographHistoricalMetadataModel(FileModifiedOn, null, PhotographCapturedOnSourceEnum.FileLastModified, false, false, null, null),
+            new PhotographHistoricalMetadataModel(null, null, PhotographCapturedOnSourceEnum.None, true, true, null, null),
+            MissingMetadata()
+        };
+        var context = CreateContext();
+        var index = 0;
+        context.Metadata.ReadHistorical(
+                Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset>())
+            .Returns(_ => variants[index++]);
+        var files = Enumerable.Range(0, variants.Length).Select(value => File([(byte)value])).ToArray();
+
+        // Act
+        var result = await context.Sut.PrepareSelectionAsync(files, CancellationToken.None);
+
+        // Assert
+        result.Select(photo => photo.Timestamp.State).Should().Equal(
+            ImportTimestampStateEnum.LocalWallClock,
+            ImportTimestampStateEnum.WeakFallback,
+            ImportTimestampStateEnum.Unusable,
+            ImportTimestampStateEnum.Missing);
+    }
+
+    [Fact]
+    public async Task ItShouldContinueWithSanitisedPhotoWhenMetadataExtractionFails()
+    {
+        // Arrange
+        var context = CreateContext();
+        context.Metadata.ReadHistorical(
+                Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset>())
+            .Returns(_ => throw new InvalidDataException("private metadata detail"));
+
+        // Act
+        var result = await context.Sut.PrepareSelectionAsync([File(OriginalBytes)], CancellationToken.None);
+
+        // Assert
+        result.Single().IsReady.Should().BeTrue();
+        result.Single().MetadataStatus.Should().Be(ImportMetadataStatusEnum.Failed);
+        result.Single().MetadataError.Should().Be("metadata-unavailable");
+        await context.Logging.Received(1).LogErrorAsync(
+            "preparing a historical photograph",
+            Arg.Is<string>(message =>
+                message.Contains(nameof(InvalidDataException), StringComparison.Ordinal)
+                && !message.Contains("private metadata detail", StringComparison.Ordinal)),
+            CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ItShouldExtractMetadataBeforeSanitisingAndRegisteringBytes()
+    {
+        // Arrange
+        var context = CreateContext();
+
+        // Act
+        await context.Sut.PrepareSelectionAsync([File(OriginalBytes)], CancellationToken.None);
+
+        // Assert
+        Received.InOrder(() =>
+        {
+            context.Metadata.ReadHistorical(
+                Arg.Is<byte[]>(bytes => bytes.SequenceEqual(OriginalBytes)),
+                PhotographContentTypeConstants.Jpeg,
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset>());
+            context.Metadata.Sanitise(
+                Arg.Is<byte[]>(bytes => bytes.SequenceEqual(OriginalBytes)),
+                PhotographContentTypeConstants.Jpeg);
+            context.Registry.RegisterAsync(
+                Arg.Is<byte[]>(bytes => bytes.SequenceEqual(SanitisedBytes)),
+                PhotographContentTypeConstants.Jpeg,
+                Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
+    public async Task ItShouldClearRegisteredResourcesWhenCancelled()
+    {
+        // Arrange
+        var context = CreateContext();
+        using var cancellation = new CancellationTokenSource();
+        context.Registry.RegisterAsync(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                cancellation.Cancel();
+                return new ImportPhotoBlobRegistrationModel("token", "blob:thumbnail");
+            });
+        var files = new[] { File([1]), File([2]) };
+
+        // Act
+        var act = () => context.Sut.PrepareSelectionAsync(files, cancellation.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        await context.Registry.Received(2).ClearAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRemoveTheBlobBeforeMarkingAPhotoRemoved()
+    {
+        // Arrange
+        var context = CreateContext();
+        var photo = (await context.Sut.PrepareSelectionAsync(
+            [File(OriginalBytes)],
+            CancellationToken.None)).Single();
+
+        // Act
+        await context.Sut.RemoveAsync(photo, CancellationToken.None);
+
+        // Assert
+        photo.IsRemoved.Should().BeTrue();
+        await context.Registry.Received(1).RemoveAsync(
+            Arg.Is<string>(token => token == photo.BlobToken),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Photographs/Services/PhotographMetadataServiceTests/WhenTestingReadHistorical.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Photographs/Services/PhotographMetadataServiceTests/WhenTestingReadHistorical.cs
@@ -1,0 +1,116 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Web.Features.Photographs.Enums;
+using FishingLogBook.Web.Features.Photographs.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Photographs.Services.PhotographMetadataServiceTests;
+
+public class WhenTestingReadHistorical : BasePhotographMetadataServiceTest
+{
+    [Fact]
+    public void ItShouldPreserveAnExplicitOffset()
+    {
+        // Arrange
+        var bytes = Jpeg(new ExifContent
+        {
+            ExifText =
+            {
+                [DateTimeOriginalTag] = "2025:06:14 09:30:00",
+                [OffsetTimeOriginalTag] = "+01:00"
+            }
+        });
+        var sut = new PhotographMetadataService(BrowserTime(TimeSpan.FromHours(4)));
+
+        // Act
+        var result = sut.ReadHistorical(bytes, PhotographContentTypeConstants.Jpeg, null, ReferenceNow);
+
+        // Assert
+        result.ExplicitInstant.Should().Be(DateTimeOffset.Parse("2025-06-14T09:30:00+01:00"));
+        result.LocalWallClock.Should().BeNull();
+        result.CapturedOnSource.Should().Be(PhotographCapturedOnSourceEnum.ExifOriginal);
+        result.CapturedOnWasMalformed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItShouldPreserveAnOffsetlessExifValueAsAnAmbiguousWallClock()
+    {
+        // Arrange
+        var bytes = Jpeg(new ExifContent
+        {
+            ExifText = { [DateTimeOriginalTag] = "2025:06:14 09:30:00" }
+        });
+        var sut = new PhotographMetadataService(BrowserTime(TimeSpan.FromHours(4)));
+
+        // Act
+        var result = sut.ReadHistorical(bytes, PhotographContentTypeConstants.Jpeg, null, ReferenceNow);
+
+        // Assert
+        result.ExplicitInstant.Should().BeNull();
+        result.LocalWallClock.Should().Be(new DateTime(2025, 6, 14, 9, 30, 0));
+        result.LocalWallClock!.Value.Kind.Should().Be(DateTimeKind.Unspecified);
+        result.CapturedOnWasPresent.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ItShouldReportMalformedExifWithoutReplacingItWithFileLastModified()
+    {
+        // Arrange
+        var bytes = Jpeg(new ExifContent
+        {
+            ExifText = { [DateTimeOriginalTag] = "not-a-date" }
+        });
+        var sut = new PhotographMetadataService(BrowserTime(TimeSpan.Zero));
+
+        // Act
+        var result = sut.ReadHistorical(
+            bytes,
+            PhotographContentTypeConstants.Jpeg,
+            ReferenceNow.AddDays(-1),
+            ReferenceNow);
+
+        // Assert
+        result.ExplicitInstant.Should().BeNull();
+        result.LocalWallClock.Should().BeNull();
+        result.CapturedOnWasPresent.Should().BeTrue();
+        result.CapturedOnWasMalformed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ItShouldUseFileLastModifiedOnlyWhenExifIsMissing()
+    {
+        // Arrange
+        var fallback = ReferenceNow.AddDays(-1);
+        var sut = new PhotographMetadataService(BrowserTime(TimeSpan.Zero));
+
+        // Act
+        var result = sut.ReadHistorical(
+            JpegWithoutExif(),
+            PhotographContentTypeConstants.Jpeg,
+            fallback,
+            ReferenceNow);
+
+        // Assert
+        result.ExplicitInstant.Should().Be(fallback);
+        result.CapturedOnSource.Should().Be(PhotographCapturedOnSourceEnum.FileLastModified);
+        result.CapturedOnWasPresent.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItShouldPreserveOptionalGpsWithoutRequestingBrowserTime()
+    {
+        // Arrange
+        var bytes = Jpeg(new ExifContent { Latitude = 53.3498, Longitude = -6.2603 });
+        var time = BrowserTime(TimeSpan.Zero);
+        var sut = new PhotographMetadataService(time);
+
+        // Act
+        var result = sut.ReadHistorical(bytes, PhotographContentTypeConstants.Jpeg, null, ReferenceNow);
+
+        // Assert
+        result.HasCoordinates.Should().BeTrue();
+        result.Latitude.Should().BeApproximately(53.3498, 0.0001);
+        result.Longitude.Should().BeApproximately(-6.2603, 0.0001);
+        time.DidNotReceive().FromDateTimeLocalValueAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

- add an Import-specific multi-photo picker with a configurable 20-photo batch cap
- process selected photographs sequentially with the existing 10 MiB/type validation and sanitisation rules
- extend the repository-owned metadata parser to preserve explicit-offset instants, offset-less historical wall-clock values, malformed metadata state, weak file timestamps, and optional EXIF GPS
- store only sanitised payloads in a transient browser Blob registry and retain opaque tokens plus bounded object-URL thumbnails in Import state
- provide retrieval, individual removal, replacement/cancellation, clear-all, and disposal cleanup paths
- retain unsupported, oversized, metadata-unavailable, failed, and cancelled selections as explicit per-photo outcomes
- document the pending Android and iPhone physical-device validation checklist

No grouping, wizard review, Trip suggestions, persistence, duplicate detection, reverse geocoding, database, or API work is included.

## Validation

- `dotnet format FishingLogBook.sln --no-restore`
- `dotnet build FishingLogBook.sln --no-restore`
- `dotnet test tests/FishingLogBook.Web.Tests/FishingLogBook.Web.Tests.csproj --no-build` — 1,750 passed
- `npm test` — 402 passed
- `npm run test:browser` — 159 passed, 7 expected platform skips

The focused Blob lifecycle tests pass in Chromium and WebKit. The build retains one existing unrelated nullable-analysis warning.

## Physical-device status

- Android installed PWA: pending
- iPhone Home Screen PWA: pending

CI proves behavior after the browser supplies a file, but cannot prove native picker metadata retention, HEIC transcoding, or device memory pressure. Native HEIC remains unsupported unless the platform supplies it as JPEG, PNG, or WebP.

## Self Review

- Issue/AC: PASS — ordered multi-selection, historical metadata extraction, sanitised transient storage, outcomes, cancellation, and cleanup are implemented
- Architecture/CQRS: PASS — Web-only feature services and browser module; no server/API/persistence changes
- Rules: PASS — feature-first placement, three-file component structure, DI registration, formatting, matching Web and browser tests
- Security/privacy: PASS — EXIF/GPS is extracted locally before sanitisation; original metadata-bearing bytes are not retained; only sanitised bytes enter the registry; no current-location permission is requested
- Database/migrations: N/A
- Tests/coverage: PASS — parser mapping, validation outcomes, ordering, sanitisation order, failure/cancellation cleanup, picker behavior, and Blob lifecycle are covered
- Browser: PASS — real Chromium/WebKit tests prove Blob registration, byte retrieval, thumbnail object URLs, removal, and clear-all behavior
- Web/UI/localisation: PASS — the minimal picker introduces no user-visible text
- Code smells: PASS — sequential processing and small feature-owned abstractions; no new EXIF dependency or state framework
- CI/deployment: PASS — no configuration, migration, secret, or deployment action required

### Findings discovered during self-review

1. Cancelling .NET interop during asynchronous thumbnail generation could allow a late Blob registration after cleanup.
2. A metadata extraction exception initially failed the entire otherwise-valid photograph.
3. Malformed EXIF initially lost whether it originated from the original or digitized timestamp.
4. jsdom tests alone could not prove actual Blob/object-URL/image decoding behavior.

### Fixes made

1. Made the current one-file Blob registration atomic, then honor cancellation and clear before processing another file.
2. Keep the sanitised photo ready with an explicit metadata-failed state.
3. Preserve the malformed EXIF source.
4. Added real Chromium and WebKit lifecycle coverage.

## Deliberate gaps

- physical Android/iPhone picker validation remains pending
- HEIC depends on native picker transcoding to a supported MIME type
- no #215 grouping
- no #216/#217 review or split/merge UI
- no #220 Trip suggestions
- no #218 persistence
- no #219 duplicate hashing
- no #222 reverse geocoding

Closes #214