### PR TITLE
FLB#218 | Persist imported catches, trips and photographs

### DIFF
--- a/.claude/rules/self-review.md
+++ b/.claude/rules/self-review.md
@@ -143,6 +143,14 @@ For every changed production method/use case, identify happy path, guard/validat
 dependency failure, not-found/existing-state, negative/no-op, security/ownership, and
 important boundary values — then compare with the tests that exist.
 
+For grouping, batching, ranges, windows, thresholds, and cumulative logic, verify that
+tests prove the complete business invariant rather than only adjacent or pairwise cases.
+Require a bridging/transitive counterexample where neighbouring inputs are individually
+valid but their combined result would violate the invariant (for example, `0, 4, 8`
+minutes for a five-minute maximum group span). Verify the exact boundary and the smallest
+meaningful value beyond it, and ensure test names state the business invariant rather
+than the implementation strategy.
+
 ### Mock interactions
 
 For NSubstitute: assert the observable result **and** meaningful dependency behaviour

--- a/.claude/rules/testing-csharp.md
+++ b/.claude/rules/testing-csharp.md
@@ -87,6 +87,25 @@ Assert more than "no exception":
 After writing a test, mentally invert one line of production behaviour it covers — the test
 must fail. If it would not, add assertions.
 
+### Complete invariants for grouping and cumulative logic
+
+For grouping, batching, ranges, windows, thresholds, and other cumulative algorithms,
+tests must prove the complete business invariant rather than only pairwise or adjacent
+comparisons. Include a bridging/transitive counterexample where every neighbouring pair
+is valid but the complete result would be invalid.
+
+For example, for an inclusive five-minute maximum group span, prove at least:
+
+- `0, 4, 5 minutes` produces one group;
+- `0, 4, 8 minutes` produces two groups even though both adjacent gaps are within five
+  minutes;
+- exactly five minutes is included;
+- five minutes plus the smallest meaningful increment is excluded.
+
+Test names must describe the complete business invariant. Do not name or assert an
+implementation strategy such as adjacent chaining when that strategy is not itself the
+requirement.
+
 ## Dependency verification (mandatory)
 
 Whenever the System Under Test calls a mocked/substituted dependency, the test must

--- a/src/FishingLogBook.Web/Common/Modals/AnglerPicker/AnglerPickerModal.razor
+++ b/src/FishingLogBook.Web/Common/Modals/AnglerPicker/AnglerPickerModal.razor
@@ -1,7 +1,7 @@
 @namespace FishingLogBook.Web.Common.Modals.AnglerPicker
 
 <MudDialog id="angler-picker-modal">
-    <TitleContent><MudText Typo="Typo.h6">@Loc["Trip_InviteAngler"]</MudText></TitleContent>
+    <TitleContent><MudText Typo="Typo.h6" id="angler-picker-title">@(Model.Title ?? Loc["Trip_InviteAngler"])</MudText></TitleContent>
     <DialogContent>
         <MudStack Spacing="3">
             <MudTextField T="string" Value="_query" ValueChanged="OnQueryChangedAsync"
@@ -22,7 +22,7 @@
                         <MudText>@DisplayName(angler)</MudText>
                         <MudButton Color="Color.Primary" Variant="Variant.Filled" Size="Size.Small"
                                    OnClick="@(() => Select(angler))" id="@($"angler-picker-select-{angler.UserId:D}")">
-                            @Loc["Trip_Invite"]
+                            @(Model.ActionLabel ?? Loc["Trip_Invite"])
                         </MudButton>
                     </MudStack>
                 </MudPaper>

--- a/src/FishingLogBook.Web/Common/Modals/AnglerPicker/AnglerPickerModalModel.cs
+++ b/src/FishingLogBook.Web/Common/Modals/AnglerPicker/AnglerPickerModalModel.cs
@@ -3,4 +3,8 @@ namespace FishingLogBook.Web.Common.Modals.AnglerPicker;
 public sealed record AnglerPickerModalModel(IReadOnlyCollection<Guid>? ExcludedUserIds = null)
 {
     public IReadOnlyCollection<Guid> ExcludedUserIds { get; init; } = ExcludedUserIds ?? [];
+
+    public string? Title { get; init; }
+
+    public string? ActionLabel { get; init; }
 }

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
@@ -1,5 +1,8 @@
 @using FishingLogBook.Web.Features.Import.Models
+@using FishingLogBook.Web.Features.Import.Enums
 @using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor
+@using FishingLogBook.Web.Features.Photographs.Components.PhotographCarousel
+@using FishingLogBook.Web.Features.Photographs.Components.PhotographGridSelector
 
 <MudPaper Class="import-catch-card pa-3" Elevation="2" id="@($"import-catch-{Number}")">
     <MudStack Spacing="2">
@@ -8,37 +11,44 @@
             <MudChip T="string" Color="@StatusColor" Variant="Variant.Outlined"
                      id="@($"import-catch-{Number}-status")">@StatusLabel</MudChip>
         </MudStack>
-        <div class="import-catch-photos" id="@($"import-catch-{Number}-photos")">
-            @foreach (var photo in ProposalPhotos)
-            {
-                <label class="import-catch-photo-choice">
-                    @if (_editing)
-                    {
-                        <MudCheckBox T="bool" Value="@_selectedPhotoIds.Contains(photo.Id)"
-                                     ValueChanged="@(selected => SelectPhoto(photo.Id, selected))"
-                                     aria-label="@Loc["Import_SelectPhoto", photo.SelectionIndex + 1]"
-                                     id="@($"import-catch-{Number}-select-{photo.SelectionIndex}")" />
-                    }
-                    <img src="@photo.ThumbnailUrl" alt="@Loc["Import_PhotoAlt", photo.SelectionIndex + 1]"
-                         class="import-catch-thumbnail" />
-                </label>
-            }
-        </div>
-        <MudText id="@($"import-catch-{Number}-timestamp")">@TimestampLabel</MudText>
-        <MudText id="@($"import-catch-{Number}-method")">@Proposal.Method.Name</MudText>
-        <MudText id="@($"import-catch-{Number}-species")">@Proposal.Species.Name</MudText>
-        <MudText id="@($"import-catch-{Number}-location")">@LocationLabel</MudText>
-
         @if (_editing)
         {
+            <PhotographGridSelector Photographs="CarouselPhotographs"
+                                    IdPrefix="@($"import-catch-{Number}")"
+                                    ActivePhotographIdChanged="SelectActivePhotoAsync"
+                                    SelectedIdsChanged="SelectPhotos">
+                <SelectedActions Context="selectedCount">
+                    <MudButton Size="Size.Small" Variant="Variant.Outlined" Disabled="@(!CanSplit)"
+                               OnClick="SplitSelectedAsync" id="@($"import-catch-{Number}-split")">
+                        @Loc["Import_MoveToNewCatch"]
+                    </MudButton>
+                    <MudButton Size="Size.Small" Variant="Variant.Text" Color="Color.Error"
+                               OnClick="RemoveSelectedAsync" id="@($"import-catch-{Number}-remove-photos")">
+                        @Loc["Import_RemoveSelectedPhotos"]
+                    </MudButton>
+                </SelectedActions>
+            </PhotographGridSelector>
+            <MudText id="@($"import-catch-{Number}-timestamp")">@TimestampLabel</MudText>
+            <MudText id="@($"import-catch-{Number}-method")">@Proposal.Method.Name</MudText>
+            <MudText id="@($"import-catch-{Number}-species")">@Proposal.Species.Name</MudText>
+            <MudText id="@($"import-catch-{Number}-location")">@LocationLabel</MudText>
             <MudStack Spacing="2" id="@($"import-catch-{Number}-editor")">
-                <MudTextField T="string" Value="@_caughtOnLocal" ValueChanged="SetCaughtOnLocal"
-                              Label="@Loc["Import_CaughtOn"]" InputType="InputType.DateTimeLocal"
-                              Immediate="true"
-                              Error="@_caughtOnInvalid" ErrorText="@Loc["Import_CaughtOnRequired"]"
-                              id="@($"import-catch-{Number}-caught-on")" />
-                <MudButton Variant="Variant.Outlined" OnClick="ConfirmCaughtOn"
-                           id="@($"import-catch-{Number}-confirm-caught-on")">@Loc["Import_ConfirmCaughtOn"]</MudButton>
+                <div class="import-catch-caught-on-row">
+                    <MudTextField T="string" Value="@_caughtOnLocal" ValueChanged="SetCaughtOnLocal"
+                                  Label="@Loc["Import_CaughtOn"]" InputType="InputType.DateTimeLocal"
+                                  Immediate="true"
+                                  Error="@_caughtOnInvalid" ErrorText="@Loc["Import_CaughtOnRequired"]"
+                                  id="@($"import-catch-{Number}-caught-on")" />
+                    <MudTooltip Text="@Loc["Import_ConfirmCaughtOn"]" ShowOnClick="true">
+                        <MudButton StartIcon="@Icons.Material.Filled.Check" Size="Size.Small"
+                                   Variant="Variant.Filled" Color="Color.Primary"
+                                   OnClick="ConfirmCaughtOn" Class="import-catch-confirm-caught-on"
+                                   aria-label="@Loc["Import_ConfirmCaughtOn"]"
+                                   id="@($"import-catch-{Number}-confirm-caught-on")">
+                            <span class="import-catch-confirm-caught-on-label">@Loc["Import_ConfirmCaughtOn"]</span>
+                        </MudButton>
+                    </MudTooltip>
+                </div>
                 @if (Proposal.RequiresCanonicalReview)
                 {
                     <MudAlert Severity="Severity.Warning">@Loc["Import_MergeValuesNeedReview"]</MudAlert>
@@ -96,15 +106,6 @@
                     </MudStack>
                 }
 
-                <MudStack Row="true" Spacing="1" Class="flex-wrap">
-                    <MudButton Variant="Variant.Outlined" Disabled="@(!CanSplit)" OnClick="SplitSelectedAsync"
-                               id="@($"import-catch-{Number}-split")">@Loc["Import_MoveToNewCatch"]</MudButton>
-                    <MudButton Variant="Variant.Text" Color="Color.Error" Disabled="@(_selectedPhotoIds.Count == 0)"
-                               OnClick="RemoveSelectedAsync" id="@($"import-catch-{Number}-remove-photos")">
-                        @Loc["Import_RemoveSelectedPhotos"]
-                    </MudButton>
-                </MudStack>
-
                 @if (MergeTargets.Count > 0)
                 {
                     <MudText Typo="Typo.caption">@Loc["Import_MergeWith"]</MudText>
@@ -131,13 +132,36 @@
         }
         else
         {
+            <div class="import-catch-summary">
+                <div class="import-catch-summary-photo" id="@($"import-catch-{Number}-photos")">
+                    <PhotographCarousel Photographs="CarouselPhotographs"
+                                        Compact="true"
+                                        ActivePhotographId="_activePhotoId"
+                                        ActivePhotographIdChanged="SelectActivePhotoAsync"
+                                        IdPrefix="@($"import-catch-{Number}-carousel")" />
+                </div>
+                <MudStack Spacing="1" Class="import-catch-summary-details">
+                    <MudText id="@($"import-catch-{Number}-timestamp")">@TimestampLabel</MudText>
+                    <MudText id="@($"import-catch-{Number}-species-method")">
+                        <span id="@($"import-catch-{Number}-species")">@Proposal.Species.Name</span>
+                        · <span id="@($"import-catch-{Number}-method")">@Proposal.Method.Name</span>
+                    </MudText>
+                    <MudText Typo="Typo.body2" Class="mud-text-secondary" id="@($"import-catch-{Number}-location")">@LocationLabel</MudText>
+                    @if (MeasurementLabel is not null)
+                    {
+                        <MudText Typo="Typo.body2" Class="mud-text-secondary" id="@($"import-catch-{Number}-measurements")">@MeasurementLabel</MudText>
+                    }
+                </MudStack>
+            </div>
             <MudStack Row="true" Spacing="1" Justify="Justify.FlexEnd">
                 @if (Editable)
                 {
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="OpenEditor"
-                               id="@($"import-catch-{Number}-edit")">@Loc["Import_ReviewEdit"]</MudButton>
+                               id="@($"import-catch-{Number}-edit")">
+                        @Loc[Proposal.ReviewStatus == ImportCatchReviewStatusEnum.Reviewed ? "Import_Edit" : "Import_ReviewEdit"]
+                    </MudButton>
                 }
-                @if (Proposal.CanConfirmDisplayedValues)
+                @if (Proposal.ReviewStatus != ImportCatchReviewStatusEnum.Reviewed && Proposal.CanConfirmDisplayedValues)
                 {
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ConfirmAsync"
                                id="@($"import-catch-{Number}-confirm")">@Loc["Import_ConfirmCatch"]</MudButton>

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
@@ -49,6 +49,18 @@
                         </MudButton>
                     </MudTooltip>
                 </div>
+                @if (RequiresUtcOffsetControl)
+                {
+                    <MudSelect T="TimeSpan?" Value="_utcOffset" ValueChanged="SetUtcOffset"
+                               Label="@Loc["Import_UtcOffset"]" Required="true"
+                               Error="_utcOffsetInvalid" ErrorText="@Loc["Import_UtcOffsetRequired"]"
+                               id="@($"import-catch-{Number}-utc-offset")">
+                        @foreach (var offset in UtcOffsetOptions)
+                        {
+                            <MudSelectItem T="TimeSpan?" Value="@((TimeSpan?)offset)">@UtcOffsetLabel(offset)</MudSelectItem>
+                        }
+                    </MudSelect>
+                }
                 @if (Proposal.RequiresCanonicalReview)
                 {
                     <MudAlert Severity="Severity.Warning">@Loc["Import_MergeValuesNeedReview"]</MudAlert>

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
@@ -19,11 +19,15 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     private const int MaxChipOptions = 6;
     private readonly HashSet<Guid> _selectedPhotoIds = [];
     private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private static readonly IReadOnlyList<TimeSpan> UtcOffsetOptions =
+        [.. Enumerable.Range(0, 53).Select(index => TimeSpan.FromMinutes(-720 + (index * 30)))];
     private string _caughtOnLocal = string.Empty;
     private ImportTimestampModel? _caughtOnBasis;
     private Guid? _activePhotoId;
     private bool _caughtOnInvalid;
     private bool _editing;
+    private TimeSpan? _utcOffset;
+    private bool _utcOffsetInvalid;
 
     [Parameter, EditorRequired] public ImportCatchProposalModel Proposal { get; set; } = default!;
     [Parameter, EditorRequired] public ImportBatchModel Batch { get; set; } = default!;
@@ -88,6 +92,8 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
             .Where(item => !item.Proposal.IsRemoved && item.Proposal.Id != Proposal.Id)];
 
     private bool CanSplit => _selectedPhotoIds.Count > 0 && _selectedPhotoIds.Count < Proposal.PhotoIds.Count;
+    private bool RequiresUtcOffsetControl => _caughtOnBasis is not null
+        && (_caughtOnBasis.LocalWallClock.HasValue || !_caughtOnBasis.Instant.HasValue);
     private bool ShowLocationDecision => Proposal.HasUnresolvedGpsConflict || Proposal.Location?.HasCanonicalCoordinates == true;
     private Color StatusColor => Proposal.ReviewStatus == ImportCatchReviewStatusEnum.Reviewed
         ? Color.Success : Proposal.CanBeReviewed ? Color.Info : Color.Warning;
@@ -145,6 +151,8 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         _editing = true;
         _caughtOnBasis = DisplayedTimestamp;
         _caughtOnLocal = EditorValue(DisplayedTimestamp);
+        _utcOffset = DisplayedTimestamp.LocalWallClock.HasValue ? DisplayedTimestamp.Instant?.Offset : null;
+        _utcOffsetInvalid = false;
     }
     private void CloseEditor()
     {
@@ -155,9 +163,16 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     {
         _caughtOnLocal = value;
         _caughtOnInvalid = false;
-        var caughtOn = TryParseCaughtOn(value, out var parsed)
-            ? ConfirmedCaughtOn(parsed)
-            : ImportTimestampModel.Missing();
+        _utcOffsetInvalid = false;
+        var caughtOn = !TryParseCaughtOn(value, out var parsed)
+            ? ImportTimestampModel.Missing()
+            : RequiresUtcOffsetControl
+                ? (_caughtOnBasis ?? Proposal.CaughtOn).EditLocalWallClock(parsed)
+                : ConfirmedCaughtOn(parsed);
+        if (RequiresUtcOffsetControl)
+        {
+            _utcOffset = null;
+        }
         Batch.SetCatchCaughtOn(Proposal.Id, caughtOn);
     }
     private void SelectPhotos(IReadOnlySet<Guid> selectedPhotoIds)
@@ -178,19 +193,23 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         _caughtOnBasis = DisplayedTimestamp;
         _caughtOnLocal = EditorValue(DisplayedTimestamp);
         _caughtOnInvalid = false;
+        _utcOffset = DisplayedTimestamp.LocalWallClock.HasValue ? DisplayedTimestamp.Instant?.Offset : null;
+        _utcOffsetInvalid = false;
         return Task.CompletedTask;
     }
 
     private void ConfirmCaughtOn()
     {
-        if (!TryParseCaughtOn(_caughtOnLocal, out var caughtOn))
+        if (!TryConfirmCaughtOn())
         {
-            _caughtOnInvalid = true;
             return;
         }
+    }
 
-        Batch.SetCatchCaughtOn(Proposal.Id, ConfirmedCaughtOn(caughtOn));
-        _caughtOnInvalid = false;
+    private void SetUtcOffset(TimeSpan? utcOffset)
+    {
+        _utcOffset = utcOffset;
+        _utcOffsetInvalid = false;
     }
 
     private static bool TryParseCaughtOn(string value, out DateTime caughtOn)
@@ -270,13 +289,10 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
 
     private async Task ContinueAsync()
     {
-        if (!TryParseCaughtOn(_caughtOnLocal, out var caughtOn))
+        if (!TryConfirmCaughtOn())
         {
-            _caughtOnInvalid = true;
             return;
         }
-
-        Batch.SetCatchCaughtOn(Proposal.Id, ConfirmedCaughtOn(caughtOn));
         if (!Proposal.CanConfirmDisplayedValues)
         {
             return;
@@ -298,6 +314,36 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     private ImportTimestampModel ConfirmedCaughtOn(DateTime caughtOn)
     {
         return (_caughtOnBasis ?? Proposal.CaughtOn).Confirm(caughtOn);
+    }
+
+    private bool TryConfirmCaughtOn()
+    {
+        if (!TryParseCaughtOn(_caughtOnLocal, out var caughtOn))
+        {
+            _caughtOnInvalid = true;
+            return false;
+        }
+
+        if (RequiresUtcOffsetControl && !_utcOffset.HasValue)
+        {
+            _utcOffsetInvalid = true;
+            return false;
+        }
+
+        var confirmed = RequiresUtcOffsetControl
+            ? (_caughtOnBasis ?? Proposal.CaughtOn).ConfirmLocalWallClock(caughtOn, _utcOffset!.Value)
+            : ConfirmedCaughtOn(caughtOn);
+        Batch.SetCatchCaughtOn(Proposal.Id, confirmed);
+        _caughtOnInvalid = false;
+        _utcOffsetInvalid = false;
+        return true;
+    }
+
+    private static string UtcOffsetLabel(TimeSpan offset)
+    {
+        var sign = offset < TimeSpan.Zero ? '-' : '+';
+        var absolute = offset.Duration();
+        return $"UTC{sign}{absolute.Hours:D2}:{absolute.Minutes:D2}";
     }
 
     private FishingMethodDto? FindMethod(Guid id) => Preferences.Catalogue.Methods.SingleOrDefault(method => method.Id == id);

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
@@ -1,8 +1,11 @@
 using System.Globalization;
 using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Shared.Enums;
 using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Photographs.Models;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Localization;
 using Microsoft.AspNetCore.Components;
@@ -18,6 +21,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private string _caughtOnLocal = string.Empty;
     private ImportTimestampModel? _caughtOnBasis;
+    private Guid? _activePhotoId;
     private bool _caughtOnInvalid;
     private bool _editing;
 
@@ -31,10 +35,48 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     [Parameter] public EventCallback Changed { get; set; }
 
     [Inject] private IModalService ModalService { get; set; } = default!;
+    [Inject] private IMeasurementService Measurement { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     private IReadOnlyList<ImportSelectedPhotoModel> ProposalPhotos =>
         [.. Proposal.PhotoIds.Select(photoId => Batch.Photos.Single(photo => photo.Id == photoId))];
+
+    private IReadOnlyList<PhotographCarouselItemModel> CarouselPhotographs =>
+        [.. ProposalPhotos.Select(photo => new PhotographCarouselItemModel(
+            photo.Id,
+            photo.ContentType,
+            RemoteUrl: photo.ThumbnailUrl))];
+
+    private ImportSelectedPhotoModel ActivePhoto => ProposalPhotos.First(photo => photo.Id == _activePhotoId);
+
+    private ImportTimestampModel DisplayedTimestamp => Proposal.CaughtOn;
+
+    private string? MeasurementLabel
+    {
+        get
+        {
+            var values = new List<string>();
+            var weight = Measurement.ToDisplayWeight(Proposal.Weight, Preferences.WeightUnit);
+            if (weight.HasValue)
+            {
+                var unit = Preferences.WeightUnit == WeightUnitEnum.Lb
+                    ? Loc["Catch_WeightUnitShort_Lb"]
+                    : Loc["Catch_WeightUnitShort_Kg"];
+                values.Add($"{weight.Value.ToString("0.##", CultureInfo.CurrentCulture)} {unit}");
+            }
+
+            var length = Measurement.ToDisplayLength(Proposal.Length, Preferences.LengthUnit);
+            if (length.HasValue)
+            {
+                var unit = Preferences.LengthUnit == LengthUnitEnum.In
+                    ? Loc["Catch_LengthUnitShort_In"]
+                    : Loc["Catch_LengthUnitShort_Cm"];
+                values.Add($"{length.Value.ToString("0.##", CultureInfo.CurrentCulture)} {unit}");
+            }
+
+            return values.Count == 0 ? null : string.Join(" · ", values);
+        }
+    }
 
     private IReadOnlyList<(ImportSelectedPhotoModel Photo, ImportLocationModel Location)> LocationOptions =>
         [.. ProposalPhotos.Where(photo => photo.Location.HasCanonicalCoordinates)
@@ -69,13 +111,13 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         }
     }
 
-    private string TimestampLabel => Proposal.CaughtOn.State switch
+    private string TimestampLabel => DisplayedTimestamp.State switch
     {
-        ImportTimestampStateEnum.ExplicitInstant => Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
-        ImportTimestampStateEnum.UserConfirmed when Proposal.CaughtOn.Instant is { } instant => instant.ToString("dd MMM yyyy · HH:mm zzz"),
-        ImportTimestampStateEnum.UserConfirmed => Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm"),
-        ImportTimestampStateEnum.LocalWallClock => Loc["Import_TimestampAmbiguous", Proposal.CaughtOn.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm")],
-        ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak", Proposal.CaughtOn.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz")],
+        ImportTimestampStateEnum.ExplicitInstant => DisplayedTimestamp.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
+        ImportTimestampStateEnum.UserConfirmed when DisplayedTimestamp.Instant is { } instant => instant.ToString("dd MMM yyyy · HH:mm zzz"),
+        ImportTimestampStateEnum.UserConfirmed => DisplayedTimestamp.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm"),
+        ImportTimestampStateEnum.LocalWallClock => Loc["Import_TimestampAmbiguous", DisplayedTimestamp.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm")],
+        ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak", DisplayedTimestamp.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz")],
         ImportTimestampStateEnum.Unusable => Loc["Import_TimestampUnusable"],
         _ => Loc["Import_TimestampMissing"]
     };
@@ -86,14 +128,29 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         : Proposal.Location?.HasCanonicalCoordinates == true ? Loc["Import_LocationAvailable"]
         : Loc["Import_LocationUnavailable"];
 
-    protected override void OnParametersSet() { if (!_editing) _caughtOnLocal = EditorValue(); }
+    protected override void OnParametersSet()
+    {
+        if (_activePhotoId is null || ProposalPhotos.All(photo => photo.Id != _activePhotoId))
+        {
+            _activePhotoId = ProposalPhotos[0].Id;
+        }
+
+        if (!_editing)
+        {
+            _caughtOnLocal = EditorValue(DisplayedTimestamp);
+        }
+    }
     private void OpenEditor()
     {
         _editing = true;
-        _caughtOnBasis = Proposal.CaughtOn;
-        _caughtOnLocal = EditorValue();
+        _caughtOnBasis = DisplayedTimestamp;
+        _caughtOnLocal = EditorValue(DisplayedTimestamp);
     }
-    private void CloseEditor() => _editing = false;
+    private void CloseEditor()
+    {
+        _selectedPhotoIds.Clear();
+        _editing = false;
+    }
     private void SetCaughtOnLocal(string value)
     {
         _caughtOnLocal = value;
@@ -103,7 +160,26 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
             : ImportTimestampModel.Missing();
         Batch.SetCatchCaughtOn(Proposal.Id, caughtOn);
     }
-    private void SelectPhoto(Guid photoId, bool selected) { if (selected) _selectedPhotoIds.Add(photoId); else _selectedPhotoIds.Remove(photoId); }
+    private void SelectPhotos(IReadOnlySet<Guid> selectedPhotoIds)
+    {
+        _selectedPhotoIds.Clear();
+        _selectedPhotoIds.UnionWith(selectedPhotoIds);
+    }
+
+    private Task SelectActivePhotoAsync(Guid? photoId)
+    {
+        if (photoId is null || ProposalPhotos.All(photo => photo.Id != photoId))
+        {
+            return Task.CompletedTask;
+        }
+
+        _activePhotoId = photoId;
+        Batch.SetCatchCaughtOn(Proposal.Id, ActivePhoto.Timestamp);
+        _caughtOnBasis = DisplayedTimestamp;
+        _caughtOnLocal = EditorValue(DisplayedTimestamp);
+        _caughtOnInvalid = false;
+        return Task.CompletedTask;
+    }
 
     private void ConfirmCaughtOn()
     {
@@ -207,14 +283,15 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         }
 
         Batch.ConfirmDisplayedCatch(Proposal.Id);
+        _selectedPhotoIds.Clear();
         _editing = false;
         _caughtOnInvalid = false;
         await Changed.InvokeAsync();
     }
 
-    private string EditorValue()
+    private static string EditorValue(ImportTimestampModel timestamp)
     {
-        var value = Proposal.CaughtOn.Instant?.DateTime ?? Proposal.CaughtOn.LocalWallClock;
+        var value = timestamp.Instant?.DateTime ?? timestamp.LocalWallClock;
         return value?.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture) ?? string.Empty;
     }
 

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.css
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.css
@@ -3,33 +3,56 @@
     overflow: hidden;
 }
 
-.import-catch-photos {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(5rem, 1fr));
-    gap: 0.5rem;
-}
-
-.import-catch-thumbnail {
-    width: 100%;
-    max-height: 8rem;
-    aspect-ratio: 1;
-    object-fit: cover;
-    border-radius: 0.5rem;
-}
-
-.import-catch-photo-choice {
-    position: relative;
-}
-
-.import-catch-photo-choice .mud-checkbox {
-    position: absolute;
-    z-index: 1;
-    background: var(--mud-palette-surface);
-    border-radius: 50%;
-}
-
 .import-catch-measurements {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.5rem;
+}
+
+.import-catch-caught-on-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.5rem;
+    align-items: end;
+    container-name: caught-on-row;
+    container-type: inline-size;
+}
+
+.import-catch-confirm-caught-on {
+    margin-bottom: 0.25rem;
+}
+
+@container caught-on-row (max-width: 30rem) {
+    .import-catch-confirm-caught-on-label {
+        display: none;
+    }
+}
+
+.import-catch-summary {
+    display: grid;
+    grid-template-columns: 6rem minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: start;
+}
+
+.import-catch-summary-photo {
+    width: 6rem;
+}
+
+.import-catch-summary-details {
+    min-width: 0;
+}
+
+@media (max-width: 360px) {
+    .import-catch-caught-on-row {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .import-catch-summary {
+        grid-template-columns: 5rem minmax(0, 1fr);
+    }
+
+    .import-catch-summary-photo {
+        width: 5rem;
+    }
 }

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportCatchProposalModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportCatchProposalModel.cs
@@ -97,7 +97,7 @@ public sealed class ImportCatchProposalModel
         && _photoIds.Count > 0;
 
     public bool CanConfirmDisplayedValues => !IsRemoved
-        && (CaughtOn.Instant.HasValue || CaughtOn.LocalWallClock.HasValue)
+        && CaughtOn.Instant.HasValue
         && Method.IsValid
         && Species.IsValid
         && _gpsConflictResolved
@@ -169,7 +169,7 @@ public sealed class ImportCatchProposalModel
 
         if (!CaughtOn.IsResolved)
         {
-            var displayedCaughtOn = CaughtOn.Instant?.DateTime ?? CaughtOn.LocalWallClock!.Value;
+            var displayedCaughtOn = CaughtOn.Instant!.Value.DateTime;
             CaughtOn = CaughtOn.Confirm(displayedCaughtOn);
         }
 

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportPersistenceResultModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportPersistenceResultModel.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Web.Features.Import.Models;
+
+public sealed record ImportPersistenceResultModel(
+    IReadOnlyList<Guid> CreatedTripIds,
+    IReadOnlyList<Guid> CatchIds,
+    int PhotographCount,
+    int ParticipantCount);

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportTimestampModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportTimestampModel.cs
@@ -41,6 +41,8 @@ public sealed record ImportTimestampModel
         }
     }
 
