### PR TITLE
FLB#217 | add split and merge corrections for proposed catches

### DIFF
--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
@@ -1,25 +1,148 @@
 @using FishingLogBook.Web.Features.Import.Models
+@using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor
 
 <MudPaper Class="import-catch-card pa-3" Elevation="2" id="@($"import-catch-{Number}")">
     <MudStack Spacing="2">
-        <MudText Typo="Typo.h6">@Loc["Import_CatchNumber", Number]</MudText>
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+            <MudText Typo="Typo.h6">@Loc["Import_CatchNumber", Number]</MudText>
+            <MudChip T="string" Color="@StatusColor" Variant="Variant.Outlined"
+                     id="@($"import-catch-{Number}-status")">@StatusLabel</MudChip>
+        </MudStack>
         <div class="import-catch-photos" id="@($"import-catch-{Number}-photos")">
             @foreach (var photo in ProposalPhotos)
             {
-                <img src="@photo.ThumbnailUrl"
-                     alt="@Loc["Import_PhotoAlt", photo.SelectionIndex + 1]"
-                     class="import-catch-thumbnail" />
+                <label class="import-catch-photo-choice">
+                    @if (_editing)
+                    {
+                        <MudCheckBox T="bool" Value="@_selectedPhotoIds.Contains(photo.Id)"
+                                     ValueChanged="@(selected => SelectPhoto(photo.Id, selected))"
+                                     aria-label="@Loc["Import_SelectPhoto", photo.SelectionIndex + 1]"
+                                     id="@($"import-catch-{Number}-select-{photo.SelectionIndex}")" />
+                    }
+                    <img src="@photo.ThumbnailUrl" alt="@Loc["Import_PhotoAlt", photo.SelectionIndex + 1]"
+                         class="import-catch-thumbnail" />
+                </label>
             }
         </div>
         <MudText id="@($"import-catch-{Number}-timestamp")">@TimestampLabel</MudText>
-        <MudText>@Proposal.Method.Name</MudText>
-        <MudText>@Proposal.Species.Name</MudText>
+        <MudText id="@($"import-catch-{Number}-method")">@Proposal.Method.Name</MudText>
+        <MudText id="@($"import-catch-{Number}-species")">@Proposal.Species.Name</MudText>
         <MudText id="@($"import-catch-{Number}-location")">@LocationLabel</MudText>
-        <MudChip T="string"
-                 Color="@(RequiresCorrection ? Color.Warning : Color.Success)"
-                 Variant="Variant.Outlined"
-                 id="@($"import-catch-{Number}-status")">
-            @(RequiresCorrection ? Loc["Import_NeedsReview"] : Loc["Import_Ready"])
-        </MudChip>
+
+        @if (_editing)
+        {
+            <MudStack Spacing="2" id="@($"import-catch-{Number}-editor")">
+                <MudTextField T="string" Value="@_caughtOnLocal" ValueChanged="SetCaughtOnLocal"
+                              Label="@Loc["Import_CaughtOn"]" InputType="InputType.DateTimeLocal"
+                              Immediate="true"
+                              Error="@_caughtOnInvalid" ErrorText="@Loc["Import_CaughtOnRequired"]"
+                              id="@($"import-catch-{Number}-caught-on")" />
+                <MudButton Variant="Variant.Outlined" OnClick="ConfirmCaughtOn"
+                           id="@($"import-catch-{Number}-confirm-caught-on")">@Loc["Import_ConfirmCaughtOn"]</MudButton>
+                @if (Proposal.RequiresCanonicalReview)
+                {
+                    <MudAlert Severity="Severity.Warning">@Loc["Import_MergeValuesNeedReview"]</MudAlert>
+                    <MudButton Variant="Variant.Outlined" OnClick="AcceptShownValues"
+                               id="@($"import-catch-{Number}-accept-merged-values")">@Loc["Import_UseShownValues"]</MudButton>
+                }
+
+                <MudText Typo="Typo.caption">@Loc["Import_FishingMethod"]</MudText>
+                <MudStack Row="true" Spacing="1" Class="flex-wrap">
+                    @foreach (var method in MethodOptions)
+                    {
+                        <MudChip T="string" Color="@(method.Id == Proposal.Method.Id ? Color.Primary : Color.Default)"
+                                 Variant="@(method.Id == Proposal.Method.Id ? Variant.Filled : Variant.Outlined)"
+                                 OnClick="@(() => SelectMethod(method))"
+                                 id="@($"import-catch-{Number}-method-{method.Code}")">@method.Name</MudChip>
+                    }
+                    <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ChooseMethodAsync"
+                               id="@($"import-catch-{Number}-method-more")">@Loc["Common_More"]</MudButton>
+                </MudStack>
+
+                <MudText Typo="Typo.caption">@Loc["Import_Species"]</MudText>
+                <MudStack Row="true" Spacing="1" Class="flex-wrap">
+                    @foreach (var species in SpeciesOptions)
+                    {
+                        <MudChip T="string" Color="@(species.Id == Proposal.Species.Id ? Color.Primary : Color.Default)"
+                                 Variant="@(species.Id == Proposal.Species.Id ? Variant.Filled : Variant.Outlined)"
+                                 OnClick="@(() => SelectSpecies(species))"
+                                 id="@($"import-catch-{Number}-species-{species.Code}")">@species.Name</MudChip>
+                    }
+                    <MudButton Size="Size.Small" Variant="Variant.Text" OnClick="ChooseSpeciesAsync"
+                               id="@($"import-catch-{Number}-species-more")">@Loc["Common_More"]</MudButton>
+                </MudStack>
+
+                <div class="import-catch-measurements">
+                    <MeasurementField IsWeight="true" Value="Proposal.Weight" ValueChanged="SetWeight"
+                                      WeightUnit="Preferences.WeightUnit" LengthUnit="Preferences.LengthUnit"
+                                      Id="@($"import-catch-{Number}-weight")" />
+                    <MeasurementField Value="Proposal.Length" ValueChanged="SetLength"
+                                      WeightUnit="Preferences.WeightUnit" LengthUnit="Preferences.LengthUnit"
+                                      Id="@($"import-catch-{Number}-length")" />
+                </div>
+
+                @if (ShowLocationDecision)
+                {
+                    <MudStack Row="true" Spacing="1" Class="flex-wrap">
+                        @foreach (var option in LocationOptions)
+                        {
+                            <MudButton Variant="Variant.Outlined" OnClick="@(() => AcceptLocation(option.Location))"
+                                       id="@($"import-catch-{Number}-location-{option.Photo.SelectionIndex}")">
+                                @Loc["Import_UsePhotoLocation", option.Photo.SelectionIndex + 1]
+                            </MudButton>
+                        }
+                        <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="RemoveLocation"
+                                   id="@($"import-catch-{Number}-remove-location")">@Loc["Import_RemoveLocation"]</MudButton>
+                    </MudStack>
+                }
+
+                <MudStack Row="true" Spacing="1" Class="flex-wrap">
+                    <MudButton Variant="Variant.Outlined" Disabled="@(!CanSplit)" OnClick="SplitSelectedAsync"
+                               id="@($"import-catch-{Number}-split")">@Loc["Import_MoveToNewCatch"]</MudButton>
+                    <MudButton Variant="Variant.Text" Color="Color.Error" Disabled="@(_selectedPhotoIds.Count == 0)"
+                               OnClick="RemoveSelectedAsync" id="@($"import-catch-{Number}-remove-photos")">
+                        @Loc["Import_RemoveSelectedPhotos"]
+                    </MudButton>
+                </MudStack>
+
+                @if (MergeTargets.Count > 0)
+                {
+                    <MudText Typo="Typo.caption">@Loc["Import_MergeWith"]</MudText>
+                    <MudStack Row="true" Spacing="1" Class="flex-wrap">
+                        @foreach (var target in MergeTargets)
+                        {
+                            <MudButton Variant="Variant.Outlined" OnClick="@(() => MergeAsync(target.Proposal))"
+                                       id="@($"import-catch-{Number}-merge-{target.Number}")">
+                                @Loc["Import_CatchNumber", target.Number]
+                            </MudButton>
+                        }
+                    </MudStack>
+                }
+
+                <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="RemoveCatchAsync"
+                           id="@($"import-catch-{Number}-remove")">@Loc["Import_RemoveCatch"]</MudButton>
+                <MudStack Row="true" Spacing="1" Justify="Justify.SpaceBetween">
+                    <MudButton Variant="Variant.Outlined" OnClick="CloseEditor"
+                               id="@($"import-catch-{Number}-close-editor")">@Loc["Common_Back"]</MudButton>
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ContinueAsync"
+                               id="@($"import-catch-{Number}-continue")">@Loc["Common_Continue"]</MudButton>
+                </MudStack>
+            </MudStack>
+        }
+        else
+        {
+            <MudStack Row="true" Spacing="1" Justify="Justify.FlexEnd">
+                @if (Editable)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OpenEditor"
+                               id="@($"import-catch-{Number}-edit")">@Loc["Import_ReviewEdit"]</MudButton>
+                }
+                @if (Proposal.CanConfirmDisplayedValues)
+                {
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ConfirmAsync"
+                               id="@($"import-catch-{Number}-confirm")">@Loc["Import_ConfirmCatch"]</MudButton>
+                }
+            </MudStack>
+        }
     </MudStack>
 </MudPaper>

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
@@ -1,75 +1,226 @@
+using System.Globalization;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
+using MudBlazor;
 
 namespace FishingLogBook.Web.Features.Import.Components.ImportCatchReviewCard;
 
