### PR TITLE
FLB#216 | build import batch and proposed-catch review wizard

### DIFF
--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
@@ -1,0 +1,25 @@
+@using FishingLogBook.Web.Features.Import.Models
+
+<MudPaper Class="import-catch-card pa-3" Elevation="2" id="@($"import-catch-{Number}")">
+    <MudStack Spacing="2">
+        <MudText Typo="Typo.h6">@Loc["Import_CatchNumber", Number]</MudText>
+        <div class="import-catch-photos" id="@($"import-catch-{Number}-photos")">
+            @foreach (var photo in ProposalPhotos)
+            {
+                <img src="@photo.ThumbnailUrl"
+                     alt="@Loc["Import_PhotoAlt", photo.SelectionIndex + 1]"
+                     class="import-catch-thumbnail" />
+            }
+        </div>
+        <MudText id="@($"import-catch-{Number}-timestamp")">@TimestampLabel</MudText>
+        <MudText>@Proposal.Method.Name</MudText>
+        <MudText>@Proposal.Species.Name</MudText>
+        <MudText id="@($"import-catch-{Number}-location")">@LocationLabel</MudText>
+        <MudChip T="string"
+                 Color="@(RequiresCorrection ? Color.Warning : Color.Success)"
+                 Variant="Variant.Outlined"
+                 id="@($"import-catch-{Number}-status")">
+            @(RequiresCorrection ? Loc["Import_NeedsReview"] : Loc["Import_Ready"])
+        </MudChip>
+    </MudStack>
+</MudPaper>

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
@@ -1,0 +1,75 @@
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Import.Components.ImportCatchReviewCard;
+
+public partial class ImportCatchReviewCard : ComponentBase
+{
+    [Parameter, EditorRequired]
+    public ImportCatchProposalModel Proposal { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public IReadOnlyList<ImportSelectedPhotoModel> Photos { get; set; } = [];
+
+    [Parameter]
+    public int Number { get; set; }
+
+    [Inject]
+    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private IReadOnlyList<ImportSelectedPhotoModel> ProposalPhotos
+    {
+        get
+        {
+            var byId = Photos.ToDictionary(photo => photo.Id);
+            return Proposal.PhotoIds.Where(byId.ContainsKey).Select(photoId => byId[photoId]).ToArray();
+        }
+    }
+
+    private bool RequiresCorrection
+    {
+        get
+        {
+            return !Proposal.CaughtOn.IsResolved
+                || Proposal.Reasons.Any(reason => reason != ImportCatchProposalReasonEnum.TrustworthyCaptureTime);
+        }
+    }
+
+    private string TimestampLabel
+    {
+        get
+        {
+            return Proposal.CaughtOn.State switch
+            {
+                ImportTimestampStateEnum.ExplicitInstant =>
+                    Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
+                ImportTimestampStateEnum.UserConfirmed =>
+                    Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
+                ImportTimestampStateEnum.LocalWallClock => Loc["Import_TimestampAmbiguous",
+                    Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm")],
+                ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak",
+                    Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz")],
+                ImportTimestampStateEnum.Unusable => Loc["Import_TimestampUnusable"],
+                _ => Loc["Import_TimestampMissing"]
+            };
+        }
+    }
+
+    private string LocationLabel
+    {
+        get
+        {
+            if (Proposal.Reasons.Contains(ImportCatchProposalReasonEnum.ConflictingGps))
+            {
+                return Loc["Import_LocationNeedsReview"];
+            }
+
+            return Proposal.Location?.HasCanonicalCoordinates == true
+                ? Loc["Import_LocationAvailable"]
+                : Loc["Import_LocationUnavailable"];
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.css
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.css
@@ -1,0 +1,18 @@
+.import-catch-card {
+    width: 100%;
+    overflow: hidden;
+}
+
+.import-catch-photos {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(5rem, 1fr));
+    gap: 0.5rem;
+}
+
+.import-catch-thumbnail {
+    width: 100%;
+    max-height: 8rem;
+    aspect-ratio: 1;
+    object-fit: cover;
+    border-radius: 0.5rem;
+}

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportPhotographPicker/ImportPhotographPicker.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportPhotographPicker/ImportPhotographPicker.razor.cs
@@ -19,6 +19,9 @@ public partial class ImportPhotographPicker : ComponentBase, IAsyncDisposable
     [Parameter]
     public EventCallback SelectionLimitExceeded { get; set; }
 
+    [Parameter]
+    public EventCallback SelectionStarted { get; set; }
+
     [Inject]
     private IImportPhotoPreparationService Preparation { get; set; } = default!;
 
@@ -32,6 +35,7 @@ public partial class ImportPhotographPicker : ComponentBase, IAsyncDisposable
             return;
         }
 
+        await SelectionStarted.InvokeAsync();
         _selectionCancellation = new CancellationTokenSource();
         _selectionTask = PrepareAsync(files, _selectionCancellation.Token);
         await _selectionTask;
@@ -67,6 +71,5 @@ public partial class ImportPhotographPicker : ComponentBase, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         await CancelSelectionAsync();
-        await Preparation.ClearAsync(CancellationToken.None);
     }
 }

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
@@ -118,6 +118,31 @@ public sealed class ImportBatchModel
         _catchProposals.Add(proposal);
     }
 