+    public bool RequiresUtcOffset => LocalWallClock.HasValue && !Instant.HasValue;
+
     public static ImportTimestampModel Missing()
     {
         return new ImportTimestampModel(
@@ -93,21 +95,35 @@ public sealed record ImportTimestampModel
             null);
     }
 
-    public static ImportTimestampModel UserConfirmed(DateTime localWallClock)
+    public ImportTimestampModel Confirm(DateTime localValue)
     {
+        if (!Instant.HasValue)
+        {
+            throw new InvalidOperationException("An explicit UTC offset is required for a historical local date and time.");
+        }
+
+        var unspecified = DateTime.SpecifyKind(localValue, DateTimeKind.Unspecified);
+        return UserConfirmed(new DateTimeOffset(unspecified, Instant.Value.Offset));
+    }
+
+    public ImportTimestampModel ConfirmLocalWallClock(DateTime localWallClock, TimeSpan utcOffset)
+    {
+        var unspecified = DateTime.SpecifyKind(localWallClock, DateTimeKind.Unspecified);
+        var instant = new DateTimeOffset(unspecified, utcOffset);
         return new ImportTimestampModel(
             ImportTimestampStateEnum.UserConfirmed,
             ImportTimestampSourceEnum.User,
-            null,
-            DateTime.SpecifyKind(localWallClock, DateTimeKind.Unspecified));
+            instant,
+            unspecified);
     }
 
-    public ImportTimestampModel Confirm(DateTime localValue)
+    public ImportTimestampModel EditLocalWallClock(DateTime localWallClock)
     {
-        var unspecified = DateTime.SpecifyKind(localValue, DateTimeKind.Unspecified);
-        return Instant is { } instant
-            ? UserConfirmed(new DateTimeOffset(unspecified, instant.Offset))
-            : UserConfirmed(unspecified);
+        return new ImportTimestampModel(
+            ImportTimestampStateEnum.LocalWallClock,
+            Source,
+            null,
+            DateTime.SpecifyKind(localWallClock, DateTimeKind.Unspecified));
     }
 
     private static void RequireExifSource(ImportTimestampSourceEnum source)

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
@@ -4,6 +4,7 @@
 @using FishingLogBook.Web.Features.Import.Components.ImportPhotographPicker
 @using FishingLogBook.Web.Features.Import.Enums
 @using FishingLogBook.Web.Features.Import.Services
+@using FishingLogBook.Web.Features.Trips.Components.TripSelector
 
 <PageTitle>@Loc["Import_PageTitle"]</PageTitle>
 
@@ -159,24 +160,41 @@
                     }
                     @for (var proposalIndex = 0; proposalIndex < ActiveTripProposals.Count; proposalIndex++)
                     {
+                        var proposalNumber = proposalIndex + 1;
                         var proposal = ActiveTripProposals[proposalIndex];
-                        <MudPaper Class="pa-3" Elevation="2" id="@($"import-trip-{proposalIndex + 1}")">
+                        <MudPaper Class="pa-3" Elevation="2" id="@($"import-trip-{proposalNumber}")">
                             <MudStack Spacing="1">
-                                <MudText Typo="Typo.h6">@Loc["Import_TripCatchCount", proposal.CatchProposalIds.Count]</MudText>
-                                <MudText>@proposal.ProposedStartedOn.ToString("d", System.Globalization.CultureInfo.CurrentCulture)</MudText>
-                                <MudText>@Loc["Import_TripTimeRange", proposal.ProposedStartedOn.ToString("t"), proposal.ProposedEndedOn.ToString("t")]</MudText>
+                                <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="flex-wrap" Spacing="1">
+                                    <MudText Typo="Typo.h6">@Loc["Import_TripCatchCount", proposal.CatchProposalIds.Count]</MudText>
+                                    <MudText Align="Align.Right" id="@($"import-trip-date-time-{proposalNumber}")">
+                                        @proposal.ProposedStartedOn.ToString("d", System.Globalization.CultureInfo.CurrentCulture)
+                                        · @Loc["Import_TripTimeRange", proposal.ProposedStartedOn.ToString("t"), proposal.ProposedEndedOn.ToString("t")]
+                                    </MudText>
+                                </MudStack>
                                 @if (proposal.Confidence == ImportTripSuggestionConfidenceEnum.Weak)
                                 {
                                     <MudAlert Severity="Severity.Warning">@Loc["Import_TripMissingGps"]</MudAlert>
                                 }
+                                @if (ExistingTripsFor(proposal).Count > 0)
+                                {
+                                    <MudAlert Severity="Severity.Warning" id="@($"import-trip-existing-warning-{proposalNumber}")">
+                                        @Loc["Import_ExistingTripFound"]
+                                    </MudAlert>
+                                    <TripSelector Trips="ExistingTripsFor(proposal)"
+                                                  SelectedTripId="proposal.ExistingTripId"
+                                                  SelectedTripIdChanged="@(tripId => ChooseExistingTrip(proposal.Id, tripId))"
+                                                  Label="@Loc["Import_AddToExistingTrip"]" />
+                                }
                                 <MudStack Row="true" Class="flex-wrap" Spacing="1">
-                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => DecideTrip(proposal.Id, ImportTripDecisionEnum.CreateNew))" id="@($"import-trip-create-{proposalIndex + 1}")">@Loc["Import_CreateTrip"]</MudButton>
-                                    <MudButton Variant="Variant.Outlined" OnClick="@(() => DecideTrip(proposal.Id, ImportTripDecisionEnum.NoTrip))" id="@($"import-trip-separate-{proposalIndex + 1}")">@Loc["Import_KeepSeparate"]</MudButton>
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => DecideTrip(proposal.Id, ImportTripDecisionEnum.CreateNew))" id="@($"import-trip-create-{proposalNumber}")">
+                                        @Loc[ExistingTripsFor(proposal).Count > 0 ? "Import_CreateAnotherTrip" : "Import_CreateTrip"]
+                                    </MudButton>
+                                    <MudButton Variant="Variant.Outlined" OnClick="@(() => DecideTrip(proposal.Id, ImportTripDecisionEnum.NoTrip))" id="@($"import-trip-separate-{proposalNumber}")">@Loc["Import_KeepSeparate"]</MudButton>
                                 </MudStack>
                                 @if (proposal.Decision == ImportTripDecisionEnum.CreateNew)
                                 {
                                     <MudText Typo="Typo.subtitle2">@Loc["Import_TripParticipants"]</MudText>
-                                    <MudStack Row="true" Class="flex-wrap" Spacing="1" id="@($"import-trip-participants-{proposalIndex + 1}")">
+                                    <MudStack Row="true" Class="flex-wrap" Spacing="1" id="@($"import-trip-participants-{proposalNumber}")">
                                         @foreach (var participant in proposal.Participants)
                                         {
                                             <MudChip T="Guid" Value="participant.UserId" OnClose="@(() => RemoveTripParticipant(proposal.Id, participant.UserId))"
@@ -185,37 +203,27 @@
                                             </MudChip>
                                         }
                                         <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => AddTripParticipantAsync(proposal))"