-public partial class ImportCatchReviewCard : ComponentBase
+public partial class ImportCatchReviewCard : ComponentBase, IDisposable
 {
-    [Parameter, EditorRequired]
-    public ImportCatchProposalModel Proposal { get; set; } = default!;
+    private const int MaxChipOptions = 6;
+    private readonly HashSet<Guid> _selectedPhotoIds = [];
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private string _caughtOnLocal = string.Empty;
+    private bool _caughtOnInvalid;
+    private bool _editing;
 
-    [Parameter, EditorRequired]
-    public IReadOnlyList<ImportSelectedPhotoModel> Photos { get; set; } = [];
+    [Parameter, EditorRequired] public ImportCatchProposalModel Proposal { get; set; } = default!;
+    [Parameter, EditorRequired] public ImportBatchModel Batch { get; set; } = default!;
+    [Parameter, EditorRequired] public AnglerPreferencesModel Preferences { get; set; } = default!;
+    [Parameter] public int Number { get; set; }
+    [Parameter] public bool Editable { get; set; }
+    [Parameter] public EventCallback<IReadOnlyList<Guid>> RemovePhotos { get; set; }
+    [Parameter] public EventCallback<Guid> RemoveCatch { get; set; }
+    [Parameter] public EventCallback Changed { get; set; }
 
-    [Parameter]
-    public int Number { get; set; }
+    [Inject] private IModalService ModalService { get; set; } = default!;
+    [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
-    [Inject]
-    private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+    private IReadOnlyList<ImportSelectedPhotoModel> ProposalPhotos =>
+        [.. Proposal.PhotoIds.Select(photoId => Batch.Photos.Single(photo => photo.Id == photoId))];
 
-    private IReadOnlyList<ImportSelectedPhotoModel> ProposalPhotos
+    private IReadOnlyList<(ImportSelectedPhotoModel Photo, ImportLocationModel Location)> LocationOptions =>
+        [.. ProposalPhotos.Where(photo => photo.Location.HasCanonicalCoordinates)
+            .Select(photo => (photo, photo.Location))
+            .DistinctBy(option => (option.Location.Latitude, option.Location.Longitude))];
+
+    private IReadOnlyList<(ImportCatchProposalModel Proposal, int Number)> MergeTargets =>
+        [.. Batch.CatchProposals.Select((proposal, index) => (Proposal: proposal, Number: index + 1))
+            .Where(item => !item.Proposal.IsRemoved && item.Proposal.Id != Proposal.Id)];
+
+    private bool CanSplit => _selectedPhotoIds.Count > 0 && _selectedPhotoIds.Count < Proposal.PhotoIds.Count;
+    private bool ShowLocationDecision => Proposal.HasUnresolvedGpsConflict || Proposal.Location?.HasCanonicalCoordinates == true;
+    private Color StatusColor => Proposal.ReviewStatus == ImportCatchReviewStatusEnum.Reviewed
+        ? Color.Success : Proposal.CanBeReviewed ? Color.Info : Color.Warning;
+    private string StatusLabel => Proposal.ReviewStatus == ImportCatchReviewStatusEnum.Reviewed
+        ? Loc["Import_Reviewed"] : Proposal.CanBeReviewed ? Loc["Import_Ready"] : Loc["Import_NeedsCorrection"];
+
+    private IReadOnlyList<CatalogueOptionModel> MethodOptions => BuildShortlist(
+        Preferences.Preferences.Methods.OrderByDescending(method => method.IsDefault)
+            .Select(method => FindMethod(method.FishingMethodId)).Where(method => method is not null)
+            .Select(method => Option(method!)), Option(Proposal.Method));
+
+    private IReadOnlyList<CatalogueOptionModel> SpeciesOptions
     {
         get
         {
-            var byId = Photos.ToDictionary(photo => photo.Id);
-            return Proposal.PhotoIds.Where(byId.ContainsKey).Select(photoId => byId[photoId]).ToArray();
+            var preferred = Preferences.Preferences.Methods
+                .FirstOrDefault(method => method.FishingMethodId == Proposal.Method.Id)?.Species ?? [];
+            return BuildShortlist(preferred.OrderByDescending(species => species.IsDefault)
+                .Select(species => FindSpecies(species.SpeciesId)).Where(species => species is not null)
+                .Select(species => Option(species!)), Option(Proposal.Species));
         }
     }
 
-    private bool RequiresCorrection
+    private string TimestampLabel => Proposal.CaughtOn.State switch
     {
-        get
+        ImportTimestampStateEnum.ExplicitInstant => Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
+        ImportTimestampStateEnum.UserConfirmed when Proposal.CaughtOn.Instant is { } instant => instant.ToString("dd MMM yyyy · HH:mm zzz"),
+        ImportTimestampStateEnum.UserConfirmed => Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm"),
+        ImportTimestampStateEnum.LocalWallClock => Loc["Import_TimestampAmbiguous", Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm")],
+        ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak", Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz")],
+        ImportTimestampStateEnum.Unusable => Loc["Import_TimestampUnusable"],
+        _ => Loc["Import_TimestampMissing"]
+    };
+
+    private string LocationLabel => Proposal.HasUnresolvedGpsConflict ? Loc["Import_LocationNeedsReview"]
+        : Proposal.Location?.Decision == ImportLocationDecisionEnum.Accepted ? Loc["Import_LocationAccepted"]
+        : Proposal.Location?.Decision == ImportLocationDecisionEnum.Removed ? Loc["Import_LocationRemoved"]
+        : Proposal.Location?.HasCanonicalCoordinates == true ? Loc["Import_LocationAvailable"]
+        : Loc["Import_LocationUnavailable"];
+
+    protected override void OnParametersSet() { if (!_editing) _caughtOnLocal = EditorValue(); }
+    private void OpenEditor() { _editing = true; _caughtOnLocal = EditorValue(); }
+    private void CloseEditor() => _editing = false;
+    private void SetCaughtOnLocal(string value) { _caughtOnLocal = value; _caughtOnInvalid = false; }
+    private void SelectPhoto(Guid photoId, bool selected) { if (selected) _selectedPhotoIds.Add(photoId); else _selectedPhotoIds.Remove(photoId); }
+
+    private void ConfirmCaughtOn()
+    {
+        if (!TryParseCaughtOn(_caughtOnLocal, out var caughtOn))
         {
-            return !Proposal.CaughtOn.IsResolved
-                || Proposal.Reasons.Any(reason => reason != ImportCatchProposalReasonEnum.TrustworthyCaptureTime);
+            _caughtOnInvalid = true;
+            return;
+        }
+
+        Batch.SetCatchCaughtOn(Proposal.Id, Proposal.CaughtOn.Confirm(caughtOn));
+        _caughtOnInvalid = false;
+    }
+
+    private static bool TryParseCaughtOn(string value, out DateTime caughtOn)
+    {
+        return DateTime.TryParseExact(
+                value,
+                "yyyy-MM-ddTHH:mm",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out caughtOn)
+            || DateTime.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles.AllowWhiteSpaces, out caughtOn)
+            || DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out caughtOn);
+    }
+
+    private void AcceptShownValues() => Proposal.ConfirmCanonicalValues();
+
+    private void SelectMethod(CatalogueOptionModel method) => Batch.SetCatchMethod(Proposal.Id, Selection(method));
+    private void SelectSpecies(CatalogueOptionModel species) => Batch.SetCatchSpecies(Proposal.Id, Selection(species));
+    private void SetWeight(decimal? weight) => Batch.SetCatchWeight(Proposal.Id, weight);
+    private void SetLength(decimal? length) => Batch.SetCatchLength(Proposal.Id, length);
+
+    private async Task ChooseMethodAsync()
+    {
+        var chosen = await ChooseAsync(Loc["Import_FishingMethod"], Preferences.Catalogue.Methods.Select(Option).ToArray());
+        if (chosen is not null) SelectMethod(chosen);
+    }
+
+    private async Task ChooseSpeciesAsync()
+    {
+        var chosen = await ChooseAsync(Loc["Import_Species"], Preferences.Catalogue.AllSpecies.Select(Option).ToArray());
+        if (chosen is not null) SelectSpecies(chosen);
+    }
+
+    private async Task<CatalogueOptionModel?> ChooseAsync(string title, IReadOnlyList<CatalogueOptionModel> options)
+    {
+        var result = await ModalService.ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
+            new CataloguePickerModalModel(title, options), _cancellationTokenSource.Token);
+        return result?.Options.SingleOrDefault();
+    }
+
+    private void AcceptLocation(ImportLocationModel location) => Batch.SetCatchLocation(Proposal.Id, location.Accept());
+    private void RemoveLocation() => Batch.SetCatchLocation(
+        Proposal.Id,
+        Proposal.Location?.Remove()
+            ?? new ImportLocationModel(null, null, false, ImportLocationDecisionEnum.Removed));
+
+    private async Task SplitSelectedAsync()
+    {
+        Batch.SplitCatch(Proposal.Id, _selectedPhotoIds, Guid.NewGuid());
+        _selectedPhotoIds.Clear();
+        await Changed.InvokeAsync();
+    }
+
+    private async Task MergeAsync(ImportCatchProposalModel target) { Batch.MergeCatches(Proposal.Id, target.Id); await Changed.InvokeAsync(); }
+    private async Task RemoveSelectedAsync() { var selected = _selectedPhotoIds.ToArray(); _selectedPhotoIds.Clear(); await RemovePhotos.InvokeAsync(selected); }
+    private async Task RemoveCatchAsync()
+    {
+        var confirmed = await ModalService.ConfirmAsync(
+            new ConfirmModalModel(
+                Loc["Import_RemoveCatchTitle"],
+                Loc["Import_RemoveCatchMessage"],
+                Loc["Import_RemoveCatchConfirm"],
+                Loc["Modal_Cancel"],
+                true),
+            _cancellationTokenSource.Token);
+        if (confirmed)
+        {
+            await RemoveCatch.InvokeAsync(Proposal.Id);
         }
     }
 
-    private string TimestampLabel
+    private async Task ConfirmAsync()
     {
-        get
-        {
-            return Proposal.CaughtOn.State switch
-            {
-                ImportTimestampStateEnum.ExplicitInstant =>
-                    Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
-                ImportTimestampStateEnum.UserConfirmed =>
-                    Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
-                ImportTimestampStateEnum.LocalWallClock => Loc["Import_TimestampAmbiguous",
-                    Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm")],
-                ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak",
-                    Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz")],
-                ImportTimestampStateEnum.Unusable => Loc["Import_TimestampUnusable"],
-                _ => Loc["Import_TimestampMissing"]
-            };
-        }
+        Batch.ConfirmDisplayedCatch(Proposal.Id);
+        await Changed.InvokeAsync();
     }
 
-    private string LocationLabel
+    private async Task ContinueAsync()
     {
-        get
+        if (!TryParseCaughtOn(_caughtOnLocal, out var caughtOn))
         {
-            if (Proposal.Reasons.Contains(ImportCatchProposalReasonEnum.ConflictingGps))
-            {
-                return Loc["Import_LocationNeedsReview"];
-            }
-
-            return Proposal.Location?.HasCanonicalCoordinates == true
-                ? Loc["Import_LocationAvailable"]
-                : Loc["Import_LocationUnavailable"];
+            _caughtOnInvalid = true;
+            return;
         }
+
+        Batch.SetCatchCaughtOn(Proposal.Id, Proposal.CaughtOn.Confirm(caughtOn));
+        if (!Proposal.CanConfirmDisplayedValues)
+        {
+            return;
+        }
+
+        Batch.ConfirmDisplayedCatch(Proposal.Id);
+        _editing = false;
+        _caughtOnInvalid = false;
+        await Changed.InvokeAsync();
+    }
+
+    private string EditorValue()
+    {
+        var value = Proposal.CaughtOn.Instant?.DateTime ?? Proposal.CaughtOn.LocalWallClock;
+        return value?.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+
+    private FishingMethodDto? FindMethod(Guid id) => Preferences.Catalogue.Methods.SingleOrDefault(method => method.Id == id);
+    private SpeciesDto? FindSpecies(Guid id) => Preferences.Catalogue.AllSpecies.SingleOrDefault(species => species.Id == id);
+    private static CatalogueOptionModel Option(FishingMethodDto value) => new(value.Id, value.Code, value.Name);
+    private static CatalogueOptionModel Option(SpeciesDto value) => new(value.Id, value.Code, value.Name);
+    private static CatalogueOptionModel Option(ImportCatalogueSelectionModel value) => new(value.Id, value.Code, value.Name);
+    private static ImportCatalogueSelectionModel Selection(CatalogueOptionModel value) => new(value.Id, value.Code, value.Name);
+
+    private static IReadOnlyList<CatalogueOptionModel> BuildShortlist(IEnumerable<CatalogueOptionModel> options, CatalogueOptionModel selected)
+    {
+        var shortlist = options.Take(MaxChipOptions).ToList();
+        if (shortlist.All(option => option.Id != selected.Id)) shortlist.Insert(0, selected);
+        return shortlist;
+    }
+
+    public void Dispose()
+    {
+        _cancellationTokenSource.Cancel();
+        _cancellationTokenSource.Dispose();
     }
 }

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
@@ -17,6 +17,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     private readonly HashSet<Guid> _selectedPhotoIds = [];
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private string _caughtOnLocal = string.Empty;
+    private ImportTimestampModel? _caughtOnBasis;
     private bool _caughtOnInvalid;
     private bool _editing;
 
@@ -70,11 +71,11 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
 
     private string TimestampLabel => Proposal.CaughtOn.State switch
     {
-        ImportTimestampStateEnum.ExplicitInstant => Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
-        ImportTimestampStateEnum.UserConfirmed when Proposal.CaughtOn.Instant is { } instant => instant.ToString("dd MMM yyyy · HH:mm zzz"),
-        ImportTimestampStateEnum.UserConfirmed => Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm"),
-        ImportTimestampStateEnum.LocalWallClock => Loc["Import_TimestampAmbiguous", Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm")],
-        ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak", Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz")],
+        ImportTimestampStateEnum.ExplicitInstant => Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy Â· HH:mm zzz"),
+        ImportTimestampStateEnum.UserConfirmed when Proposal.CaughtOn.Instant is { } instant => instant.ToString("dd MMM yyyy Â· HH:mm zzz"),
+        ImportTimestampStateEnum.UserConfirmed => Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy Â· HH:mm"),
+        ImportTimestampStateEnum.LocalWallClock => Loc["Import_TimestampAmbiguous", Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy Â· HH:mm")],
+        ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak", Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy Â· HH:mm zzz")],
         ImportTimestampStateEnum.Unusable => Loc["Import_TimestampUnusable"],
         _ => Loc["Import_TimestampMissing"]
     };