+    public void ReplaceCatchProposals(IEnumerable<ImportCatchProposalModel> proposals)
+    {
+        var replacements = proposals.ToArray();
+        var activePhotoIds = _photos.Where(photo => !photo.IsRemoved).Select(photo => photo.Id).ToHashSet();
+        if (replacements.Select(proposal => proposal.Id).Distinct().Count() != replacements.Length)
+        {
+            throw new InvalidOperationException("Catch proposal identities must be unique.");
+        }
+
+        var membership = replacements.SelectMany(proposal => proposal.PhotoIds).ToArray();
+        if (membership.Any(photoId => !activePhotoIds.Contains(photoId)))
+        {
+            throw new InvalidOperationException("Catch proposals may reference only active selected photos.");
+        }
+
+        if (membership.Distinct().Count() != membership.Length)
+        {
+            throw new InvalidOperationException("A photo cannot belong to more than one active Catch proposal.");
+        }
+
+        _catchProposals.Clear();
+        _catchProposals.AddRange(replacements);
+        _tripProposals.Clear();
+    }
+
     public void AddTripProposal(ImportTripProposalModel proposal)
     {
         if (_tripProposals.Any(existing => existing.Id == proposal.Id))

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
@@ -1,0 +1,151 @@
+@page "/import"
+@attribute [Authorize]
+@using FishingLogBook.Web.Features.Import.Components.ImportCatchReviewCard
+@using FishingLogBook.Web.Features.Import.Components.ImportPhotographPicker
+@using FishingLogBook.Web.Features.Import.Enums
+@using FishingLogBook.Web.Features.Import.Services
+
+<PageTitle>@Loc["Import_PageTitle"]</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Small" Gutters="false" Class="import-wizard-container">
+    <MudStack Spacing="3">
+        <MudText Typo="Typo.h5" Align="Align.Center" id="import-title">@Loc["Import_Title"]</MudText>
+        <MudText Typo="Typo.body2" Align="Align.Center" Class="mud-text-secondary">
+            @Loc["Import_NotSaved"]
+        </MudText>
+
+        @if (_isLoading)
+        {
+            <MudProgressCircular Indeterminate="true" Color="Color.Primary" Class="align-self-center"
+                                 id="import-loading" />
+        }
+        else if (_batch is not null)
+        {
+            @if (_batch.Stage == ImportStageEnum.BatchDetails)
+            {
+                <MudPaper Class="pa-3" Elevation="2" id="import-batch-details">
+                    <MudStack Spacing="3">
+                        <MudText Typo="Typo.h6">@Loc["Import_BatchDetailsTitle"]</MudText>
+                        <MudStack Spacing="2">
+                            <MudText Typo="Typo.caption">@Loc["Import_FishingMethod"]</MudText>
+                            <MudStack Row="true" Spacing="1" Class="flex-wrap" id="import-method-chips">
+                                @foreach (var method in MethodOptions)
+                                {
+                                    var selected = method.Id == _methodId;
+                                    <MudChip T="string"
+                                             Color="@(selected ? Color.Primary : Color.Default)"
+                                             Variant="@(selected ? Variant.Filled : Variant.Outlined)"
+                                             OnClick="@(() => SelectMethod(method.Id))"
+                                             id="@($"import-method-{method.Code}")">
+                                        @method.Name
+                                    </MudChip>
+                                }
+                                <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ChooseMethodAsync"
+                                           id="import-method-more">
+                                    @Loc["Common_More"]
+                                </MudButton>
+                            </MudStack>
+                        </MudStack>
+                        <MudStack Spacing="2">
+                            <MudText Typo="Typo.caption">@Loc["Import_Species"]</MudText>
+                            <MudStack Row="true" Spacing="1" Class="flex-wrap" id="import-species-chips">
+                                @foreach (var species in SpeciesOptions)
+                                {
+                                    var selected = species.Id == _speciesId;
+                                    <MudChip T="string"
+                                             Color="@(selected ? Color.Primary : Color.Default)"
+                                             Variant="@(selected ? Variant.Filled : Variant.Outlined)"
+                                             OnClick="@(() => SelectSpecies(species.Id))"
+                                             id="@($"import-species-{species.Code}")">
+                                        @species.Name
+                                    </MudChip>
+                                }
+                                <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ChooseSpeciesAsync"
+                                           id="import-species-more">
+                                    @Loc["Common_More"]
+                                </MudButton>
+                            </MudStack>
+                        </MudStack>
+                        <MudButton Color="Color.Primary" Variant="Variant.Filled" FullWidth="true"
+                                   Disabled="@(!_batch.CanProcessPhotos)" OnClick="ContinueToPhotos"
+                                   id="import-batch-continue">
+                            @Loc["Common_Continue"]
+                        </MudButton>
+                    </MudStack>
+                </MudPaper>
+            }
+            else if (_batch.Stage == ImportStageEnum.ChoosePhotos)
+            {
+                <MudPaper Class="pa-3" Elevation="2" id="import-choose-photos">
+                    <MudStack Spacing="3">
+                        <MudText Typo="Typo.h6">@Loc["Import_ChoosePhotosTitle"]</MudText>
+                        <ImportPhotographPicker Id="import-photo-picker"
+                                                SelectionStarted="OnSelectionStarted"
+                                                PhotosPrepared="OnPhotosPrepared"
+                                                SelectionLimitExceeded="OnSelectionLimitExceeded" />
+                        @if (_batch.IsProcessingPhotos)
+                        {
+                            <MudProgressLinear Indeterminate="true" Color="Color.Primary" id="import-processing" />
+                            <MudText role="status">@Loc["Import_ProcessingPhotos"]</MudText>
+                        }
+                        @if (_selectionLimitExceeded)
+                        {
+                            <MudAlert Severity="Severity.Error" id="import-selection-limit">
+                                @Loc["Import_SelectionLimit", ImportPhotoPreparationService.MaxPhotographs]
+                            </MudAlert>
+                        }
+                        @foreach (var photo in _batch.Photos.Where(photo => !photo.IsRemoved))
+                        {
+                            <div class="import-photo-row" id="@($"import-photo-{photo.SelectionIndex}")">
+                                @if (photo.IsReady)
+                                {
+                                    <img src="@photo.ThumbnailUrl"
+                                         alt="@Loc["Import_PhotoAlt", photo.SelectionIndex + 1]"
+                                         class="import-photo-thumbnail" />
+                                    <MudText>@PhotoMetadataLabel(photo)</MudText>
+                                }
+                                else
+                                {
+                                    <MudIcon Icon="@Icons.Material.Filled.BrokenImage" Color="Color.Error" />
+                                    <MudText Color="Color.Error">@PhotoPreparationLabel(photo)</MudText>
+                                }
+                                <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                               aria-label="@Loc["Import_RemovePhoto"]"
+                                               OnClick="@(() => RemovePhotoAsync(photo))"
+                                               id="@($"import-remove-photo-{photo.SelectionIndex}")" />
+                            </div>
+                        }
+                        <MudStack Row="true" Justify="Justify.SpaceBetween">
+                            <MudButton Variant="Variant.Text" OnClick="BackToBatch" id="import-photos-back">
+                                @Loc["Common_Back"]
+                            </MudButton>
+                            <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                                       Disabled="@(!CanReview)" OnClick="ContinueToReview"
+                                       id="import-photos-continue">
+                                @Loc["Import_ReviewCatches"]
+                            </MudButton>
+                        </MudStack>
+                    </MudStack>
+                </MudPaper>
+            }
+            else if (_batch.Stage == ImportStageEnum.ReviewCatches)
+            {
+                <MudStack Spacing="2" id="import-catch-review">
+                    <MudText Typo="Typo.h6">@Loc["Import_ReviewTitle"]</MudText>
+                    @for (var index = 0; index < _batch.CatchProposals.Count; index++)
+                    {
+                        <ImportCatchReviewCard Proposal="_batch.CatchProposals[index]"
+                                               Photos="_batch.Photos"
+                                               Number="@(index + 1)" />
+                    }
+                    <MudAlert Severity="Severity.Info" id="import-correction-boundary">
+                        @Loc["Import_CorrectionLater"]
+                    </MudAlert>
+                    <MudButton Variant="Variant.Text" OnClick="BackToPhotos" id="import-review-back">
+                        @Loc["Common_Back"]
+                    </MudButton>
+                </MudStack>
+            }
+        }
+    </MudStack>
+</MudContainer>

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
@@ -1,0 +1,303 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+using FishingLogBook.Web.Features.Profile.Models;
+using FishingLogBook.Web.Features.Profile.Providers;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Import.Pages.ImportCatchCatalogue;
+
+public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
+{
+    private const int MaxChipOptions = 6;
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private AnglerPreferencesModel _preferences = AnglerPreferencesModel.Empty;
+    private ImportBatchModel? _batch;
+    private Guid _methodId;
+    private Guid _speciesId;
+    private bool _isLoading = true;
+    private bool _selectionLimitExceeded;
+
+    [Inject] private IAnglerPreferencesProvider Preferences { get; set; } = default!;
+    [Inject] private IModalService ModalService { get; set; } = default!;
+    [Inject] private IImportCatchProposalService ProposalService { get; set; } = default!;
+    [Inject] private IImportPhotoPreparationService Preparation { get; set; } = default!;
+    [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    private bool CanReview
+    {
+        get
+        {
+            return _batch?.IsProcessingPhotos == false
+                && _batch.Photos.Any(photo => !photo.IsRemoved && photo.IsReady);
+        }
+    }
+
+    private IReadOnlyList<CatalogueOptionModel> MethodOptions
+    {
+        get
+        {
+            var preferredIds = _preferences.Preferences.Methods
+                .OrderByDescending(method => method.IsDefault)
+                .Select(method => method.FishingMethodId)
+                .ToArray();
+            var methods = preferredIds.Length > 0
+                ? preferredIds.Select(FindMethod).Where(method => method is not null).Select(method => method!)
+                : _preferences.Catalogue.Methods;
+            var selected = FindMethod(_methodId);
+            return BuildShortlist(methods.Select(Option), selected is null ? null : Option(selected));
+        }
+    }
+
+    private IReadOnlyList<CatalogueOptionModel> SpeciesOptions
+    {
+        get
+        {
+            var preferred = _preferences.Preferences.Methods
+                .FirstOrDefault(method => method.FishingMethodId == _methodId)?
+                .Species
+                .OrderByDescending(species => species.IsDefault)
+                .Select(species => FindSpecies(species.SpeciesId))
+                .Where(species => species is not null)
+                .Select(species => Option(species!))
+                .ToArray();
+            var selected = FindSpecies(_speciesId);
+            return BuildShortlist(preferred ?? [], selected is null ? null : Option(selected));
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _preferences = await Preferences.GetAsync(_cancellationTokenSource.Token);
+            ApplyPreferredDefaults();
+            _batch = NewBatch([]);
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private void ApplyPreferredDefaults()
+    {
+        var method = _preferences.Preferences.Methods.FirstOrDefault(candidate => candidate.IsDefault);
+        if (method is null)
+        {
+            return;
+        }
+
+        _methodId = method.FishingMethodId;
+        _speciesId = method.Species.FirstOrDefault(candidate => candidate.IsDefault)?.SpeciesId ?? Guid.Empty;
+    }
+
+    private async Task ChooseMethodAsync()
+    {
+        var chosen = await ChooseAsync(
+            Loc["Import_FishingMethod"],
+            _preferences.Catalogue.Methods
+                .Select(method => new CatalogueOptionModel(method.Id, method.Code, method.Name))
+                .ToArray());
+        if (chosen is not null)
+        {
+            SelectMethod(chosen.Id);
+        }
+    }
+
+    private async Task ChooseSpeciesAsync()
+    {
+        var chosen = await ChooseAsync(
+            Loc["Import_Species"],
+            _preferences.Catalogue.AllSpecies
+                .Select(species => new CatalogueOptionModel(species.Id, species.Code, species.Name))
+                .ToArray());
+        if (chosen is not null)
+        {
+            SelectSpecies(chosen.Id);
+        }
+    }
+
+    private void SelectMethod(Guid methodId)
+    {
+        _methodId = methodId;
+        ApplyDefaults();
+    }
+
+    private void SelectSpecies(Guid speciesId)
+    {
+        _speciesId = speciesId;
+        ApplyDefaults();
+    }
+
+    private async Task<CatalogueOptionModel?> ChooseAsync(
+        string title,
+        IReadOnlyList<CatalogueOptionModel> options)
+    {
+        var result = await ModalService.ShowAsync<
+            CataloguePickerModal,
+            CataloguePickerModalModel,
+            CataloguePickerModalResult>(
+                new CataloguePickerModalModel(title, options),
+                _cancellationTokenSource.Token);
+        return result?.Options.SingleOrDefault();
+    }
+
+    private void ApplyDefaults()
+    {
+        _batch?.SetDefaults(SelectedMethod(), SelectedSpecies());
+    }
+
+    private ImportCatalogueSelectionModel SelectedMethod()
+    {
+        var method = FindMethod(_methodId);
+        return method is null ? EmptySelection() : Selection(method);
+    }
+
+    private ImportCatalogueSelectionModel SelectedSpecies()
+    {
+        var species = FindSpecies(_speciesId);
+        return species is null ? EmptySelection() : Selection(species);
+    }
+
+    private FishingMethodDto? FindMethod(Guid id)
+    {
+        return _preferences.Catalogue.Methods.SingleOrDefault(candidate => candidate.Id == id);
+    }
+
+    private SpeciesDto? FindSpecies(Guid id)
+    {
+        return _preferences.Catalogue.AllSpecies.SingleOrDefault(candidate => candidate.Id == id);
+    }
+
+    private static CatalogueOptionModel Option(FishingMethodDto method)
+    {
+        return new CatalogueOptionModel(method.Id, method.Code, method.Name);
+    }
+
+    private static CatalogueOptionModel Option(SpeciesDto species)
+    {
+        return new CatalogueOptionModel(species.Id, species.Code, species.Name);
+    }
+
+    private static IReadOnlyList<CatalogueOptionModel> BuildShortlist(
+        IEnumerable<CatalogueOptionModel> options,
+        CatalogueOptionModel? selected)
+    {
+        var shortlist = options.Take(MaxChipOptions).ToList();
+        if (selected is null || shortlist.Any(option => option.Id == selected.Id))
+        {
+            return shortlist;
+        }
+
+        shortlist.Insert(0, selected);
+        return shortlist;
+    }
+
+    private static ImportCatalogueSelectionModel Selection(FishingMethodDto method)
+    {
+        return new ImportCatalogueSelectionModel(method.Id, method.Code, method.Name);
+    }
+
+    private static ImportCatalogueSelectionModel Selection(SpeciesDto species)
+    {
+        return new ImportCatalogueSelectionModel(species.Id, species.Code, species.Name);
+    }
+
+    private static ImportCatalogueSelectionModel EmptySelection()
+    {
+        return new ImportCatalogueSelectionModel(Guid.Empty, string.Empty, string.Empty);
+    }
+
+    private void ContinueToPhotos()
+    {
+        _batch?.SetStage(ImportStageEnum.ChoosePhotos);
+    }
+
+    private void BackToBatch()
+    {
+        _batch?.SetStage(ImportStageEnum.BatchDetails);
+    }
+
+    private void BackToPhotos()
+    {
+        _batch?.SetStage(ImportStageEnum.ChoosePhotos);
+    }
+
+    private void OnSelectionStarted()
+    {
+        _batch?.BeginPhotoProcessing();
+        _selectionLimitExceeded = false;
+    }
+
+    private void OnSelectionLimitExceeded()
+    {
+        _batch?.CompletePhotoProcessing();
+        _selectionLimitExceeded = true;
+    }
+
+    private void OnPhotosPrepared(IReadOnlyList<ImportSelectedPhotoModel> photos)
+    {
+        _batch = NewBatch(photos);
+        _batch.SetStage(ImportStageEnum.ChoosePhotos);
+        _batch.CompletePhotoProcessing();
+        _selectionLimitExceeded = false;
+    }
+
+    private ImportBatchModel NewBatch(IEnumerable<ImportSelectedPhotoModel> photos)
+    {
+        var batch = new ImportBatchModel(_batch?.Id ?? Guid.NewGuid(), SelectedMethod(), SelectedSpecies());
+        foreach (var photo in photos)
+        {
+            batch.AddPhoto(photo);
+        }
+
+        return batch;
+    }
+
+    private async Task RemovePhotoAsync(ImportSelectedPhotoModel photo)
+    {
+        await Preparation.RemoveAsync(photo, _cancellationTokenSource.Token);
+        _batch?.RemovePhoto(photo.Id);
+    }
+
+    private void ContinueToReview()
+    {
+        if (_batch is null || !CanReview)
+        {
+            return;
+        }
+
+        _batch.ReplaceCatchProposals(ProposalService.Propose(_batch));
+        _batch.SetStage(ImportStageEnum.ReviewCatches);
+    }
+
+    private string PhotoPreparationLabel(ImportSelectedPhotoModel photo)
+    {
+        return photo.PreparationStatus switch
+        {
+            ImportPhotoPreparationStatusEnum.UnsupportedType => Loc["Import_PhotoUnsupported"],
+            ImportPhotoPreparationStatusEnum.TooLarge => Loc["Import_PhotoTooLarge"],
+            ImportPhotoPreparationStatusEnum.Cancelled => Loc["Import_PhotoCancelled"],
+            _ => Loc["Import_PhotoFailed"]
+        };
+    }
+
+    private string PhotoMetadataLabel(ImportSelectedPhotoModel photo)
+    {
+        return photo.MetadataStatus is ImportMetadataStatusEnum.Failed or ImportMetadataStatusEnum.Unavailable
+            ? Loc["Import_MetadataUnavailable"]
+            : Loc["Import_PhotoReady"];
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cancellationTokenSource.CancelAsync();
+        await Preparation.ClearAsync(CancellationToken.None);
+        _cancellationTokenSource.Dispose();
+    }
+}

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.css
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.css
@@ -1,0 +1,26 @@
+.import-wizard-container {
+    width: 100%;
+    padding: 1rem;
+    overflow-x: hidden;
+}
+
+.import-photo-row {
+    display: grid;
+    grid-template-columns: 4rem minmax(0, 1fr) 3rem;
+    gap: 0.75rem;
+    align-items: center;
+    width: 100%;
+}
+
+.import-photo-thumbnail {
+    width: 4rem;
+    height: 4rem;
+    object-fit: cover;
+    border-radius: 0.5rem;
+}
+
+@media (max-width: 420px) {
+    .import-wizard-container {
+        padding: 0.75rem;
+    }
+}

--- a/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
+++ b/src/FishingLogBook.Web/Layouts/MainLayout/MainLayout.razor
@@ -37,6 +37,7 @@
                 <MudNavMenu>
                     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home" id="home-nav-link">@Loc["Nav_Home"]</MudNavLink>
                     <MudNavLink Href="/catches/record" Icon="@Icons.Material.Filled.AddAPhoto" id="record-catch-nav-link">@Loc["Catch_RecordNav"]</MudNavLink>
+                    <MudNavLink Href="/import" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.PhotoLibrary" id="import-catches-nav-link">@Loc["Import_Nav"]</MudNavLink>
                     <MudNavLink Href="/catches" Icon="@Icons.Material.Filled.MenuBook" id="catch-logbook-nav-link">@Loc["Catch_LogbookNav"]</MudNavLink>
                     <MudNavLink Href="/trips" Icon="@FishingLogBookIcons.FishingTrip" id="trips-nav-link">@Loc["Trip_Nav"]</MudNavLink>
                     <MudNavLink Href="/profile" Icon="@Icons.Material.Filled.Person" id="profile-nav-link">@Loc["Profile_Nav"]</MudNavLink>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1343,4 +1343,39 @@
   <data name="Trip_ParticipantOnlyAction" xml:space="preserve">
     <value>Seul le pêcheur qui a lancé cette sortie peut faire cela.</value>
   </data>
+  <data name="Common_Continue" xml:space="preserve"><value>Continuer</value></data>
+  <data name="Common_Back" xml:space="preserve"><value>Retour</value></data>
+  <data name="Import_Nav" xml:space="preserve"><value>Importer des prises</value></data>
+  <data name="Import_PageTitle" xml:space="preserve"><value>Cataloguer des prises historiques</value></data>
+  <data name="Import_Title" xml:space="preserve"><value>Cataloguer des prises historiques</value></data>
+  <data name="Import_NotSaved" xml:space="preserve"><value>Cette importation n’est pas encore enregistrée.</value></data>
+  <data name="Import_BatchDetailsTitle" xml:space="preserve"><value>Choisir les détails des prises</value></data>
+  <data name="Import_FishingMethod" xml:space="preserve"><value>Méthode de pêche</value></data>
+  <data name="Import_Species" xml:space="preserve"><value>Espèce</value></data>
+  <data name="Import_ChooseFishingMethod" xml:space="preserve"><value>Choisir la méthode de pêche</value></data>
+  <data name="Import_ChooseSpecies" xml:space="preserve"><value>Choisir l’espèce</value></data>
+  <data name="Import_ChoosePhotosTitle" xml:space="preserve"><value>Choisir des photos historiques</value></data>
+  <data name="Import_ProcessingPhotos" xml:space="preserve"><value>Préparation de vos photos…</value></data>
+  <data name="Import_SelectionLimit" xml:space="preserve"><value>Sélectionnez au maximum {0} photos à la fois.</value></data>
+  <data name="Import_PhotoAlt" xml:space="preserve"><value>Photographie historique sélectionnée {0}</value></data>
+  <data name="Import_RemovePhoto" xml:space="preserve"><value>Supprimer la photographie</value></data>
+  <data name="Import_PhotoUnsupported" xml:space="preserve"><value>Ce type de photographie n’est pas pris en charge.</value></data>
+  <data name="Import_PhotoTooLarge" xml:space="preserve"><value>Cette photographie dépasse 10 Mo.</value></data>
+  <data name="Import_PhotoCancelled" xml:space="preserve"><value>La préparation de la photographie a été annulée.</value></data>
+  <data name="Import_PhotoFailed" xml:space="preserve"><value>Cette photographie n’a pas pu être préparée.</value></data>
+  <data name="Import_MetadataUnavailable" xml:space="preserve"><value>Photo prête · détails historiques à vérifier</value></data>
+  <data name="Import_PhotoReady" xml:space="preserve"><value>Photo prête</value></data>
+  <data name="Import_ReviewCatches" xml:space="preserve"><value>Vérifier les prises</value></data>
+  <data name="Import_ReviewTitle" xml:space="preserve"><value>Prises proposées</value></data>
+  <data name="Import_CorrectionLater" xml:space="preserve"><value>Les outils de vérification et de correction seront ajoutés à la prochaine étape de cette fonctionnalité.</value></data>
+  <data name="Import_CatchNumber" xml:space="preserve"><value>Prise {0}</value></data>
+  <data name="Import_NeedsReview" xml:space="preserve"><value>À vérifier</value></data>
+  <data name="Import_Ready" xml:space="preserve"><value>Prête</value></data>
+  <data name="Import_TimestampAmbiguous" xml:space="preserve"><value>{0} · fuseau horaire à confirmer</value></data>
+  <data name="Import_TimestampWeak" xml:space="preserve"><value>{0} · date suggérée à confirmer</value></data>
+  <data name="Import_TimestampUnusable" xml:space="preserve"><value>La date de la photo n’a pas pu être utilisée</value></data>
+  <data name="Import_TimestampMissing" xml:space="preserve"><value>Date et heure requises</value></data>
+  <data name="Import_LocationNeedsReview" xml:space="preserve"><value>Les lieux des photos diffèrent · vérification requise</value></data>
+  <data name="Import_LocationAvailable" xml:space="preserve"><value>Lieu de la photo disponible</value></data>
+  <data name="Import_LocationUnavailable" xml:space="preserve"><value>Aucun lieu dans la photo</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1343,4 +1343,39 @@
   <data name="Trip_ParticipantOnlyAction" xml:space="preserve">
     <value>Only the angler who started this trip can do that.</value>
   </data>
+  <data name="Common_Continue" xml:space="preserve"><value>Continue</value></data>
+  <data name="Common_Back" xml:space="preserve"><value>Back</value></data>
+  <data name="Import_Nav" xml:space="preserve"><value>Import Catches</value></data>
+  <data name="Import_PageTitle" xml:space="preserve"><value>Catalogue historical catches</value></data>
+  <data name="Import_Title" xml:space="preserve"><value>Catalogue historical catches</value></data>
+  <data name="Import_NotSaved" xml:space="preserve"><value>This import is not saved yet.</value></data>
+  <data name="Import_BatchDetailsTitle" xml:space="preserve"><value>Choose catch details</value></data>
+  <data name="Import_FishingMethod" xml:space="preserve"><value>Fishing method</value></data>
+  <data name="Import_Species" xml:space="preserve"><value>Species</value></data>
+  <data name="Import_ChooseFishingMethod" xml:space="preserve"><value>Choose fishing method</value></data>
+  <data name="Import_ChooseSpecies" xml:space="preserve"><value>Choose species</value></data>
+  <data name="Import_ChoosePhotosTitle" xml:space="preserve"><value>Choose historical photos</value></data>
+  <data name="Import_ProcessingPhotos" xml:space="preserve"><value>Preparing your photos…</value></data>
+  <data name="Import_SelectionLimit" xml:space="preserve"><value>Select no more than {0} photos at once.</value></data>
+  <data name="Import_PhotoAlt" xml:space="preserve"><value>Selected historical photograph {0}</value></data>
+  <data name="Import_RemovePhoto" xml:space="preserve"><value>Remove photograph</value></data>
+  <data name="Import_PhotoUnsupported" xml:space="preserve"><value>This photograph type is not supported.</value></data>
+  <data name="Import_PhotoTooLarge" xml:space="preserve"><value>This photograph is larger than 10 MB.</value></data>
+  <data name="Import_PhotoCancelled" xml:space="preserve"><value>Photograph preparation was cancelled.</value></data>
+  <data name="Import_PhotoFailed" xml:space="preserve"><value>This photograph could not be prepared.</value></data>
+  <data name="Import_MetadataUnavailable" xml:space="preserve"><value>Photo ready · historical details need review</value></data>
+  <data name="Import_PhotoReady" xml:space="preserve"><value>Photo ready</value></data>
+  <data name="Import_ReviewCatches" xml:space="preserve"><value>Review catches</value></data>
+  <data name="Import_ReviewTitle" xml:space="preserve"><value>Proposed catches</value></data>
+  <data name="Import_CorrectionLater" xml:space="preserve"><value>Review and correction controls are added in the next step of this feature.</value></data>
+  <data name="Import_CatchNumber" xml:space="preserve"><value>Catch {0}</value></data>
+  <data name="Import_NeedsReview" xml:space="preserve"><value>Needs review</value></data>
+  <data name="Import_Ready" xml:space="preserve"><value>Ready</value></data>
+  <data name="Import_TimestampAmbiguous" xml:space="preserve"><value>{0} · timezone confirmation required</value></data>
+  <data name="Import_TimestampWeak" xml:space="preserve"><value>{0} · suggested date requires confirmation</value></data>
+  <data name="Import_TimestampUnusable" xml:space="preserve"><value>Photo date could not be used</value></data>
+  <data name="Import_TimestampMissing" xml:space="preserve"><value>Date and time required</value></data>
+  <data name="Import_LocationNeedsReview" xml:space="preserve"><value>Photo locations differ · review required</value></data>
+  <data name="Import_LocationAvailable" xml:space="preserve"><value>Photo location available</value></data>
+  <data name="Import_LocationUnavailable" xml:space="preserve"><value>No photo location</value></data>
 </root>

--- a/src/FishingLogBook.Web/wwwroot/css/app.css
+++ b/src/FishingLogBook.Web/wwwroot/css/app.css
@@ -122,6 +122,15 @@ html, body {
     border-color: var(--mud-palette-primary-darken);
 }
 
+.mud-button-text {
+    border: 1px solid var(--mud-palette-lines-default);
+}
+
+.mud-button-text:hover,
+.mud-button-text:focus-visible {
+    border-color: currentColor;
+}
+
 .profile-default-label {
     font-size: 0.75em;
     text-transform: lowercase;

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -1,0 +1,138 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Import.Components.ImportCatchReviewCard;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Components.ImportCatchReviewCardTests;
+
+public class WhenTestingRender
+{
+    private static readonly DateTimeOffset CapturedOn = DateTimeOffset.Parse("2025-06-14T09:30:00+01:00");
+
+    [Theory]
+    [MemberData(nameof(ReviewTimestamps))]
+    public async Task ItShouldPresentUnresolvedTimestampsAsNeedingReview(
+        ImportTimestampModel timestamp,
+        ImportCatchProposalReasonEnum reason,
+        string expected)
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, reason);
+
+        // Act
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Photos, [photo])
+            .Add(component => component.Number, 1));
+
+        // Assert
+        cut.Find("#import-catch-1-timestamp").TextContent.Should().Contain(expected);
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Needs review");
+    }
+
+    [Fact]
+    public async Task ItShouldPreserveTheHistoricalOffsetForATrustworthyTimestamp()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.FromExplicitInstant(CapturedOn, ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+
+        // Act
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal,
+                Proposal(photo, timestamp, ImportCatchProposalReasonEnum.TrustworthyCaptureTime))
+            .Add(component => component.Photos, [photo])
+            .Add(component => component.Number, 1));
+
+        // Assert
+        cut.Find("#import-catch-1-timestamp").TextContent.Should().Contain("+01:00");
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Ready");
+    }
+
+    [Fact]
+    public async Task ItShouldPresentConflictingGpsWithoutExposingCoordinates()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.FromExplicitInstant(CapturedOn, ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(
+            photo,
+            timestamp,
+            ImportCatchProposalReasonEnum.TrustworthyCaptureTime,
+            ImportCatchProposalReasonEnum.ConflictingGps);
+
+        // Act
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Photos, [photo])
+            .Add(component => component.Number, 1));
+
+        // Assert
+        cut.Find("#import-catch-1-location").TextContent.Should().Contain("review required");
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Needs review");
+        cut.Markup.Should().NotContain("53.3498");
+    }
+
+    public static TheoryData<ImportTimestampModel, ImportCatchProposalReasonEnum, string> ReviewTimestamps => new()
+    {
+        { ImportTimestampModel.Missing(), ImportCatchProposalReasonEnum.MissingTimestamp, "Date and time required" },
+        { ImportTimestampModel.Unusable(ImportTimestampSourceEnum.ExifOriginal), ImportCatchProposalReasonEnum.UnusableTimestamp, "could not be used" },
+        { ImportTimestampModel.FromWeakFallback(CapturedOn), ImportCatchProposalReasonEnum.WeakTimestamp, "suggested date requires confirmation" },
+        {
+            ImportTimestampModel.FromLocalWallClock(
+                new DateTime(2025, 6, 14, 9, 30, 0),
+                ImportTimestampSourceEnum.ExifOriginal),
+            ImportCatchProposalReasonEnum.AmbiguousTimestamp,
+            "timezone confirmation required"
+        }
+    };
+
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        return context;
+    }
+
+    private static ImportSelectedPhotoModel Photo(ImportTimestampModel timestamp)
+    {
+        var photo = new ImportSelectedPhotoModel(
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            0,
+            "image/jpeg",
+            1024,
+            "token",
+            "catch.jpg",
+            "blob:thumbnail");
+        photo.SetPreparation(ImportPhotoPreparationStatusEnum.Ready, "token", "blob:thumbnail");
+        photo.SetMetadata(
+            ImportMetadataStatusEnum.Available,
+            timestamp,
+            new ImportLocationModel(53.3498, -6.2603, true));
+        return photo;
+    }
+
+    private static ImportCatchProposalModel Proposal(
+        ImportSelectedPhotoModel photo,
+        ImportTimestampModel timestamp,
+        params ImportCatchProposalReasonEnum[] reasons)
+    {
+        return new ImportCatchProposalModel(
+            Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            [photo.Id],
+            timestamp,
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "Fly", "Fly"),
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "BrownTrout", "Brown Trout"),
+            photo.Location,
+            reasons);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportPhotographPickerTests/WhenTestingSelection.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportPhotographPickerTests/WhenTestingSelection.cs
@@ -69,7 +69,33 @@ public class WhenTestingSelection : BaseImportPhotographPickerTest
     }
 
     [Fact]