-                                                   id="@($"import-trip-add-participant-{proposalIndex + 1}")">
+                                                   id="@($"import-trip-add-participant-{proposalNumber}")">
                                             @Loc["Import_AddTripParticipant"]
                                         </MudButton>
                                     </MudStack>
                                 }
-                                @if (ExistingTripsFor(proposal).Count > 0)
-                                {
-                                    <MudSelect T="Guid?" Label="@Loc["Import_AddToExistingTrip"]" Value="proposal.ExistingTripId"
-                                               ValueChanged="@(tripId => { if (tripId.HasValue) ChooseExistingTrip(proposal.Id, tripId.Value); })"
-                                               id="@($"import-trip-existing-{proposalIndex + 1}")">
-                                        @foreach (var trip in ExistingTripsFor(proposal))
-                                        {
-                                            <MudSelectItem T="Guid?" Value="trip.Id">@(trip.Title ?? trip.StartedOn.ToString("g"))</MudSelectItem>
-                                        }
-                                    </MudSelect>
-                                }
                                 @for (var catchIndex = 0; catchIndex < proposal.CatchProposalIds.Count; catchIndex++)
                                 {
+                                    var catchNumber = catchIndex + 1;
                                     var catchId = proposal.CatchProposalIds[catchIndex];
                                     var catchProposal = CatchProposal(catchId);
                                     var thumbnail = CatchThumbnail(catchProposal);
-                                    <div class="import-trip-catch-row" id="@($"import-trip-catch-{proposalIndex + 1}-{catchIndex + 1}")">
+                                    <div class="import-trip-catch-row" id="@($"import-trip-catch-{proposalNumber}-{catchNumber}")">
                                         <img src="@thumbnail.ThumbnailUrl"
-                                             alt="@Loc["Import_TripCatchPhotoAlt", catchIndex + 1]"
+                                             alt="@Loc["Import_TripCatchPhotoAlt", catchNumber]"
                                              class="import-trip-catch-thumbnail" />
-                                        <MudText>@Loc["Import_TripCatchNumber", catchIndex + 1]</MudText>
+                                        <MudText>@Loc["Import_TripCatchNumber", catchNumber]</MudText>
                                         <MudIconButton Icon="@Icons.Material.Filled.RemoveCircleOutline"
                                                        Color="Color.Error"
                                                        aria-label="@Loc["Import_RemoveCatchFromTrip"]"
                                                        OnClick="@(() => RemoveCatchFromTrip(proposal.Id, catchId))"
-                                                       id="@($"import-trip-remove-{proposalIndex + 1}-{catchIndex + 1}")" />
+                                                       id="@($"import-trip-remove-{proposalNumber}-{catchNumber}")" />
                                     </div>
                                 }
                             </MudStack>
@@ -230,9 +238,46 @@
             }
             else if (_batch.Stage == ImportStageEnum.Confirm)
             {
-                <MudAlert Severity="Severity.Info" id="import-confirmation-boundary">
-                    @Loc["Import_ConfirmationBoundary"]
-                </MudAlert>
+                @if (_isPersisted && _persistenceResult is not null)
+                {
+                    <MudAlert Severity="Severity.Success" id="import-success">
+                        @Loc["Import_Success", _persistenceResult.CatchIds.Count, _persistenceResult.PhotographCount, _persistenceResult.CreatedTripIds.Count]
+                    </MudAlert>
+                    <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="1">
+                        <MudButton Variant="Variant.Outlined" OnClick="NavigateToTrips" id="import-view-trips">@Loc["Import_ViewTrips"]</MudButton>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="NavigateToCatches" id="import-view-catches">@Loc["Import_ViewCatches"]</MudButton>
+                    </MudStack>
+                }
+                else
+                {
+                    <MudPaper Class="pa-3" Elevation="2" id="import-confirmation-summary">
+                        <MudStack Spacing="2">
+                            <MudText Typo="Typo.h6">@Loc["Import_ConfirmTitle"]</MudText>
+                            <MudText id="import-confirmation-boundary">@Loc["Import_ConfirmationBoundary"]</MudText>
+                            <MudText id="import-summary-catches">@Loc["Import_SummaryCatches", ActiveCatchProposals.Count]</MudText>
+                            <MudText id="import-summary-photos">@Loc["Import_SummaryPhotos", ActivePhotoCount]</MudText>
+                            <MudText id="import-summary-new-trips">@Loc["Import_SummaryNewTrips", NewTripCount]</MudText>
+                            <MudText id="import-summary-existing-trips">@Loc["Import_SummaryExistingTrips", ExistingTripAssignmentCount]</MudText>
+                            <MudText id="import-summary-standalone">@Loc["Import_SummaryStandalone", StandaloneCatchCount]</MudText>
+                        </MudStack>
+                    </MudPaper>
+                    @if (_persistenceError is not null)
+                    {
+                        <MudAlert Severity="Severity.Error" id="import-persistence-error">@_persistenceError</MudAlert>
+                    }
+                    <MudStack Row="true" Justify="Justify.SpaceBetween">
+                        <MudButton Variant="Variant.Text" Disabled="_isPersisting" OnClick="BackToCatchReview" id="import-confirm-back">@Loc["Common_Back"]</MudButton>
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_isPersisting"
+                                   OnClick="PersistAsync" id="import-confirm">
+                            @if (_isPersisting)
+                            {
+                                <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2"
+                                                     id="import-confirm-spinner" />
+                            }
+                            @Loc[_isPersisting ? "Import_Importing" : "Import_ConfirmImport"]
+                        </MudButton>
+                    </MudStack>
+                }
             }
         }
     </MudStack>

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
@@ -1,4 +1,5 @@
 using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Common.Modals.AnglerPicker;
 using FishingLogBook.Web.Features.Import.Enums;
@@ -22,6 +23,10 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
     private Guid _speciesId;
     private bool _isLoading = true;
     private bool _selectionLimitExceeded;
+    private bool _isPersisting;
+    private bool _isPersisted;
+    private string? _persistenceError;
+    private ImportPersistenceResultModel? _persistenceResult;
     private IReadOnlyDictionary<Guid, IReadOnlyList<TripSummaryDto>> _existingTrips =
         new Dictionary<Guid, IReadOnlyList<TripSummaryDto>>();
 
@@ -31,6 +36,9 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
     [Inject] private IImportPhotoPreparationService Preparation { get; set; } = default!;
     [Inject] private IImportTripProposalService TripProposalService { get; set; } = default!;
     [Inject] private IImportExistingTripService ExistingTripService { get; set; } = default!;
+    [Inject] private IImportPersistenceService PersistenceService { get; set; } = default!;
+    [Inject] private INetworkService NetworkService { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
 
     private bool CanReview
@@ -297,10 +305,78 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
         }
     }
 