@@ -86,9 +87,22 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         : Loc["Import_LocationUnavailable"];
 
     protected override void OnParametersSet() { if (!_editing) _caughtOnLocal = EditorValue(); }
-    private void OpenEditor() { _editing = true; _caughtOnLocal = EditorValue(); }
+    private void OpenEditor()
+    {
+        _editing = true;
+        _caughtOnBasis = Proposal.CaughtOn;
+        _caughtOnLocal = EditorValue();
+    }
     private void CloseEditor() => _editing = false;
-    private void SetCaughtOnLocal(string value) { _caughtOnLocal = value; _caughtOnInvalid = false; }
+    private void SetCaughtOnLocal(string value)
+    {
+        _caughtOnLocal = value;
+        _caughtOnInvalid = false;
+        var caughtOn = TryParseCaughtOn(value, out var parsed)
+            ? ConfirmedCaughtOn(parsed)
+            : ImportTimestampModel.Missing();
+        Batch.SetCatchCaughtOn(Proposal.Id, caughtOn);
+    }
     private void SelectPhoto(Guid photoId, bool selected) { if (selected) _selectedPhotoIds.Add(photoId); else _selectedPhotoIds.Remove(photoId); }
 
     private void ConfirmCaughtOn()
@@ -99,7 +113,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
             return;
         }
 
-        Batch.SetCatchCaughtOn(Proposal.Id, Proposal.CaughtOn.Confirm(caughtOn));
+        Batch.SetCatchCaughtOn(Proposal.Id, ConfirmedCaughtOn(caughtOn));
         _caughtOnInvalid = false;
     }
 
@@ -186,7 +200,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
             return;
         }
 
-        Batch.SetCatchCaughtOn(Proposal.Id, Proposal.CaughtOn.Confirm(caughtOn));
+        Batch.SetCatchCaughtOn(Proposal.Id, ConfirmedCaughtOn(caughtOn));
         if (!Proposal.CanConfirmDisplayedValues)
         {
             return;
@@ -202,6 +216,11 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     {
         var value = Proposal.CaughtOn.Instant?.DateTime ?? Proposal.CaughtOn.LocalWallClock;
         return value?.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+
+    private ImportTimestampModel ConfirmedCaughtOn(DateTime caughtOn)
+    {
+        return (_caughtOnBasis ?? Proposal.CaughtOn).Confirm(caughtOn);
     }
 
     private FishingMethodDto? FindMethod(Guid id) => Preferences.Catalogue.Methods.SingleOrDefault(method => method.Id == id);
@@ -224,3 +243,4 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         _cancellationTokenSource.Dispose();
     }
 }
+

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
@@ -17,6 +17,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     private readonly HashSet<Guid> _selectedPhotoIds = [];
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private string _caughtOnLocal = string.Empty;
+    private ImportTimestampModel? _caughtOnBasis;
     private bool _caughtOnInvalid;
     private bool _editing;
 
@@ -86,9 +87,22 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         : Loc["Import_LocationUnavailable"];
 
     protected override void OnParametersSet() { if (!_editing) _caughtOnLocal = EditorValue(); }
-    private void OpenEditor() { _editing = true; _caughtOnLocal = EditorValue(); }
+    private void OpenEditor()
+    {
+        _editing = true;
+        _caughtOnBasis = Proposal.CaughtOn;
+        _caughtOnLocal = EditorValue();
+    }
     private void CloseEditor() => _editing = false;
-    private void SetCaughtOnLocal(string value) { _caughtOnLocal = value; _caughtOnInvalid = false; }
+    private void SetCaughtOnLocal(string value)
+    {
+        _caughtOnLocal = value;
+        _caughtOnInvalid = false;
+        var caughtOn = TryParseCaughtOn(value, out var parsed)
+            ? ConfirmedCaughtOn(parsed)
+            : ImportTimestampModel.Missing();
+        Batch.SetCatchCaughtOn(Proposal.Id, caughtOn);
+    }
     private void SelectPhoto(Guid photoId, bool selected) { if (selected) _selectedPhotoIds.Add(photoId); else _selectedPhotoIds.Remove(photoId); }
 
     private void ConfirmCaughtOn()
@@ -99,7 +113,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
             return;
         }
 
-        Batch.SetCatchCaughtOn(Proposal.Id, Proposal.CaughtOn.Confirm(caughtOn));
+        Batch.SetCatchCaughtOn(Proposal.Id, ConfirmedCaughtOn(caughtOn));
         _caughtOnInvalid = false;
     }
 
@@ -186,7 +200,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
             return;
         }
 
-        Batch.SetCatchCaughtOn(Proposal.Id, Proposal.CaughtOn.Confirm(caughtOn));
+        Batch.SetCatchCaughtOn(Proposal.Id, ConfirmedCaughtOn(caughtOn));
         if (!Proposal.CanConfirmDisplayedValues)
         {
             return;
@@ -202,6 +216,11 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     {
         var value = Proposal.CaughtOn.Instant?.DateTime ?? Proposal.CaughtOn.LocalWallClock;
         return value?.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+
+    private ImportTimestampModel ConfirmedCaughtOn(DateTime caughtOn)
+    {
+        return (_caughtOnBasis ?? Proposal.CaughtOn).Confirm(caughtOn);
     }
 
     private FishingMethodDto? FindMethod(Guid id) => Preferences.Catalogue.Methods.SingleOrDefault(method => method.Id == id);

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.css
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.css
@@ -16,3 +16,20 @@
     object-fit: cover;
     border-radius: 0.5rem;
 }
+
+.import-catch-photo-choice {
+    position: relative;
+}
+
+.import-catch-photo-choice .mud-checkbox {
+    position: absolute;
+    z-index: 1;
+    background: var(--mud-palette-surface);
+    border-radius: 50%;
+}
+
+.import-catch-measurements {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+}

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
@@ -55,6 +55,15 @@ public sealed class ImportBatchModel
         }
     }
 
+    public bool CanAdvanceToTrips
+    {
+        get
+        {
+            var active = _catchProposals.Where(proposal => !proposal.IsRemoved).ToArray();
+            return active.Length > 0 && active.All(proposal => proposal.IsReadyForConfirmation);
+        }
+    }
+
     public void SetDefaults(
         ImportCatalogueSelectionModel fishingMethod,
         ImportCatalogueSelectionModel species)
@@ -184,6 +193,7 @@ public sealed class ImportBatchModel
         }
 
         RemoveInactiveCatchMemberships();
+        _tripProposals.Clear();
     }
 
     public void RemoveCatchProposal(Guid catchProposalId)
@@ -194,11 +204,136 @@ public sealed class ImportBatchModel
             return;
         }
 
-        proposal.Remove();
-        foreach (var tripProposal in _tripProposals)
+        foreach (var photoId in proposal.PhotoIds.ToArray())
         {
-            tripProposal.RemoveCatch(catchProposalId);
+            _photos.Single(photo => photo.Id == photoId).Remove();
+            proposal.RemovePhoto(photoId);
         }
+
+
+        _tripProposals.Clear();
+    }
+
+    public void SetCatchCaughtOn(Guid catchProposalId, ImportTimestampModel caughtOn)
+    {
+        ActiveCatch(catchProposalId).SetCaughtOn(caughtOn);
+        _tripProposals.Clear();
+    }
+
+    public void SetCatchMethod(Guid catchProposalId, ImportCatalogueSelectionModel method)
+    {
+        ActiveCatch(catchProposalId).OverrideMethod(method);
+        _tripProposals.Clear();
+    }
+
+    public void SetCatchSpecies(Guid catchProposalId, ImportCatalogueSelectionModel species)
+    {
+        ActiveCatch(catchProposalId).OverrideSpecies(species);
+        _tripProposals.Clear();
+    }
+
+    public void SetCatchLocation(Guid catchProposalId, ImportLocationModel? location)
+    {
+        ActiveCatch(catchProposalId).SetLocation(location);
+        _tripProposals.Clear();
+    }
+
+    public void SetCatchWeight(Guid catchProposalId, decimal? weight)
+    {
+        ActiveCatch(catchProposalId).SetWeight(weight);
+        _tripProposals.Clear();
+    }
+
+    public void SetCatchLength(Guid catchProposalId, decimal? length)
+    {
+        ActiveCatch(catchProposalId).SetLength(length);
+        _tripProposals.Clear();
+    }
+
+    public void MarkCatchReviewed(Guid catchProposalId)
+    {
+        ActiveCatch(catchProposalId).MarkReviewed();
+    }
+
+    public void ConfirmDisplayedCatch(Guid catchProposalId)
+    {
+        ActiveCatch(catchProposalId).ConfirmDisplayedValues();
+        _tripProposals.Clear();
+    }
+
+    public ImportCatchProposalModel SplitCatch(
+        Guid catchProposalId,
+        IEnumerable<Guid> selectedPhotoIds,
+        Guid newCatchProposalId)
+    {
+        if (newCatchProposalId == Guid.Empty
+            || _catchProposals.Any(proposal => proposal.Id == newCatchProposalId))
+        {
+            throw new InvalidOperationException("A split requires a new unique Catch proposal identity.");
+        }
+
+        var source = ActiveCatch(catchProposalId);
+        var selected = selectedPhotoIds.Distinct().ToArray();
+        if (selected.Length == 0
+            || selected.Length >= source.PhotoIds.Count
+            || selected.Any(photoId => !source.PhotoIds.Contains(photoId)))
+        {
+            throw new InvalidOperationException("A split must move some, but not all, photos from its source Catch.");
+        }
+
+        var ordered = OrderedPhotoIds(selected);
+        foreach (var photoId in ordered)
+        {
+            source.RemovePhoto(photoId);
+        }
+
+        var firstPhoto = _photos.Single(photo => photo.Id == ordered[0]);
+        var reasons = ReasonsFor(firstPhoto.Timestamp).ToList();
+        var locations = ordered
+            .Select(photoId => _photos.Single(photo => photo.Id == photoId).Location)
+            .Where(location => location.HasCanonicalCoordinates)
+            .DistinctBy(location => (location.Latitude, location.Longitude))
+            .ToArray();
+        if (locations.Length > 1)
+        {
+            reasons.Add(ImportCatchProposalReasonEnum.ConflictingGps);
+        }
+
+        var created = new ImportCatchProposalModel(
+            newCatchProposalId,
+            ordered,
+            firstPhoto.Timestamp,
+            source.Method,
+            source.Species,
+            locations.Length == 1 ? locations[0] : null,
+            reasons);
+        AddCatchProposal(created);
+        SortCatchProposals();
+        _tripProposals.Clear();
+        return created;
+    }
+
+    public void MergeCatches(Guid primaryCatchProposalId, Guid absorbedCatchProposalId)
+    {
+        if (primaryCatchProposalId == absorbedCatchProposalId)
+        {
+            throw new InvalidOperationException("A Catch proposal cannot be merged with itself.");
+        }
+
+        var primary = ActiveCatch(primaryCatchProposalId);
+        var absorbed = ActiveCatch(absorbedCatchProposalId);
+        var conflicts = primary.CaughtOn != absorbed.CaughtOn
+            || primary.Method != absorbed.Method
+            || primary.Species != absorbed.Species
+            || primary.Location != absorbed.Location;
+        primary.SetPhotos(OrderedPhotoIds(primary.PhotoIds.Concat(absorbed.PhotoIds)));
+        if (conflicts)
+        {
+            primary.RequireCanonicalReview();
+        }
+
+        absorbed.Remove();
+        _tripProposals.Clear();
     }
 
     public void Cancel()