-    public async Task ItShouldClearTransientResourcesWhenDisposed()
+    public async Task ItShouldReportThatSelectionProcessingStarted()
+    {
+        // Arrange
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        preparation.PrepareSelectionAsync(
+                Arg.Any<IReadOnlyList<IBrowserFile>>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+        await using var context = CreateContext(preparation);
+        var started = false;
+        var cut = context.Render<ImportPhotographPicker>(parameters => parameters
+            .Add(component => component.Id, "import-picker")
+            .Add(component => component.SelectionStarted, () => started = true));
+
+        // Act
+        cut.FindComponent<InputFile>().UploadFiles(
+            InputFileContent.CreateFromBinary([1], "photo.jpg", contentType: "image/jpeg"));
+
+        // Assert
+        started.Should().BeTrue();
+        await preparation.Received(1).PrepareSelectionAsync(
+            Arg.Is<IReadOnlyList<IBrowserFile>>(files => files.Count == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotClearWizardOwnedResourcesWhenDisposed()
     {
         // Arrange
         var preparation = Substitute.For<IImportPhotoPreparationService>();
@@ -82,6 +108,6 @@ public class WhenTestingSelection : BaseImportPhotographPickerTest
         await cut.Instance.DisposeAsync();
 
         // Assert
-        await preparation.Received(1).ClearAsync(CancellationToken.None);
+        await preparation.DidNotReceive().ClearAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingBatch.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingBatch.cs
@@ -54,6 +54,42 @@ public class WhenTestingBatch : BaseImportModelTest
     }
 
     [Fact]
+    public void ItShouldReplaceCatchProposalsWithoutRetainingOldMemberships()
+    {
+        // Arrange
+        var batch = Batch();
+        batch.AddPhoto(Photo());
+        batch.AddPhoto(Photo(SecondPhotoId, 1));
+        batch.AddCatchProposal(Catch());
+        var replacement = Catch(SecondCatchId, [PhotoId, SecondPhotoId]);
+
+        // Act
+        batch.ReplaceCatchProposals([replacement]);
+
+        // Assert
+        batch.CatchProposals.Should().Equal(replacement);
+    }
+
+    [Fact]
+    public void ItShouldRejectInvalidReplacementWithoutDiscardingCurrentProposals()
+    {
+        // Arrange
+        var batch = Batch();
+        var current = Catch();
+        batch.AddPhoto(Photo());
+        batch.AddCatchProposal(current);
+        var invalid = Catch(SecondCatchId, [Guid.NewGuid()]);
+        Action replace = () => batch.ReplaceCatchProposals([invalid]);
+
+        // Act
+        var assertion = replace.Should();
+
+        // Assert
+        assertion.Throw<InvalidOperationException>();
+        batch.CatchProposals.Should().Equal(current);
+    }
+
+    [Fact]
     public void ItShouldAllowTripProposalsToReferenceReviewedCatchesOnly()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
@@ -1,0 +1,137 @@
+using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+using FishingLogBook.Web.Features.Profile.Models;
+using FishingLogBook.Web.Features.Profile.Providers;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Pages.ImportCatchCatalogueTests;
+
+public class BaseImportCatchCatalogueTest
+{
+    protected static readonly Guid MethodId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    protected static readonly Guid SecondMethodId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    protected static readonly Guid SpeciesId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    protected static readonly DateTimeOffset CapturedOn = DateTimeOffset.Parse("2025-06-14T09:30:00+01:00");
+
+    protected static BunitContext CreateContext(
+        IImportCatchProposalService proposal,
+        IImportPhotoPreparationService preparation,
+        IAnglerPreferencesProvider? preferences = null,
+        IModalService? modalService = null)
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        context.Services.AddSingleton(proposal);
+        context.Services.AddSingleton(preparation);
+        context.Services.AddSingleton(preferences ?? Preferences());
+        context.Services.AddSingleton(modalService ?? SelectingModal(MethodId, SpeciesId));
+        return context;
+    }
+
+    protected static IModalService SelectingModal(params Guid[] selections)
+    {
+        var remaining = new Queue<Guid>(selections);
+        var modal = Substitute.For<IModalService>();
+        modal.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
+                Arg.Any<CataloguePickerModalModel>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var model = call.Arg<CataloguePickerModalModel>();
+                var selectedId = remaining.Dequeue();
+                return new CataloguePickerModalResult(model.Options.Single(option => option.Id == selectedId));
+            });
+        return modal;
+    }
+
+    protected static IAnglerPreferencesProvider Preferences()
+    {
+        return Preferences(includeDefaults: true);
+    }
+
+    protected static IAnglerPreferencesProvider Preferences(bool includeDefaults)
+    {
+        var provider = Substitute.For<IAnglerPreferencesProvider>();
+        provider.GetAsync(Arg.Any<CancellationToken>()).Returns(new AnglerPreferencesModel(
+            new FishingCatalogueDto(
+                [
+                    new FishingMethodDto(MethodId, "Fly", "Fly"),
+                    new FishingMethodDto(SecondMethodId, "Lure", "Lure")
+                ],
+                [new SpeciesDto(SpeciesId, "BrownTrout", "Brown Trout")]),
+            new FishingPreferencesDto(includeDefaults
+                ? [
+                    new FishingMethodPreferenceDto(
+                        MethodId,
+                        "Fly",
+                        "Fly",
+                        true,
+                        [new FishingSpeciesPreferenceDto(SpeciesId, "BrownTrout", "Brown Trout", true)])
+                ]
+                : []),
+            WeightUnitEnum.Kg,
+            LengthUnitEnum.Cm));
+        return provider;
+    }
+
+    protected static ImportSelectedPhotoModel ReadyPhoto(
+        int index,
+        ImportTimestampModel? timestamp = null,
+        ImportMetadataStatusEnum metadataStatus = ImportMetadataStatusEnum.Available)
+    {
+        var photo = new ImportSelectedPhotoModel(
+            Guid.Parse($"44444444-4444-4444-4444-{index + 1:D12}"),
+            index,
+            "image/jpeg",
+            1024,
+            $"token-{index}",
+            $"photo-{index}.jpg",
+            $"blob:thumbnail-{index}");
+        photo.SetPreparation(ImportPhotoPreparationStatusEnum.Ready, $"token-{index}", $"blob:thumbnail-{index}");
+        photo.SetMetadata(
+            metadataStatus,
+            timestamp ?? ImportTimestampModel.FromExplicitInstant(
+                CapturedOn.AddMinutes(index),
+                ImportTimestampSourceEnum.ExifOriginal),
+            new ImportLocationModel(null, null, false));
+        return photo;
+    }
+
+    protected static ImportSelectedPhotoModel FailedPhoto(int index)
+    {
+        var photo = new ImportSelectedPhotoModel(
+            Guid.Parse($"55555555-5555-5555-5555-{index + 1:D12}"),
+            index,
+            "image/heic",
+            1024,
+            null,
+            $"failed-{index}.heic");
+        photo.SetPreparation(ImportPhotoPreparationStatusEnum.UnsupportedType);
+        return photo;
+    }
+
+    protected static IReadOnlyList<ImportCatchProposalModel> ProposalsFor(ImportBatchModel batch)
+    {
+        return batch.Photos
+            .Where(photo => photo.IsReady && !photo.IsRemoved)
+            .Select(photo => new ImportCatchProposalModel(
+                Guid.NewGuid(),
+                [photo.Id],
+                photo.Timestamp,
+                batch.FishingMethod,
+                batch.Species,
+                reasons: [photo.Timestamp.IsResolved
+                    ? ImportCatchProposalReasonEnum.TrustworthyCaptureTime
+                    : ImportCatchProposalReasonEnum.MissingTimestamp]))
+            .ToArray();
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
@@ -1,0 +1,360 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Import.Components.ImportCatchReviewCard;
+using FishingLogBook.Web.Features.Import.Components.ImportPhotographPicker;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Pages.ImportCatchCatalogue;
+using FishingLogBook.Web.Features.Import.Services;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Pages.ImportCatchCatalogueTests;
+
+public class WhenTestingWizard : BaseImportCatchCatalogueTest
+{
+    [Fact]
+    public async Task ItShouldEnterTheWizardAtBatchDetailsFromTheImportRoute()
+    {
+        // Arrange
+        var route = typeof(ImportCatchCatalogue).GetCustomAttributes(typeof(RouteAttribute), inherit: false)
+            .Cast<RouteAttribute>()
+            .Single();
+        await using var context = CreateContext(
+            Substitute.For<IImportCatchProposalService>(),
+            Substitute.For<IImportPhotoPreparationService>());
+
+        // Act
+        var cut = context.Render<ImportCatchCatalogue>();
+        var batchDetails = cut.WaitForElement("#import-batch-details");
+
+        // Assert
+        route.Template.Should().Be("/import");
+        batchDetails.Should().NotBeNull();
+        cut.FindAll("#import-photo-selection").Should().BeEmpty();
+        cut.FindAll("#import-catch-review").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldRequireBothBatchDefaultsBeforeContinuing()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        var modal = SelectingModal(MethodId, SpeciesId);
+        await using var context = CreateContext(
+            proposal,
+            preparation,
+            preferences: Preferences(includeDefaults: false),
+            modalService: modal);
+        var cut = context.Render<ImportCatchCatalogue>();
+        cut.WaitForElement("#import-batch-details");
+
+        // Act
+        cut.Find("#import-method-more").Click();
+
+        // Assert
+        cut.Find("#import-batch-continue").HasAttribute("disabled").Should().BeTrue();
+        cut.Find("#import-species-more").Click();
+        cut.Find("#import-batch-continue").HasAttribute("disabled").Should().BeFalse();
+        await modal.Received(1).ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
+            Arg.Is<CataloguePickerModalModel>(model =>
+                model.Title == "Fishing method"
+                && model.Options.Any(option => option.Id == MethodId)),
+            Arg.Any<CancellationToken>());
+        await modal.Received(1).ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
+            Arg.Is<CataloguePickerModalModel>(model =>
+                model.Title == "Species"
+                && model.Options.Any(option => option.Id == SpeciesId)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldApplyConfiguredDefaultsAndKeepThemChangeable()
+    {
+        // Arrange
+        await using var context = CreateContext(
+            Substitute.For<IImportCatchProposalService>(),
+            Substitute.For<IImportPhotoPreparationService>(),
+            modalService: SelectingModal(SecondMethodId));
+
+        // Act
+        var cut = context.Render<ImportCatchCatalogue>();
+        cut.WaitForElement("#import-batch-details");
+
+        // Assert
+        cut.Find("#import-method-Fly").ClassList.Should().Contain("mud-chip-filled");
+        cut.FindAll("#import-method-Lure").Should().BeEmpty();
+        cut.Find("#import-species-BrownTrout").ClassList.Should().Contain("mud-chip-filled");
+        cut.Find("#import-batch-continue").HasAttribute("disabled").Should().BeFalse();
+
+        // Act
+        cut.Find("#import-method-more").Click();
+
+        // Assert
+        cut.Find("#import-method-Lure").ClassList.Should().Contain("mud-chip-filled");
+        cut.Find("#import-batch-continue").HasAttribute("disabled").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldReuseThePickerAndPreventReviewWithoutAUsablePhoto()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+
+        // Act
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([FailedPhoto(0)]));
+
+        // Assert
+        cut.Find("#import-photo-0").TextContent.Should().Contain("not supported");
+        cut.Find("#import-photos-continue").HasAttribute("disabled").Should().BeTrue();
+        proposal.DidNotReceive().Propose(Arg.Any<ImportBatchModel>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepPreparedPhotosUsableWhenHistoricalMetadataIsUnavailable()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var photo = ReadyPhoto(0, ImportTimestampModel.Missing(), ImportMetadataStatusEnum.Unavailable);
+
+        // Act
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([photo]));
+
+        // Assert
+        cut.Find("#import-photo-0").TextContent.Should().Contain("historical details need review");
+        cut.Find("#import-photos-continue").HasAttribute("disabled").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldShowProcessingStateAndPreventProgressionWhilePreparing()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+
+        // Act
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.SelectionStarted.InvokeAsync());
+
+        // Assert
+        cut.Find("#import-processing").Should().NotBeNull();
+        cut.Find("#import-photos-continue").HasAttribute("disabled").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldLocaliseTheWizardInFrench()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.French);
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+
+        // Act
+        var cut = context.Render<ImportCatchCatalogue>();
+        cut.WaitForElement("#import-batch-details");
+
+        // Assert
+        cut.Find("#import-title").TextContent.Should().Contain("Cataloguer des prises historiques");
+        cut.Find("#import-method-chips").TextContent.Should().Contain("Fly");
+        cut.Find("#import-method-more").TextContent.Should().Contain("Plus");
+    }
+
+    [Fact]
+    public async Task ItShouldGenerateProposalsThroughTheGroupingBoundaryAndRenderEachMembership()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var photos = new[] { ReadyPhoto(0), ReadyPhoto(1) };
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync(photos));
+
+        // Act
+        cut.Find("#import-photos-continue").Click();
+
+        // Assert
+        cut.FindComponents<ImportCatchReviewCard>().Should().HaveCount(2);
+        proposal.Received(1).Propose(Arg.Is<ImportBatchModel>(batch =>
+            batch.FishingMethod.Id == MethodId
+            && batch.Species.Id == SpeciesId
+            && batch.Photos.Count == 2));
+    }
+
+    [Fact]
+    public async Task ItShouldShowGroupedPhotosTogetherAndExcludeFailedPhotosFromMembership()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call =>
+        {
+            var batch = call.Arg<ImportBatchModel>();
+            var ready = batch.Photos.Where(photo => photo.IsReady).ToArray();
+            return
+            [
+                new ImportCatchProposalModel(
+                    Guid.NewGuid(), ready.Select(photo => photo.Id), ready[0].Timestamp,
+                    batch.FishingMethod, batch.Species,
+                    reasons: [FishingLogBook.Web.Features.Import.Enums.ImportCatchProposalReasonEnum.TrustworthyCaptureTime])
+            ];
+        });
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(0), ReadyPhoto(1), FailedPhoto(2)]));
+
+        // Act
+        cut.Find("#import-photos-continue").Click();
+
+        // Assert
+        cut.FindComponents<ImportCatchReviewCard>().Should().ContainSingle();
+        cut.FindAll("#import-catch-1-photos img").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ItShouldPreserveStateOnBackAndRegenerateWithoutDuplicates()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(0)]));
+        cut.Find("#import-photos-continue").Click();
+
+        // Act
+        cut.Find("#import-review-back").Click();
+        cut.Find("#import-photos-continue").Click();
+
+        // Assert
+        cut.FindComponents<ImportCatchReviewCard>().Should().ContainSingle();
+        proposal.Received(2).Propose(Arg.Any<ImportBatchModel>());
+    }
+
+    [Fact]
+    public async Task ItShouldKeepThumbnailResourcesWhenReturningFromReview()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var photo = ReadyPhoto(0);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([photo]));
+        cut.Find("#import-photos-continue").Click();
+
+        // Act
+        cut.Find("#import-review-back").Click();
+
+        // Assert
+        cut.Find("#import-photo-0 img").GetAttribute("src").Should().Be(photo.ThumbnailUrl);
+        await preparation.DidNotReceive().ClearAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldRegenerateWithChangedDefaultsAndChangedPhotos()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(
+            proposal,
+            preparation,
+            modalService: SelectingModal(SecondMethodId));
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(0)]));
+        cut.Find("#import-photos-back").Click();
+        cut.Find("#import-method-more").Click();
+        cut.Find("#import-batch-continue").Click();
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(1)]));
+
+        // Act
+        cut.Find("#import-photos-continue").Click();
+
+        // Assert
+        proposal.Received(1).Propose(Arg.Is<ImportBatchModel>(batch =>
+            batch.FishingMethod.Id == SecondMethodId
+            && batch.Photos.Count == 1
+            && batch.Photos[0].SelectionIndex == 1));
+        cut.Find("#import-catch-1").TextContent.Should().Contain("Lure");
+    }
+
+    [Fact]
+    public async Task ItShouldRemovePhotosThroughThePreparationLifecycle()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var photo = ReadyPhoto(0);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([photo]));
+
+        // Act
+        cut.Find("#import-remove-photo-0").Click();
+
+        // Assert
+        await preparation.Received(1).RemoveAsync(photo, Arg.Any<CancellationToken>());
+        cut.FindAll("#import-photo-0").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldClearTransientPhotoResourcesWhenDisposed()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        preparation.ClearAsync(Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        cut.WaitForElement("#import-batch-details");
+
+        // Act
+        await cut.Instance.DisposeAsync();
+
+        // Assert
+        await preparation.Received(1).ClearAsync(CancellationToken.None);
+    }
+
+    private static Task SelectDefaultsAndContinueAsync(IRenderedComponent<ImportCatchCatalogue> cut)
+    {
+        cut.WaitForElement("#import-batch-details");
+        cut.Find("#import-method-Fly").Click();
+        cut.Find("#import-species-BrownTrout").Click();
+        cut.Find("#import-batch-continue").Click();
+        return Task.CompletedTask;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingAuthentication.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingAuthentication.cs
@@ -23,6 +23,7 @@ public class WhenTestingAuthentication : BaseMainLayoutTest
         cut.FindAll("#app-drawer").Should().BeEmpty();
         cut.FindAll("#app-menu-button").Should().BeEmpty();
         cut.FindAll("#record-catch-nav-link").Should().BeEmpty();
+        cut.FindAll("#import-catches-nav-link").Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingMenu.cs
+++ b/tests/FishingLogBook.Web.Tests/Layouts/MainLayoutTests/WhenTestingMenu.cs
@@ -2,6 +2,8 @@ using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Web.Layouts.MainLayout;
 using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace FishingLogBook.Web.Tests.Layouts.MainLayoutTests;
 
@@ -24,6 +26,8 @@ public class WhenTestingMenu : BaseMainLayoutTest
         cut.Find("#profile-nav-link").GetAttribute("href").Should().Be("/profile");
         cut.Find("#install-nav-link").GetAttribute("href").Should().Be("/install");
         cut.Find("#record-catch-nav-link").GetAttribute("href").Should().Be("/catches/record");
+        cut.Find("#import-catches-nav-link").GetAttribute("href").Should().Be("/import");
+        cut.Find("#import-catches-nav-link").TextContent.Should().Contain("Import Catches");
         cut.Find("#catch-logbook-nav-link").GetAttribute("href").Should().Be("/catches");
         cut.Find("#trips-nav-link").GetAttribute("href").Should().Be("/trips");
         cut.Find("#trips-nav-link").TextContent.Should().Contain("Trips");
@@ -48,8 +52,25 @@ public class WhenTestingMenu : BaseMainLayoutTest
         // Assert
         cut.Find("#profile-nav-link").TextContent.Should().Contain("Profil");
         cut.Find("#record-catch-nav-link").TextContent.Should().Contain("Enregistrer une prise");
+        cut.Find("#import-catches-nav-link").TextContent.Should().Contain("Importer des prises");
         cut.Find("#catch-logbook-nav-link").TextContent.Should().Contain("Prises");
         cut.Find("#trips-nav-link").TextContent.Should().Contain("Sorties");
         cut.Find("#app-menu-button").GetAttribute("aria-label").Should().Be("Ouvrir le menu");
+    }
+
+    [Fact]
+    public async Task ItShouldMarkImportActiveOnlyAtTheImportEntryRoute()
+    {
+        // Arrange
+        using var culture = TestCulture.Use(CultureNames.English);
+        await using var context = CreateContext(isAuthenticated: true);
+        context.Services.GetRequiredService<NavigationManager>().NavigateTo("/import");
+
+        // Act
+        var cut = context.Render<MainLayout>();
+
+        // Assert
+        cut.Find("#import-catches-nav-link").ClassList.Should().Contain("active");
+        cut.Find("#catch-logbook-nav-link").ClassList.Should().NotContain("active");
     }
 }