+    private int ActivePhotoCount => ActiveCatchProposals.Sum(proposal => proposal.PhotoIds.Count);
+
+    private int NewTripCount => ActiveTripProposals.Count(
+        proposal => proposal.Decision == ImportTripDecisionEnum.CreateNew);
+
+    private int ExistingTripAssignmentCount => ActiveTripProposals.Count(
+        proposal => proposal.Decision == ImportTripDecisionEnum.UseExisting);
+
+    private int StandaloneCatchCount
+    {
+        get
+        {
+            var assigned = ActiveTripProposals.SelectMany(proposal => proposal.CatchProposalIds).ToHashSet();
+            return ActiveCatchProposals.Count(proposal => !assigned.Contains(proposal.Id));
+        }
+    }
+
+    private async Task PersistAsync()
+    {
+        if (_batch is null || _isPersisting || _isPersisted)
+        {
+            return;
+        }
+
+        _isPersisting = true;
+        try
+        {
+            _persistenceError = null;
+            if (!await NetworkService.IsOnlineAsync(_cancellationTokenSource.Token))
+            {
+                _persistenceError = Loc["Import_OnlineRequired"];
+                return;
+            }
+
+            _persistenceResult = await PersistenceService.PersistAsync(
+                _batch,
+                _cancellationTokenSource.Token);
+            _isPersisted = true;
+            await Preparation.ClearAsync(CancellationToken.None);
+        }
+        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            _persistenceError = Loc["Import_PersistenceFailed"];
+        }
+        finally
+        {
+            _isPersisting = false;
+        }
+    }
+
+    private void NavigateToCatches()
+    {
+        Navigation.NavigateTo("/catches");
+    }
+
+    private void NavigateToTrips()
+    {
+        Navigation.NavigateTo("/trips");
+    }
+
     private async Task AddTripParticipantAsync(ImportTripProposalModel proposal)
     {
         var selected = await ModalService.ShowAsync<AnglerPickerModal, AnglerPickerModalModel, AnglerPickerModalResult>(
-            new AnglerPickerModalModel(proposal.Participants.Select(participant => participant.UserId).ToArray()),
+            new AnglerPickerModalModel(proposal.Participants.Select(participant => participant.UserId).ToArray())
+            {
+                Title = Loc["Import_AddTripParticipant"],
+                ActionLabel = Loc["Import_Add"]
+            },
             _cancellationTokenSource.Token);
         if (selected is not null)
         {

--- a/src/FishingLogBook.Web/Features/Import/Services/IImportPersistenceService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/IImportPersistenceService.cs
@@ -1,0 +1,10 @@
+using FishingLogBook.Web.Features.Import.Models;
+
+namespace FishingLogBook.Web.Features.Import.Services;
+
+public interface IImportPersistenceService
+{
+    Task<ImportPersistenceResultModel> PersistAsync(
+        ImportBatchModel batch,
+        CancellationToken cancellationToken);
+}

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportCatchProposalService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportCatchProposalService.cs
@@ -5,7 +5,7 @@ namespace FishingLogBook.Web.Features.Import.Services;
 
 public sealed class ImportCatchProposalService : IImportCatchProposalService
 {
-    public static readonly TimeSpan SameCatchTimeThreshold = TimeSpan.FromMinutes(2);
+    public static readonly TimeSpan SameCatchTimeThreshold = TimeSpan.FromMinutes(5);
 
     private const double CompatibleLocationDistanceMetres = 250;
     private const double EarthRadiusMetres = 6371000;
@@ -13,30 +13,54 @@ public sealed class ImportCatchProposalService : IImportCatchProposalService
     public IReadOnlyList<ImportCatchProposalModel> Propose(ImportBatchModel batch)
     {
         var photos = batch.Photos.Where(photo => !photo.IsRemoved && photo.IsReady).ToArray();
-        var eligible = photos
+        var explicitInstants = photos
             .Where(HasTrustworthyTimestamp)
             .OrderBy(photo => photo.Timestamp.Instant)
             .ThenBy(photo => photo.SelectionIndex)
             .ToArray();
+        var localWallClocks = photos
+            .Where(HasCompatibleLocalTimestamp)
+            .OrderBy(photo => photo.Timestamp.LocalWallClock)
+            .ThenBy(photo => photo.SelectionIndex)
+            .ToArray();
+        var weakFallbacks = photos
+            .Where(HasCompatibleWeakTimestamp)
+            .OrderBy(photo => photo.Timestamp.Instant)
+            .ThenBy(photo => photo.SelectionIndex)
+            .ToArray();
         var unresolved = photos
-            .Where(photo => !HasTrustworthyTimestamp(photo))
+            .Where(photo => !HasTrustworthyTimestamp(photo)
+                && !HasCompatibleLocalTimestamp(photo)
+                && !HasCompatibleWeakTimestamp(photo))
             .OrderBy(photo => photo.SelectionIndex)
             .ToArray();
 
-        var proposals = GroupEligiblePhotos(eligible, batch);
+        var proposals = GroupEligiblePhotos(
+            explicitInstants,
+            photo => photo.Timestamp.Instant!.Value.UtcDateTime,
+            batch);
+        proposals.AddRange(GroupEligiblePhotos(
+            localWallClocks,
+            photo => photo.Timestamp.LocalWallClock!.Value,
+            batch));
+        proposals.AddRange(GroupEligiblePhotos(
+            weakFallbacks,
+            photo => photo.Timestamp.Instant!.Value.UtcDateTime,
+            batch));
         proposals.AddRange(unresolved.Select(photo => CreateProposal([photo], batch)));
         return proposals;
     }
 
     private static List<ImportCatchProposalModel> GroupEligiblePhotos(
         IReadOnlyList<ImportSelectedPhotoModel> photos,
+        Func<ImportSelectedPhotoModel, DateTime> timestamp,
         ImportBatchModel batch)
     {
         var proposals = new List<ImportCatchProposalModel>();
         var group = new List<ImportSelectedPhotoModel>();
         foreach (var photo in photos)
         {
-            if (group.Count > 0 && photo.Timestamp.Instant - group[^1].Timestamp.Instant > SameCatchTimeThreshold)
+            if (group.Count > 0 && timestamp(photo) - timestamp(group[0]) > SameCatchTimeThreshold)
             {
                 proposals.Add(CreateProposal(group, batch));
                 group = [];
@@ -77,6 +101,18 @@ public sealed class ImportCatchProposalService : IImportCatchProposalService
     private static bool HasTrustworthyTimestamp(ImportSelectedPhotoModel photo)
     {
         return photo.Timestamp.IsResolved && photo.Timestamp.Instant.HasValue;
+    }
+
+    private static bool HasCompatibleLocalTimestamp(ImportSelectedPhotoModel photo)
+    {
+        return photo.Timestamp.State == ImportTimestampStateEnum.LocalWallClock
+            && photo.Timestamp.LocalWallClock.HasValue;
+    }
+
+    private static bool HasCompatibleWeakTimestamp(ImportSelectedPhotoModel photo)
+    {
+        return photo.Timestamp.State == ImportTimestampStateEnum.WeakFallback
+            && photo.Timestamp.Instant.HasValue;
     }
 
     private static ImportCatchProposalReasonEnum TimestampReason(ImportTimestampModel timestamp)

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportExistingTripService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportExistingTripService.cs
@@ -43,8 +43,8 @@ public sealed class ImportExistingTripService : IImportExistingTripService
         return trip.Status == TripConstants.Completed
             && trip.Role is TripParticipantConstants.Owner or TripParticipantConstants.Participant
             && trip.EndedOn.HasValue
-            && trip.StartedOn.DateTime <= proposal.ProposedEndedOn
-            && trip.EndedOn.Value.DateTime >= proposal.ProposedStartedOn;
+            && trip.StartedOn.Date <= proposal.ProposedEndedOn.Date
+            && trip.EndedOn.Value.Date >= proposal.ProposedStartedOn.Date;
     }
 
     private static bool IsSpatiallyCompatible(

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
@@ -336,12 +336,8 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             throw new InvalidOperationException("Every imported Catch requires a reviewed historical date and time.");
         }
 
-        return timestamp.Instant ?? ToInstant(timestamp.LocalWallClock!.Value);
-    }
-
-    private static DateTimeOffset ToInstant(DateTime value)
-    {
-        return new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Local));
+        return timestamp.Instant
+            ?? throw new InvalidOperationException("Every imported Catch requires a deterministic historical instant with an explicitly confirmed UTC offset.");
     }
 
     private static void Validate(ImportBatchModel batch)

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
@@ -1,0 +1,354 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Users.Clients;
+
+namespace FishingLogBook.Web.Features.Import.Services;
+
+public sealed class ImportPersistenceService : IImportPersistenceService
+{
+    private readonly ITripClient _tripClient;
+    private readonly ITripParticipantClient _participantClient;
+    private readonly ICatchClient _catchClient;
+    private readonly ICurrentUserClient _currentUserClient;
+    private readonly IImportPhotoBlobRegistryService _blobRegistry;
+
+    public ImportPersistenceService(
+        ITripClient tripClient,
+        ITripParticipantClient participantClient,
+        ICatchClient catchClient,
+        ICurrentUserClient currentUserClient,
+        IImportPhotoBlobRegistryService blobRegistry)
+    {
+        _tripClient = tripClient;
+        _participantClient = participantClient;
+        _catchClient = catchClient;
+        _currentUserClient = currentUserClient;
+        _blobRegistry = blobRegistry;
+    }
+
+    public async Task<ImportPersistenceResultModel> PersistAsync(
+        ImportBatchModel batch,
+        CancellationToken cancellationToken)
+    {
+        Validate(batch);
+        var currentUser = await _currentUserClient.GetCurrentAsync(cancellationToken);
+        var tripIds = new List<Guid>();
+        var catchIds = new List<Guid>();
+        var participantCount = 0;
+        var photographCount = 0;
+        var tripByCatch = new Dictionary<Guid, Guid>();
+
+        foreach (var proposal in batch.TripProposals.Where(proposal => !proposal.IsRemoved))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var tripId = proposal.Decision == ImportTripDecisionEnum.CreateNew
+                ? await CreateTripAsync(batch, proposal, currentUser.UserId, cancellationToken)
+                : proposal.ExistingTripId;
+            if (tripId.HasValue)
+            {
+                if (proposal.Decision == ImportTripDecisionEnum.CreateNew)
+                {
+                    tripIds.Add(tripId.Value);
+                }
+
+                foreach (var catchId in proposal.CatchProposalIds)
+                {
+                    tripByCatch.Add(catchId, tripId.Value);
+                }
+            }
+
+            if (proposal.Decision == ImportTripDecisionEnum.CreateNew)
+            {
+                participantCount += await PersistParticipantsAsync(
+                    proposal,
+                    currentUser.UserId,
+                    cancellationToken);
+                await RequireTripAsync(batch, proposal, currentUser.UserId, cancellationToken);
+            }
+        }
+
+        foreach (var proposal in batch.CatchProposals.Where(proposal => !proposal.IsRemoved))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            tripByCatch.TryGetValue(proposal.Id, out var tripId);
+            var persisted = await PersistCatchAsync(
+                batch,
+                proposal,
+                currentUser.UserId,
+                tripId == Guid.Empty ? null : tripId,
+                cancellationToken);
+            catchIds.Add(persisted.Id);
+            photographCount += persisted.Photographs.Count;
+        }
+
+        return new ImportPersistenceResultModel(
+            tripIds.Distinct().ToArray(),
+            catchIds,
+            photographCount,
+            participantCount);
+    }
+
+    private async Task<Guid> CreateTripAsync(
+        ImportBatchModel batch,
+        ImportTripProposalModel proposal,
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        var trip = new TripDto(
+            proposal.Id,
+            proposal.ProposedStatus,
+            TripStartedOn(batch, proposal),
+            TripEndedOn(batch, proposal),
+            ToTripLocation(batch, proposal))
+        {
+            OwnerUserId = ownerUserId,
+            Title = proposal.ProposedTitle,
+            PlaceName = proposal.ProposedPlaceName
+        };
+        var persisted = await _tripClient.UpsertAsync(trip, cancellationToken)
+            ?? throw new InvalidOperationException("The authoritative Trip create response was missing.");
+        if (persisted.Id != proposal.Id)
+        {
+            throw new InvalidOperationException("The authoritative Trip identity did not match the Import proposal.");
+        }
+
+        return persisted.Id;
+    }
+
+    private async Task<int> PersistParticipantsAsync(
+        ImportTripProposalModel proposal,
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        var current = await _participantClient.GetAsync(proposal.Id, cancellationToken)
+            ?? throw new InvalidOperationException("The new Trip participants could not be read.");
+        var existing = current.Participants.Select(participant => participant.UserId).ToHashSet();
+        existing.Add(ownerUserId);
+        var added = 0;
+        foreach (var participant in proposal.Participants.DistinctBy(participant => participant.UserId))
+        {
+            if (existing.Contains(participant.UserId))
+            {
+                continue;
+            }
+
+            var response = await _participantClient.InviteAsync(
+                proposal.Id,
+                new InviteTripParticipantDto(participant.UserId),
+                cancellationToken);
+            if (response is null)
+            {
+                throw new InvalidOperationException("A selected Trip participant could not be invited.");
+            }
+
+            existing.Add(participant.UserId);
+            added++;
+        }
+
+        var verified = await _participantClient.GetAsync(proposal.Id, cancellationToken)
+            ?? throw new InvalidOperationException("The new Trip participants could not be verified.");
+        if (proposal.Participants.Any(participant =>
+                participant.UserId != ownerUserId
+                && verified.Participants.All(actual => actual.UserId != participant.UserId)))
+        {
+            throw new InvalidOperationException("The authoritative Trip participant state is incomplete.");
+        }
+
+        return added;
+    }
+
+    private async Task<CatchViewDto> PersistCatchAsync(
+        ImportBatchModel batch,
+        ImportCatchProposalModel proposal,
+        Guid userId,
+        Guid? tripId,
+        CancellationToken cancellationToken)
+    {
+        var caughtOn = ToInstant(proposal.CaughtOn);
+        var location = ToLocation(proposal.Location, caughtOn);
+        var photographs = proposal.PhotoIds
+            .Select(photoId => batch.Photos.Single(photo => photo.Id == photoId && !photo.IsRemoved))
+            .Select(photo => new CatchPhotographDto(photo.Id, proposal.Id, photo.ContentType))
+            .ToArray();
+        var request = new CatchDto(proposal.Id, caughtOn, photographs, location)
+        {
+            CaughtByUserId = userId,
+            RecordedByUserId = userId,
+            TripId = tripId,
+            SpeciesName = proposal.Species.Name,
+            Method = proposal.Method.Name,
+            Weight = proposal.Weight,
+            Length = proposal.Length
+        };
+        var persisted = await _catchClient.UpsertAsync(request, cancellationToken)
+            ?? throw new InvalidOperationException("The authoritative Catch create response was missing.");
+        if (persisted.Id != proposal.Id || persisted.TripId != tripId)
+        {
+            throw new InvalidOperationException("The authoritative Catch identity or Trip relationship is incorrect.");
+        }
+
+        var current = await RequireCatchAsync(proposal.Id, cancellationToken);
+        foreach (var photoId in proposal.PhotoIds)
+        {
+            var photo = batch.Photos.Single(candidate => candidate.Id == photoId && !candidate.IsRemoved);
+            if (string.IsNullOrWhiteSpace(photo.BlobToken))
+            {
+                throw new InvalidOperationException("An imported photograph has no prepared bytes.");
+            }
+
+            var bytes = await _blobRegistry.GetBytesAsync(photo.BlobToken, cancellationToken);
+            var upload = await _catchClient.CreatePhotographUploadAsync(
+                proposal.Id,
+                new PhotographUploadRequestDto(photo.Id, photo.ContentType),
+                cancellationToken);
+            await _catchClient.UploadPhotographAsync(upload.UploadUrl, bytes, photo.ContentType, cancellationToken);
+            await _catchClient.RecordPhotographAsync(
+                proposal.Id,
+                new RecordPhotographDto(photo.Id, upload.ObjectKey, photo.ContentType),
+                cancellationToken);
+            current = await RequireCatchAsync(proposal.Id, cancellationToken);
+        }
+
+        if (!HasExpectedCatch(current, request)
+            || proposal.PhotoIds.Any(photoId => current.Photographs.All(photo => photo.Id != photoId)))
+        {
+            throw new InvalidOperationException("The authoritative Catch state is incomplete.");
+        }
+
+        return current;
+    }
+
+    private static bool HasExpectedCatch(CatchViewDto current, CatchDto expected)
+    {
+        return current.Id == expected.Id
+            && current.CaughtOn == expected.CaughtOn
+            && current.CaughtByUserId == expected.CaughtByUserId
+            && current.RecordedByUserId == expected.RecordedByUserId
+            && current.TripId == expected.TripId
+            && string.Equals(current.SpeciesName, expected.SpeciesName, StringComparison.Ordinal)
+            && string.Equals(current.Method, expected.Method, StringComparison.Ordinal)
+            && current.Weight == expected.Weight
+            && current.Length == expected.Length
+            && HasExpectedLocation(current.Location, expected.Location);
+    }
+
+    private static bool HasExpectedLocation(CatchLocationExposureDto? current, CatchLocationDto? expected)
+    {
+        if (current is null || expected is null)
+        {
+            return current is null && expected is null;
+        }
+
+        return current.Latitude == expected.Latitude
+            && current.Longitude == expected.Longitude
+            && current.CapturedOn == expected.CapturedOn
+            && string.Equals(current.Source, expected.Source, StringComparison.Ordinal)
+            && string.Equals(current.Visibility, expected.Visibility, StringComparison.Ordinal);
+    }
+
+    private async Task RequireTripAsync(
+        ImportBatchModel batch,
+        ImportTripProposalModel expected,
+        Guid ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        var detail = await _tripClient.GetDetailAsync(expected.Id, cancellationToken);
+        var trip = detail?.Trip;
+        if (trip is null
+            || trip.Id != expected.Id
+            || trip.OwnerUserId != ownerUserId
+            || trip.Status != expected.ProposedStatus
+            || trip.StartedOn != TripStartedOn(batch, expected)
+            || trip.EndedOn != TripEndedOn(batch, expected))
+        {
+            throw new InvalidOperationException("The authoritative Trip could not be verified.");
+        }
+    }
+
+    private static TripLocationDto? ToTripLocation(
+        ImportBatchModel batch,
+        ImportTripProposalModel proposal)
+    {
+        var location = proposal.RepresentativeLocation;
+        if (location is not { Decision: ImportLocationDecisionEnum.Accepted, HasCanonicalCoordinates: true })
+        {
+            return null;
+        }
+
+        return new TripLocationDto(
+            location.Latitude!.Value,
+            location.Longitude!.Value,
+            null,
+            TripStartedOn(batch, proposal),
+            LocationDefaults.PhotoMetadata,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+    }
+
+    private static DateTimeOffset TripStartedOn(
+        ImportBatchModel batch,
+        ImportTripProposalModel proposal)
+    {
+        return proposal.CatchProposalIds
+            .Select(catchId => batch.CatchProposals.Single(candidate => candidate.Id == catchId))
+            .Min(candidate => ToInstant(candidate.CaughtOn));
+    }
+
+    private static DateTimeOffset TripEndedOn(
+        ImportBatchModel batch,
+        ImportTripProposalModel proposal)
+    {
+        return proposal.CatchProposalIds
+            .Select(catchId => batch.CatchProposals.Single(candidate => candidate.Id == catchId))
+            .Max(candidate => ToInstant(candidate.CaughtOn));
+    }
+
+    private async Task<CatchViewDto> RequireCatchAsync(Guid catchId, CancellationToken cancellationToken)
+    {
+        return await _catchClient.GetAsync(catchId, cancellationToken)
+            ?? throw new InvalidOperationException("The authoritative Catch could not be verified.");
+    }
+
+    private static CatchLocationDto? ToLocation(ImportLocationModel? location, DateTimeOffset caughtOn)
+    {
+        if (location is not { Decision: ImportLocationDecisionEnum.Accepted, HasCanonicalCoordinates: true })
+        {
+            return null;
+        }
+
+        return new CatchLocationDto(
+            location.Latitude!.Value,
+            location.Longitude!.Value,
+            null,
+            caughtOn,
+            LocationDefaults.PhotoMetadata,
+            LocationDefaults.Private,
+            LocationDefaults.ConsentVersion);
+    }
+
+    private static DateTimeOffset ToInstant(ImportTimestampModel timestamp)
+    {
+        if (!timestamp.IsResolved)
+        {
+            throw new InvalidOperationException("Every imported Catch requires a reviewed historical date and time.");
+        }
+
+        return timestamp.Instant ?? ToInstant(timestamp.LocalWallClock!.Value);
+    }
+
+    private static DateTimeOffset ToInstant(DateTime value)
+    {
+        return new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Local));
+    }
+
+    private static void Validate(ImportBatchModel batch)
+    {
+        if (!batch.IsReadyForConfirmation)
+        {
+            throw new InvalidOperationException("The Import batch is not ready for persistence.");
+        }
+    }
+}

--- a/src/FishingLogBook.Web/Features/Photographs/Components/PhotographGridSelector/PhotographGridSelector.razor
+++ b/src/FishingLogBook.Web/Features/Photographs/Components/PhotographGridSelector/PhotographGridSelector.razor
@@ -1,0 +1,36 @@
+@namespace FishingLogBook.Web.Features.Photographs.Components.PhotographGridSelector
+@using FishingLogBook.Web.Features.Photographs.Models
+
+<div class="photograph-grid-selector" id="@($"{IdPrefix}-photos")">
+    <div class="photograph-grid-selector-grid">
+        @for (var index = 0; index < Photographs.Count; index++)
+        {
+            var photograph = Photographs[index];
+            var photographNumber = index + 1;
+            <div class="photograph-grid-selector-choice">
+                <MudCheckBox T="bool"
+                             Value="@_selectedIds.Contains(photograph.Id)"
+                             ValueChanged="@(selected => SelectAsync(photograph.Id, selected))"
+                             aria-label="@Loc["Photograph_SelectNumbered", photographNumber]"
+                             id="@($"{IdPrefix}-select-{index}")" />
+                <button type="button" class="photograph-grid-selector-open"
+                        @onclick="@(() => OpenAsync(photograph.Id))"
+                        aria-label="@Loc["Photograph_AltNumbered", photographNumber, Photographs.Count]"
+                        id="@($"{IdPrefix}-open-{index}")">
+                    <MudImage Src="@ToPhotoUrl(photograph)"
+                              Alt="@Loc["Photograph_AltNumbered", photographNumber, Photographs.Count]"
+                              ObjectFit="ObjectFit.Cover"
+                              Class="photograph-grid-selector-thumbnail"
+                              id="@($"{IdPrefix}-photo-{index}")" />
+                </button>
+            </div>
+        }
+    </div>
+
+    @if (_selectedIds.Count > 0 && SelectedActions is not null)
+    {
+        <div class="photograph-grid-selector-actions" id="@($"{IdPrefix}-selected-actions")">
+            @SelectedActions(_selectedIds.Count)
+        </div>
+    }
+</div>

--- a/src/FishingLogBook.Web/Features/Photographs/Components/PhotographGridSelector/PhotographGridSelector.razor.cs
+++ b/src/FishingLogBook.Web/Features/Photographs/Components/PhotographGridSelector/PhotographGridSelector.razor.cs
@@ -1,0 +1,50 @@
+using FishingLogBook.Web.Features.Photographs.Models;
+using FishingLogBook.Web.Localization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+
+namespace FishingLogBook.Web.Features.Photographs.Components.PhotographGridSelector;
+
+public partial class PhotographGridSelector : ComponentBase
+{
+    private readonly HashSet<Guid> _selectedIds = [];
+
+    [Parameter, EditorRequired] public IReadOnlyList<PhotographCarouselItemModel> Photographs { get; set; } = [];
+    [Parameter, EditorRequired] public string IdPrefix { get; set; } = string.Empty;
+    [Parameter] public EventCallback<IReadOnlySet<Guid>> SelectedIdsChanged { get; set; }
+    [Parameter] public EventCallback<Guid?> ActivePhotographIdChanged { get; set; }
+    [Parameter] public RenderFragment<int>? SelectedActions { get; set; }
+
+    [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+
+    protected override void OnParametersSet()
+    {
+        _selectedIds.RemoveWhere(selectedId => Photographs.All(photo => photo.Id != selectedId));
+    }
+
+    private async Task SelectAsync(Guid photographId, bool selected)
+    {
+        if (selected)
+        {
+            _selectedIds.Add(photographId);
+        }
+        else
+        {
+            _selectedIds.Remove(photographId);
+        }
+
+        await SelectedIdsChanged.InvokeAsync(_selectedIds);
+    }
+
+    private static string? ToPhotoUrl(PhotographCarouselItemModel photograph)
+    {
+        return photograph.Bytes is { Length: > 0 }
+            ? $"data:{photograph.ContentType};base64,{Convert.ToBase64String(photograph.Bytes)}"
+            : photograph.RemoteUrl;
+    }
+
+    private Task OpenAsync(Guid photographId)
+    {
+        return ActivePhotographIdChanged.InvokeAsync(photographId);
+    }
+}

--- a/src/FishingLogBook.Web/Features/Photographs/Components/PhotographGridSelector/PhotographGridSelector.razor.css
+++ b/src/FishingLogBook.Web/Features/Photographs/Components/PhotographGridSelector/PhotographGridSelector.razor.css
@@ -1,0 +1,42 @@
+.photograph-grid-selector-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 5.5rem);
+    gap: 0.5rem;
+}
+
+.photograph-grid-selector-choice {
+    position: relative;
+    min-width: 0;
+    width: 5.5rem;
+}
+
+.photograph-grid-selector-open {
+    display: block;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+}
+
+.photograph-grid-selector-choice .mud-checkbox {
+    position: absolute;
+    z-index: 1;
+    background: var(--mud-palette-surface);
+    border-radius: 50%;
+}
+
+::deep .photograph-grid-selector-thumbnail {
+    width: 100%;
+    height: 5.5rem;
+    aspect-ratio: 1;
+    object-fit: cover;
+    border-radius: 0.5rem;
+}
+
+.photograph-grid-selector-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripSelector/TripSelector.razor
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripSelector/TripSelector.razor
@@ -1,0 +1,22 @@
+@namespace FishingLogBook.Web.Features.Trips.Components.TripSelector
+
+<MudStack Spacing="1" id="trip-selector">
+    @if (!string.IsNullOrWhiteSpace(Label))
+    {
+        <MudText Typo="Typo.caption">@Label</MudText>
+    }
+    <MudStack Row="true" Spacing="1" Class="flex-wrap" id="trip-selector-options">
+        @foreach (var trip in Trips)
+        {
+            var selected = trip.Id == SelectedTripId;
+            <MudChip T="Guid"
+                     Value="trip.Id"
+                     Color="@(selected ? Color.Primary : Color.Default)"
+                     Variant="@(selected ? Variant.Filled : Variant.Outlined)"
+                     OnClick="@(() => SelectAsync(trip.Id))"
+                     id="@($"trip-selector-{trip.Id:D}")">
+                @DisplayLabel(trip)
+            </MudChip>
+        }
+    </MudStack>
+</MudStack>

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripSelector/TripSelector.razor.cs
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripSelector/TripSelector.razor.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+using FishingLogBook.Shared.Dtos;
+using Microsoft.AspNetCore.Components;
+
+namespace FishingLogBook.Web.Features.Trips.Components.TripSelector;
+
+public partial class TripSelector : ComponentBase
+{
+    [Parameter]
+    [EditorRequired]
+    public IReadOnlyList<TripSummaryDto> Trips { get; set; } = [];
+
+    [Parameter]
+    public Guid? SelectedTripId { get; set; }
+
+    [Parameter]
+    public EventCallback<Guid> SelectedTripIdChanged { get; set; }
+
+    [Parameter]
+    public string? Label { get; set; }
+
+    private async Task SelectAsync(Guid tripId)
+    {
+        if (SelectedTripIdChanged.HasDelegate)
+        {
+            await SelectedTripIdChanged.InvokeAsync(tripId);
+        }
+    }
+
+    private static string DisplayLabel(TripSummaryDto trip)
+    {
+        return string.IsNullOrWhiteSpace(trip.Title)
+            ? trip.StartedOn.ToString("g", CultureInfo.CurrentCulture)
+            : trip.Title;
+    }
+}