@@ -220,5 +355,37 @@ public sealed class ImportBatchModel
                 tripProposal.RemoveCatch(catchId);
             }
         }
+    }
+
+    private ImportCatchProposalModel ActiveCatch(Guid catchProposalId)
+    {
+        return _catchProposals.SingleOrDefault(proposal => proposal.Id == catchProposalId && !proposal.IsRemoved)
+            ?? throw new InvalidOperationException("The active Catch proposal was not found.");
+    }
+
+    private Guid[] OrderedPhotoIds(IEnumerable<Guid> photoIds)
+    {
+        var selectionOrder = _photos.ToDictionary(photo => photo.Id, photo => photo.SelectionIndex);
+        return photoIds.Distinct().OrderBy(photoId => selectionOrder[photoId]).ToArray();
+    }
+
+    private void SortCatchProposals()
+    {
+        var selectionOrder = _photos.ToDictionary(photo => photo.Id, photo => photo.SelectionIndex);
+        _catchProposals.Sort((left, right) =>
+            left.PhotoIds.Min(photoId => selectionOrder[photoId])
+                .CompareTo(right.PhotoIds.Min(photoId => selectionOrder[photoId])));
+    }
+
+    private static IEnumerable<ImportCatchProposalReasonEnum> ReasonsFor(ImportTimestampModel timestamp)
+    {
+        yield return timestamp.State switch
+        {
+            ImportTimestampStateEnum.ExplicitInstant => ImportCatchProposalReasonEnum.TrustworthyCaptureTime,
+            ImportTimestampStateEnum.LocalWallClock => ImportCatchProposalReasonEnum.AmbiguousTimestamp,
+            ImportTimestampStateEnum.WeakFallback => ImportCatchProposalReasonEnum.WeakTimestamp,
+            ImportTimestampStateEnum.Unusable => ImportCatchProposalReasonEnum.UnusableTimestamp,
+            _ => ImportCatchProposalReasonEnum.MissingTimestamp
+        };
     }
 }

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
@@ -210,7 +210,6 @@ public sealed class ImportBatchModel
             proposal.RemovePhoto(photoId);
         }
 
-
         _tripProposals.Clear();
     }
 
@@ -389,3 +388,4 @@ public sealed class ImportBatchModel
         };
     }
 }
+

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
@@ -210,7 +210,6 @@ public sealed class ImportBatchModel
             proposal.RemovePhoto(photoId);
         }
 
-
         _tripProposals.Clear();
     }
 

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportCatchProposalModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportCatchProposalModel.cs
@@ -6,6 +6,8 @@ public sealed class ImportCatchProposalModel
 {
     private readonly List<Guid> _photoIds;
     private readonly IReadOnlyList<ImportCatchProposalReasonEnum> _reasons;
+    private bool _canonicalReviewRequired;
+    private bool _gpsConflictResolved;
 
     public ImportCatchProposalModel(
         Guid id,
@@ -14,7 +16,9 @@ public sealed class ImportCatchProposalModel
         ImportCatalogueSelectionModel inheritedMethod,
         ImportCatalogueSelectionModel inheritedSpecies,
         ImportLocationModel? location = null,
-        IEnumerable<ImportCatchProposalReasonEnum>? reasons = null)
+        IEnumerable<ImportCatchProposalReasonEnum>? reasons = null,
+        decimal? weight = null,
+        decimal? length = null)
     {
         if (id == Guid.Empty)
         {
@@ -37,7 +41,10 @@ public sealed class ImportCatchProposalModel
         InheritedMethod = inheritedMethod;
         InheritedSpecies = inheritedSpecies;
         Location = location;
+        Weight = weight;
+        Length = length;
         _reasons = reasons?.Distinct().ToArray() ?? [];
+        _gpsConflictResolved = !_reasons.Contains(ImportCatchProposalReasonEnum.ConflictingGps);
     }
 
     public Guid Id { get; }
@@ -47,6 +54,10 @@ public sealed class ImportCatchProposalModel
     public ImportTimestampModel CaughtOn { get; private set; }
 
     public ImportLocationModel? Location { get; private set; }
+
+    public decimal? Weight { get; private set; }
+
+    public decimal? Length { get; private set; }
 
     public IReadOnlyList<ImportCatchProposalReasonEnum> Reasons => _reasons;
 
@@ -72,36 +83,109 @@ public sealed class ImportCatchProposalModel
         {
             return !IsRemoved
                 && ReviewStatus == ImportCatchReviewStatusEnum.Reviewed
-                && CaughtOn.IsResolved
-                && Method.IsValid
-                && Species.IsValid
-                && _photoIds.Count > 0;
+                && CanBeReviewed;
         }
     }
+
+    public bool CanBeReviewed => !IsRemoved
+        && CaughtOn.IsResolved
+        && Method.IsValid
+        && Species.IsValid
+        && IsLocationDecisionResolved
+        && _gpsConflictResolved
+        && !_canonicalReviewRequired
+        && _photoIds.Count > 0;
+
+    public bool CanConfirmDisplayedValues => !IsRemoved
+        && (CaughtOn.Instant.HasValue || CaughtOn.LocalWallClock.HasValue)
+        && Method.IsValid
+        && Species.IsValid
+        && _gpsConflictResolved
+        && _photoIds.Count > 0;
+
+    public bool IsLocationDecisionResolved => Location is null
+        || !Location.HistoricalGpsPresent
+        || Location.Decision != ImportLocationDecisionEnum.Undecided;
+
+    public bool HasUnresolvedGpsConflict => !_gpsConflictResolved;
+
+    public bool RequiresCanonicalReview => _canonicalReviewRequired;
 
     public void SetCaughtOn(ImportTimestampModel caughtOn)
     {
         CaughtOn = caughtOn;
+        CanonicalValueChanged();
     }
 
     public void SetLocation(ImportLocationModel? location)
     {
         Location = location;
+        _gpsConflictResolved = location is null
+            || !location.HistoricalGpsPresent
+            || location.Decision != ImportLocationDecisionEnum.Undecided;
+        CanonicalValueChanged();
     }
 
     public void OverrideMethod(ImportCatalogueSelectionModel? method)
     {
         MethodOverride = method;
+        CanonicalValueChanged();
     }
 
     public void OverrideSpecies(ImportCatalogueSelectionModel? species)
     {
         SpeciesOverride = species;
+        CanonicalValueChanged();
+    }
+
+    public void SetWeight(decimal? weight)
+    {
+        Weight = weight;
+        CanonicalValueChanged();
+    }
+
+    public void SetLength(decimal? length)
+    {
+        Length = length;
+        CanonicalValueChanged();
     }
 
     public void MarkReviewed()
     {
+        if (!CanBeReviewed)
+        {
+            throw new InvalidOperationException("The Catch proposal still requires correction.");
+        }
+
         ReviewStatus = ImportCatchReviewStatusEnum.Reviewed;
+    }
+
+    public void ConfirmDisplayedValues()
+    {
+        if (!CanConfirmDisplayedValues)
+        {
+            throw new InvalidOperationException("The Catch proposal has no complete displayed values to confirm.");
+        }
+
+        if (!CaughtOn.IsResolved)
+        {
+            var displayedCaughtOn = CaughtOn.Instant?.DateTime ?? CaughtOn.LocalWallClock!.Value;
+            CaughtOn = CaughtOn.Confirm(displayedCaughtOn);
+        }
+
+        if (Location is { HasCanonicalCoordinates: true, Decision: ImportLocationDecisionEnum.Undecided })
+        {
+            Location = Location.Accept();
+        }
+
+        ConfirmCanonicalValues();
+        MarkReviewed();
+    }
+
+    public void ConfirmCanonicalValues()
+    {
+        _canonicalReviewRequired = false;
+        ReviewStatus = ImportCatchReviewStatusEnum.Draft;
     }
 
     public void AddPhoto(Guid photoId)
@@ -112,11 +196,28 @@ public sealed class ImportCatchProposalModel
         }
 
         _photoIds.Add(photoId);
+        ReviewStatus = ImportCatchReviewStatusEnum.Draft;
+    }
+
+    public void SetPhotos(IEnumerable<Guid> photoIds)
+    {
+        var replacements = photoIds.ToArray();
+        if (replacements.Length == 0
+            || replacements.Any(photoId => photoId == Guid.Empty)
+            || replacements.Distinct().Count() != replacements.Length)
+        {
+            throw new InvalidOperationException("A Catch proposal requires unique valid photos.");
+        }
+
+        _photoIds.Clear();
+        _photoIds.AddRange(replacements);
+        ReviewStatus = ImportCatchReviewStatusEnum.Draft;
     }
 
     public void RemovePhoto(Guid photoId)
     {
         _photoIds.Remove(photoId);
+        ReviewStatus = ImportCatchReviewStatusEnum.Draft;
         if (_photoIds.Count == 0)
         {
             IsRemoved = true;
@@ -126,5 +227,17 @@ public sealed class ImportCatchProposalModel
     public void Remove()
     {
         IsRemoved = true;
+    }
+
+    public void RequireCanonicalReview()
+    {
+        _canonicalReviewRequired = true;
+        ReviewStatus = ImportCatchReviewStatusEnum.Draft;
+    }
+
+    private void CanonicalValueChanged()
+    {
+        _canonicalReviewRequired = false;
+        ReviewStatus = ImportCatchReviewStatusEnum.Draft;
     }
 }

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportTimestampModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportTimestampModel.cs
@@ -93,6 +93,23 @@ public sealed record ImportTimestampModel
             null);
     }
 