### PR DESCRIPTION
## Summary

- add the authenticated, mobile-first Import Catches workflow at `/import`
- load preference-first method/species choices and apply configured defaults while keeping them changeable
- select and prepare historical photos, then generate deterministic proposed catch groups for review
- preserve transient thumbnail resources across wizard navigation and clean them up when the workflow closes
- add a globally visible, theme-aware border to text-variant secondary buttons
- localise the workflow in English and French

## Scope

This PR implements the initial batch-context and proposed-group review slice for #216.

Individual proposed-catch correction controls remain deliberately deferred to #217. No final Catch records are persisted.

Part of #216.

## Validation

- `dotnet format FishingLogBook.sln --no-restore`
- `dotnet build FishingLogBook.sln --no-restore`
- `dotnet test tests/FishingLogBook.Web.Tests/FishingLogBook.Web.Tests.csproj --no-restore` — 1,791 passed
- JavaScript tests — 402 passed
- browser suite — passed on isolated retry after one unrelated offline-shell timeout
- `git diff --check`

## Self Review

- Issue/AC: PASS for the scoped initial wizard; per-group corrections are explicitly deferred to #217
- Architecture/CQRS: PASS — Web-only transient workflow using existing providers, modal, picker, and grouping boundary
- Rules: PASS
- Security/privacy: PASS — no persistence or additional location exposure
- Database/migrations: N/A
- Tests/coverage: PASS — batch defaults, catalogue fallback, navigation, photo lifecycle, grouping, review, back navigation, localisation, and resource cleanup covered
- Browser: N/A for authenticated Blazor workflow; current browser harness is not an authenticated host, and bUnit covers component state and interactions
- Web/UI/localisation: PASS
- Code smells: PASS
- CI/deployment: PASS — no manual deployment or migration steps

### Findings discovered during self-review

1. The photo picker disposed its shared Blob registry when entering Review, breaking thumbnails after returning.
2. A value selected through MORE could disappear outside the preference shortlist.
3. Import initially ignored configured default method/species values.

### Fixes made

1. Moved transient-resource ownership to the wizard page and added Review → Back regression coverage.
2. Retained explicit catalogue selections in the visible shortlist.
3. Applied configured defaults while preserving manual changes and no-default fallback.

### Remaining deliberate gaps

- Individual catch override/edit controls are implemented by #217.
- Final Catch persistence is outside this slice.