--- a/src/FishingLogBook.Web/Features/Trips/Components/TripSelector/TripSelector.razor.css
+++ b/src/FishingLogBook.Web/Features/Trips/Components/TripSelector/TripSelector.razor.css
@@ -1,0 +1,3 @@
+#trip-selector-options {
+    align-items: center;
+}

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1390,6 +1390,8 @@
   <data name="Import_CaughtOn" xml:space="preserve"><value>Date et heure de la prise</value></data>
   <data name="Import_CaughtOnRequired" xml:space="preserve"><value>Saisissez une date et une heure historiques valides.</value></data>
   <data name="Import_ConfirmCaughtOn" xml:space="preserve"><value>Confirmer la date et lâ€™heure</value></data>
+  <data name="Import_UtcOffset" xml:space="preserve"><value>Décalage UTC</value></data>
+  <data name="Import_UtcOffsetRequired" xml:space="preserve"><value>Choisissez le décalage UTC historique.</value></data>
   <data name="Import_SelectPhoto" xml:space="preserve"><value>SÃ©lectionner la photographie {0}</value></data>
   <data name="Import_UsePhotoLocation" xml:space="preserve"><value>Utiliser le lieu de la photo {0}</value></data>
   <data name="Import_RemoveLocation" xml:space="preserve"><value>Supprimer le lieu</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -195,6 +195,9 @@
   <data name="Photograph_AltNumbered" xml:space="preserve">
     <value>Photographie de la prise {0} sur {1}</value>
   </data>
+  <data name="Photograph_SelectNumbered" xml:space="preserve">
+    <value>Sélectionner la photographie {0}</value>
+  </data>
   <data name="Photograph_Unsupported" xml:space="preserve">
     <value>Ce format de photo n'est pas pris en charge. Utilisez JPEG, PNG ou WebP.</value>
   </data>
@@ -1381,6 +1384,7 @@
   <data name="Import_Reviewed" xml:space="preserve"><value>VÃ©rifiÃ©e</value></data>
   <data name="Import_NeedsCorrection" xml:space="preserve"><value>À vérifier</value></data>
   <data name="Import_ReviewEdit" xml:space="preserve"><value>Vérifier</value></data>
+  <data name="Import_Edit" xml:space="preserve"><value>Modifier</value></data>
   <data name="Import_ConfirmCatch" xml:space="preserve"><value>Confirmer la prise</value></data>
   <data name="Import_CorrectCatches" xml:space="preserve"><value>Corriger les prises</value></data>
   <data name="Import_CaughtOn" xml:space="preserve"><value>Date et heure de la prise</value></data>
@@ -1393,7 +1397,7 @@
   <data name="Import_LocationRemoved" xml:space="preserve"><value>Lieu supprimÃ©</value></data>
   <data name="Import_MoveToNewCatch" xml:space="preserve"><value>DÃ©placer la sÃ©lection vers une nouvelle prise</value></data>
   <data name="Import_RemoveSelectedPhotos" xml:space="preserve"><value>Supprimer les photos sÃ©lectionnÃ©es</value></data>
-  <data name="Import_MergeWith" xml:space="preserve"><value>Fusionner avecâ€¦</value></data>
+  <data name="Import_MergeWith" xml:space="preserve"><value>Fusionner avec...</value></data>
   <data name="Import_RemoveCatch" xml:space="preserve"><value>Retirer la prise de lâ€™importation</value></data>
   <data name="Import_CorrectionsComplete" xml:space="preserve"><value>Toutes les prises sont vÃ©rifiÃ©es et prÃªtes pour les suggestions de sorties.</value></data>
   <data name="Import_MergeValuesNeedReview" xml:space="preserve"><value>Les prises fusionnÃ©es avaient des informations diffÃ©rentes. VÃ©rifiez les valeurs affichÃ©es avant de confirmer.</value></data>
@@ -1408,6 +1412,8 @@
   <data name="Import_TripTimeRange" xml:space="preserve"><value>{0} – {1}</value></data>
   <data name="Import_TripMissingGps" xml:space="preserve"><value>Les informations de localisation sont incomplètes pour cette suggestion.</value></data>
   <data name="Import_CreateTrip" xml:space="preserve"><value>Créer une sortie</value></data>
+  <data name="Import_CreateAnotherTrip" xml:space="preserve"><value>Créer une autre sortie</value></data>
+  <data name="Import_ExistingTripFound" xml:space="preserve"><value>Une sortie existe déjà à cette date. Ajoutez-y ces prises ou créez délibérément une autre sortie.</value></data>
   <data name="Import_KeepSeparate" xml:space="preserve"><value>Conserver les prises séparément</value></data>
   <data name="Import_AddToExistingTrip" xml:space="preserve"><value>Ajouter à une sortie existante</value></data>
   <data name="Import_RemoveCatchFromTrip" xml:space="preserve"><value>Retirer la prise de la sortie suggérée</value></data>
@@ -1416,4 +1422,18 @@
   <data name="Import_TripCatchPhotoAlt" xml:space="preserve"><value>Miniature de la prise {0}</value></data>
   <data name="Import_TripParticipants" xml:space="preserve"><value>Pêcheurs de cette sortie</value></data>
   <data name="Import_AddTripParticipant" xml:space="preserve"><value>Ajouter un pêcheur</value></data>
+  <data name="Import_Add" xml:space="preserve"><value>Ajouter</value></data>
+  <data name="Import_ConfirmTitle" xml:space="preserve"><value>Confirmer l’importation historique</value></data>
+  <data name="Import_SummaryCatches" xml:space="preserve"><value>Prises : {0}</value></data>
+  <data name="Import_SummaryPhotos" xml:space="preserve"><value>Photographies : {0}</value></data>
+  <data name="Import_SummaryNewTrips" xml:space="preserve"><value>Nouvelles sorties : {0}</value></data>
+  <data name="Import_SummaryExistingTrips" xml:space="preserve"><value>Affectations à des sorties existantes : {0}</value></data>
+  <data name="Import_SummaryStandalone" xml:space="preserve"><value>Prises indépendantes : {0}</value></data>
+  <data name="Import_ConfirmImport" xml:space="preserve"><value>Importer les prises</value></data>
+  <data name="Import_Importing" xml:space="preserve"><value>Importation…</value></data>
+  <data name="Import_OnlineRequired" xml:space="preserve"><value>L’importation historique nécessite une connexion Internet.</value></data>
+  <data name="Import_PersistenceFailed" xml:space="preserve"><value>L’importation n’a pas pu être terminée. Vos choix vérifiés restent disponibles pendant cette session.</value></data>
+  <data name="Import_Success" xml:space="preserve"><value>{0} prises, {1} photographies et {2} sorties ont été importées.</value></data>
+  <data name="Import_ViewCatches" xml:space="preserve"><value>Voir les prises</value></data>
+  <data name="Import_ViewTrips" xml:space="preserve"><value>Voir les sorties</value></data>
 </root>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1390,6 +1390,8 @@
   <data name="Import_CaughtOn" xml:space="preserve"><value>Caught on</value></data>
   <data name="Import_CaughtOnRequired" xml:space="preserve"><value>Enter a valid historical date and time.</value></data>
   <data name="Import_ConfirmCaughtOn" xml:space="preserve"><value>Confirm date and time</value></data>
+  <data name="Import_UtcOffset" xml:space="preserve"><value>UTC offset</value></data>
+  <data name="Import_UtcOffsetRequired" xml:space="preserve"><value>Choose the historical UTC offset.</value></data>
   <data name="Import_SelectPhoto" xml:space="preserve"><value>Select photograph {0}</value></data>
   <data name="Import_UsePhotoLocation" xml:space="preserve"><value>Use photo {0} location</value></data>
   <data name="Import_RemoveLocation" xml:space="preserve"><value>Remove location</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -195,6 +195,9 @@
   <data name="Photograph_AltNumbered" xml:space="preserve">
     <value>Catch photograph {0} of {1}</value>
   </data>
+  <data name="Photograph_SelectNumbered" xml:space="preserve">
+    <value>Select photograph {0}</value>
+  </data>
   <data name="Photograph_Unsupported" xml:space="preserve">
     <value>This photo format isn't supported. Please use JPEG, PNG or WebP.</value>
   </data>
@@ -1381,6 +1384,7 @@
   <data name="Import_Reviewed" xml:space="preserve"><value>Reviewed</value></data>
   <data name="Import_NeedsCorrection" xml:space="preserve"><value>Needs review</value></data>
   <data name="Import_ReviewEdit" xml:space="preserve"><value>Review</value></data>
+  <data name="Import_Edit" xml:space="preserve"><value>Edit</value></data>
   <data name="Import_ConfirmCatch" xml:space="preserve"><value>Confirm catch</value></data>
   <data name="Import_CorrectCatches" xml:space="preserve"><value>Correct catches</value></data>
   <data name="Import_CaughtOn" xml:space="preserve"><value>Caught on</value></data>
@@ -1393,7 +1397,7 @@
   <data name="Import_LocationRemoved" xml:space="preserve"><value>Location removed</value></data>
   <data name="Import_MoveToNewCatch" xml:space="preserve"><value>Move selected to new catch</value></data>
   <data name="Import_RemoveSelectedPhotos" xml:space="preserve"><value>Remove selected photos</value></data>
-  <data name="Import_MergeWith" xml:space="preserve"><value>Merge withâ€¦</value></data>
+  <data name="Import_MergeWith" xml:space="preserve"><value>Merge with...</value></data>
   <data name="Import_RemoveCatch" xml:space="preserve"><value>Remove catch from import</value></data>
   <data name="Import_CorrectionsComplete" xml:space="preserve"><value>All catches are reviewed and ready for Trip suggestions.</value></data>
   <data name="Import_MergeValuesNeedReview" xml:space="preserve"><value>The merged catches had different details. Review the shown values before confirming.</value></data>
@@ -1408,6 +1412,8 @@
   <data name="Import_TripTimeRange" xml:space="preserve"><value>{0} – {1}</value></data>
   <data name="Import_TripMissingGps" xml:space="preserve"><value>Location evidence is incomplete for this suggestion.</value></data>
   <data name="Import_CreateTrip" xml:space="preserve"><value>Create Trip</value></data>
+  <data name="Import_CreateAnotherTrip" xml:space="preserve"><value>Create another Trip</value></data>
+  <data name="Import_ExistingTripFound" xml:space="preserve"><value>An existing Trip was found on this date. Add these catches to it, or deliberately create another Trip.</value></data>
   <data name="Import_KeepSeparate" xml:space="preserve"><value>Keep as separate catches</value></data>
   <data name="Import_AddToExistingTrip" xml:space="preserve"><value>Add to existing Trip</value></data>
   <data name="Import_RemoveCatchFromTrip" xml:space="preserve"><value>Remove catch from suggested Trip</value></data>
@@ -1416,4 +1422,18 @@
   <data name="Import_TripCatchPhotoAlt" xml:space="preserve"><value>Thumbnail for Catch {0}</value></data>
   <data name="Import_TripParticipants" xml:space="preserve"><value>Anglers on this Trip</value></data>
   <data name="Import_AddTripParticipant" xml:space="preserve"><value>Add angler</value></data>
+  <data name="Import_Add" xml:space="preserve"><value>Add</value></data>
+  <data name="Import_ConfirmTitle" xml:space="preserve"><value>Confirm historical import</value></data>
+  <data name="Import_SummaryCatches" xml:space="preserve"><value>Catches: {0}</value></data>
+  <data name="Import_SummaryPhotos" xml:space="preserve"><value>Photographs: {0}</value></data>
+  <data name="Import_SummaryNewTrips" xml:space="preserve"><value>New Trips: {0}</value></data>
+  <data name="Import_SummaryExistingTrips" xml:space="preserve"><value>Existing Trip assignments: {0}</value></data>
+  <data name="Import_SummaryStandalone" xml:space="preserve"><value>Standalone catches: {0}</value></data>
+  <data name="Import_ConfirmImport" xml:space="preserve"><value>Import catches</value></data>
+  <data name="Import_Importing" xml:space="preserve"><value>Importing…</value></data>
+  <data name="Import_OnlineRequired" xml:space="preserve"><value>Historical Import requires an internet connection.</value></data>
+  <data name="Import_PersistenceFailed" xml:space="preserve"><value>The import could not be completed. Your reviewed choices remain available in this session.</value></data>
+  <data name="Import_Success" xml:space="preserve"><value>Imported {0} catches, {1} photographs and {2} Trips successfully.</value></data>
+  <data name="Import_ViewCatches" xml:space="preserve"><value>View catches</value></data>
+  <data name="Import_ViewTrips" xml:space="preserve"><value>View Trips</value></data>
 </root>

--- a/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
+++ b/src/FishingLogBook.Web/ServiceCollectionExtensions.cs
@@ -115,6 +115,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IImportPhotoPreparationService, ImportPhotoPreparationService>();
         services.AddScoped<IImportCatchProposalService, ImportCatchProposalService>();
         services.AddScoped<IImportTripProposalService, ImportTripProposalService>();
+        services.AddScoped<IImportPersistenceService, ImportPersistenceService>();
         services.AddScoped<IImportExistingTripService, ImportExistingTripService>();
         services.AddScoped<ICatchPhotographProposalService, CatchPhotographProposalService>();
         services.AddSingleton<DiagnosticStatusModel>();