+    public static ImportTimestampModel UserConfirmed(DateTime localWallClock)
+    {
+        return new ImportTimestampModel(
+            ImportTimestampStateEnum.UserConfirmed,
+            ImportTimestampSourceEnum.User,
+            null,
+            DateTime.SpecifyKind(localWallClock, DateTimeKind.Unspecified));
+    }
+
+    public ImportTimestampModel Confirm(DateTime localValue)
+    {
+        var unspecified = DateTime.SpecifyKind(localValue, DateTimeKind.Unspecified);
+        return Instant is { } instant
+            ? UserConfirmed(new DateTimeOffset(unspecified, instant.Offset))
+            : UserConfirmed(unspecified);
+    }
+
     private static void RequireExifSource(ImportTimestampSourceEnum source)
     {
         if (source is not ImportTimestampSourceEnum.ExifOriginal

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
@@ -132,18 +132,25 @@
             {
                 <MudStack Spacing="2" id="import-catch-review">
                     <MudText Typo="Typo.h6">@Loc["Import_ReviewTitle"]</MudText>
-                    @for (var index = 0; index < _batch.CatchProposals.Count; index++)
+                    @for (var index = 0; index < ActiveCatchProposals.Count; index++)
                     {
-                        <ImportCatchReviewCard Proposal="_batch.CatchProposals[index]"
-                                               Photos="_batch.Photos"
-                                               Number="@(index + 1)" />
+                        <ImportCatchReviewCard Proposal="ActiveCatchProposals[index]" Batch="_batch"
+                                               Preferences="_preferences" Number="@(index + 1)" Editable="true"
+                                               RemovePhotos="RemoveCorrectionPhotosAsync"
+                                               RemoveCatch="RemoveCorrectionCatchAsync"
+                                               Changed="OnCorrectionsChanged" />
                     }
-                    <MudAlert Severity="Severity.Info" id="import-correction-boundary">
-                        @Loc["Import_CorrectionLater"]
-                    </MudAlert>
-                    <MudButton Variant="Variant.Text" OnClick="BackToPhotos" id="import-review-back">
-                        @Loc["Common_Back"]
-                    </MudButton>
+                    @if (_correctionsComplete)
+                    {
+                        <MudAlert Severity="Severity.Success" id="import-corrections-complete">@Loc["Import_CorrectionsComplete"]</MudAlert>
+                    }
+                    <MudStack Row="true" Justify="Justify.SpaceBetween">
+                        <MudButton Variant="Variant.Text" OnClick="BackToPhotos" id="import-review-back">@Loc["Common_Back"]</MudButton>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!_batch.CanAdvanceToTrips)"
+                                   OnClick="CompleteCorrections" id="import-review-continue">
+                            @Loc["Import_ContinueToTrips"]
+                        </MudButton>
+                    </MudStack>
                 </MudStack>
             }
         }

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
@@ -20,6 +20,7 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
     private Guid _methodId;
     private Guid _speciesId;
     private bool _isLoading = true;
+    private bool _correctionsComplete;
     private bool _selectionLimitExceeded;
 
     [Inject] private IAnglerPreferencesProvider Preferences { get; set; } = default!;
@@ -36,6 +37,9 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
                 && _batch.Photos.Any(photo => !photo.IsRemoved && photo.IsReady);
         }
     }
+
+    private IReadOnlyList<ImportCatchProposalModel> ActiveCatchProposals =>
+        [.. _batch?.CatchProposals.Where(proposal => !proposal.IsRemoved) ?? []];
 
     private IReadOnlyList<CatalogueOptionModel> MethodOptions
     {
@@ -226,6 +230,52 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
     private void BackToPhotos()
     {
         _batch?.SetStage(ImportStageEnum.ChoosePhotos);
+    }
+
+    private void OnCorrectionsChanged()
+    {
+        _correctionsComplete = false;
+        StateHasChanged();
+    }
+
+    private void CompleteCorrections()
+    {
+        if (_batch?.CanAdvanceToTrips == true)
+        {
+            _correctionsComplete = true;
+        }
+    }
+
+    private async Task RemoveCorrectionPhotosAsync(IReadOnlyList<Guid> photoIds)
+    {
+        if (_batch is null)
+        {
+            return;
+        }
+
+        foreach (var photoId in photoIds)
+        {
+            var photo = _batch.Photos.Single(photo => photo.Id == photoId);
+            await Preparation.RemoveAsync(photo, _cancellationTokenSource.Token);
+            _batch.RemovePhoto(photoId);
+        }
+    }
+
+    private async Task RemoveCorrectionCatchAsync(Guid catchProposalId)
+    {
+        if (_batch is null)
+        {
+            return;
+        }
+
+        var proposal = _batch.CatchProposals.Single(proposal => proposal.Id == catchProposalId);
+        foreach (var photoId in proposal.PhotoIds.ToArray())
+        {
+            var photo = _batch.Photos.Single(photo => photo.Id == photoId);
+            await Preparation.RemoveAsync(photo, _cancellationTokenSource.Token);
+        }
+
+        _batch.RemoveCatchProposal(catchProposalId);
     }
 
     private void OnSelectionStarted()

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1378,4 +1378,28 @@
   <data name="Import_LocationNeedsReview" xml:space="preserve"><value>Les lieux des photos diffèrent · vérification requise</value></data>
   <data name="Import_LocationAvailable" xml:space="preserve"><value>Lieu de la photo disponible</value></data>
   <data name="Import_LocationUnavailable" xml:space="preserve"><value>Aucun lieu dans la photo</value></data>
+  <data name="Import_Reviewed" xml:space="preserve"><value>VÃ©rifiÃ©e</value></data>
+  <data name="Import_NeedsCorrection" xml:space="preserve"><value>À vérifier</value></data>
+  <data name="Import_ReviewEdit" xml:space="preserve"><value>Vérifier</value></data>
+  <data name="Import_ConfirmCatch" xml:space="preserve"><value>Confirmer la prise</value></data>
+  <data name="Import_CorrectCatches" xml:space="preserve"><value>Corriger les prises</value></data>
+  <data name="Import_CaughtOn" xml:space="preserve"><value>Date et heure de la prise</value></data>
+  <data name="Import_CaughtOnRequired" xml:space="preserve"><value>Saisissez une date et une heure historiques valides.</value></data>
+  <data name="Import_ConfirmCaughtOn" xml:space="preserve"><value>Confirmer la date et lâ€™heure</value></data>
+  <data name="Import_SelectPhoto" xml:space="preserve"><value>SÃ©lectionner la photographie {0}</value></data>
+  <data name="Import_UsePhotoLocation" xml:space="preserve"><value>Utiliser le lieu de la photo {0}</value></data>
+  <data name="Import_RemoveLocation" xml:space="preserve"><value>Supprimer le lieu</value></data>
+  <data name="Import_LocationAccepted" xml:space="preserve"><value>Lieu de la photo acceptÃ©</value></data>
+  <data name="Import_LocationRemoved" xml:space="preserve"><value>Lieu supprimÃ©</value></data>
+  <data name="Import_MoveToNewCatch" xml:space="preserve"><value>DÃ©placer la sÃ©lection vers une nouvelle prise</value></data>
+  <data name="Import_RemoveSelectedPhotos" xml:space="preserve"><value>Supprimer les photos sÃ©lectionnÃ©es</value></data>
+  <data name="Import_MergeWith" xml:space="preserve"><value>Fusionner avecâ€¦</value></data>
+  <data name="Import_RemoveCatch" xml:space="preserve"><value>Retirer la prise de lâ€™importation</value></data>
+  <data name="Import_CorrectionsComplete" xml:space="preserve"><value>Toutes les prises sont vÃ©rifiÃ©es et prÃªtes pour les suggestions de sorties.</value></data>
+  <data name="Import_MergeValuesNeedReview" xml:space="preserve"><value>Les prises fusionnÃ©es avaient des informations diffÃ©rentes. VÃ©rifiez les valeurs affichÃ©es avant de confirmer.</value></data>
+  <data name="Import_UseShownValues" xml:space="preserve"><value>Utiliser les valeurs affichÃ©es</value></data>
+  <data name="Import_RemoveCatchTitle" xml:space="preserve"><value>Retirer cette priseÂ ?</value></data>
+  <data name="Import_RemoveCatchMessage" xml:space="preserve"><value>Toutes les photographies de cette prise seront exclues de lâ€™importation.</value></data>
+  <data name="Import_RemoveCatchConfirm" xml:space="preserve"><value>Retirer la prise</value></data>
+  <data name="Import_ContinueToTrips" xml:space="preserve"><value>Continuer vers les suggestions de sorties</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1378,4 +1378,28 @@
   <data name="Import_LocationNeedsReview" xml:space="preserve"><value>Photo locations differ · review required</value></data>
   <data name="Import_LocationAvailable" xml:space="preserve"><value>Photo location available</value></data>
   <data name="Import_LocationUnavailable" xml:space="preserve"><value>No photo location</value></data>
+  <data name="Import_Reviewed" xml:space="preserve"><value>Reviewed</value></data>
+  <data name="Import_NeedsCorrection" xml:space="preserve"><value>Needs review</value></data>
+  <data name="Import_ReviewEdit" xml:space="preserve"><value>Review</value></data>
+  <data name="Import_ConfirmCatch" xml:space="preserve"><value>Confirm catch</value></data>
+  <data name="Import_CorrectCatches" xml:space="preserve"><value>Correct catches</value></data>
+  <data name="Import_CaughtOn" xml:space="preserve"><value>Caught on</value></data>
+  <data name="Import_CaughtOnRequired" xml:space="preserve"><value>Enter a valid historical date and time.</value></data>
+  <data name="Import_ConfirmCaughtOn" xml:space="preserve"><value>Confirm date and time</value></data>
+  <data name="Import_SelectPhoto" xml:space="preserve"><value>Select photograph {0}</value></data>
+  <data name="Import_UsePhotoLocation" xml:space="preserve"><value>Use photo {0} location</value></data>
+  <data name="Import_RemoveLocation" xml:space="preserve"><value>Remove location</value></data>
+  <data name="Import_LocationAccepted" xml:space="preserve"><value>Photo location accepted</value></data>
+  <data name="Import_LocationRemoved" xml:space="preserve"><value>Location removed</value></data>
+  <data name="Import_MoveToNewCatch" xml:space="preserve"><value>Move selected to new catch</value></data>
+  <data name="Import_RemoveSelectedPhotos" xml:space="preserve"><value>Remove selected photos</value></data>
+  <data name="Import_MergeWith" xml:space="preserve"><value>Merge withâ€¦</value></data>
+  <data name="Import_RemoveCatch" xml:space="preserve"><value>Remove catch from import</value></data>
+  <data name="Import_CorrectionsComplete" xml:space="preserve"><value>All catches are reviewed and ready for Trip suggestions.</value></data>
+  <data name="Import_MergeValuesNeedReview" xml:space="preserve"><value>The merged catches had different details. Review the shown values before confirming.</value></data>
+  <data name="Import_UseShownValues" xml:space="preserve"><value>Use shown values</value></data>
+  <data name="Import_RemoveCatchTitle" xml:space="preserve"><value>Remove this catch?</value></data>
+  <data name="Import_RemoveCatchMessage" xml:space="preserve"><value>All photographs in this catch will be excluded from the import.</value></data>
+  <data name="Import_RemoveCatchConfirm" xml:space="preserve"><value>Remove catch</value></data>
+  <data name="Import_ContinueToTrips" xml:space="preserve"><value>Continue to Trip suggestions</value></data>
 </root>

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -9,6 +9,7 @@ using FishingLogBook.Web.Features.Import.Components.ImportCatchReviewCard;
 using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
 using FishingLogBook.Web.Features.Profile.Models;
+using FishingLogBook.Web.Tests.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
 using NSubstitute;
@@ -154,6 +155,7 @@ public class WhenTestingRender
     public async Task ItShouldAcceptTheLocalisedValueReturnedByTheDateTimePicker()
     {
         // Arrange
+        using var culture = TestCulture.Use("en-GB");
         await using var context = CreateContext();
         var timestamp = ImportTimestampModel.FromLocalWallClock(
             new DateTime(2009, 2, 2, 15, 6, 0),

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -206,6 +206,49 @@ public class WhenTestingRender
     }
 
     [Fact]
+    public async Task ItShouldImmediatelyRequireReviewWhenAReviewedCaughtOnValueBecomesInvalid()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.FromExplicitInstant(CapturedOn, ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, ImportCatchProposalReasonEnum.TrustworthyCaptureTime);
+        var batch = Batch(photo, proposal);
+        proposal.MarkReviewed();
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Act
+        cut.Find("#import-catch-1-caught-on").Input(string.Empty);
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Needs review");
+        batch.CanAdvanceToTrips.Should().BeFalse();
+
+        // Act
+        cut.Find("#import-catch-1-continue").Click();
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Needs review");
+        batch.CanAdvanceToTrips.Should().BeFalse();
+
+        // Act
+        cut.Find("#import-catch-1-caught-on").Input("2024-06-14T09:20");
+        cut.Find("#import-catch-1-continue").Click();
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        batch.CanAdvanceToTrips.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ItShouldResolveConflictingGpsOnlyAfterAnExplicitLocationChoice()
     {
         // Arrange
@@ -342,3 +385,4 @@ public class WhenTestingRender
             LengthUnitEnum.Cm);
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -206,6 +206,49 @@ public class WhenTestingRender
     }
 
     [Fact]
+    public async Task ItShouldImmediatelyRequireReviewWhenAReviewedCaughtOnValueBecomesInvalid()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.FromExplicitInstant(CapturedOn, ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, ImportCatchProposalReasonEnum.TrustworthyCaptureTime);
+        var batch = Batch(photo, proposal);
+        proposal.MarkReviewed();
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Act
+        cut.Find("#import-catch-1-caught-on").Input(string.Empty);
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Needs review");
+        batch.CanAdvanceToTrips.Should().BeFalse();
+
+        // Act
+        cut.Find("#import-catch-1-continue").Click();
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Needs review");
+        batch.CanAdvanceToTrips.Should().BeFalse();
+
+        // Act
+        cut.Find("#import-catch-1-caught-on").Input("2024-06-14T09:20");
+        cut.Find("#import-catch-1-continue").Click();
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        batch.CanAdvanceToTrips.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ItShouldResolveConflictingGpsOnlyAfterAnExplicitLocationChoice()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -1,10 +1,17 @@
 using AwesomeAssertions;
 using Bunit;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Import.Components.ImportCatchReviewCard;
 using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Profile.Models;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor.Services;
+using NSubstitute;
 
 namespace FishingLogBook.Web.Tests.Features.Import.Components.ImportCatchReviewCardTests;
 
@@ -23,11 +30,13 @@ public class WhenTestingRender
         await using var context = CreateContext();
         var photo = Photo(timestamp);
         var proposal = Proposal(photo, timestamp, reason);
+        var batch = Batch(photo, proposal);
 
         // Act
         var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
             .Add(component => component.Proposal, proposal)
-            .Add(component => component.Photos, [photo])
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
             .Add(component => component.Number, 1));
 
         // Assert
