### PR TITLE
FLB#215 | Propose deterministic catch groups from selected photos

### DIFF
--- a/.claude/rules/csharp.md
+++ b/.claude/rules/csharp.md
@@ -114,7 +114,9 @@ name must match the type name**.
 | `Args/` | `Args` | `FishingLogBook.Application/Args/` | `FilterCatchesArgs` |
 | `Mappings/` | `MappingRegistration` | `FishingLogBook.Application/Common/Mappings/` | `UserMappingRegistration` |
 
-**Enums:** do not use `Type` or other suffixes in `Enums/` — use `Enum` only.
+**Enums:** do not use `Type` or other suffixes in `Enums/` — use `Enum` only. Every enum
+member must declare an explicit numeric value so inserting or reordering members cannot
+silently change its representation.
 
 **DTO properties** may drop the `Enum` suffix when the meaning is clear (e.g. property
 `Method` of type `CatchMethodEnum`).

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportCatchProposalReasonEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportCatchProposalReasonEnum.cs
@@ -1,0 +1,11 @@
+namespace FishingLogBook.Web.Features.Import.Enums;
+
+public enum ImportCatchProposalReasonEnum
+{
+    TrustworthyCaptureTime = 0,
+    MissingTimestamp = 1,
+    AmbiguousTimestamp = 2,
+    WeakTimestamp = 3,
+    UnusableTimestamp = 4,
+    ConflictingGps = 5
+}

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportCatchReviewStatusEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportCatchReviewStatusEnum.cs
@@ -2,6 +2,6 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportCatchReviewStatusEnum
 {
-    Draft,
-    Reviewed
+    Draft = 0,
+    Reviewed = 1
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportDuplicateStatusEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportDuplicateStatusEnum.cs
@@ -2,8 +2,8 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportDuplicateStatusEnum
 {
-    NotChecked,
-    None,
-    Warning,
-    Duplicate
+    NotChecked = 0,
+    None = 1,
+    Warning = 2,
+    Duplicate = 3
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportLocationDecisionEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportLocationDecisionEnum.cs
@@ -2,7 +2,7 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportLocationDecisionEnum
 {
-    Undecided,
-    Accepted,
-    Removed
+    Undecided = 0,
+    Accepted = 1,
+    Removed = 2
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportLocationLookupStatusEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportLocationLookupStatusEnum.cs
@@ -2,9 +2,9 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportLocationLookupStatusEnum
 {
-    NotRequested,
-    Pending,
-    Resolved,
-    NoResult,
-    Failed
+    NotRequested = 0,
+    Pending = 1,
+    Resolved = 2,
+    NoResult = 3,
+    Failed = 4
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportMetadataStatusEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportMetadataStatusEnum.cs
@@ -2,9 +2,9 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportMetadataStatusEnum
 {
-    NotStarted,
-    Processing,
-    Available,
-    Unavailable,
-    Failed
+    NotStarted = 0,
+    Processing = 1,
+    Available = 2,
+    Unavailable = 3,
+    Failed = 4
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportPhotoPreparationStatusEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportPhotoPreparationStatusEnum.cs
@@ -2,10 +2,10 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportPhotoPreparationStatusEnum
 {
-    Pending,
-    Ready,
-    UnsupportedType,
-    TooLarge,
-    PreparationFailed,
-    Cancelled
+    Pending = 0,
+    Ready = 1,
+    UnsupportedType = 2,
+    TooLarge = 3,
+    PreparationFailed = 4,
+    Cancelled = 5
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportStageEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportStageEnum.cs
@@ -2,10 +2,10 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportStageEnum
 {
-    BatchDetails,
-    ChoosePhotos,
-    ReviewCatches,
-    CorrectCatches,
-    ReviewTrips,
-    Confirm
+    BatchDetails = 0,
+    ChoosePhotos = 1,
+    ReviewCatches = 2,
+    CorrectCatches = 3,
+    ReviewTrips = 4,
+    Confirm = 5
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportTimestampSourceEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportTimestampSourceEnum.cs
@@ -2,9 +2,9 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportTimestampSourceEnum
 {
-    None,
-    ExifOriginal,
-    ExifDigitized,
-    FileLastModified,
-    User
+    None = 0,
+    ExifOriginal = 1,
+    ExifDigitized = 2,
+    FileLastModified = 3,
+    User = 4
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportTimestampStateEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportTimestampStateEnum.cs
@@ -2,10 +2,10 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportTimestampStateEnum
 {
-    Missing,
-    Unusable,
-    ExplicitInstant,
-    LocalWallClock,
-    WeakFallback,
-    UserConfirmed
+    Missing = 0,
+    Unusable = 1,
+    ExplicitInstant = 2,
+    LocalWallClock = 3,
+    WeakFallback = 4,
+    UserConfirmed = 5
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportTripDecisionEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportTripDecisionEnum.cs
@@ -2,8 +2,8 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportTripDecisionEnum
 {
-    Undecided,
-    CreateNew,
-    UseExisting,
-    NoTrip
+    Undecided = 0,
+    CreateNew = 1,
+    UseExisting = 2,
+    NoTrip = 3
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportTripSuggestionConfidenceEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportTripSuggestionConfidenceEnum.cs
@@ -2,7 +2,7 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportTripSuggestionConfidenceEnum
 {
-    None,
-    Weak,
-    Strong
+    None = 0,
+    Weak = 1,
+    Strong = 2
 }

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportTripSuggestionReasonEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportTripSuggestionReasonEnum.cs
@@ -2,10 +2,10 @@ namespace FishingLogBook.Web.Features.Import.Enums;
 
 public enum ImportTripSuggestionReasonEnum
 {
-    SameDate,
-    NearbyCoordinates,
-    ContinuousTime,
-    MissingGps,
-    ConsistentMethod,
-    ConsistentLocation
+    SameDate = 0,
+    NearbyCoordinates = 1,
+    ContinuousTime = 2,
+    MissingGps = 3,
+    ConsistentMethod = 4,
+    ConsistentLocation = 5
 }

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportCatchProposalModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportCatchProposalModel.cs
@@ -5,6 +5,7 @@ namespace FishingLogBook.Web.Features.Import.Models;
 public sealed class ImportCatchProposalModel
 {
     private readonly List<Guid> _photoIds;
+    private readonly IReadOnlyList<ImportCatchProposalReasonEnum> _reasons;
 
     public ImportCatchProposalModel(
         Guid id,
@@ -12,7 +13,8 @@ public sealed class ImportCatchProposalModel
         ImportTimestampModel caughtOn,
         ImportCatalogueSelectionModel inheritedMethod,
         ImportCatalogueSelectionModel inheritedSpecies,
-        ImportLocationModel? location = null)
+        ImportLocationModel? location = null,
+        IEnumerable<ImportCatchProposalReasonEnum>? reasons = null)
     {
         if (id == Guid.Empty)
         {
@@ -35,6 +37,7 @@ public sealed class ImportCatchProposalModel
         InheritedMethod = inheritedMethod;
         InheritedSpecies = inheritedSpecies;
         Location = location;
+        _reasons = reasons?.Distinct().ToArray() ?? [];
     }
 
     public Guid Id { get; }
@@ -44,6 +47,8 @@ public sealed class ImportCatchProposalModel
     public ImportTimestampModel CaughtOn { get; private set; }
 
     public ImportLocationModel? Location { get; private set; }
+
+    public IReadOnlyList<ImportCatchProposalReasonEnum> Reasons => _reasons;
 
     public ImportCatalogueSelectionModel InheritedMethod { get; }
 

--- a/src/FishingLogBook.Web/Features/Import/Services/IImportCatchProposalService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/IImportCatchProposalService.cs
@@ -1,0 +1,8 @@
+using FishingLogBook.Web.Features.Import.Models;
+
+namespace FishingLogBook.Web.Features.Import.Services;
+
+public interface IImportCatchProposalService
+{
+    IReadOnlyList<ImportCatchProposalModel> Propose(ImportBatchModel batch);
+}

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportCatchProposalService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportCatchProposalService.cs
@@ -1,0 +1,133 @@
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+
+namespace FishingLogBook.Web.Features.Import.Services;
+
+public sealed class ImportCatchProposalService : IImportCatchProposalService
+{
+    public static readonly TimeSpan SameCatchTimeThreshold = TimeSpan.FromMinutes(2);
+
+    private const double CompatibleLocationDistanceMetres = 250;
+    private const double EarthRadiusMetres = 6371000;
+
+    public IReadOnlyList<ImportCatchProposalModel> Propose(ImportBatchModel batch)
+    {
+        var photos = batch.Photos.Where(photo => !photo.IsRemoved && photo.IsReady).ToArray();
+        var eligible = photos
+            .Where(HasTrustworthyTimestamp)
+            .OrderBy(photo => photo.Timestamp.Instant)
+            .ThenBy(photo => photo.SelectionIndex)
+            .ToArray();
+        var unresolved = photos
+            .Where(photo => !HasTrustworthyTimestamp(photo))
+            .OrderBy(photo => photo.SelectionIndex)
+            .ToArray();
+
+        var proposals = GroupEligiblePhotos(eligible, batch);
+        proposals.AddRange(unresolved.Select(photo => CreateProposal([photo], batch)));
+        return proposals;
+    }
+
+    private static List<ImportCatchProposalModel> GroupEligiblePhotos(
+        IReadOnlyList<ImportSelectedPhotoModel> photos,
+        ImportBatchModel batch)
+    {
+        var proposals = new List<ImportCatchProposalModel>();
+        var group = new List<ImportSelectedPhotoModel>();
+        foreach (var photo in photos)
+        {
+            if (group.Count > 0 && photo.Timestamp.Instant - group[^1].Timestamp.Instant > SameCatchTimeThreshold)
+            {
+                proposals.Add(CreateProposal(group, batch));
+                group = [];
+            }
+
+            group.Add(photo);
+        }
+
+        if (group.Count > 0)
+        {
+            proposals.Add(CreateProposal(group, batch));
+        }
+
+        return proposals;
+    }
+
+    private static ImportCatchProposalModel CreateProposal(
+        IReadOnlyList<ImportSelectedPhotoModel> photos,
+        ImportBatchModel batch)
+    {
+        var hasGpsConflict = HasGpsConflict(photos);
+        var reasons = new List<ImportCatchProposalReasonEnum> { TimestampReason(photos[0].Timestamp) };
+        if (hasGpsConflict)
+        {
+            reasons.Add(ImportCatchProposalReasonEnum.ConflictingGps);
+        }
+
+        return new ImportCatchProposalModel(
+            Guid.NewGuid(),
+            photos.Select(photo => photo.Id),
+            photos[0].Timestamp,
+            batch.FishingMethod,
+            batch.Species,
+            hasGpsConflict ? null : RepresentativeLocation(photos),
+            reasons);
+    }
+
+    private static bool HasTrustworthyTimestamp(ImportSelectedPhotoModel photo)
+    {
+        return photo.Timestamp.IsResolved && photo.Timestamp.Instant.HasValue;
+    }
+
+    private static ImportCatchProposalReasonEnum TimestampReason(ImportTimestampModel timestamp)
+    {
+        return timestamp.State switch
+        {
+            ImportTimestampStateEnum.LocalWallClock => ImportCatchProposalReasonEnum.AmbiguousTimestamp,
+            ImportTimestampStateEnum.WeakFallback => ImportCatchProposalReasonEnum.WeakTimestamp,
+            ImportTimestampStateEnum.Unusable => ImportCatchProposalReasonEnum.UnusableTimestamp,
+            ImportTimestampStateEnum.Missing => ImportCatchProposalReasonEnum.MissingTimestamp,
+            _ => ImportCatchProposalReasonEnum.TrustworthyCaptureTime
+        };
+    }
+
+    private static ImportLocationModel? RepresentativeLocation(IReadOnlyList<ImportSelectedPhotoModel> photos)
+    {
+        return photos.FirstOrDefault(photo => photo.Location.HasCanonicalCoordinates)?.Location;
+    }
+
+    private static bool HasGpsConflict(IReadOnlyList<ImportSelectedPhotoModel> photos)
+    {
+        var located = photos.Where(photo => photo.Location.HasCanonicalCoordinates).ToArray();
+        for (var first = 0; first < located.Length - 1; first++)
+        {
+            for (var second = first + 1; second < located.Length; second++)
+            {
+                if (DistanceMetres(located[first].Location, located[second].Location)
+                    > CompatibleLocationDistanceMetres)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static double DistanceMetres(ImportLocationModel first, ImportLocationModel second)
+    {
+        var firstLatitude = ToRadians(first.Latitude!.Value);
+        var secondLatitude = ToRadians(second.Latitude!.Value);
+        var latitudeDelta = ToRadians(second.Latitude.Value - first.Latitude.Value);
+        var longitudeDelta = ToRadians(second.Longitude!.Value - first.Longitude!.Value);
+        var haversine = (Math.Sin(latitudeDelta / 2) * Math.Sin(latitudeDelta / 2))
+            + (Math.Cos(firstLatitude) * Math.Cos(secondLatitude)
+                * Math.Sin(longitudeDelta / 2) * Math.Sin(longitudeDelta / 2));
+        return 2 * EarthRadiusMetres * Math.Asin(Math.Min(1, Math.Sqrt(haversine)));
+    }
+
+    private static double ToRadians(double degrees)
+    {
+        return degrees * Math.PI / 180;
+    }
+}

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -113,6 +113,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPhotographPreparationService, PhotographPreparationService>();
         services.AddScoped<IImportPhotoBlobRegistryService, ImportPhotoBlobRegistryService>();
         services.AddScoped<IImportPhotoPreparationService, ImportPhotoPreparationService>();
+        services.AddScoped<IImportCatchProposalService, ImportCatchProposalService>();
         services.AddScoped<ICatchPhotographProposalService, CatchPhotographProposalService>();
         services.AddSingleton<DiagnosticStatusModel>();
         services.AddScoped<ILoggingService, LoggingService>();

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportCatchProposalServiceTests/BaseImportCatchProposalServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportCatchProposalServiceTests/BaseImportCatchProposalServiceTest.cs
@@ -1,0 +1,65 @@
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportCatchProposalServiceTests;
+
+public class BaseImportCatchProposalServiceTest
+{
+    protected static readonly ImportCatchProposalService Sut = new();
+    protected static readonly DateTimeOffset CapturedOn = DateTimeOffset.Parse("2025-06-14T09:00:00Z");
+
+    protected static ImportBatchModel Batch(params ImportSelectedPhotoModel[] photos)
+    {
+        var batch = new ImportBatchModel(
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            new ImportCatalogueSelectionModel(
+                Guid.Parse("22222222-2222-2222-2222-222222222222"),
+                "Fly",
+                "Fly"),
+            new ImportCatalogueSelectionModel(
+                Guid.Parse("33333333-3333-3333-3333-333333333333"),
+                "BrownTrout",
+                "Brown Trout"));
+        foreach (var photo in photos)
+        {
+            batch.AddPhoto(photo);
+        }
+
+        return batch;
+    }
+
+    protected static ImportSelectedPhotoModel Photo(
+        int index,
+        ImportTimestampModel timestamp,
+        double? latitude = null,
+        double? longitude = null,
+        bool ready = true)
+    {
+        var photo = new ImportSelectedPhotoModel(
+            Guid.Parse($"44444444-4444-4444-4444-{index + 1:D12}"),
+            index,
+            "image/jpeg",
+            1024,
+            ready ? $"blob-{index}" : null,
+            $"photo-{index}.jpg",
+            ready ? $"blob:thumbnail-{index}" : null);
+        photo.SetMetadata(
+            ImportMetadataStatusEnum.Available,
+            timestamp,
+            new ImportLocationModel(latitude, longitude, latitude.HasValue));
+        if (ready)
+        {
+            photo.SetPreparation(ImportPhotoPreparationStatusEnum.Ready, $"blob-{index}", $"blob:thumbnail-{index}");
+        }
+
+        return photo;
+    }
+
+    protected static ImportTimestampModel ExplicitAt(TimeSpan offset)
+    {
+        return ImportTimestampModel.FromExplicitInstant(
+            CapturedOn.Add(offset),
+            ImportTimestampSourceEnum.ExifOriginal);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportCatchProposalServiceTests/WhenTestingPropose.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportCatchProposalServiceTests/WhenTestingPropose.cs
@@ -1,0 +1,253 @@
+using AwesomeAssertions;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportCatchProposalServiceTests;
+
+public class WhenTestingPropose : BaseImportCatchProposalServiceTest
+{
+    [Theory]
+    [InlineData(119, 1)]
+    [InlineData(120, 1)]
+    [InlineData(121, 2)]
+    public void ItShouldApplyTheInclusiveTwoMinuteThreshold(int gapSeconds, int expectedGroups)
+    {
+        // Arrange
+        var first = Photo(0, ExplicitAt(TimeSpan.Zero));
+        var second = Photo(1, ExplicitAt(TimeSpan.FromSeconds(gapSeconds)));
+
+        // Act
+        var proposals = Sut.Propose(Batch(first, second));
+
+        // Assert
+        ImportCatchProposalService.SameCatchTimeThreshold.Should().Be(TimeSpan.FromMinutes(2));
+        proposals.Should().HaveCount(expectedGroups);
+    }
+
+    [Fact]
+    public void ItShouldCreateOneSingletonForOneTrustworthyPhoto()
+    {
+        // Arrange
+        var photo = Photo(0, ExplicitAt(TimeSpan.Zero));
+
+        // Act
+        var proposal = Sut.Propose(Batch(photo)).Single();
+
+        // Assert
+        proposal.PhotoIds.Should().Equal(photo.Id);
+        proposal.CaughtOn.Should().Be(photo.Timestamp);
+        proposal.Reasons.Should().Equal(ImportCatchProposalReasonEnum.TrustworthyCaptureTime);
+    }
+
+    [Fact]
+    public void ItShouldChainAdjacentPhotographsWithinTheThreshold()
+    {
+        // Arrange
+        var photos = new[]
+        {
+            Photo(0, ExplicitAt(TimeSpan.Zero)),
+            Photo(1, ExplicitAt(TimeSpan.FromSeconds(90))),
+            Photo(2, ExplicitAt(TimeSpan.FromMinutes(3)))
+        };
+
+        // Act
+        var proposals = Sut.Propose(Batch(photos));
+
+        // Assert
+        proposals.Should().ContainSingle();
+        proposals[0].PhotoIds.Should().Equal(photos.Select(photo => photo.Id));
+    }
+
+    [Fact]
+    public void ItShouldSplitWhenTheAdjacentGapExceedsTheThreshold()
+    {
+        // Arrange
+        var photos = new[]
+        {
+            Photo(0, ExplicitAt(TimeSpan.Zero)),
+            Photo(1, ExplicitAt(TimeSpan.FromMinutes(1))),
+            Photo(2, ExplicitAt(TimeSpan.FromMinutes(4)))
+        };
+
+        // Act
+        var proposals = Sut.Propose(Batch(photos));
+
+        // Assert
+        proposals.Select(proposal => proposal.PhotoIds.Count).Should().Equal(2, 1);
+    }
+
+    [Fact]
+    public void ItShouldSortChronologicallyAndUseSelectionIndexForTies()
+    {
+        // Arrange
+        var later = Photo(0, ExplicitAt(TimeSpan.FromMinutes(5)));
+        var tiedSecond = Photo(2, ExplicitAt(TimeSpan.Zero));
+        var tiedFirst = Photo(1, ExplicitAt(TimeSpan.Zero));
+
+        // Act
+        var proposals = Sut.Propose(Batch(later, tiedSecond, tiedFirst));
+
+        // Assert
+        proposals[0].PhotoIds.Should().Equal(tiedFirst.Id, tiedSecond.Id);
+        proposals[1].PhotoIds.Should().Equal(later.Id);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnresolvedTimestamps))]
+    public void ItShouldKeepUnresolvedTimestampsAsReviewableSingletons(
+        ImportTimestampModel timestamp,
+        ImportCatchProposalReasonEnum expectedReason)
+    {
+        // Arrange
+        var first = Photo(0, timestamp);
+        var second = Photo(1, timestamp);
+
+        // Act
+        var proposals = Sut.Propose(Batch(second, first));
+
+        // Assert
+        proposals.Should().HaveCount(2);
+        proposals.SelectMany(proposal => proposal.PhotoIds).Should().Equal(first.Id, second.Id);
+        proposals.Should().OnlyContain(proposal => proposal.CaughtOn == timestamp);
+        proposals.Should().OnlyContain(proposal => proposal.Reasons.Contains(expectedReason));
+    }
+
+    [Fact]
+    public void ItShouldGroupEquivalentInstantsWithDifferentOffsets()
+    {
+        // Arrange
+        var first = Photo(0, ImportTimestampModel.FromExplicitInstant(
+            DateTimeOffset.Parse("2025-06-14T10:00:00+01:00"),
+            ImportTimestampSourceEnum.ExifOriginal));
+        var second = Photo(1, ImportTimestampModel.FromExplicitInstant(
+            DateTimeOffset.Parse("2025-06-14T05:00:00-04:00"),
+            ImportTimestampSourceEnum.ExifDigitized));
+
+        // Act
+        var proposals = Sut.Propose(Batch(first, second));
+
+        // Assert
+        proposals.Should().ContainSingle();
+        proposals[0].PhotoIds.Should().Equal(first.Id, second.Id);
+    }
+
+    [Fact]
+    public void ItShouldUseTheEarliestCompatibleLocationWithoutRequiringGps()
+    {
+        // Arrange
+        var withoutGps = Photo(0, ExplicitAt(TimeSpan.Zero));
+        var earliestGps = Photo(1, ExplicitAt(TimeSpan.FromSeconds(30)), 53.2707, -9.0570);
+        var nearbyGps = Photo(2, ExplicitAt(TimeSpan.FromSeconds(60)), 53.2708, -9.0569);
+
+        // Act
+        var proposal = Sut.Propose(Batch(nearbyGps, withoutGps, earliestGps)).Single();
+
+        // Assert
+        proposal.PhotoIds.Should().Equal(withoutGps.Id, earliestGps.Id, nearbyGps.Id);
+        proposal.Location.Should().Be(earliestGps.Location);
+        proposal.Reasons.Should().NotContain(ImportCatchProposalReasonEnum.ConflictingGps);
+    }
+
+    [Fact]
+    public void ItShouldRetainTimeGroupingButFlagMateriallyConflictingGps()
+    {
+        // Arrange
+        var first = Photo(0, ExplicitAt(TimeSpan.Zero), 53.2707, -9.0568);
+        var second = Photo(1, ExplicitAt(TimeSpan.FromMinutes(1)), 51.8985, -8.4756);
+
+        // Act
+        var proposal = Sut.Propose(Batch(first, second)).Single();
+
+        // Assert
+        proposal.PhotoIds.Should().Equal(first.Id, second.Id);
+        proposal.Location.Should().BeNull();
+        proposal.Reasons.Should().Contain(ImportCatchProposalReasonEnum.ConflictingGps);
+    }
+
+    [Fact]
+    public void ItShouldIncludeEveryReadyActivePhotoExactlyOnceAndLeaveFailuresInTheBatch()
+    {
+        // Arrange
+        var ready = Photo(0, ExplicitAt(TimeSpan.Zero));
+        var failed = Photo(1, ImportTimestampModel.Missing(), ready: false);
+        var removed = Photo(2, ExplicitAt(TimeSpan.FromMinutes(1)));
+        removed.Remove();
+        var batch = Batch(ready, failed, removed);
+
+        // Act
+        var proposals = Sut.Propose(batch);
+
+        // Assert
+        proposals.SelectMany(proposal => proposal.PhotoIds).Should().Equal(ready.Id);
+        batch.Photos.Should().Contain(failed);
+        failed.IsReady.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItShouldProduceProposalsAcceptedByTheBatchMembershipInvariants()
+    {
+        // Arrange
+        var photos = new[]
+        {
+            Photo(0, ExplicitAt(TimeSpan.Zero)),
+            Photo(1, ExplicitAt(TimeSpan.FromMinutes(1))),
+            Photo(2, ExplicitAt(TimeSpan.FromMinutes(5))),
+            Photo(3, ImportTimestampModel.Missing())
+        };
+        var batch = Batch(photos);
+
+        // Act
+        var proposals = Sut.Propose(batch);
+        foreach (var proposal in proposals)
+        {
+            batch.AddCatchProposal(proposal);
+        }
+
+        // Assert
+        batch.CatchProposals.Should().Equal(proposals);
+        batch.CatchProposals.SelectMany(proposal => proposal.PhotoIds)
+            .Should().BeEquivalentTo(photos.Select(photo => photo.Id));
+    }
+
+    [Fact]
+    public void ItShouldRepeatTheSameGroupingAndDerivedValues()
+    {
+        // Arrange
+        var photos = new[]
+        {
+            Photo(2, ExplicitAt(TimeSpan.FromMinutes(5))),
+            Photo(0, ExplicitAt(TimeSpan.Zero), 53.2707, -9.0570),
+            Photo(1, ExplicitAt(TimeSpan.FromMinutes(1)), 53.2708, -9.0569),
+            Photo(3, ImportTimestampModel.Missing())
+        };
+        var batch = Batch(photos);
+
+        // Act
+        var first = Sut.Propose(batch);
+        var second = Sut.Propose(batch);
+
+        // Assert
+        first.Select(proposal => proposal.PhotoIds).Should().BeEquivalentTo(
+            second.Select(proposal => proposal.PhotoIds),
+            options => options.WithStrictOrdering());
+        first.Select(proposal => proposal.CaughtOn).Should().Equal(second.Select(proposal => proposal.CaughtOn));
+        first.Select(proposal => proposal.Location).Should().Equal(second.Select(proposal => proposal.Location));
+        first.Select(proposal => proposal.Reasons).Should().BeEquivalentTo(
+            second.Select(proposal => proposal.Reasons),
+            options => options.WithStrictOrdering());
+    }
+
+    public static TheoryData<ImportTimestampModel, ImportCatchProposalReasonEnum> UnresolvedTimestamps => new()
+    {
+        { ImportTimestampModel.Missing(), ImportCatchProposalReasonEnum.MissingTimestamp },
+        { ImportTimestampModel.Unusable(ImportTimestampSourceEnum.ExifOriginal), ImportCatchProposalReasonEnum.UnusableTimestamp },
+        { ImportTimestampModel.FromWeakFallback(CapturedOn), ImportCatchProposalReasonEnum.WeakTimestamp },
+        {
+            ImportTimestampModel.FromLocalWallClock(
+                new DateTime(2025, 6, 14, 9, 0, 0),
+                ImportTimestampSourceEnum.ExifOriginal),
+            ImportCatchProposalReasonEnum.AmbiguousTimestamp
+        }
+    };
+}


### PR DESCRIPTION
## Summary

- add a deterministic Import catch-proposal service using the approved two-minute inclusive adjacent-gap policy
- group only trustworthy captured instants, with stable selection-index tie-breaking
- retain missing, weak, malformed, and timezone-ambiguous timestamps as reviewable singleton proposals
- use GPS only as optional supporting context and flag materially conflicting coordinates
- preserve failed/unready photographs in the Import batch without creating invalid proposal membership
- add lightweight proposal reasons and explicit numeric values for all Import enums
- document the repository convention requiring explicit enum values

Closes #215

## Validation

- `dotnet format FishingLogBook.sln --no-restore`
- `dotnet build FishingLogBook.sln --no-restore`
- Import-focused tests: 60 passed
- full Web tests: 1,767 passed
- JavaScript tests: 402 passed
- browser tests: 159 passed, 7 expected skips
- full solution tests were attempted; PostgreSQL Testcontainers could not start because local Docker named-pipe access was denied

## Scope

No UI, persistence, API, database, blob-lifecycle, Trip grouping, reverse-geocoding, duplicate detection, or split/merge implementation is included.

## Self Review

- Issue/AC: PASS — deterministic ordering, inclusive boundary, chaining, unresolved timestamps, optional GPS, batch invariants, and repeat execution are covered.
- Architecture/CQRS: PASS — pure transient Web service with no browser, API, database, or persistence dependency.
- Rules: PASS — feature-first placement, DI registration, explicit enum values, and matching tests.
- Security/privacy: PASS — historical coordinates remain local transient state and are not logged.
- Database/migrations: N/A.
- Tests/coverage: PASS — boundary, chaining, ordering, timestamp eligibility, GPS, failed-photo, invariant, and repeatability tests.
- Browser: PASS — existing browser suite passed; the grouping engine is pure C# and requires no browser-specific test harness.
- Web/UI/localisation: N/A — no UI or user-visible text.
- Code smells: PASS — threshold and GPS compatibility values are named and the service remains focused.
- CI/deployment: PASS — no deployment or configuration changes.

### Findings discovered during self-review

1. Returned proposal membership needed explicit coverage against existing `ImportBatchModel` invariants.
2. The repository rules did not explicitly require numeric values for enum members.

### Fixes made

1. Added a test that inserts every generated proposal through the batch invariants.
2. Added explicit numeric values to all Import enums and documented the convention in `csharp.md`.

### Remaining deliberate gaps

- The two-minute threshold remains provisional for product validation and is isolated for later tuning.
- Split/merge correction belongs to #217.
- Review UI belongs to #216.
- Trip suggestions belong to #220.