--- a/tests/FishingLogBook.Web.Tests/Common/Modals/AnglerPickerModalTests/WhenTestingSelect.cs
+++ b/tests/FishingLogBook.Web.Tests/Common/Modals/AnglerPickerModalTests/WhenTestingSelect.cs
@@ -10,6 +10,30 @@ namespace FishingLogBook.Web.Tests.Common.Modals.AnglerPickerModalTests;
 public class WhenTestingSelect : BaseAnglerPickerModalTest
 {
     [Fact]
+    public async Task ItShouldRenderContextSpecificSelectionLabels()
+    {
+        // Arrange
+        var angler = new AnglerSummaryDto(Guid.NewGuid(), "Patrick", null, "Galway", null);
+        var profileClient = Substitute.For<IProfileClient>();
+        profileClient.FindAnglersAsync("Patrick", Arg.Any<CancellationToken>()).Returns([angler]);
+        await using var context = CreateContext(profileClient);
+        var model = new AnglerPickerModalModel
+        {
+            Title = "Add angler",
+            ActionLabel = "Add"
+        };
+        var (cut, _) = await ShowAsync(context, model);
+
+        // Act
+        await cut.Find("#angler-picker-search").InputAsync(new() { Value = "Patrick" });
+
+        // Assert
+        cut.Find("#angler-picker-title").TextContent.Should().Be("Add angler");
+        cut.WaitForElement($"#angler-picker-select-{angler.UserId:D}").TextContent.Should().Be("Add");
+        await profileClient.Received(1).FindAnglersAsync("Patrick", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldReturnTheSelectedAnglerWithoutPersistingAnything()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -12,6 +12,7 @@ using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Tests.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
 using MudBlazor;
+using MudBlazor.Extensions;
 using MudBlazor.Services;
 using NSubstitute;
 
@@ -66,6 +67,7 @@ public class WhenTestingRender
         // Assert
         cut.Find("#import-catch-1-timestamp").TextContent.Should().Contain("+01:00");
         cut.Find("#import-catch-1-status").TextContent.Should().Contain("Ready");
+        cut.FindAll("#import-catch-1-utc-offset").Should().BeEmpty();
     }
 
     [Fact]
@@ -241,12 +243,37 @@ public class WhenTestingRender
 
         // Act
         cut.Find("#import-catch-1-confirm-caught-on").Click();
+        cut.Find("#import-catch-1-continue").Click();
+
+        // Assert
+        proposal.IsReadyForConfirmation.Should().BeFalse();
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        cut.Find("#import-catch-1-editor").Should().NotBeNull();
+        cut.Find("#import-catch-1-utc-offset").Should().NotBeNull();
+        var offsets = cut.FindComponents<MudSelectItem<TimeSpan?>>()
+            .Select(item => item.Instance.GetState(component => component.Value))
+            .ToArray();
+        offsets.Should().HaveCount(53);
+        offsets.Should().Contain(TimeSpan.FromHours(-12));
+        offsets.Should().Contain(TimeSpan.FromHours(5.5));
+        offsets.Should().Contain(TimeSpan.FromHours(14));
+
+        // Act
+        await SelectUtcOffsetAsync(cut, TimeSpan.FromHours(5.5));
+        cut.Find("#import-catch-1-confirm-caught-on").Click();
         cut.Find("#import-catch-1-close-editor").Click();
 
         // Assert
-        proposal.CaughtOn.Instant.Should().BeNull();
+        proposal.CaughtOn.Instant.Should().Be(
+            new DateTimeOffset(2024, 6, 14, 9, 20, 0, TimeSpan.FromHours(5.5)));
         proposal.CaughtOn.LocalWallClock.Should().Be(new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Unspecified));
         cut.Find("#import-catch-1-status").TextContent.Should().Contain("Ready");
+
+        // Act
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Assert
+        cut.FindComponent<MudSelect<TimeSpan?>>().Instance.GetState(x => x.Value).Should().Be(TimeSpan.FromHours(5.5));
     }
 
     [Fact]
@@ -270,10 +297,13 @@ public class WhenTestingRender
 
         // Act
         cut.Find("#import-catch-1-caught-on").Input("09/04/2026 03:06 PM");
+        await SelectUtcOffsetAsync(cut, TimeSpan.FromHours(-5));
         cut.Find("#import-catch-1-confirm-caught-on").Click();
 
         // Assert
         proposal.CaughtOn.LocalWallClock.Should().Be(new DateTime(2026, 4, 9, 15, 6, 0));
+        proposal.CaughtOn.Instant.Should().Be(
+            new DateTimeOffset(2026, 4, 9, 15, 6, 0, TimeSpan.FromHours(-5)));
         cut.FindAll(".mud-input-error").Should().BeEmpty();
     }
 
@@ -297,6 +327,7 @@ public class WhenTestingRender
 
         // Act
         cut.Find("#import-catch-1-caught-on").Input("09/04/2026 03:06 PM");
+        await SelectUtcOffsetAsync(cut, TimeSpan.FromHours(1));
         cut.Find("#import-catch-1-continue").Click();
 
         // Assert
@@ -483,5 +514,12 @@ public class WhenTestingRender
             new FishingPreferencesDto([]),
             WeightUnitEnum.Kg,
             LengthUnitEnum.Cm);
+    }
+
+    private static Task SelectUtcOffsetAsync(
+        IRenderedComponent<ImportCatchReviewCard> cut,
+        TimeSpan offset)
+    {
+        return cut.InvokeAsync(() => cut.FindComponent<MudSelect<TimeSpan?>>().Instance.ValueChanged.InvokeAsync(offset));
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -11,6 +11,7 @@ using FishingLogBook.Web.Features.Import.Models;
 using FishingLogBook.Web.Features.Profile.Models;
 using FishingLogBook.Web.Tests.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
+using MudBlazor;
 using MudBlazor.Services;
 using NSubstitute;
 
@@ -83,14 +84,97 @@ public class WhenTestingRender
             .Add(component => component.Editable, true));
 
         // Act
-        var review = cut.Find("#import-catch-1-edit");
+        var reviewLabel = cut.Find("#import-catch-1-edit").TextContent;
         cut.Find("#import-catch-1-confirm").Click();
 
         // Assert
-        review.TextContent.Should().Contain("Review");
+        reviewLabel.Should().Contain("Review");
         proposal.CaughtOn.State.Should().Be(ImportTimestampStateEnum.UserConfirmed);
         proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
         cut.Find("#import-catch-1-status").TextContent.Should().Contain("Reviewed");
+        cut.Find("#import-catch-1-edit").TextContent.Should().Contain("Edit");
+        cut.FindAll("#import-catch-1-confirm").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldUseTheActiveCarouselPhotographTimestampForConfirmation()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var firstTimestamp = ImportTimestampModel.FromWeakFallback(CapturedOn);
+        var secondTimestamp = ImportTimestampModel.FromWeakFallback(CapturedOn.AddMinutes(4));
+        var firstPhoto = Photo(firstTimestamp);
+        var secondPhoto = Photo(secondTimestamp, 1);
+        var proposal = new ImportCatchProposalModel(
+            Guid.NewGuid(),
+            [firstPhoto.Id, secondPhoto.Id],
+            firstTimestamp,
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "Fly", "Fly"),
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "BrownTrout", "Brown Trout"),
+            reasons: [ImportCatchProposalReasonEnum.WeakTimestamp]);
+        var batch = new ImportBatchModel(Guid.NewGuid(), proposal.Method, proposal.Species);
+        batch.AddPhoto(firstPhoto);
+        batch.AddPhoto(secondPhoto);
+        batch.AddCatchProposal(proposal);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+
+        // Act
+        cut.Find("#import-catch-1-carousel-photo-next").Click();
+
+        // Assert
+        proposal.CaughtOn.Should().Be(secondTimestamp);
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        cut.Find("#import-catch-1-timestamp").TextContent.Should().Contain("09:34");
+
+        // Act
+        cut.Find("#import-catch-1-confirm").Click();
+
+        // Assert
+        proposal.CaughtOn.State.Should().Be(ImportTimestampStateEnum.UserConfirmed);
+        proposal.CaughtOn.Instant.Should().Be(CapturedOn.AddMinutes(4));
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+    }
+
+    [Fact]
+    public async Task ItShouldUseTheOpenedGridPhotographTimestampInTheEditor()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var firstTimestamp = ImportTimestampModel.FromWeakFallback(CapturedOn);
+        var secondTimestamp = ImportTimestampModel.FromWeakFallback(CapturedOn.AddMinutes(4));
+        var firstPhoto = Photo(firstTimestamp);
+        var secondPhoto = Photo(secondTimestamp, 1);
+        var proposal = new ImportCatchProposalModel(
+            Guid.NewGuid(),
+            [firstPhoto.Id, secondPhoto.Id],
+            firstTimestamp,
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "Fly", "Fly"),
+            new ImportCatalogueSelectionModel(Guid.NewGuid(), "BrownTrout", "Brown Trout"),
+            reasons: [ImportCatchProposalReasonEnum.WeakTimestamp]);
+        var batch = new ImportBatchModel(Guid.NewGuid(), proposal.Method, proposal.Species);
+        batch.AddPhoto(firstPhoto);
+        batch.AddPhoto(secondPhoto);
+        batch.AddCatchProposal(proposal);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, batch)
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+        cut.Find("#import-catch-1-edit").Click();
+
+        // Act
+        cut.Find("#import-catch-1-open-1").Click();
+
+        // Assert
+        proposal.CaughtOn.Should().Be(secondTimestamp);
+        cut.Find("#import-catch-1-caught-on").GetAttribute("value").Should().Contain("09:34");
+        cut.Find("#import-catch-1-select-1").HasAttribute("checked").Should().BeFalse();
     }
 
     [Fact]
@@ -142,6 +226,20 @@ public class WhenTestingRender
 
         // Act
         cut.Find("#import-catch-1-caught-on").Input("2024-06-14T09:20");
+
+        // Assert
+        cut.Find("#import-catch-1-confirm-caught-on").GetAttribute("aria-label").Should()
+            .Be("Confirm date and time");
+        cut.Find(".import-catch-confirm-caught-on-label").TextContent.Should()
+            .Be("Confirm date and time");
+        cut.FindComponents<MudTooltip>().Should().ContainSingle(tooltip =>
+            tooltip.Instance.Text == "Confirm date and time"
+            && tooltip.Instance.ShowOnHover
+            && tooltip.Instance.ShowOnFocus
+            && tooltip.Instance.ShowOnClick);
+        cut.Find("#import-catch-1-confirm-caught-on").Closest(".import-catch-caught-on-row").Should().NotBeNull();
+
+        // Act
         cut.Find("#import-catch-1-confirm-caught-on").Click();
         cut.Find("#import-catch-1-close-editor").Click();
 
@@ -337,16 +435,16 @@ public class WhenTestingRender
         return context;
     }
 
-    private static ImportSelectedPhotoModel Photo(ImportTimestampModel timestamp)
+    private static ImportSelectedPhotoModel Photo(ImportTimestampModel timestamp, int index = 0)
     {
         var photo = new ImportSelectedPhotoModel(
-            Guid.Parse("11111111-1111-1111-1111-111111111111"),
-            0,
+            Guid.Parse($"11111111-1111-1111-1111-{index + 1:D12}"),
+            index,
             "image/jpeg",
             1024,
             "token",
-            "catch.jpg",
-            "blob:thumbnail");
+            $"catch-{index}.jpg",
+            $"blob:thumbnail-{index}");
         photo.SetPreparation(ImportPhotoPreparationStatusEnum.Ready, "token", "blob:thumbnail");
         photo.SetMetadata(
             ImportMetadataStatusEnum.Available,

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingTimestamp.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingTimestamp.cs
@@ -90,7 +90,7 @@ public class WhenTestingTimestamp : BaseImportModelTest
     }
 
     [Fact]
-    public void ItShouldConfirmAnOffsetLessWallClockWithoutApplyingTheCurrentTimezone()
+    public void ItShouldRequireAnExplicitOffsetToConfirmALocalWallClock()
     {
         // Arrange
         var wallClock = new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Local);
@@ -99,13 +99,61 @@ public class WhenTestingTimestamp : BaseImportModelTest
             ImportTimestampSourceEnum.ExifOriginal);
 
         // Act
-        var confirmed = proposed.Confirm(wallClock);
+        Action confirm = () => proposed.Confirm(wallClock);
 
         // Assert
+        confirm.Should().Throw<InvalidOperationException>()
+            .WithMessage("*explicit UTC offset*");
+        proposed.RequiresUtcOffset.Should().BeTrue();
+        proposed.IsResolved.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(4, 0)]
+    [InlineData(-5, 0)]
+    [InlineData(5, 30)]
+    public void ItShouldCreateAnExactUserConfirmedInstantFromALocalWallClockAndOffset(
+        int offsetHours,
+        int offsetMinutes)
+    {
+        // Arrange
+        var wallClock = new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Local);
+        var proposed = ImportTimestampModel.FromLocalWallClock(
+            wallClock,
+            ImportTimestampSourceEnum.ExifOriginal);
+        var sign = offsetHours < 0 ? -1 : 1;
+        var offset = new TimeSpan(offsetHours, sign * offsetMinutes, 0);
+
+        // Act
+        var confirmed = proposed.ConfirmLocalWallClock(wallClock, offset);
+
+        // Assert
+        confirmed.State.Should().Be(ImportTimestampStateEnum.UserConfirmed);
+        confirmed.Instant.Should().Be(new DateTimeOffset(2024, 6, 14, 9, 20, 0, offset));
+        confirmed.LocalWallClock.Should().Be(new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Unspecified));
+        confirmed.RequiresUtcOffset.Should().BeFalse();
         confirmed.IsResolved.Should().BeTrue();
-        confirmed.Instant.Should().BeNull();
-        confirmed.LocalWallClock.Should().Be(DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified));
-        confirmed.LocalWallClock!.Value.Kind.Should().Be(DateTimeKind.Unspecified);
+    }
+
+    [Fact]
+    public void ItShouldRequireOffsetReconfirmationAfterEditingAConfirmedLocalWallClock()
+    {
+        // Arrange
+        var original = new DateTime(2024, 6, 14, 9, 20, 0);
+        var confirmed = ImportTimestampModel.FromLocalWallClock(
+                original,
+                ImportTimestampSourceEnum.ExifOriginal)
+            .ConfirmLocalWallClock(original, TimeSpan.FromHours(1));
+
+        // Act
+        var edited = confirmed.EditLocalWallClock(original.AddMinutes(10));
+
+        // Assert
+        edited.State.Should().Be(ImportTimestampStateEnum.LocalWallClock);
+        edited.Instant.Should().BeNull();
+        edited.LocalWallClock.Should().Be(original.AddMinutes(10));
+        edited.RequiresUtcOffset.Should().BeTrue();
+        edited.IsResolved.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Import.Enums;
@@ -26,7 +27,9 @@ public class BaseImportCatchCatalogueTest
         IImportPhotoPreparationService preparation,
         IAnglerPreferencesProvider? preferences = null,
         IModalService? modalService = null,
-        IImportTripProposalService? tripProposalService = null)
+        IImportTripProposalService? tripProposalService = null,
+        IImportPersistenceService? persistenceService = null,
+        INetworkService? networkService = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -36,6 +39,21 @@ public class BaseImportCatchCatalogueTest
         context.Services.AddSingleton(proposal);
         context.Services.AddSingleton(preparation);
         context.Services.AddSingleton(tripProposalService ?? new ImportTripProposalService());
+        var persistence = persistenceService ?? Substitute.For<IImportPersistenceService>();
+        if (persistenceService is null)
+        {
+            persistence.PersistAsync(Arg.Any<ImportBatchModel>(), Arg.Any<CancellationToken>())
+                .Returns(new ImportPersistenceResultModel([], [], 0, 0));
+        }
+
+        context.Services.AddSingleton(persistence);
+        var network = networkService ?? Substitute.For<INetworkService>();
+        if (networkService is null)
+        {
+            network.IsOnlineAsync(Arg.Any<CancellationToken>()).Returns(true);
+        }
+
+        context.Services.AddSingleton(network);
         var existingTrips = Substitute.For<IImportExistingTripService>();
         existingTrips.GetCandidatesAsync(
                 Arg.Any<IReadOnlyList<ImportTripProposalModel>>(),

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
@@ -232,7 +232,8 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
 
         // Assert
         cut.FindComponents<ImportCatchReviewCard>().Should().ContainSingle();
-        cut.FindAll("#import-catch-1-photos img").Should().HaveCount(2);
+        cut.FindAll("#import-catch-1-photos img").Should().ContainSingle();
+        cut.Find("#import-catch-1-carousel-photo-count").TextContent.Should().Contain("1 of 2");
     }
 
     [Fact]
@@ -287,7 +288,15 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         // Arrange
         var proposal = Substitute.For<IImportCatchProposalService>();
         proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
-        await using var context = CreateContext(proposal, Substitute.For<IImportPhotoPreparationService>());
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        var persistence = Substitute.For<IImportPersistenceService>();
+        var persistenceCompletion = new TaskCompletionSource<ImportPersistenceResultModel>();
+        persistence.PersistAsync(Arg.Any<ImportBatchModel>(), Arg.Any<CancellationToken>())
+            .Returns(persistenceCompletion.Task);
+        await using var context = CreateContext(
+            proposal,
+            preparation,
+            persistenceService: persistence);
         var cut = context.Render<ImportCatchCatalogue>();
         await SelectDefaultsAndContinueAsync(cut);
         await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
@@ -314,6 +323,70 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
 
         // Assert
         cut.Find("#import-confirmation-boundary").Should().NotBeNull();
+
+        // Act
+        cut.Find("#import-confirm").Click();
+
+        // Assert
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("#import-confirm").HasAttribute("disabled").Should().BeTrue();
+            cut.Find("#import-confirm-spinner").Should().NotBeNull();
+        });
+
+        // Act
+        cut.Find("#import-confirm").Click();
+        persistenceCompletion.SetResult(new ImportPersistenceResultModel([], [Guid.NewGuid()], 1, 0));
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#import-success").Should().NotBeNull());
+        await persistence.Received(1).PersistAsync(
+            Arg.Is<ImportBatchModel>(batch => batch.IsReadyForConfirmation),
+            Arg.Any<CancellationToken>());
+        await preparation.Received(1).ClearAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ItShouldRenderStableSequentialCatchNumbersInATripSuggestion()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var tripProposal = Substitute.For<IImportTripProposalService>();
+        tripProposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call =>
+        {
+            var batch = call.Arg<ImportBatchModel>();
+            return [new ImportTripProposalModel(
+                Guid.NewGuid(),
+                batch.CatchProposals.Select(candidate => candidate.Id),
+                ImportTripSuggestionConfidenceEnum.Strong,
+                [],
+                CapturedOn.DateTime,
+                CapturedOn.AddMinutes(3).DateTime)];
+        });
+        await using var context = CreateContext(
+            proposal,
+            Substitute.For<IImportPhotoPreparationService>(),
+            tripProposalService: tripProposal);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(0), ReadyPhoto(1), ReadyPhoto(2), ReadyPhoto(3)]));
+        cut.Find("#import-photos-continue").Click();
+        for (var catchNumber = 1; catchNumber <= 4; catchNumber++)
+        {
+            cut.Find($"#import-catch-{catchNumber}-confirm").Click();
+        }
+
+        // Act
+        cut.Find("#import-review-continue").Click();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#import-trip-review").Should().NotBeNull());
+        for (var catchNumber = 1; catchNumber <= 4; catchNumber++)
+        {
+            cut.Find($"#import-trip-catch-1-{catchNumber}").TextContent.Should().Contain($"Catch {catchNumber}");
+        }
     }
 
     [Fact]