@@ -42,17 +51,45 @@ public class WhenTestingRender
         await using var context = CreateContext();
         var timestamp = ImportTimestampModel.FromExplicitInstant(CapturedOn, ImportTimestampSourceEnum.ExifOriginal);
         var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, ImportCatchProposalReasonEnum.TrustworthyCaptureTime);
+        var batch = Batch(photo, proposal);
 
         // Act
         var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
-            .Add(component => component.Proposal,
-                Proposal(photo, timestamp, ImportCatchProposalReasonEnum.TrustworthyCaptureTime))
-            .Add(component => component.Photos, [photo])
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
             .Add(component => component.Number, 1));
 
         // Assert
         cut.Find("#import-catch-1-timestamp").TextContent.Should().Contain("+01:00");
         cut.Find("#import-catch-1-status").TextContent.Should().Contain("Ready");
+    }
+
+    [Fact]
+    public async Task ItShouldOfferReviewAndConfirmTogetherForDisplayedSuggestedValues()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.FromWeakFallback(CapturedOn);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, ImportCatchProposalReasonEnum.WeakTimestamp);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, Batch(photo, proposal))
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+
+        // Act
+        var review = cut.Find("#import-catch-1-edit");
+        cut.Find("#import-catch-1-confirm").Click();
+
+        // Assert
+        review.TextContent.Should().Contain("Review");
+        proposal.CaughtOn.State.Should().Be(ImportTimestampStateEnum.UserConfirmed);
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Reviewed");
     }
 
     [Fact]
@@ -67,17 +104,167 @@ public class WhenTestingRender
             timestamp,
             ImportCatchProposalReasonEnum.TrustworthyCaptureTime,
             ImportCatchProposalReasonEnum.ConflictingGps);
+        var batch = Batch(photo, proposal);
 
         // Act
         var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
             .Add(component => component.Proposal, proposal)
-            .Add(component => component.Photos, [photo])
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
             .Add(component => component.Number, 1));
 
         // Assert
         cut.Find("#import-catch-1-location").TextContent.Should().Contain("review required");
         cut.Find("#import-catch-1-status").TextContent.Should().Contain("Needs review");
         cut.Markup.Should().NotContain("53.3498");
+    }
+
+    [Fact]
+    public async Task ItShouldConfirmAMissingHistoricalWallClockWithoutAddingAnOffset()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.Missing();
+        var photo = Photo(timestamp);
+        var proposal = new ImportCatchProposalModel(
+            Guid.NewGuid(), [photo.Id], timestamp,
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "Fly", "Fly"),
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "BrownTrout", "Brown Trout"));
+        var batch = Batch(photo, proposal);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Act
+        cut.Find("#import-catch-1-caught-on").Input("2024-06-14T09:20");
+        cut.Find("#import-catch-1-confirm-caught-on").Click();
+        cut.Find("#import-catch-1-close-editor").Click();
+
+        // Assert
+        proposal.CaughtOn.Instant.Should().BeNull();
+        proposal.CaughtOn.LocalWallClock.Should().Be(new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Unspecified));
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Ready");
+    }
+
+    [Fact]
+    public async Task ItShouldAcceptTheLocalisedValueReturnedByTheDateTimePicker()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.FromLocalWallClock(
+            new DateTime(2009, 2, 2, 15, 6, 0),
+            ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, ImportCatchProposalReasonEnum.AmbiguousTimestamp);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, Batch(photo, proposal))
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Act
+        cut.Find("#import-catch-1-caught-on").Input("09/04/2026 03:06 PM");
+        cut.Find("#import-catch-1-confirm-caught-on").Click();
+
+        // Assert
+        proposal.CaughtOn.LocalWallClock.Should().Be(new DateTime(2026, 4, 9, 15, 6, 0));
+        cut.FindAll(".mud-input-error").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldContinueFromTheEditorWithoutRequiringBack()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.FromLocalWallClock(
+            new DateTime(2009, 2, 2, 15, 6, 0),
+            ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, ImportCatchProposalReasonEnum.AmbiguousTimestamp);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, Batch(photo, proposal))
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Act
+        cut.Find("#import-catch-1-caught-on").Input("09/04/2026 03:06 PM");
+        cut.Find("#import-catch-1-continue").Click();
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        cut.FindAll("#import-catch-1-editor").Should().BeEmpty();
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Reviewed");
+    }
+
+    [Fact]
+    public async Task ItShouldResolveConflictingGpsOnlyAfterAnExplicitLocationChoice()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var timestamp = ImportTimestampModel.FromExplicitInstant(CapturedOn, ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp,
+            ImportCatchProposalReasonEnum.TrustworthyCaptureTime,
+            ImportCatchProposalReasonEnum.ConflictingGps);
+        var batch = Batch(photo, proposal);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Act
+        cut.Find("#import-catch-1-location-0").Click();
+
+        // Assert
+        proposal.HasUnresolvedGpsConflict.Should().BeFalse();
+        proposal.Location!.Decision.Should().Be(ImportLocationDecisionEnum.Accepted);
+        cut.Find("#import-catch-1-location").TextContent.Should().Contain("accepted");
+    }
+
+    [Fact]
+    public async Task ItShouldReviewWeightAndLengthWithTheSharedMeasurementEditors()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var modal = context.Services.GetRequiredService<IModalService>();
+        modal.ShowAsync<MeasurementEditorModal, MeasurementEditorModel, MeasurementEditorResult>(
+                Arg.Is<MeasurementEditorModel>(model => model.IsWeight),
+                Arg.Any<CancellationToken>())
+            .Returns(new MeasurementEditorResult(2.5m));
+        modal.ShowAsync<MeasurementEditorModal, MeasurementEditorModel, MeasurementEditorResult>(
+                Arg.Is<MeasurementEditorModel>(model => !model.IsWeight),
+                Arg.Any<CancellationToken>())
+            .Returns(new MeasurementEditorResult(48m));
+        var timestamp = ImportTimestampModel.FromExplicitInstant(CapturedOn, ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, ImportCatchProposalReasonEnum.TrustworthyCaptureTime);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, Batch(photo, proposal))
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+
+        // Act
+        cut.Find("#import-catch-1-edit").Click();
+        cut.Find("#import-catch-1-weight").Click();
+        cut.Find("#import-catch-1-length").Click();
+
+        // Assert
+        proposal.Weight.Should().Be(2.5m);
+        proposal.Length.Should().Be(48m);
     }
 
     public static TheoryData<ImportTimestampModel, ImportCatchProposalReasonEnum, string> ReviewTimestamps => new()
@@ -100,6 +287,8 @@ public class WhenTestingRender
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
+        context.Services.AddSingleton<IMeasurementService, MeasurementService>();
+        context.Services.AddSingleton(Substitute.For<IModalService>());
         return context;
     }
 
@@ -132,7 +321,24 @@ public class WhenTestingRender
             timestamp,
             new ImportCatalogueSelectionModel(Guid.NewGuid(), "Fly", "Fly"),
             new ImportCatalogueSelectionModel(Guid.NewGuid(), "BrownTrout", "Brown Trout"),
-            photo.Location,
+            reasons.Contains(ImportCatchProposalReasonEnum.ConflictingGps) ? photo.Location : photo.Location.Accept(),
             reasons);
+    }
+
+    private static ImportBatchModel Batch(ImportSelectedPhotoModel photo, ImportCatchProposalModel proposal)
+    {
+        var batch = new ImportBatchModel(Guid.NewGuid(), proposal.Method, proposal.Species);
+        batch.AddPhoto(photo);
+        batch.AddCatchProposal(proposal);
+        return batch;
+    }
+
+    private static AnglerPreferencesModel Preferences()
+    {
+        return new AnglerPreferencesModel(
+            new FishingCatalogueDto([], []),
+            new FishingPreferencesDto([]),
+            WeightUnitEnum.Kg,
+            LengthUnitEnum.Cm);
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingBatch.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingBatch.cs
@@ -165,8 +165,8 @@ public class WhenTestingBatch : BaseImportModelTest
 
         // Assert
         catchProposal.IsRemoved.Should().BeTrue();
-        tripProposal.CatchProposalIds.Should().BeEmpty();
-        tripProposal.IsRemoved.Should().BeTrue();
+        batch.Photos.Single().IsRemoved.Should().BeTrue();
+        batch.TripProposals.Should().BeEmpty();
     }
 
     [Fact]
@@ -179,11 +179,13 @@ public class WhenTestingBatch : BaseImportModelTest
         batch.AddCatchProposal(catchProposal);
 
         // Act
-        catchProposal.MarkReviewed();
+        Action review = catchProposal.MarkReviewed;
 
         // Assert
+        review.Should().Throw<InvalidOperationException>();
         batch.IsReadyForConfirmation.Should().BeFalse();
         catchProposal.SetCaughtOn(ImportTimestampModel.UserConfirmed(CapturedOn));
+        catchProposal.MarkReviewed();
         batch.IsReadyForConfirmation.Should().BeTrue();
     }
 
@@ -209,6 +211,150 @@ public class WhenTestingBatch : BaseImportModelTest
         batch.TripProposals.Should().HaveCount(2);
         batch.TripProposals.SelectMany(proposal => proposal.CatchProposalIds)
             .Should().BeEquivalentTo([CatchId, SecondCatchId]);
+    }
+
+    [Fact]
+    public void ItShouldSplitSelectedPhotosIntoAnOrderedNewCatchAndInvalidateTrips()
+    {
+        // Arrange
+        var batch = Batch();
+        batch.AddPhoto(Photo(PhotoId, 0));
+        batch.AddPhoto(Photo(SecondPhotoId, 1));
+        var source = Catch(photoIds: [PhotoId, SecondPhotoId]);
+        source.MarkReviewed();
+        batch.AddCatchProposal(source);
+        batch.AddTripProposal(Trip());
+
+        // Act
+        var created = batch.SplitCatch(CatchId, [SecondPhotoId], SecondCatchId);
+
+        // Assert
+        source.PhotoIds.Should().Equal(PhotoId);
+        source.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        created.PhotoIds.Should().Equal(SecondPhotoId);
+        created.Method.Should().Be(source.Method);
+        created.Species.Should().Be(source.Species);
+        batch.CatchProposals.Should().Equal(source, created);
+        batch.CatchProposals.SelectMany(proposal => proposal.PhotoIds).Should().OnlyHaveUniqueItems();
+        batch.TripProposals.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItShouldRejectASplitThatWouldEmptyTheSourceCatch()
+    {
+        // Arrange
+        var batch = Batch();
+        batch.AddPhoto(Photo());
+        var source = Catch();
+        batch.AddCatchProposal(source);
+        Action split = () => batch.SplitCatch(CatchId, [PhotoId], SecondCatchId);
+
+        // Act
+        var assertion = split.Should();
+
+        // Assert
+        assertion.Throw<InvalidOperationException>();
+        source.PhotoIds.Should().Equal(PhotoId);
+        batch.CatchProposals.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void ItShouldRejectADuplicateSplitIdentityBeforeChangingMembership()
+    {
+        // Arrange
+        var batch = Batch();
+        batch.AddPhoto(Photo());
+        batch.AddPhoto(Photo(SecondPhotoId, 1));
+        var source = Catch(photoIds: [PhotoId, SecondPhotoId]);
+        batch.AddCatchProposal(source);
+        Action split = () => batch.SplitCatch(CatchId, [SecondPhotoId], CatchId);
+
+        // Act
+        var assertion = split.Should();
+
+        // Assert
+        assertion.Throw<InvalidOperationException>();
+        source.PhotoIds.Should().Equal(PhotoId, SecondPhotoId);
+    }
+
+    [Fact]
+    public void ItShouldMergeCatchesWithoutDuplicatingPhotosAndInvalidateTrips()
+    {
+        // Arrange
+        var batch = Batch();
+        batch.AddPhoto(Photo(PhotoId, 1));
+        batch.AddPhoto(Photo(SecondPhotoId, 0));
+        var primary = Catch(photoIds: [PhotoId]);
+        var absorbed = Catch(SecondCatchId, [SecondPhotoId]);
+        primary.MarkReviewed();
+        absorbed.MarkReviewed();
+        batch.AddCatchProposal(primary);
+        batch.AddCatchProposal(absorbed);
+        batch.AddTripProposal(Trip(catchIds: [CatchId, SecondCatchId]));
+
+        // Act
+        batch.MergeCatches(CatchId, SecondCatchId);
+
+        // Assert
+        primary.PhotoIds.Should().Equal(SecondPhotoId, PhotoId);
+        primary.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        absorbed.IsRemoved.Should().BeTrue();
+        batch.CatchProposals.Where(proposal => !proposal.IsRemoved).Should().ContainSingle();
+        batch.TripProposals.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItShouldRequireCanonicalReviewWhenMergedValuesConflict()
+    {
+        // Arrange
+        var batch = Batch();
+        batch.AddPhoto(Photo());
+        batch.AddPhoto(Photo(SecondPhotoId, 1));
+        var primary = Catch();
+        var absorbed = new ImportCatchProposalModel(
+            SecondCatchId,
+            [SecondPhotoId],
+            ImportTimestampModel.UserConfirmed(CapturedOn.AddHours(1)),
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "Bait", "Bait"),
+            Species());
+        batch.AddCatchProposal(primary);
+        batch.AddCatchProposal(absorbed);
+
+        // Act
+        batch.MergeCatches(CatchId, SecondCatchId);
+        Action reviewBeforeConfirmation = () => batch.MarkCatchReviewed(CatchId);
+
+        // Assert
+        reviewBeforeConfirmation.Should().Throw<InvalidOperationException>();
+
+        // Act
+        primary.ConfirmCanonicalValues();
+        batch.MarkCatchReviewed(CatchId);
+
+        // Assert
+        primary.IsReadyForConfirmation.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ItShouldKeepCatchOverridesSeparateFromBatchDefaultsAndOtherCatches()
+    {
+        // Arrange
+        var batch = Batch();
+        batch.AddPhoto(Photo());
+        batch.AddPhoto(Photo(SecondPhotoId, 1));
+        var first = Catch();
+        var second = Catch(SecondCatchId, [SecondPhotoId]);
+        batch.AddCatchProposal(first);
+        batch.AddCatchProposal(second);
+        var method = new ImportCatalogueSelectionModel(Guid.NewGuid(), "Bait", "Bait");
+
+        // Act
+        batch.SetCatchMethod(CatchId, method);
+
+        // Assert
+        first.Method.Should().Be(method);
+        second.Method.Should().Be(Method());
+        batch.FishingMethod.Should().Be(Method());
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingCatchProposal.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingCatchProposal.cs
@@ -56,6 +56,29 @@ public class WhenTestingCatchProposal : BaseImportModelTest
     }
 
     [Fact]
+    public void ItShouldLeaveReviewedStateWhenTheCaughtOnValueBecomesInvalid()
+    {
+        // Arrange
+        var proposal = Catch();
+        proposal.MarkReviewed();
+
+        // Act
+        proposal.SetCaughtOn(ImportTimestampModel.Missing());
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        proposal.IsReadyForConfirmation.Should().BeFalse();
+
+        // Act
+        proposal.SetCaughtOn(ImportTimestampModel.UserConfirmed(CapturedOn));
+        proposal.MarkReviewed();
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        proposal.IsReadyForConfirmation.Should().BeTrue();
+    }
+
+    [Fact]
     public void ItShouldBecomeRemovedWhenItsLastPhotoIsRemoved()
     {
         // Arrange
@@ -128,3 +151,4 @@ public class WhenTestingCatchProposal : BaseImportModelTest
         proposal.IsReadyForConfirmation.Should().BeTrue();
     }
 }
+

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingCatchProposal.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingCatchProposal.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
 
 namespace FishingLogBook.Web.Tests.Features.Import.Models.ImportModelTests;
@@ -44,11 +45,13 @@ public class WhenTestingCatchProposal : BaseImportModelTest
         var proposal = Catch(caughtOn: ImportTimestampModel.Missing());
 
         // Act
-        proposal.MarkReviewed();
+        Action review = proposal.MarkReviewed;
 
         // Assert
+        review.Should().Throw<InvalidOperationException>();
         proposal.IsReadyForConfirmation.Should().BeFalse();
         proposal.SetCaughtOn(ImportTimestampModel.UserConfirmed(CapturedOn));
+        proposal.MarkReviewed();
         proposal.IsReadyForConfirmation.Should().BeTrue();
     }
 
@@ -65,5 +68,63 @@ public class WhenTestingCatchProposal : BaseImportModelTest
         proposal.PhotoIds.Should().BeEmpty();
         proposal.IsRemoved.Should().BeTrue();
         proposal.IsReadyForConfirmation.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItShouldAllowMissingGpsButRequireADecisionForAvailableGps()
+    {
+        // Arrange
+        var withoutGps = Catch();
+        var withGps = new ImportCatchProposalModel(
+            Guid.NewGuid(), [PhotoId], ImportTimestampModel.UserConfirmed(CapturedOn), Method(), Species(),
+            new ImportLocationModel(53.3498, -6.2603, true));
+
+        // Act
+        withoutGps.MarkReviewed();
+        Action reviewWithUndecidedGps = withGps.MarkReviewed;
+
+        // Assert
+        withoutGps.IsReadyForConfirmation.Should().BeTrue();
+        reviewWithUndecidedGps.Should().Throw<InvalidOperationException>();
+
+        // Act
+        withGps.SetLocation(withGps.Location!.Accept());
+        withGps.MarkReviewed();
+
+        // Assert
+        withGps.IsReadyForConfirmation.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ItShouldRequireExplicitResolutionOfConflictingGps()
+    {
+        // Arrange
+        var proposal = new ImportCatchProposalModel(
+            Guid.NewGuid(), [PhotoId], ImportTimestampModel.UserConfirmed(CapturedOn), Method(), Species(),
+            reasons: [ImportCatchProposalReasonEnum.ConflictingGps]);
+        Action review = proposal.MarkReviewed;
+
+        // Act
+        var assertion = review.Should();
+
+        // Assert
+        assertion.Throw<InvalidOperationException>();
+        proposal.HasUnresolvedGpsConflict.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ItShouldTreatConfirmingTheDisplayedFallbackAsExplicitTimestampApproval()
+    {
+        // Arrange
+        var proposal = Catch(caughtOn: ImportTimestampModel.FromWeakFallback(CapturedOn));
+
+        // Act
+        proposal.ConfirmDisplayedValues();
+
+        // Assert
+        proposal.CaughtOn.State.Should().Be(ImportTimestampStateEnum.UserConfirmed);
+        proposal.CaughtOn.Instant.Should().Be(CapturedOn);
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        proposal.IsReadyForConfirmation.Should().BeTrue();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingCatchProposal.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingCatchProposal.cs
@@ -56,6 +56,29 @@ public class WhenTestingCatchProposal : BaseImportModelTest
     }
 
     [Fact]
+    public void ItShouldLeaveReviewedStateWhenTheCaughtOnValueBecomesInvalid()
+    {
+        // Arrange
+        var proposal = Catch();
+        proposal.MarkReviewed();
+
+        // Act
+        proposal.SetCaughtOn(ImportTimestampModel.Missing());
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        proposal.IsReadyForConfirmation.Should().BeFalse();
+
+        // Act
+        proposal.SetCaughtOn(ImportTimestampModel.UserConfirmed(CapturedOn));
+        proposal.MarkReviewed();
+
+        // Assert
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        proposal.IsReadyForConfirmation.Should().BeTrue();
+    }
+
+    [Fact]
     public void ItShouldBecomeRemovedWhenItsLastPhotoIsRemoved()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingTimestamp.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingTimestamp.cs
@@ -88,4 +88,39 @@ public class WhenTestingTimestamp : BaseImportModelTest
         resolved.Should().BeTrue();
         timestamp.Source.Should().Be(ImportTimestampSourceEnum.User);
     }
+
+    [Fact]
+    public void ItShouldConfirmAnOffsetLessWallClockWithoutApplyingTheCurrentTimezone()
+    {
+        // Arrange
+        var wallClock = new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Local);
+        var proposed = ImportTimestampModel.FromLocalWallClock(
+            wallClock,
+            ImportTimestampSourceEnum.ExifOriginal);
+
+        // Act
+        var confirmed = proposed.Confirm(wallClock);
+
+        // Assert
+        confirmed.IsResolved.Should().BeTrue();
+        confirmed.Instant.Should().BeNull();
+        confirmed.LocalWallClock.Should().Be(DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified));
+        confirmed.LocalWallClock!.Value.Kind.Should().Be(DateTimeKind.Unspecified);
+    }
+
+    [Fact]
+    public void ItShouldPreserveTheHistoricalOffsetWhenCorrectingAnExplicitInstant()
+    {
+        // Arrange
+        var proposed = ImportTimestampModel.FromExplicitInstant(
+            CapturedOn,
+            ImportTimestampSourceEnum.ExifOriginal);
+        var correction = new DateTime(2025, 6, 14, 10, 15, 0);
+
+        // Act
+        var confirmed = proposed.Confirm(correction);
+
+        // Assert
+        confirmed.Instant.Should().Be(new DateTimeOffset(correction, CapturedOn.Offset));
+    }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
@@ -2,6 +2,7 @@ using Bunit;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
 using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
 using FishingLogBook.Web.Features.Import.Services;