@@ -370,7 +443,17 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
             .InvokeAsync([ReadyPhoto(0), ReadyPhoto(1)]));
         cut.Find("#import-photos-continue").Click();
         cut.Find("#import-catch-1-edit").Click();
+
+        // Assert
+        cut.FindAll("#import-catch-1-selected-actions").Should().BeEmpty();
+
+        // Act
         cut.Find("#import-catch-1-select-1").Change(true);
+
+        // Assert
+        cut.Find("#import-catch-1-selected-actions").Should().NotBeNull();
+        cut.Find("#import-catch-1-split").ClassList.Should().Contain(className => className.EndsWith("size-small"));
+        cut.Find("#import-catch-1-remove-photos").ClassList.Should().Contain(className => className.EndsWith("size-small"));
 
         // Act
         cut.Find("#import-catch-1-split").Click();

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportCatchProposalServiceTests/WhenTestingPropose.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportCatchProposalServiceTests/WhenTestingPropose.cs
@@ -8,10 +8,10 @@ namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportCatchProposalS
 public class WhenTestingPropose : BaseImportCatchProposalServiceTest
 {
     [Theory]
-    [InlineData(119, 1)]
-    [InlineData(120, 1)]
-    [InlineData(121, 2)]
-    public void ItShouldApplyTheInclusiveTwoMinuteThreshold(int gapSeconds, int expectedGroups)
+    [InlineData(299, 1)]
+    [InlineData(300, 1)]
+    [InlineData(301, 2)]
+    public void ItShouldApplyTheInclusiveFiveMinuteThreshold(int gapSeconds, int expectedGroups)
     {
         // Arrange
         var first = Photo(0, ExplicitAt(TimeSpan.Zero));
@@ -21,7 +21,7 @@ public class WhenTestingPropose : BaseImportCatchProposalServiceTest
         var proposals = Sut.Propose(Batch(first, second));
 
         // Assert
-        ImportCatchProposalService.SameCatchTimeThreshold.Should().Be(TimeSpan.FromMinutes(2));
+        ImportCatchProposalService.SameCatchTimeThreshold.Should().Be(TimeSpan.FromMinutes(5));
         proposals.Should().HaveCount(expectedGroups);
     }
 
@@ -41,7 +41,7 @@ public class WhenTestingPropose : BaseImportCatchProposalServiceTest
     }
 
     [Fact]
-    public void ItShouldChainAdjacentPhotographsWithinTheThreshold()
+    public void ItShouldGroupPhotographsWhenTheCompleteSpanIsWithinTheThreshold()
     {
         // Arrange
         var photos = new[]
@@ -60,6 +60,26 @@ public class WhenTestingPropose : BaseImportCatchProposalServiceTest
     }
 
     [Fact]
+    public void ItShouldNotChainWeakFallbackPhotographsBeyondTheFiveMinuteGroupSpan()
+    {
+        // Arrange
+        var photos = new[]
+        {
+            Photo(0, ImportTimestampModel.FromWeakFallback(CapturedOn)),
+            Photo(1, ImportTimestampModel.FromWeakFallback(CapturedOn.AddMinutes(4))),
+            Photo(2, ImportTimestampModel.FromWeakFallback(CapturedOn.AddMinutes(8)))
+        };
+
+        // Act
+        var proposals = Sut.Propose(Batch(photos));
+
+        // Assert
+        proposals.Select(proposal => proposal.PhotoIds.Count).Should().Equal(2, 1);
+        proposals[0].PhotoIds.Should().Equal(photos[0].Id, photos[1].Id);
+        proposals[1].PhotoIds.Should().Equal(photos[2].Id);
+    }
+
+    [Fact]
     public void ItShouldSplitWhenTheAdjacentGapExceedsTheThreshold()
     {
         // Arrange
@@ -67,7 +87,7 @@ public class WhenTestingPropose : BaseImportCatchProposalServiceTest
         {
             Photo(0, ExplicitAt(TimeSpan.Zero)),
             Photo(1, ExplicitAt(TimeSpan.FromMinutes(1))),
-            Photo(2, ExplicitAt(TimeSpan.FromMinutes(4)))
+            Photo(2, ExplicitAt(TimeSpan.FromMinutes(7)))
         };
 
         // Act
@@ -81,7 +101,7 @@ public class WhenTestingPropose : BaseImportCatchProposalServiceTest
     public void ItShouldSortChronologicallyAndUseSelectionIndexForTies()
     {
         // Arrange
-        var later = Photo(0, ExplicitAt(TimeSpan.FromMinutes(5)));
+        var later = Photo(0, ExplicitAt(TimeSpan.FromMinutes(6)));
         var tiedSecond = Photo(2, ExplicitAt(TimeSpan.Zero));
         var tiedFirst = Photo(1, ExplicitAt(TimeSpan.Zero));
 
@@ -130,6 +150,50 @@ public class WhenTestingPropose : BaseImportCatchProposalServiceTest
         // Assert
         proposals.Should().ContainSingle();
         proposals[0].PhotoIds.Should().Equal(first.Id, second.Id);
+    }
+
+    [Fact]
+    public void ItShouldGroupLocalExifTimesWithinFiveMinutesAndKeepThemReviewable()
+    {
+        // Arrange
+        var capturedOn = new DateTime(2025, 6, 14, 9, 0, 0);
+        var first = Photo(0, ImportTimestampModel.FromLocalWallClock(
+            capturedOn,
+            ImportTimestampSourceEnum.ExifOriginal));
+        var second = Photo(1, ImportTimestampModel.FromLocalWallClock(
+            capturedOn.AddMinutes(5),
+            ImportTimestampSourceEnum.ExifDigitized));
+
+        // Act
+        var proposal = Sut.Propose(Batch(second, first)).Single();
+
+        // Assert
+        proposal.PhotoIds.Should().Equal(first.Id, second.Id);
+        proposal.CaughtOn.Should().Be(first.Timestamp);
+        proposal.Reasons.Should().Contain(ImportCatchProposalReasonEnum.AmbiguousTimestamp);
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+    }
+
+    [Theory]
+    [InlineData(300, 1)]
+    [InlineData(301, 2)]
+    public void ItShouldApplyTheFiveMinuteThresholdToWeakFallbackTimes(
+        int gapSeconds,
+        int expectedGroups)
+    {
+        // Arrange
+        var first = Photo(0, ImportTimestampModel.FromWeakFallback(CapturedOn));
+        var second = Photo(1, ImportTimestampModel.FromWeakFallback(CapturedOn.AddSeconds(gapSeconds)));
+
+        // Act
+        var proposals = Sut.Propose(Batch(second, first));
+
+        // Assert
+        proposals.Should().HaveCount(expectedGroups);
+        proposals.SelectMany(proposal => proposal.PhotoIds).Should().Equal(first.Id, second.Id);
+        proposals.Should().OnlyContain(proposal =>
+            proposal.Reasons.Contains(ImportCatchProposalReasonEnum.WeakTimestamp)
+            && proposal.ReviewStatus == ImportCatchReviewStatusEnum.Draft);
     }
 
     [Fact]
@@ -241,13 +305,6 @@ public class WhenTestingPropose : BaseImportCatchProposalServiceTest
     public static TheoryData<ImportTimestampModel, ImportCatchProposalReasonEnum> UnresolvedTimestamps => new()
     {
         { ImportTimestampModel.Missing(), ImportCatchProposalReasonEnum.MissingTimestamp },
-        { ImportTimestampModel.Unusable(ImportTimestampSourceEnum.ExifOriginal), ImportCatchProposalReasonEnum.UnusableTimestamp },
-        { ImportTimestampModel.FromWeakFallback(CapturedOn), ImportCatchProposalReasonEnum.WeakTimestamp },
-        {
-            ImportTimestampModel.FromLocalWallClock(
-                new DateTime(2025, 6, 14, 9, 0, 0),
-                ImportTimestampSourceEnum.ExifOriginal),
-            ImportCatchProposalReasonEnum.AmbiguousTimestamp
-        }
+        { ImportTimestampModel.Unusable(ImportTimestampSourceEnum.ExifOriginal), ImportCatchProposalReasonEnum.UnusableTimestamp }
     };
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportExistingTripServiceTests/WhenTestingGetCandidates.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportExistingTripServiceTests/WhenTestingGetCandidates.cs
@@ -33,6 +33,25 @@ public class WhenTestingGetCandidates
     }
 
     [Fact]