@@ -30,6 +31,7 @@ public class BaseImportCatchCatalogueTest
         context.JSInterop.Mode = JSRuntimeMode.Loose;
         context.Services.AddMudServices();
         context.Services.AddLocalization();
+        context.Services.AddSingleton<IMeasurementService, MeasurementService>();
         context.Services.AddSingleton(proposal);
         context.Services.AddSingleton(preparation);
         context.Services.AddSingleton(preferences ?? Preferences());

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
@@ -194,6 +194,9 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
 
         // Assert
         cut.FindComponents<ImportCatchReviewCard>().Should().HaveCount(2);
+        var reviewButton = cut.Find("#import-catch-1-edit");
+        reviewButton.TextContent.Should().Contain("Review");
+        reviewButton.ClassList.Should().Contain("mud-button-filled-primary");
         proposal.Received(1).Propose(Arg.Is<ImportBatchModel>(batch =>
             batch.FishingMethod.Id == MethodId
             && batch.Species.Id == SpeciesId
@@ -276,6 +279,129 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         // Assert
         cut.Find("#import-photo-0 img").GetAttribute("src").Should().Be(photo.ThumbnailUrl);
         await preparation.DidNotReceive().ClearAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldFastConfirmReadyCatchesAndReachTheTripReviewBoundary()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        await using var context = CreateContext(proposal, Substitute.For<IImportPhotoPreparationService>());
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(0)]));
+        cut.Find("#import-photos-continue").Click();
+
+        // Act
+        cut.Find("#import-catch-1-confirm").Click();
+
+        // Assert
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Reviewed");
+        cut.Find("#import-review-continue").HasAttribute("disabled").Should().BeFalse();
+
+        // Act
+        cut.Find("#import-review-continue").Click();
+
+        // Assert
+        cut.Find("#import-corrections-complete").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ItShouldOverrideOneCatchThroughTheExistingCataloguePickerWithoutChangingBatchDefaults()
+    {
+        // Arrange
+        ImportCatchProposalModel? created = null;
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call =>
+        {
+            var batch = call.Arg<ImportBatchModel>();
+            created = ProposalsFor(batch).Single();
+            return [created];
+        });
+        var modal = SelectingModal(SecondMethodId);
+        await using var context = CreateContext(
+            proposal, Substitute.For<IImportPhotoPreparationService>(), modalService: modal);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(0)]));
+        cut.Find("#import-photos-continue").Click();
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Act
+        cut.Find("#import-catch-1-method-more").Click();
+
+        // Assert
+        created!.Method.Id.Should().Be(SecondMethodId);
+        created.InheritedMethod.Id.Should().Be(MethodId);
+        cut.Find("#import-catch-1-method").TextContent.Should().Contain("Lure");
+        await modal.Received(1).ShowAsync<CataloguePickerModal, CataloguePickerModalModel, CataloguePickerModalResult>(
+            Arg.Is<CataloguePickerModalModel>(model => model.Options.Any(option => option.Id == SecondMethodId)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSplitAndMergePhotosWithoutRerunningAutomaticGrouping()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call =>
+        {
+            var batch = call.Arg<ImportBatchModel>();
+            return [new ImportCatchProposalModel(
+                Guid.NewGuid(), batch.Photos.Select(photo => photo.Id), batch.Photos[0].Timestamp,
+                batch.FishingMethod, batch.Species,
+                reasons: [ImportCatchProposalReasonEnum.TrustworthyCaptureTime])];
+        });
+        await using var context = CreateContext(proposal, Substitute.For<IImportPhotoPreparationService>());
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(0), ReadyPhoto(1)]));
+        cut.Find("#import-photos-continue").Click();
+        cut.Find("#import-catch-1-edit").Click();
+        cut.Find("#import-catch-1-select-1").Change(true);
+
+        // Act
+        cut.Find("#import-catch-1-split").Click();
+
+        // Assert
+        cut.FindComponents<ImportCatchReviewCard>().Should().HaveCount(2);
+        proposal.Received(1).Propose(Arg.Any<ImportBatchModel>());
+
+        // Act
+        cut.Find("#import-catch-1-merge-2").Click();
+
+        // Assert
+        cut.FindComponents<ImportCatchReviewCard>().Should().ContainSingle();
+        cut.FindAll("#import-catch-1-photos img").Should().HaveCount(2);
+        proposal.Received(1).Propose(Arg.Any<ImportBatchModel>());
+    }
+
+    [Fact]
+    public async Task ItShouldReleaseSelectedPhotoResourcesDuringCorrection()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var photo = ReadyPhoto(0);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared.InvokeAsync([photo]));
+        cut.Find("#import-photos-continue").Click();
+        cut.Find("#import-catch-1-edit").Click();
+        cut.Find("#import-catch-1-select-0").Change(true);
+
+        // Act
+        cut.Find("#import-catch-1-remove-photos").Click();
+
+        // Assert
+        await preparation.Received(1).RemoveAsync(photo, Arg.Any<CancellationToken>());
+        cut.FindComponents<ImportCatchReviewCard>().Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add deterministic split, adjacent merge, photo removal, and Catch removal corrections for proposed Import groups
- preserve photo order and explicit per-Catch method/species choices through correction
- allow users to review and confirm proposed values directly, including caught-on date/time, weight, length, and location decisions
- reuse the existing catalogue selectors and measurement editor
- keep thumbnails available while navigating backwards
- remove the redundant Correct Catches screen and enable Continue to Trip suggestions once every Catch is reviewed
- localise all new UI in English and French

Closes #217

## Validation

- `dotnet format FishingLogBook.sln --no-restore --verify-no-changes` — passed
- Web tests — 1,814 passed
- JavaScript unit tests — 402 passed
- Browser tests — 158 passed, 7 skipped; one unrelated offline-shell cold-start test timed out in the full run and passed immediately when rerun in isolation
- focused Import card/wizard tests — 30 passed
- full solution build was attempted but the locally running API held output DLLs open; the affected projects had built successfully before the copy step failed

## Self review

- Issue/AC: PASS — split, merge, deterministic ordering, override preservation, understandable review flow, and core interaction coverage are implemented
- Architecture/CQRS: PASS — changes remain within the client-side Import draft/review boundary; no server or persistence flow was introduced
- Rules: PASS — repository workflow, Blazor, C#, testing, localisation, and GitHub rules reviewed
- Security/privacy: PASS — no new network calls, identity handling, logging, or coordinate exposure
- Database/migrations: N/A — no schema or persistence changes
- Tests/coverage: PASS — model and bUnit coverage proves split/merge, removal, edits, review state, timestamp confirmation, measurement editing, and navigation
- Browser: PASS with deliberate boundary — existing browser/PWA suite exercised; authenticated Import UI remains covered at bUnit level because the Playwright harness is not an authenticated Blazor host
- Web/UI/localisation: PASS — EN/FR resources added and existing shared selectors/measurement UX reused
- Code smells: PASS — correction operations remain on the Import batch/proposal models and the UI delegates to those boundaries
- CI/deployment: PASS — no migration, infrastructure, configuration, or manual deployment step required

## Findings discovered during self-review

1. Split needed a new unique proposal identity and deterministic photo ordering.
2. Catch provenance-style timestamp approval needed to preserve an existing explicit offset and an unspecified historical wall clock.
3. The separate Correct Catches transition became redundant after correction actions moved onto the review cards.
4. The date/time input could return a localised browser value rather than ISO.
5. Weight and length editing needed to reuse the established measurement modal.
6. Editing a reviewed caught-on field could temporarily leave the stale Reviewed state visible.

## Fixes made

1. Enforced unique split identities and deterministic ordering.
2. Preserved timestamp semantics and added explicit displayed-value confirmation.
3. Consolidated corrections into Proposed Catches and replaced the redundant transition with Continue to Trip suggestions.
4. Accepted ISO and current-culture date/time picker values with regression coverage.
5. Reused the shared weight/length measurement fields and placed them side by side.
6. Invalidated review state immediately as caught-on input changes, while retaining the original timestamp basis for offset-safe correction.

## Remaining deliberate gaps

- Import persistence remains outside #217.
- Trip suggestion implementation remains the next slice.
- No new Playwright authenticated Import journey was added because the current browser harness does not host authenticated Blazor UI.