+    public async Task ItShouldOfferAnExistingTripOnTheSameDateWhenItsTimesDoNotOverlap()
+    {
+        // Arrange
+        var trip = Summary(StartedOn.AddHours(-6), StartedOn.AddHours(-4));
+        var client = Substitute.For<ITripClient>();
+        client.GetMyAsync(Arg.Any<CancellationToken>()).Returns([trip]);
+        var proposal = Proposal();
+        var sut = new ImportExistingTripService(client);
+
+        // Act
+        var candidates = await sut.GetCandidatesAsync([proposal], CancellationToken.None);
+
+        // Assert
+        candidates[proposal.Id].Should().ContainSingle().Which.Should().Be(trip);
+        await client.Received(1).GetMyAsync(Arg.Any<CancellationToken>());
+        await client.DidNotReceive().GetDetailAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldFetchOnlyTemporallyCompatibleDetailsAndExcludeAnIncompatibleLocation()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/BaseImportPersistenceServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/BaseImportPersistenceServiceTest.cs
@@ -1,0 +1,130 @@
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Catch.Clients;
+using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
+using FishingLogBook.Web.Features.Trips.Clients;
+using FishingLogBook.Web.Features.Users.Clients;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportPersistenceServiceTests;
+
+public class BaseImportPersistenceServiceTest
+{
+    protected static readonly Guid UserId = Guid.Parse("10000000-0000-0000-0000-000000000001");
+    protected static readonly Guid CatchId = Guid.Parse("20000000-0000-0000-0000-000000000001");
+    protected static readonly Guid PhotoId = Guid.Parse("30000000-0000-0000-0000-000000000001");
+    protected static readonly Guid TripId = Guid.Parse("40000000-0000-0000-0000-000000000001");
+    protected static readonly Guid ParticipantId = Guid.Parse("50000000-0000-0000-0000-000000000001");
+    protected static readonly DateTimeOffset CaughtOn = DateTimeOffset.Parse("2009-02-02T15:06:00+01:00");
+
+    protected ITripClient TripClient { get; } = Substitute.For<ITripClient>();
+    protected ITripParticipantClient ParticipantClient { get; } = Substitute.For<ITripParticipantClient>();
+    protected ICatchClient CatchClient { get; } = Substitute.For<ICatchClient>();
+    protected ICurrentUserClient CurrentUserClient { get; } = Substitute.For<ICurrentUserClient>();
+    protected IImportPhotoBlobRegistryService BlobRegistry { get; } = Substitute.For<IImportPhotoBlobRegistryService>();
+
+    protected ImportPersistenceService CreateSut()
+    {
+        CurrentUserClient.GetCurrentAsync(Arg.Any<CancellationToken>())
+            .Returns(new CurrentUserDto(UserId, "angler@example.test", "test", "subject"));
+        BlobRegistry.GetBytesAsync("token", Arg.Any<CancellationToken>()).Returns([1, 2, 3]);
+        TripDto? persistedTrip = null;
+        TripClient.UpsertAsync(Arg.Any<TripDto>(), Arg.Any<CancellationToken>()).Returns(call =>
+        {
+            persistedTrip = call.Arg<TripDto>();
+            return persistedTrip;
+        });
+        TripClient.GetDetailAsync(TripId, Arg.Any<CancellationToken>()).Returns(_ =>
+            new TripDetailDto(new TripViewDto(
+                TripId,
+                UserId,
+                persistedTrip!.Status,
+                persistedTrip.StartedOn,
+                persistedTrip.EndedOn)));
+        var participantReads = 0;
+        ParticipantClient.GetAsync(TripId, Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            participantReads++;
+            return new TripParticipantsDto(TripId, "Owner")
+            {
+                Participants = participantReads > 1
+                    ? [new TripParticipantDto(ParticipantId, "Invited", "Angler", null, CaughtOn)]
+                    : []
+            };
+        });
+        ParticipantClient.InviteAsync(TripId, Arg.Any<InviteTripParticipantDto>(), Arg.Any<CancellationToken>())
+            .Returns(new TripParticipantsDto(TripId, "Owner")
+            {
+                Participants = [new TripParticipantDto(ParticipantId, "Invited", "Angler", null, CaughtOn)]
+            });
+        CatchDto? persistedCatch = null;
+        CatchClient.UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>()).Returns(call =>
+        {
+            persistedCatch = call.Arg<CatchDto>();
+            return persistedCatch;
+        });
+        CatchClient.CreatePhotographUploadAsync(CatchId, Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(new PhotographUploadDto("object", "https://upload.test"));
+        var reads = 0;
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            reads++;
+            return new CatchViewDto(CatchId, UserId, CaughtOn, new CatchLocationExposureDto
+            {
+                Latitude = 53.1,
+                Longitude = -6.2,
+                CapturedOn = CaughtOn,
+                Source = LocationDefaults.PhotoMetadata,
+                Visibility = LocationDefaults.Private
+            })
+            {
+                RecordedByUserId = UserId,
+                TripId = persistedCatch?.TripId,
+                SpeciesName = persistedCatch?.SpeciesName,
+                Method = persistedCatch?.Method,
+                Weight = persistedCatch?.Weight,
+                Length = persistedCatch?.Length,
+                Photographs = reads > 1 ? [new CatchPhotographViewDto(PhotoId, "image/jpeg", "https://photo.test")] : []
+            };
+        });
+        return new ImportPersistenceService(TripClient, ParticipantClient, CatchClient, CurrentUserClient, BlobRegistry);
+    }
+
+    protected static ImportBatchModel Batch(ImportTripDecisionEnum decision, bool participant = false)
+    {
+        var method = new ImportCatalogueSelectionModel(Guid.NewGuid(), "Fly", "Fly");
+        var species = new ImportCatalogueSelectionModel(Guid.NewGuid(), "BrownTrout", "Brown Trout");
+        var batch = new ImportBatchModel(Guid.NewGuid(), method, species);
+        var photo = new ImportSelectedPhotoModel(PhotoId, 0, "image/jpeg", 3, "token", "fish.jpg", "blob:thumb");
+        photo.SetPreparation(ImportPhotoPreparationStatusEnum.Ready, "token", "blob:thumb");
+        batch.AddPhoto(photo);
+        var location = new ImportLocationModel(53.1, -6.2, true).Accept();
+        var proposal = new ImportCatchProposalModel(
+            CatchId,
+            [PhotoId],
+            ImportTimestampModel.UserConfirmed(CaughtOn),
+            method,
+            species,
+            location,
+            weight: 2.5m,
+            length: 42m);
+        proposal.MarkReviewed();
+        batch.AddCatchProposal(proposal);
+        var trip = new ImportTripProposalModel(
+            TripId,
+            [CatchId],
+            ImportTripSuggestionConfidenceEnum.Strong,
+            [],
+            CaughtOn.DateTime,
+            CaughtOn.DateTime);
+        trip.Decide(decision, decision == ImportTripDecisionEnum.UseExisting ? TripId : null);
+        if (participant)
+        {
+            trip.AddParticipant(new AnglerSummaryDto(ParticipantId, "Angler", null, null, null));
+        }
+
+        batch.AddTripProposal(trip);
+        return batch;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/BaseImportPersistenceServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/BaseImportPersistenceServiceTest.cs
@@ -70,11 +70,11 @@ public class BaseImportPersistenceServiceTest
         CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(_ =>
         {
             reads++;
-            return new CatchViewDto(CatchId, UserId, CaughtOn, new CatchLocationExposureDto
+            return new CatchViewDto(CatchId, UserId, persistedCatch!.CaughtOn, new CatchLocationExposureDto
             {
                 Latitude = 53.1,
                 Longitude = -6.2,
-                CapturedOn = CaughtOn,
+                CapturedOn = persistedCatch.CaughtOn,
                 Source = LocationDefaults.PhotoMetadata,
                 Visibility = LocationDefaults.Private
             })
@@ -91,7 +91,10 @@ public class BaseImportPersistenceServiceTest
         return new ImportPersistenceService(TripClient, ParticipantClient, CatchClient, CurrentUserClient, BlobRegistry);
     }
 
-    protected static ImportBatchModel Batch(ImportTripDecisionEnum decision, bool participant = false)
+    protected static ImportBatchModel Batch(
+        ImportTripDecisionEnum decision,
+        bool participant = false,
+        ImportTimestampModel? timestamp = null)
     {
         var method = new ImportCatalogueSelectionModel(Guid.NewGuid(), "Fly", "Fly");
         var species = new ImportCatalogueSelectionModel(Guid.NewGuid(), "BrownTrout", "Brown Trout");
@@ -103,7 +106,7 @@ public class BaseImportPersistenceServiceTest
         var proposal = new ImportCatchProposalModel(
             CatchId,
             [PhotoId],
-            ImportTimestampModel.UserConfirmed(CaughtOn),
+            timestamp ?? ImportTimestampModel.UserConfirmed(CaughtOn),
             method,
             species,
             location,
@@ -116,8 +119,8 @@ public class BaseImportPersistenceServiceTest
             [CatchId],
             ImportTripSuggestionConfidenceEnum.Strong,
             [],
-            CaughtOn.DateTime,
-            CaughtOn.DateTime);
+            proposal.CaughtOn.Instant!.Value.DateTime,
+            proposal.CaughtOn.Instant.Value.DateTime);
         trip.Decide(decision, decision == ImportTripDecisionEnum.UseExisting ? TripId : null);
         if (participant)
         {

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
@@ -1,12 +1,54 @@
 using AwesomeAssertions;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.Import.Enums;
+using FishingLogBook.Web.Features.Import.Models;
 using NSubstitute;
 
 namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportPersistenceServiceTests;
 
 public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
 {
+    [Fact]
+    public async Task ItShouldPersistTheExactExplicitlyConfirmedHistoricalOffset()
+    {
+        // Arrange
+        var wallClock = new DateTime(2009, 2, 2, 15, 6, 0, DateTimeKind.Local);
+        var confirmed = ImportTimestampModel.FromLocalWallClock(
+                wallClock,
+                ImportTimestampSourceEnum.ExifOriginal)
+            .ConfirmLocalWallClock(wallClock, TimeSpan.FromHours(5.5));
+        var batch = Batch(ImportTripDecisionEnum.NoTrip, timestamp: confirmed);
+        var sut = CreateSut();
+
+        // Act
+        await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        var expected = new DateTimeOffset(2009, 2, 2, 15, 6, 0, TimeSpan.FromHours(5.5));
+        await CatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(record => record.CaughtOn == expected),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistAnExplicitExifOffsetUnchanged()
+    {
+        // Arrange
+        var explicitTimestamp = ImportTimestampModel.FromExplicitInstant(
+            CaughtOn,
+            ImportTimestampSourceEnum.ExifOriginal);
+        var batch = Batch(ImportTripDecisionEnum.NoTrip, timestamp: explicitTimestamp);
+        var sut = CreateSut();
+
+        // Act
+        await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await CatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(record => record.CaughtOn == CaughtOn),
+            Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task ItShouldPersistANewTripParticipantsCatchAndPhotographThroughAuthoritativeClients()
     {

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
@@ -1,0 +1,163 @@
+using AwesomeAssertions;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Import.Enums;
+using NSubstitute;
+
+namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportPersistenceServiceTests;
+
+public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
+{
+    [Fact]
+    public async Task ItShouldPersistANewTripParticipantsCatchAndPhotographThroughAuthoritativeClients()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.CreateNew, participant: true);
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        result.CreatedTripIds.Should().Equal(TripId);
+        result.CatchIds.Should().Equal(CatchId);
+        result.PhotographCount.Should().Be(1);
+        await TripClient.Received(1).UpsertAsync(
+            Arg.Is<TripDto>(trip =>
+                trip.Id == TripId
+                && trip.OwnerUserId == UserId
+                && trip.Status == "Completed"
+                && trip.StartedOn == CaughtOn
+                && trip.EndedOn == CaughtOn),
+            Arg.Any<CancellationToken>());
+        await ParticipantClient.Received(1).InviteAsync(
+            TripId,
+            Arg.Is<InviteTripParticipantDto>(request => request.UserId == ParticipantId),
+            Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(record =>
+                record.Id == CatchId
+                && record.TripId == TripId
+                && record.CaughtOn == CaughtOn
+                && record.CaughtByUserId == UserId
+                && record.RecordedByUserId == UserId
+                && record.Method == "Fly"
+                && record.SpeciesName == "Brown Trout"
+                && record.Weight == 2.5m
+                && record.Length == 42m
+                && record.Location != null),
+            Arg.Any<CancellationToken>());
+        await BlobRegistry.Received(1).GetBytesAsync("token", Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).RecordPhotographAsync(
+            CatchId,
+            Arg.Is<RecordPhotographDto>(photo => photo.PhotographId == PhotoId && photo.ObjectKey == "object"),
+            Arg.Any<CancellationToken>());
+        await CatchClient.Received(2).GetAsync(CatchId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldUseAnExistingTripWithoutMutatingParticipants()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.UseExisting);
+        var sut = CreateSut();
+
+        // Act
+        await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await TripClient.DidNotReceive().UpsertAsync(Arg.Any<TripDto>(), Arg.Any<CancellationToken>());
+        await ParticipantClient.DidNotReceive().InviteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<InviteTripParticipantDto>(),
+            Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(record => record.TripId == TripId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldPersistAStandaloneCatchWithoutATrip()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+
+        // Act
+        await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await TripClient.DidNotReceive().UpsertAsync(Arg.Any<TripDto>(), Arg.Any<CancellationToken>());
+        await ParticipantClient.DidNotReceive().InviteAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<InviteTripParticipantDto>(),
+            Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(record => record.TripId == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStopBeforeCreatingACatchWhenTripCreationFails()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.CreateNew);
+        var sut = CreateSut();
+        TripClient.UpsertAsync(Arg.Any<TripDto>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<TripDto?>(new HttpRequestException("failed")));
+
+        // Act
+        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await action.Should().ThrowAsync<HttpRequestException>();
+        await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<PhotographUploadRequestDto>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStopBeforeCreatingACatchWhenParticipantPersistenceFails()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.CreateNew, participant: true);
+        var sut = CreateSut();
+        ParticipantClient.InviteAsync(
+                TripId,
+                Arg.Any<InviteTripParticipantDto>(),
+                Arg.Any<CancellationToken>())
+            .Returns((TripParticipantsDto?)null);
+
+        // Act
+        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await action.Should().ThrowAsync<InvalidOperationException>();
+        await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSurfaceUploadFailureWithoutRecordingThePhotograph()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+        CatchClient.UploadPhotographAsync(
+                Arg.Any<string>(),
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new HttpRequestException("upload failed")));
+
+        // Act
+        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await action.Should().ThrowAsync<HttpRequestException>();
+        await CatchClient.DidNotReceive().RecordPhotographAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<RecordPhotographDto>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportTripProposalServiceTests/WhenTestingPropose.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportTripProposalServiceTests/WhenTestingPropose.cs
@@ -213,8 +213,12 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
     public void ItShouldUseAConfirmedOffsetlessWallClockWithoutInventingAnOffset()
     {
         // Arrange
-        var first = ImportTimestampModel.UserConfirmed(new DateTime(2024, 6, 14, 9, 0, 0));
-        var second = ImportTimestampModel.UserConfirmed(new DateTime(2024, 6, 14, 10, 0, 0));
+        var firstLocal = new DateTime(2024, 6, 14, 9, 0, 0);
+        var secondLocal = new DateTime(2024, 6, 14, 10, 0, 0);
+        var first = ImportTimestampModel.FromLocalWallClock(firstLocal, ImportTimestampSourceEnum.ExifOriginal)
+            .ConfirmLocalWallClock(firstLocal, TimeSpan.FromHours(1));
+        var second = ImportTimestampModel.FromLocalWallClock(secondLocal, ImportTimestampSourceEnum.ExifOriginal)
+            .ConfirmLocalWallClock(secondLocal, TimeSpan.FromHours(1));
         var batch = Batch(
             new CatchSpec(TimeSpan.Zero, Timestamp: first),
             new CatchSpec(TimeSpan.Zero, Timestamp: second));

--- a/tests/FishingLogBook.Web.Tests/Features/Photographs/Components/PhotographGridSelectorTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Photographs/Components/PhotographGridSelectorTests/WhenTestingRender.cs
@@ -1,0 +1,125 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Web.Features.Photographs.Components.PhotographGridSelector;
+using FishingLogBook.Web.Features.Photographs.Models;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using MudBlazor.Services;
+
+namespace FishingLogBook.Web.Tests.Features.Photographs.Components.PhotographGridSelectorTests;
+
+public class WhenTestingRender
+{
+    [Fact]
+    public async Task ItShouldHideSelectedActionsUntilAPhotographIsSelected()
+    {
+        // Arrange
+        await using var context = CreateContext();
+
+        // Act
+        var cut = RenderSelector(context, Photographs());
+
+        // Assert
+        cut.FindAll("#grid-selected-actions").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItShouldShowActionsBesideTheGridAndRaiseTheSelectedIdentities()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var photographs = Photographs();
+        IReadOnlySet<Guid> selectedIds = new HashSet<Guid>();
+        var cut = RenderSelector(context, photographs, ids => selectedIds = ids.ToHashSet());
+
+        // Act
+        cut.Find("#grid-select-1").Change(true);
+
+        // Assert
+        selectedIds.Should().BeEquivalentTo([photographs[1].Id]);
+        cut.Find("#grid-selected-actions").TextContent.Should().Contain("1 selected");
+        cut.Find("#grid-selected-actions").PreviousElementSibling!.ClassList
+            .Should().Contain("photograph-grid-selector-grid");
+    }
+
+    [Fact]
+    public async Task ItShouldRenderLocalBytesAndRemoteUrls()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var photographs = new[]
+        {
+            new PhotographCarouselItemModel(Guid.NewGuid(), "image/jpeg", [1, 2, 3]),
+            new PhotographCarouselItemModel(Guid.NewGuid(), "image/jpeg", RemoteUrl: "blob:thumbnail")
+        };
+
+        // Act
+        var cut = RenderSelector(context, photographs);
+
+        // Assert
+        cut.Find("#grid-photo-0").GetAttribute("src").Should().StartWith("data:image/jpeg;base64,");
+        cut.Find("#grid-photo-1").GetAttribute("src").Should().Be("blob:thumbnail");
+    }
+
+    [Fact]
+    public async Task ItShouldRaiseTheOpenedPhotographWithoutChangingSelection()
+    {
+        // Arrange
+        await using var context = CreateContext();
+        var photographs = Photographs();
+        Guid? activePhotographId = null;
+        IReadOnlySet<Guid> selectedIds = new HashSet<Guid>();
+        var cut = context.Render<PhotographGridSelector>(parameters => parameters
+            .Add(selector => selector.Photographs, photographs)
+            .Add(selector => selector.IdPrefix, "grid")
+            .Add(selector => selector.ActivePhotographIdChanged,
+                EventCallback.Factory.Create<Guid?>(this, id => activePhotographId = id))
+            .Add(selector => selector.SelectedIdsChanged,
+                EventCallback.Factory.Create<IReadOnlySet<Guid>>(this, ids => selectedIds = ids.ToHashSet())));
+
+        // Act
+        cut.Find("#grid-open-1").Click();
+
+        // Assert
+        activePhotographId.Should().Be(photographs[1].Id);
+        selectedIds.Should().BeEmpty();
+    }
+
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        context.Services.AddLocalization();
+        return context;
+    }
+
+    private static IRenderedComponent<PhotographGridSelector> RenderSelector(
+        BunitContext context,
+        IReadOnlyList<PhotographCarouselItemModel> photographs,
+        Action<IReadOnlySet<Guid>>? selectedIdsChanged = null)
+    {
+        return context.Render<PhotographGridSelector>(parameters => parameters
+            .Add(selector => selector.Photographs, photographs)
+            .Add(selector => selector.IdPrefix, "grid")
+            .Add(selector => selector.SelectedIdsChanged,
+                EventCallback.Factory.Create(
+                    typeof(WhenTestingRender),
+                    selectedIdsChanged ?? (_ => { })))
+            .Add(selector => selector.SelectedActions, count => builder =>
+            {
+                builder.OpenElement(0, "span");
+                builder.AddContent(1, $"{count} selected");
+                builder.CloseElement();
+            }));
+    }
+
+    private static IReadOnlyList<PhotographCarouselItemModel> Photographs()
+    {
+        return
+        [
+            new PhotographCarouselItemModel(Guid.NewGuid(), "image/jpeg", RemoteUrl: "blob:first"),
+            new PhotographCarouselItemModel(Guid.NewGuid(), "image/jpeg", RemoteUrl: "blob:second")
+        ];
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripSelectorTests/BaseTripSelectorTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripSelectorTests/BaseTripSelectorTest.cs
@@ -1,0 +1,15 @@
+using Bunit;
+using MudBlazor.Services;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Components.TripSelectorTests;
+
+public class BaseTripSelectorTest
+{
+    protected static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddMudServices();
+        return context;
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripSelectorTests/WhenTestingSelection.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Trips/Components/TripSelectorTests/WhenTestingSelection.cs
@@ -1,0 +1,46 @@
+using AwesomeAssertions;
+using Bunit;
+using FishingLogBook.Shared.Constants;
+using FishingLogBook.Shared.Dtos;
+using FishingLogBook.Web.Features.Trips.Components.TripSelector;
+
+namespace FishingLogBook.Web.Tests.Features.Trips.Components.TripSelectorTests;
+
+public class WhenTestingSelection : BaseTripSelectorTest
+{
+    [Fact]
+    public async Task ItShouldRenderTripsAsPillsAndPublishTheSelectedIdentity()
+    {
+        // Arrange
+        var first = Trip("Morning session", "11111111-1111-1111-1111-111111111111");
+        var second = Trip(null, "22222222-2222-2222-2222-222222222222");
+        Guid? selected = null;
+        await using var context = CreateContext();
+        var cut = context.Render<TripSelector>(parameters => parameters
+            .Add(component => component.Trips, [first, second])
+            .Add(component => component.SelectedTripId, first.Id)
+            .Add(component => component.SelectedTripIdChanged, tripId => selected = tripId)
+            .Add(component => component.Label, "Add to existing Trip"));
+
+        // Act
+        cut.Find($"#trip-selector-{second.Id:D}").Click();
+
+        // Assert
+        cut.Find("#trip-selector").TextContent.Should().Contain("Add to existing Trip");
+        cut.Find($"#trip-selector-{first.Id:D}").ClassList.Should().Contain("mud-chip-filled");
+        cut.Find($"#trip-selector-{second.Id:D}").TextContent.Should().Contain("2026");
+        selected.Should().Be(second.Id);
+    }
+
+    private static TripSummaryDto Trip(string? title, string id)
+    {
+        return new TripSummaryDto(
+            Guid.Parse(id),
+            TripConstants.Completed,
+            DateTimeOffset.Parse("2026-08-27T14:42:00Z"),
+            DateTimeOffset.Parse("2026-08-27T14:46:00Z"))
+        {
+            Title = title
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- persist confirmed historical Trips, participants, Catches, and photographs through the authoritative online APIs
- verify persisted records and uploaded photographs before reporting Import success
- prevent duplicate submission and surface progress, success, and failure states
- reuse existing Trips on the same historical date or allow deliberate creation of another Trip
- add reusable Trip pill selection and photograph grid selection components
- refine Import review, carousel, timestamp confirmation, five-minute grouping, and responsive layouts
- update testing rules to require complete grouping/window invariants and transitive bridge cases

## Architecture

- Import uses authoritative online Trip APIs through `ITripClient`
- existing Trip candidates are loaded online rather than through IndexedDB or `ITripStore`
- the shared angler picker is selection-only and has no persistence side effects
- new-Trip participant selections remain transient Import wizard state
- the existing Trip invitation flow calls `InviteAsync` only after picker selection
- final Trip, Catch, participant, and photograph persistence is authoritative and online
- Import does not use the local-first synchroniser path

## Validation

- formatting completed successfully
- focused Web tests cover Import persistence, wizard behavior, Catch review, Trip selection, photograph selection, carousel timestamp behavior, and five-minute grouping boundaries
- latest focused run: 53 passed, 0 failed
- manual browser verification performed during implementation

## Self Review

- Issue/AC: PASS — confirmed Import data persists through authoritative APIs with verified success behavior
- Architecture/CQRS: PASS — online clients remain behind the Import persistence service; no IndexedDB or synchroniser coupling
- Rules: PASS — applicable Web, C#, testing, and workflow rules reviewed
- Security/privacy: PASS — current authenticated user context is used and no additional location exposure was introduced
- Database/migrations: N/A
- Tests/coverage: PASS — persistence orchestration, failures, duplicate submission, grouping invariants, selection, and review transitions covered
- Browser: PASS — manually exercised; bUnit tests cover deterministic component workflows
- Web/UI/localisation: PASS — responsive controls, EN/FR strings, accessible labels, tooltips, and selection states covered
- Code smells: PASS — reusable selectors remain selection-only and feature responsibilities stay separated
- CI/deployment: PASS — no infrastructure, migration, or configuration changes required

### Findings discovered during self-review

1. Adjacent timestamp chaining could create a Catch whose complete span exceeded five minutes.
2. Grid selection state could survive leaving the editor.
3. Weak fallback timestamps were unnecessarily excluded from safe five-minute grouping.

### Fixes made

1. Grouping now enforces a maximum five-minute span from the first photograph, including a transitive bridge regression test.
2. Editor exit clears selection state.
3. Compatible weak fallback photographs group separately while remaining subject to explicit review.

### Remaining deliberate gaps

- Import remains online-only.
- Reverse-geocoded display labels remain outside #218.

Closes #218