### PR TITLE
FLB#221 | Harden Import persistence and progress

### DIFF
--- a/src/FishingLogBook.Web/BrowserTests/README.md
+++ b/src/FishingLogBook.Web/BrowserTests/README.md
@@ -12,6 +12,7 @@ excluded from publish.
 - Catch IndexedDB write/read
 - Close/reload/read of Catch records
 - Photograph persistence
+- Import Blob registration and cleanup for the full 20-photo V1 batch
 - Diagnostic database isolation from the Catch database
 - A simplified service-worker application shell (Chromium also checks offline navigation)
 
@@ -30,6 +31,9 @@ Home Screen PWA, or iOS IndexedDB.
   A deterministic authenticated Playwright host needs architecture beyond a product
   feature ticket and must not contaminate production Web auth. Profile confidence
   comes from bUnit, API, Testcontainers, and ProfileClient tests.
+- The authenticated Import wizard from photo selection through authoritative Catch/Trip
+  reread. The current harness serves JavaScript/PWA fixtures and cannot authenticate or
+  host the production Blazor workflow without test-only authentication architecture.
 
 ## Commands
 

--- a/src/FishingLogBook.Web/BrowserTests/import-photo-blob-registry.spec.js
+++ b/src/FishingLogBook.Web/BrowserTests/import-photo-blob-registry.spec.js
@@ -31,16 +31,19 @@ test.describe('Import photo blob registry', () => {
         expect(result.missingAfterRemoval).toBe(true);
     });
 
-    test('keeps sequential registrations distinct and clears all entries', async ({ page }) => {
+    test('keeps a full twenty-photo batch distinct and clears every entry', async ({ page }) => {
         await page.goto(harness);
         await expect(page.locator('#status')).toHaveText('ready');
 
         const result = await page.evaluate(async () => {
-            const first = await window.importPhotoHarness.registerTestImage(true);
-            const second = await window.importPhotoHarness.registerTestImage(false);
+            const registrations = [];
+            for (let index = 0; index < 20; index += 1) {
+                registrations.push(await window.importPhotoHarness.registerTestImage(index % 2 === 0));
+            }
+
             window.importPhotoHarness.clear();
             const missing = [];
-            for (const registration of [first, second]) {
+            for (const registration of registrations) {
                 try {
                     await window.importPhotoHarness.readLength(registration.token);
                     missing.push(false);
@@ -49,11 +52,11 @@ test.describe('Import photo blob registry', () => {
                 }
             }
 
-            return { first, second, missing };
+            return { registrations, missing };
         });
 
-        expect(result.first.token).not.toBe(result.second.token);
-        expect(result.first.thumbnailUrl).not.toBe(result.second.thumbnailUrl);
-        expect(result.missing).toEqual([true, true]);
+        expect(new Set(result.registrations.map(registration => registration.token)).size).toBe(20);
+        expect(new Set(result.registrations.map(registration => registration.thumbnailUrl)).size).toBe(20);
+        expect(result.missing).toEqual(Array(20).fill(true));
     });
 });

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportPersistenceFailureEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportPersistenceFailureEnum.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Web.Features.Import.Enums;
+
+public enum ImportPersistenceFailureEnum
+{
+    Trip = 1,
+    Catch = 2,
+    Photograph = 3,
+    Verification = 4
+}

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportPersistenceStageEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportPersistenceStageEnum.cs
@@ -1,0 +1,9 @@
+namespace FishingLogBook.Web.Features.Import.Enums;
+
+public enum ImportPersistenceStageEnum
+{
+    SavingTrip = 1,
+    SavingCatch = 2,
+    UploadingPhotograph = 3,
+    Verifying = 4
+}

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
@@ -56,6 +56,65 @@ public sealed class ImportBatchModel
         }
     }
 
+    public void ValidateForPersistence(DateTimeOffset now)
+    {
+        if (!CanProcessPhotos)
+        {
+            throw new InvalidOperationException("The Import batch requires valid catalogue selections.");
+        }
+
+        var activePhotos = _photos.Where(photo => !photo.IsRemoved).ToArray();
+        var activeCatches = _catchProposals.Where(proposal => !proposal.IsRemoved).ToArray();
+        if (activePhotos.Length == 0 || activeCatches.Length == 0 || activePhotos.Any(photo => !photo.IsReady))
+        {
+            throw new InvalidOperationException("The Import batch requires active photographs and Catches.");
+        }
+
+        if (activePhotos.Select(photo => photo.Id).Distinct().Count() != activePhotos.Length
+            || activeCatches.Select(proposal => proposal.Id).Distinct().Count() != activeCatches.Length)
+        {
+            throw new InvalidOperationException("Active Import identities must be unique.");
+        }
+
+        var memberships = activeCatches.SelectMany(proposal => proposal.PhotoIds).ToArray();
+        var activePhotoIds = activePhotos.Select(photo => photo.Id).ToHashSet();
+        if (memberships.Length != activePhotos.Length
+            || memberships.Distinct().Count() != memberships.Length
+            || memberships.Any(photoId => !activePhotoIds.Contains(photoId)))
+        {
+            throw new InvalidOperationException("Every active photograph must belong to exactly one active Catch.");
+        }
+
+        if (activeCatches.Any(proposal => !proposal.IsReadyForConfirmation
+                || !proposal.CaughtOn.Instant.HasValue
+                || proposal.CaughtOn.Instant.Value > now))
+        {
+            throw new InvalidOperationException("Every active Catch must be reviewed with a valid historical timestamp.");
+        }
+
+        ValidateTripProposals(activeCatches.Select(proposal => proposal.Id).ToHashSet());
+    }
+
+    private void ValidateTripProposals(HashSet<Guid> activeCatchIds)
+    {
+        var activeTrips = _tripProposals.Where(proposal => !proposal.IsRemoved).ToArray();
+        if (activeTrips.Any(proposal => !proposal.IsDecisionComplete
+                || proposal.CatchProposalIds.Any(catchId => !activeCatchIds.Contains(catchId))
+                || proposal.Participants.Select(participant => participant.UserId).Distinct().Count()
+                    != proposal.Participants.Count
+                || (proposal.Decision == ImportTripDecisionEnum.UseExisting
+                    && (!proposal.ExistingTripId.HasValue || proposal.ExistingTripId == Guid.Empty))))
+        {
+            throw new InvalidOperationException("Every active Trip proposal requires a valid final decision.");
+        }
+
+        var tripMemberships = activeTrips.SelectMany(proposal => proposal.CatchProposalIds).ToArray();
+        if (tripMemberships.Distinct().Count() != tripMemberships.Length)
+        {
+            throw new InvalidOperationException("An active Catch may belong to at most one Trip decision.");
+        }
+    }
+
     public bool CanAdvanceToTrips
     {
         get

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
@@ -48,71 +48,80 @@ public sealed class ImportBatchModel
     {
         get
         {
-            var activeCatches = _catchProposals.Where(proposal => !proposal.IsRemoved).ToArray();
-            return CanProcessPhotos
-                && activeCatches.Length > 0
-                && activeCatches.All(proposal => proposal.IsReadyForConfirmation)
-                && _tripProposals.All(proposal => proposal.IsDecisionComplete);
+            return PersistenceValidationError(DateTimeOffset.UtcNow) is null;
         }
     }
 
     public void ValidateForPersistence(DateTimeOffset now)
     {
+        var error = PersistenceValidationError(now);
+        if (error is not null)
+        {
+            throw new InvalidOperationException(error);
+        }
+    }
+
+    private string? PersistenceValidationError(DateTimeOffset now)
+    {
         if (!CanProcessPhotos)
         {
-            throw new InvalidOperationException("The Import batch requires valid catalogue selections.");
+            return "The Import batch requires valid catalogue selections.";
         }
 
         var activePhotos = _photos.Where(photo => !photo.IsRemoved).ToArray();
         var activeCatches = _catchProposals.Where(proposal => !proposal.IsRemoved).ToArray();
+        return ActiveRecordsValidationError(activePhotos, activeCatches)
+            ?? TripValidationError(activeCatches, now);
+    }
+
+    private static string? ActiveRecordsValidationError(
+        ImportSelectedPhotoModel[] activePhotos,
+        ImportCatchProposalModel[] activeCatches)
+    {
         if (activePhotos.Length == 0 || activeCatches.Length == 0 || activePhotos.Any(photo => !photo.IsReady))
         {
-            throw new InvalidOperationException("The Import batch requires active photographs and Catches.");
+            return "The Import batch requires active photographs and Catches.";
         }
 
         if (activePhotos.Select(photo => photo.Id).Distinct().Count() != activePhotos.Length
             || activeCatches.Select(proposal => proposal.Id).Distinct().Count() != activeCatches.Length)
         {
-            throw new InvalidOperationException("Active Import identities must be unique.");
+            return "Active Import identities must be unique.";
         }
 
         var memberships = activeCatches.SelectMany(proposal => proposal.PhotoIds).ToArray();
         var activePhotoIds = activePhotos.Select(photo => photo.Id).ToHashSet();
-        if (memberships.Length != activePhotos.Length
+        return memberships.Length != activePhotos.Length
             || memberships.Distinct().Count() != memberships.Length
-            || memberships.Any(photoId => !activePhotoIds.Contains(photoId)))
-        {
-            throw new InvalidOperationException("Every active photograph must belong to exactly one active Catch.");
-        }
+            || memberships.Any(photoId => !activePhotoIds.Contains(photoId))
+                ? "Every active photograph must belong to exactly one active Catch."
+                : null;
+    }
 
+    private string? TripValidationError(ImportCatchProposalModel[] activeCatches, DateTimeOffset now)
+    {
         if (activeCatches.Any(proposal => !proposal.IsReadyForConfirmation
                 || !proposal.CaughtOn.Instant.HasValue
                 || proposal.CaughtOn.Instant.Value > now))
         {
-            throw new InvalidOperationException("Every active Catch must be reviewed with a valid historical timestamp.");
+            return "Every active Catch must be reviewed with a valid historical timestamp.";
         }
 
-        ValidateTripProposals(activeCatches.Select(proposal => proposal.Id).ToHashSet());
-    }
-
-    private void ValidateTripProposals(HashSet<Guid> activeCatchIds)
-    {
         var activeTrips = _tripProposals.Where(proposal => !proposal.IsRemoved).ToArray();
         if (activeTrips.Any(proposal => !proposal.IsDecisionComplete
-                || proposal.CatchProposalIds.Any(catchId => !activeCatchIds.Contains(catchId))
+                || proposal.CatchProposalIds.Any(catchId => activeCatches.All(candidate => candidate.Id != catchId))
                 || proposal.Participants.Select(participant => participant.UserId).Distinct().Count()
                     != proposal.Participants.Count
                 || (proposal.Decision == ImportTripDecisionEnum.UseExisting
                     && (!proposal.ExistingTripId.HasValue || proposal.ExistingTripId == Guid.Empty))))
         {
-            throw new InvalidOperationException("Every active Trip proposal requires a valid final decision.");
+            return "Every active Trip proposal requires a valid final decision.";
         }
 
         var tripMemberships = activeTrips.SelectMany(proposal => proposal.CatchProposalIds).ToArray();
-        if (tripMemberships.Distinct().Count() != tripMemberships.Length)
-        {
-            throw new InvalidOperationException("An active Catch may belong to at most one Trip decision.");
-        }
+        return tripMemberships.Distinct().Count() != tripMemberships.Length
+            ? "An active Catch may belong to at most one Trip decision."
+            : null;
     }
 
     public bool CanAdvanceToTrips

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportPersistenceProgressModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportPersistenceProgressModel.cs
@@ -1,0 +1,8 @@
+using FishingLogBook.Web.Features.Import.Enums;
+
+namespace FishingLogBook.Web.Features.Import.Models;
+
+public sealed record ImportPersistenceProgressModel(
+    ImportPersistenceStageEnum Stage,
+    int Current,
+    int Total);

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportPersistenceResultModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportPersistenceResultModel.cs
@@ -1,7 +1,21 @@
+using FishingLogBook.Web.Features.Import.Enums;
+
 namespace FishingLogBook.Web.Features.Import.Models;
 
 public sealed record ImportPersistenceResultModel(
     IReadOnlyList<Guid> CreatedTripIds,
     IReadOnlyList<Guid> CatchIds,
     int PhotographCount,
-    int ParticipantCount);
+    int ParticipantCount,
+    ImportPersistenceFailureEnum? Failure = null,
+    Exception? FailureException = null)
+{
+    public bool IsSuccess => Failure is null;
+
+    public static ImportPersistenceResultModel Failed(
+        ImportPersistenceFailureEnum failure,
+        Exception exception)
+    {
+        return new ImportPersistenceResultModel([], [], 0, 0, failure, exception);
+    }
+}

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
@@ -277,6 +277,12 @@
                             @Loc[_isPersisting ? "Import_Importing" : "Import_ConfirmImport"]
                         </MudButton>
                     </MudStack>
+                    @if (_isPersisting)
+                    {
+                        <MudText id="import-persistence-progress" Typo="Typo.body2">
+                            @PersistenceProgressLabel()
+                        </MudText>
+                    }
                 }
             }
         }

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
@@ -267,15 +267,22 @@
                     }
                     <MudStack Row="true" Justify="Justify.SpaceBetween">
                         <MudButton Variant="Variant.Text" Disabled="_isPersisting" OnClick="BackToCatchReview" id="import-confirm-back">@Loc["Common_Back"]</MudButton>
-                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_isPersisting"
-                                   OnClick="PersistAsync" id="import-confirm">
+                        <MudStack Row="true" Spacing="1">
                             @if (_isPersisting)
                             {
-                                <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2"
-                                                     id="import-confirm-spinner" />
+                                <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="CancelPersistence"
+                                           id="import-cancel-persistence">@Loc["Common_Cancel"]</MudButton>
                             }
-                            @Loc[_isPersisting ? "Import_Importing" : "Import_ConfirmImport"]
-                        </MudButton>
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_isPersisting"
+                                       OnClick="PersistAsync" id="import-confirm">
+                                @if (_isPersisting)
+                                {
+                                    <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2"
+                                                         id="import-confirm-spinner" />
+                                }
+                                @Loc[_isPersisting ? "Import_Importing" : "Import_ConfirmImport"]
+                            </MudButton>
+                        </MudStack>
                     </MudStack>
                     @if (_isPersisting)
                     {

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
@@ -27,6 +27,7 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
     private bool _isPersisted;
     private string? _persistenceError;
     private ImportPersistenceResultModel? _persistenceResult;
+    private ImportPersistenceProgressModel? _persistenceProgress;
     private IReadOnlyDictionary<Guid, IReadOnlyList<TripSummaryDto>> _existingTrips =
         new Dictionary<Guid, IReadOnlyList<TripSummaryDto>>();
 
@@ -333,6 +334,7 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
         try
         {
             _persistenceError = null;
+            _persistenceProgress = null;
             if (!await NetworkService.IsOnlineAsync(_cancellationTokenSource.Token))
             {
                 _persistenceError = Loc["Import_OnlineRequired"];
@@ -341,7 +343,8 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
 
             _persistenceResult = await PersistenceService.PersistAsync(
                 _batch,
-                _cancellationTokenSource.Token);
+                _cancellationTokenSource.Token,
+                new Progress<ImportPersistenceProgressModel>(OnPersistenceProgress));
             _isPersisted = true;
             await Preparation.ClearAsync(CancellationToken.None);
         }
@@ -357,6 +360,29 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
         {
             _isPersisting = false;
         }
+    }
+
+    private void OnPersistenceProgress(ImportPersistenceProgressModel progress)
+    {
+        _persistenceProgress = progress;
+        StateHasChanged();
+    }
+
+    private string PersistenceProgressLabel()
+    {
+        if (_persistenceProgress is null)
+        {
+            return Loc["Import_Importing"];
+        }
+
+        var resource = _persistenceProgress.Stage switch
+        {
+            ImportPersistenceStageEnum.SavingTrip => "Import_ProgressSavingTrip",
+            ImportPersistenceStageEnum.SavingCatch => "Import_ProgressSavingCatch",
+            ImportPersistenceStageEnum.UploadingPhotograph => "Import_ProgressUploadingPhotograph",
+            _ => "Import_ProgressVerifying"
+        };
+        return Loc[resource, _persistenceProgress.Current, _persistenceProgress.Total];
     }
 
     private void NavigateToCatches()

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
@@ -2,6 +2,7 @@ using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Common.Modals.AnglerPicker;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
 using FishingLogBook.Web.Features.Import.Services;
@@ -17,6 +18,7 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
 {
     private const int MaxChipOptions = 6;
     private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private CancellationTokenSource? _persistenceCancellationTokenSource;
     private AnglerPreferencesModel _preferences = AnglerPreferencesModel.Empty;
     private ImportBatchModel? _batch;
     private Guid _methodId;
@@ -41,6 +43,7 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
     [Inject] private INetworkService NetworkService { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+    [Inject] private ILoggingService Logging { get; set; } = default!;
 
     private bool CanReview
     {
@@ -331,11 +334,14 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
         }
 
         _isPersisting = true;
+        using var persistenceCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+            _cancellationTokenSource.Token);
+        _persistenceCancellationTokenSource = persistenceCancellationTokenSource;
         try
         {
             _persistenceError = null;
             _persistenceProgress = null;
-            if (!await NetworkService.IsOnlineAsync(_cancellationTokenSource.Token))
+            if (!await NetworkService.IsOnlineAsync(persistenceCancellationTokenSource.Token))
             {
                 _persistenceError = Loc["Import_OnlineRequired"];
                 return;
@@ -343,23 +349,55 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
 
             _persistenceResult = await PersistenceService.PersistAsync(
                 _batch,
-                _cancellationTokenSource.Token,
+                persistenceCancellationTokenSource.Token,
                 new Progress<ImportPersistenceProgressModel>(OnPersistenceProgress));
             _isPersisted = true;
             await Preparation.ClearAsync(CancellationToken.None);
         }
-        catch (OperationCanceledException) when (_cancellationTokenSource.IsCancellationRequested)
+        catch (OperationCanceledException) when (persistenceCancellationTokenSource.IsCancellationRequested)
         {
-            throw;
+            _persistenceError = null;
         }
-        catch
+        catch (ImportPersistenceException exception)
+        {
+            _persistenceError = PersistenceFailureLabel(exception.Failure);
+            await LogPersistenceFailureAsync(exception);
+        }
+        catch (Exception exception)
         {
             _persistenceError = Loc["Import_PersistenceFailed"];
+            await LogPersistenceFailureAsync(exception);
         }
         finally
         {
             _isPersisting = false;
+            _persistenceCancellationTokenSource = null;
         }
+    }
+
+    private string PersistenceFailureLabel(ImportPersistenceFailureEnum failure)
+    {
+        var resource = failure switch
+        {
+            ImportPersistenceFailureEnum.Trip => "Import_TripPersistenceFailed",
+            ImportPersistenceFailureEnum.Catch => "Import_CatchPersistenceFailed",
+            ImportPersistenceFailureEnum.Photograph => "Import_PhotographPersistenceFailed",
+            _ => "Import_VerificationFailed"
+        };
+        return Loc[resource];
+    }
+
+    private Task LogPersistenceFailureAsync(Exception exception)
+    {
+        return Logging.LogErrorAsync(
+            "persisting a historical Import",
+            $"Historical Import persistence stopped ({exception.GetType().Name}).",
+            CancellationToken.None);
+    }
+
+    private void CancelPersistence()
+    {
+        _persistenceCancellationTokenSource?.Cancel();
     }
 
     private void OnPersistenceProgress(ImportPersistenceProgressModel progress)
@@ -525,6 +563,11 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        if (_persistenceCancellationTokenSource is not null)
+        {
+            await _persistenceCancellationTokenSource.CancelAsync();
+        }
+
         await _cancellationTokenSource.CancelAsync();
         await Preparation.ClearAsync(CancellationToken.None);
         _cancellationTokenSource.Dispose();

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
@@ -351,17 +351,23 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
                 _batch,
                 persistenceCancellationTokenSource.Token,
                 new Progress<ImportPersistenceProgressModel>(OnPersistenceProgress));
+            if (!_persistenceResult.IsSuccess)
+            {
+                _persistenceError = PersistenceFailureLabel(_persistenceResult.Failure!.Value);
+                if (_persistenceResult.FailureException is not null)
+                {
+                    await LogPersistenceFailureAsync(_persistenceResult.FailureException);
+                }
+
+                return;
+            }
+
             _isPersisted = true;
             await Preparation.ClearAsync(CancellationToken.None);
         }
         catch (OperationCanceledException) when (persistenceCancellationTokenSource.IsCancellationRequested)
         {
             _persistenceError = null;
-        }
-        catch (ImportPersistenceException exception)
-        {
-            _persistenceError = PersistenceFailureLabel(exception.Failure);
-            await LogPersistenceFailureAsync(exception);
         }
         catch (Exception exception)
         {

--- a/src/FishingLogBook.Web/Features/Import/Services/IImportPersistenceService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/IImportPersistenceService.cs
@@ -6,5 +6,6 @@ public interface IImportPersistenceService
 {
     Task<ImportPersistenceResultModel> PersistAsync(
         ImportBatchModel batch,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken,
+        IProgress<ImportPersistenceProgressModel>? progress = null);
 }

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
@@ -31,7 +31,8 @@ public sealed class ImportPersistenceService : IImportPersistenceService
 
     public async Task<ImportPersistenceResultModel> PersistAsync(
         ImportBatchModel batch,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IProgress<ImportPersistenceProgressModel>? progress = null)
     {
         Validate(batch);
         var currentUser = await _currentUserClient.GetCurrentAsync(cancellationToken);
@@ -40,10 +41,20 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         var participantCount = 0;
         var photographCount = 0;
         var tripByCatch = new Dictionary<Guid, Guid>();
+        var tripProposals = batch.TripProposals.Where(proposal => !proposal.IsRemoved).ToArray();
+        var catchProposals = batch.CatchProposals.Where(proposal => !proposal.IsRemoved).ToArray();
+        var photographTotal = catchProposals.Sum(proposal => proposal.PhotoIds.Count);
+        var tripNumber = 0;
+        var catchNumber = 0;
+        var photographNumber = 0;
 
-        foreach (var proposal in batch.TripProposals.Where(proposal => !proposal.IsRemoved))
+        foreach (var proposal in tripProposals)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            progress?.Report(new ImportPersistenceProgressModel(
+                ImportPersistenceStageEnum.SavingTrip,
+                ++tripNumber,
+                tripProposals.Length));
             var tripId = proposal.Decision == ImportTripDecisionEnum.CreateNew
                 ? await CreateTripAsync(batch, proposal, currentUser.UserId, cancellationToken)
                 : proposal.ExistingTripId;
@@ -70,19 +81,31 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             }
         }
 
-        foreach (var proposal in batch.CatchProposals.Where(proposal => !proposal.IsRemoved))
+        foreach (var proposal in catchProposals)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            progress?.Report(new ImportPersistenceProgressModel(
+                ImportPersistenceStageEnum.SavingCatch,
+                ++catchNumber,
+                catchProposals.Length));
             tripByCatch.TryGetValue(proposal.Id, out var tripId);
             var persisted = await PersistCatchAsync(
                 batch,
                 proposal,
                 currentUser.UserId,
                 tripId == Guid.Empty ? null : tripId,
-                cancellationToken);
+                cancellationToken,
+                progress,
+                photographTotal,
+                () => ++photographNumber);
             catchIds.Add(persisted.Id);
             photographCount += persisted.Photographs.Count;
         }
+
+        progress?.Report(new ImportPersistenceProgressModel(
+            ImportPersistenceStageEnum.Verifying,
+            1,
+            1));
 
         return new ImportPersistenceResultModel(
             tripIds.Distinct().ToArray(),
@@ -108,6 +131,13 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             Title = proposal.ProposedTitle,
             PlaceName = proposal.ProposedPlaceName
         };
+        var existing = await _tripClient.GetDetailAsync(proposal.Id, cancellationToken);
+        if (existing?.Trip is not null)
+        {
+            EnsureExpectedTrip(existing.Trip, trip);
+            return existing.Trip.Id;
+        }
+
         var persisted = await _tripClient.UpsertAsync(trip, cancellationToken)
             ?? throw new InvalidOperationException("The authoritative Trip create response was missing.");
         if (persisted.Id != proposal.Id)
@@ -165,7 +195,10 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         ImportCatchProposalModel proposal,
         Guid userId,
         Guid? tripId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IProgress<ImportPersistenceProgressModel>? progress,
+        int photographTotal,
+        Func<int> nextPhotographNumber)
     {
         var caughtOn = ToInstant(proposal.CaughtOn);
         var location = ToLocation(proposal.Location, caughtOn);
@@ -183,16 +216,34 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             Weight = proposal.Weight,
             Length = proposal.Length
         };
-        var persisted = await _catchClient.UpsertAsync(request, cancellationToken)
-            ?? throw new InvalidOperationException("The authoritative Catch create response was missing.");
-        if (persisted.Id != proposal.Id || persisted.TripId != tripId)
+        var current = await _catchClient.GetAsync(proposal.Id, cancellationToken);
+        if (current is null)
         {
-            throw new InvalidOperationException("The authoritative Catch identity or Trip relationship is incorrect.");
+            var persisted = await _catchClient.UpsertAsync(request, cancellationToken)
+                ?? throw new InvalidOperationException("The authoritative Catch create response was missing.");
+            if (persisted.Id != proposal.Id || persisted.TripId != tripId)
+            {
+                throw new InvalidOperationException("The authoritative Catch identity or Trip relationship is incorrect.");
+            }
+
+            current = await RequireCatchAsync(proposal.Id, cancellationToken);
+        }
+        else if (!HasExpectedCatch(current, request))
+        {
+            throw new InvalidOperationException("An authoritative Catch conflicts with the Import proposal.");
         }
 
-        var current = await RequireCatchAsync(proposal.Id, cancellationToken);
         foreach (var photoId in proposal.PhotoIds)
         {
+            progress?.Report(new ImportPersistenceProgressModel(
+                ImportPersistenceStageEnum.UploadingPhotograph,
+                nextPhotographNumber(),
+                photographTotal));
+            if (current.Photographs.Any(photo => photo.Id == photoId))
+            {
+                continue;
+            }
+
             var photo = batch.Photos.Single(candidate => candidate.Id == photoId && !candidate.IsRemoved);
             if (string.IsNullOrWhiteSpace(photo.BlobToken))
             {
@@ -219,6 +270,20 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         }
 
         return current;
+    }
+
+    private static void EnsureExpectedTrip(TripViewDto current, TripDto expected)
+    {
+        if (current.Id != expected.Id
+            || current.OwnerUserId != expected.OwnerUserId
+            || current.Status != expected.Status
+            || current.StartedOn != expected.StartedOn
+            || current.EndedOn != expected.EndedOn
+            || !string.Equals(current.Title, expected.Title, StringComparison.Ordinal)
+            || !string.Equals(current.PlaceName, expected.PlaceName, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("An authoritative Trip conflicts with the Import proposal.");
+        }
     }
 
     private static bool HasExpectedCatch(CatchViewDto current, CatchDto expected)
@@ -342,9 +407,6 @@ public sealed class ImportPersistenceService : IImportPersistenceService
 
     private static void Validate(ImportBatchModel batch)
     {
-        if (!batch.IsReadyForConfirmation)
-        {
-            throw new InvalidOperationException("The Import batch is not ready for persistence.");
-        }
+        batch.ValidateForPersistence(DateTimeOffset.UtcNow);
     }
 }

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
@@ -131,18 +131,28 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             Title = proposal.ProposedTitle,
             PlaceName = proposal.ProposedPlaceName
         };
-        var existing = await _tripClient.GetDetailAsync(proposal.Id, cancellationToken);
+        var existing = await ExecuteAsync(
+            () => _tripClient.GetDetailAsync(proposal.Id, cancellationToken),
+            ImportPersistenceFailureEnum.Verification,
+            "The authoritative Trip could not be reconciled.");
         if (existing?.Trip is not null)
         {
             EnsureExpectedTrip(existing.Trip, trip);
             return existing.Trip.Id;
         }
 
-        var persisted = await _tripClient.UpsertAsync(trip, cancellationToken)
-            ?? throw new InvalidOperationException("The authoritative Trip create response was missing.");
+        var persisted = await ExecuteAsync(
+                () => _tripClient.UpsertAsync(trip, cancellationToken),
+                ImportPersistenceFailureEnum.Trip,
+                "The Trip could not be saved.")
+            ?? throw new ImportPersistenceException(
+                ImportPersistenceFailureEnum.Trip,
+                "The authoritative Trip create response was missing.");
         if (persisted.Id != proposal.Id)
         {
-            throw new InvalidOperationException("The authoritative Trip identity did not match the Import proposal.");
+            throw new ImportPersistenceException(
+                ImportPersistenceFailureEnum.Verification,
+                "The authoritative Trip identity did not match the Import proposal.");
         }
 
         return persisted.Id;
@@ -153,8 +163,13 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         Guid ownerUserId,
         CancellationToken cancellationToken)
     {
-        var current = await _participantClient.GetAsync(proposal.Id, cancellationToken)
-            ?? throw new InvalidOperationException("The new Trip participants could not be read.");
+        var current = await ExecuteAsync(
+                () => _participantClient.GetAsync(proposal.Id, cancellationToken),
+                ImportPersistenceFailureEnum.Verification,
+                "The new Trip participants could not be read.")
+            ?? throw new ImportPersistenceException(
+                ImportPersistenceFailureEnum.Verification,
+                "The new Trip participants could not be read.");
         var existing = current.Participants.Select(participant => participant.UserId).ToHashSet();
         existing.Add(ownerUserId);
         var added = 0;
@@ -165,10 +180,13 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                 continue;
             }
 
-            var response = await _participantClient.InviteAsync(
-                proposal.Id,
-                new InviteTripParticipantDto(participant.UserId),
-                cancellationToken);
+            var response = await ExecuteAsync(
+                () => _participantClient.InviteAsync(
+                    proposal.Id,
+                    new InviteTripParticipantDto(participant.UserId),
+                    cancellationToken),
+                ImportPersistenceFailureEnum.Trip,
+                "A Trip participant could not be added.");
             if (response is null)
             {
                 throw new InvalidOperationException("A selected Trip participant could not be invited.");
@@ -178,8 +196,13 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             added++;
         }
 
-        var verified = await _participantClient.GetAsync(proposal.Id, cancellationToken)
-            ?? throw new InvalidOperationException("The new Trip participants could not be verified.");
+        var verified = await ExecuteAsync(
+                () => _participantClient.GetAsync(proposal.Id, cancellationToken),
+                ImportPersistenceFailureEnum.Verification,
+                "The new Trip participants could not be verified.")
+            ?? throw new ImportPersistenceException(
+                ImportPersistenceFailureEnum.Verification,
+                "The new Trip participants could not be verified.");
         if (proposal.Participants.Any(participant =>
                 participant.UserId != ownerUserId
                 && verified.Participants.All(actual => actual.UserId != participant.UserId)))
@@ -216,11 +239,19 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             Weight = proposal.Weight,
             Length = proposal.Length
         };
-        var current = await _catchClient.GetAsync(proposal.Id, cancellationToken);
+        var current = await ExecuteAsync(
+            () => _catchClient.GetAsync(proposal.Id, cancellationToken),
+            ImportPersistenceFailureEnum.Verification,
+            "The authoritative Catch could not be reconciled.");
         if (current is null)
         {
-            var persisted = await _catchClient.UpsertAsync(request, cancellationToken)
-                ?? throw new InvalidOperationException("The authoritative Catch create response was missing.");
+            var persisted = await ExecuteAsync(
+                    () => _catchClient.UpsertAsync(request, cancellationToken),
+                    ImportPersistenceFailureEnum.Catch,
+                    "The Catch could not be saved.")
+                ?? throw new ImportPersistenceException(
+                    ImportPersistenceFailureEnum.Catch,
+                    "The authoritative Catch create response was missing.");
             if (persisted.Id != proposal.Id || persisted.TripId != tripId)
             {
                 throw new InvalidOperationException("The authoritative Catch identity or Trip relationship is incorrect.");
@@ -230,7 +261,9 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         }
         else if (!HasExpectedCatch(current, request))
         {
-            throw new InvalidOperationException("An authoritative Catch conflicts with the Import proposal.");
+            throw new ImportPersistenceException(
+                ImportPersistenceFailureEnum.Verification,
+                "An authoritative Catch conflicts with the Import proposal.");
         }
 
         foreach (var photoId in proposal.PhotoIds)
@@ -239,8 +272,20 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                 ImportPersistenceStageEnum.UploadingPhotograph,
                 nextPhotographNumber(),
                 photographTotal));
-            if (current.Photographs.Any(photo => photo.Id == photoId))
+            var existingPhotograph = current.Photographs.SingleOrDefault(photo => photo.Id == photoId);
+            if (existingPhotograph is not null)
             {
+                var expectedContentType = batch.Photos.Single(candidate => candidate.Id == photoId).ContentType;
+                if (!string.Equals(
+                        existingPhotograph.ContentType,
+                        expectedContentType,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ImportPersistenceException(
+                        ImportPersistenceFailureEnum.Verification,
+                        "An authoritative photograph conflicts with the Import proposal.");
+                }
+
                 continue;
             }
 
@@ -250,16 +295,29 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                 throw new InvalidOperationException("An imported photograph has no prepared bytes.");
             }
 
-            var bytes = await _blobRegistry.GetBytesAsync(photo.BlobToken, cancellationToken);
-            var upload = await _catchClient.CreatePhotographUploadAsync(
-                proposal.Id,
-                new PhotographUploadRequestDto(photo.Id, photo.ContentType),
-                cancellationToken);
-            await _catchClient.UploadPhotographAsync(upload.UploadUrl, bytes, photo.ContentType, cancellationToken);
-            await _catchClient.RecordPhotographAsync(
-                proposal.Id,
-                new RecordPhotographDto(photo.Id, upload.ObjectKey, photo.ContentType),
-                cancellationToken);
+            var bytes = await ExecuteAsync(
+                () => _blobRegistry.GetBytesAsync(photo.BlobToken, cancellationToken),
+                ImportPersistenceFailureEnum.Photograph,
+                "The prepared photograph could not be read.");
+            var upload = await ExecuteAsync(
+                () => _catchClient.CreatePhotographUploadAsync(
+                    proposal.Id,
+                    new PhotographUploadRequestDto(photo.Id, photo.ContentType),
+                    cancellationToken),
+                ImportPersistenceFailureEnum.Photograph,
+                "The photograph upload could not be prepared.");
+            await ExecuteAsync(
+                () => _catchClient.UploadPhotographAsync(
+                    upload.UploadUrl, bytes, photo.ContentType, cancellationToken),
+                ImportPersistenceFailureEnum.Photograph,
+                "The photograph could not be uploaded.");
+            await ExecuteAsync(
+                () => _catchClient.RecordPhotographAsync(
+                    proposal.Id,
+                    new RecordPhotographDto(photo.Id, upload.ObjectKey, photo.ContentType),
+                    cancellationToken),
+                ImportPersistenceFailureEnum.Photograph,
+                "The uploaded photograph could not be registered.");
             current = await RequireCatchAsync(proposal.Id, cancellationToken);
         }
 
@@ -280,9 +338,12 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             || current.StartedOn != expected.StartedOn
             || current.EndedOn != expected.EndedOn
             || !string.Equals(current.Title, expected.Title, StringComparison.Ordinal)
-            || !string.Equals(current.PlaceName, expected.PlaceName, StringComparison.Ordinal))
+            || !string.Equals(current.PlaceName, expected.PlaceName, StringComparison.Ordinal)
+            || current.Location != expected.Location)
         {
-            throw new InvalidOperationException("An authoritative Trip conflicts with the Import proposal.");
+            throw new ImportPersistenceException(
+                ImportPersistenceFailureEnum.Verification,
+                "An authoritative Trip conflicts with the Import proposal.");
         }
     }
 
@@ -320,7 +381,10 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         Guid ownerUserId,
         CancellationToken cancellationToken)
     {
-        var detail = await _tripClient.GetDetailAsync(expected.Id, cancellationToken);
+        var detail = await ExecuteAsync(
+            () => _tripClient.GetDetailAsync(expected.Id, cancellationToken),
+            ImportPersistenceFailureEnum.Verification,
+            "The authoritative Trip could not be verified.");
         var trip = detail?.Trip;
         if (trip is null
             || trip.Id != expected.Id
@@ -329,7 +393,9 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             || trip.StartedOn != TripStartedOn(batch, expected)
             || trip.EndedOn != TripEndedOn(batch, expected))
         {
-            throw new InvalidOperationException("The authoritative Trip could not be verified.");
+            throw new ImportPersistenceException(
+                ImportPersistenceFailureEnum.Verification,
+                "The authoritative Trip could not be verified.");
         }
     }
 
@@ -373,8 +439,13 @@ public sealed class ImportPersistenceService : IImportPersistenceService
 
     private async Task<CatchViewDto> RequireCatchAsync(Guid catchId, CancellationToken cancellationToken)
     {
-        return await _catchClient.GetAsync(catchId, cancellationToken)
-            ?? throw new InvalidOperationException("The authoritative Catch could not be verified.");
+        return await ExecuteAsync(
+                () => _catchClient.GetAsync(catchId, cancellationToken),
+                ImportPersistenceFailureEnum.Verification,
+                "The authoritative Catch could not be verified.")
+            ?? throw new ImportPersistenceException(
+                ImportPersistenceFailureEnum.Verification,
+                "The authoritative Catch could not be verified.");
     }
 
     private static CatchLocationDto? ToLocation(ImportLocationModel? location, DateTimeOffset caughtOn)
@@ -408,5 +479,43 @@ public sealed class ImportPersistenceService : IImportPersistenceService
     private static void Validate(ImportBatchModel batch)
     {
         batch.ValidateForPersistence(DateTimeOffset.UtcNow);
+    }
+
+    private static async Task<T> ExecuteAsync<T>(
+        Func<Task<T>> action,
+        ImportPersistenceFailureEnum failure,
+        string message)
+    {
+        try
+        {
+            return await action();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (ImportPersistenceException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            throw new ImportPersistenceException(failure, message, exception);
+        }
+    }
+
+    private static async Task ExecuteAsync(
+        Func<Task> action,
+        ImportPersistenceFailureEnum failure,
+        string message)
+    {
+        await ExecuteAsync(
+            async () =>
+            {
+                await action();
+                return true;
+            },
+            failure,
+            message);
     }
 }

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
@@ -34,6 +34,27 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         CancellationToken cancellationToken,
         IProgress<ImportPersistenceProgressModel>? progress = null)
     {
+        var context = new PersistenceContext();
+        try
+        {
+            return await PersistCoreAsync(batch, cancellationToken, progress, context);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            return ImportPersistenceResultModel.Failed(context.Failure, exception);
+        }
+    }
+
+    private async Task<ImportPersistenceResultModel> PersistCoreAsync(
+        ImportBatchModel batch,
+        CancellationToken cancellationToken,
+        IProgress<ImportPersistenceProgressModel>? progress,
+        PersistenceContext context)
+    {
         Validate(batch);
         var currentUser = await _currentUserClient.GetCurrentAsync(cancellationToken);
         var tripIds = new List<Guid>();
@@ -56,7 +77,7 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                 ++tripNumber,
                 tripProposals.Length));
             var tripId = proposal.Decision == ImportTripDecisionEnum.CreateNew
-                ? await CreateTripAsync(batch, proposal, currentUser.UserId, cancellationToken)
+                ? await CreateTripAsync(batch, proposal, currentUser.UserId, cancellationToken, context)
                 : proposal.ExistingTripId;
             if (tripId.HasValue)
             {
@@ -76,8 +97,9 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                 participantCount += await PersistParticipantsAsync(
                     proposal,
                     currentUser.UserId,
-                    cancellationToken);
-                await RequireTripAsync(batch, proposal, currentUser.UserId, cancellationToken);
+                    cancellationToken,
+                    context);
+                await RequireTripAsync(batch, proposal, currentUser.UserId, cancellationToken, context);
             }
         }
 
@@ -97,7 +119,8 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                 cancellationToken,
                 progress,
                 photographTotal,
-                () => ++photographNumber);
+                () => ++photographNumber,
+                context);
             catchIds.Add(persisted.Id);
             photographCount += persisted.Photographs.Count;
         }
@@ -118,7 +141,8 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         ImportBatchModel batch,
         ImportTripProposalModel proposal,
         Guid ownerUserId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        PersistenceContext context)
     {
         var trip = new TripDto(
             proposal.Id,
@@ -134,7 +158,7 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         var existing = await ExecuteAsync(
             () => _tripClient.GetDetailAsync(proposal.Id, cancellationToken),
             ImportPersistenceFailureEnum.Verification,
-            "The authoritative Trip could not be reconciled.");
+            "The authoritative Trip could not be reconciled.", context);
         if (existing?.Trip is not null)
         {
             EnsureExpectedTrip(existing.Trip, trip);
@@ -144,15 +168,12 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         var persisted = await ExecuteAsync(
                 () => _tripClient.UpsertAsync(trip, cancellationToken),
                 ImportPersistenceFailureEnum.Trip,
-                "The Trip could not be saved.")
-            ?? throw new ImportPersistenceException(
-                ImportPersistenceFailureEnum.Trip,
-                "The authoritative Trip create response was missing.");
+                "The Trip could not be saved.", context)
+            ?? throw new InvalidOperationException("The authoritative Trip create response was missing.");
         if (persisted.Id != proposal.Id)
         {
-            throw new ImportPersistenceException(
-                ImportPersistenceFailureEnum.Verification,
-                "The authoritative Trip identity did not match the Import proposal.");
+            context.Failure = ImportPersistenceFailureEnum.Verification;
+            throw new InvalidOperationException("The authoritative Trip identity did not match the Import proposal.");
         }
 
         return persisted.Id;
@@ -161,15 +182,14 @@ public sealed class ImportPersistenceService : IImportPersistenceService
     private async Task<int> PersistParticipantsAsync(
         ImportTripProposalModel proposal,
         Guid ownerUserId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        PersistenceContext context)
     {
         var current = await ExecuteAsync(
                 () => _participantClient.GetAsync(proposal.Id, cancellationToken),
                 ImportPersistenceFailureEnum.Verification,
-                "The new Trip participants could not be read.")
-            ?? throw new ImportPersistenceException(
-                ImportPersistenceFailureEnum.Verification,
-                "The new Trip participants could not be read.");
+                "The new Trip participants could not be read.", context)
+            ?? throw new InvalidOperationException("The new Trip participants could not be read.");
         var existing = current.Participants.Select(participant => participant.UserId).ToHashSet();
         existing.Add(ownerUserId);
         var added = 0;
@@ -186,7 +206,7 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                     new InviteTripParticipantDto(participant.UserId),
                     cancellationToken),
                 ImportPersistenceFailureEnum.Trip,
-                "A Trip participant could not be added.");
+                "A Trip participant could not be added.", context);
             if (response is null)
             {
                 throw new InvalidOperationException("A selected Trip participant could not be invited.");
@@ -199,10 +219,8 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         var verified = await ExecuteAsync(
                 () => _participantClient.GetAsync(proposal.Id, cancellationToken),
                 ImportPersistenceFailureEnum.Verification,
-                "The new Trip participants could not be verified.")
-            ?? throw new ImportPersistenceException(
-                ImportPersistenceFailureEnum.Verification,
-                "The new Trip participants could not be verified.");
+                "The new Trip participants could not be verified.", context)
+            ?? throw new InvalidOperationException("The new Trip participants could not be verified.");
         if (proposal.Participants.Any(participant =>
                 participant.UserId != ownerUserId
                 && verified.Participants.All(actual => actual.UserId != participant.UserId)))
@@ -221,7 +239,8 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         CancellationToken cancellationToken,
         IProgress<ImportPersistenceProgressModel>? progress,
         int photographTotal,
-        Func<int> nextPhotographNumber)
+        Func<int> nextPhotographNumber,
+        PersistenceContext context)
     {
         var caughtOn = ToInstant(proposal.CaughtOn);
         var location = ToLocation(proposal.Location, caughtOn);
@@ -242,28 +261,25 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         var current = await ExecuteAsync(
             () => _catchClient.GetAsync(proposal.Id, cancellationToken),
             ImportPersistenceFailureEnum.Verification,
-            "The authoritative Catch could not be reconciled.");
+            "The authoritative Catch could not be reconciled.", context);
         if (current is null)
         {
             var persisted = await ExecuteAsync(
                     () => _catchClient.UpsertAsync(request, cancellationToken),
                     ImportPersistenceFailureEnum.Catch,
-                    "The Catch could not be saved.")
-                ?? throw new ImportPersistenceException(
-                    ImportPersistenceFailureEnum.Catch,
-                    "The authoritative Catch create response was missing.");
+                    "The Catch could not be saved.", context)
+                ?? throw new InvalidOperationException("The authoritative Catch create response was missing.");
             if (persisted.Id != proposal.Id || persisted.TripId != tripId)
             {
                 throw new InvalidOperationException("The authoritative Catch identity or Trip relationship is incorrect.");
             }
 
-            current = await RequireCatchAsync(proposal.Id, cancellationToken);
+            current = await RequireCatchAsync(proposal.Id, cancellationToken, context);
         }
         else if (!HasExpectedCatch(current, request))
         {
-            throw new ImportPersistenceException(
-                ImportPersistenceFailureEnum.Verification,
-                "An authoritative Catch conflicts with the Import proposal.");
+            context.Failure = ImportPersistenceFailureEnum.Verification;
+            throw new InvalidOperationException("An authoritative Catch conflicts with the Import proposal.");
         }
 
         foreach (var photoId in proposal.PhotoIds)
@@ -281,9 +297,8 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                         expectedContentType,
                         StringComparison.OrdinalIgnoreCase))
                 {
-                    throw new ImportPersistenceException(
-                        ImportPersistenceFailureEnum.Verification,
-                        "An authoritative photograph conflicts with the Import proposal.");
+                    context.Failure = ImportPersistenceFailureEnum.Verification;
+                    throw new InvalidOperationException("An authoritative photograph conflicts with the Import proposal.");
                 }
 
                 continue;
@@ -298,27 +313,27 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             var bytes = await ExecuteAsync(
                 () => _blobRegistry.GetBytesAsync(photo.BlobToken, cancellationToken),
                 ImportPersistenceFailureEnum.Photograph,
-                "The prepared photograph could not be read.");
+                "The prepared photograph could not be read.", context);
             var upload = await ExecuteAsync(
                 () => _catchClient.CreatePhotographUploadAsync(
                     proposal.Id,
                     new PhotographUploadRequestDto(photo.Id, photo.ContentType),
                     cancellationToken),
                 ImportPersistenceFailureEnum.Photograph,
-                "The photograph upload could not be prepared.");
+                "The photograph upload could not be prepared.", context);
             await ExecuteAsync(
                 () => _catchClient.UploadPhotographAsync(
                     upload.UploadUrl, bytes, photo.ContentType, cancellationToken),
                 ImportPersistenceFailureEnum.Photograph,
-                "The photograph could not be uploaded.");
+                "The photograph could not be uploaded.", context);
             await ExecuteAsync(
                 () => _catchClient.RecordPhotographAsync(
                     proposal.Id,
                     new RecordPhotographDto(photo.Id, upload.ObjectKey, photo.ContentType),
                     cancellationToken),
                 ImportPersistenceFailureEnum.Photograph,
-                "The uploaded photograph could not be registered.");
-            current = await RequireCatchAsync(proposal.Id, cancellationToken);
+                "The uploaded photograph could not be registered.", context);
+            current = await RequireCatchAsync(proposal.Id, cancellationToken, context);
         }
 
         if (!HasExpectedCatch(current, request)
@@ -341,9 +356,7 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             || !string.Equals(current.PlaceName, expected.PlaceName, StringComparison.Ordinal)
             || current.Location != expected.Location)
         {
-            throw new ImportPersistenceException(
-                ImportPersistenceFailureEnum.Verification,
-                "An authoritative Trip conflicts with the Import proposal.");
+            throw new InvalidOperationException("An authoritative Trip conflicts with the Import proposal.");
         }
     }
 
@@ -379,12 +392,13 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         ImportBatchModel batch,
         ImportTripProposalModel expected,
         Guid ownerUserId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        PersistenceContext context)
     {
         var detail = await ExecuteAsync(
             () => _tripClient.GetDetailAsync(expected.Id, cancellationToken),
             ImportPersistenceFailureEnum.Verification,
-            "The authoritative Trip could not be verified.");
+            "The authoritative Trip could not be verified.", context);
         var trip = detail?.Trip;
         if (trip is null
             || trip.Id != expected.Id
@@ -393,9 +407,7 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             || trip.StartedOn != TripStartedOn(batch, expected)
             || trip.EndedOn != TripEndedOn(batch, expected))
         {
-            throw new ImportPersistenceException(
-                ImportPersistenceFailureEnum.Verification,
-                "The authoritative Trip could not be verified.");
+            throw new InvalidOperationException("The authoritative Trip could not be verified.");
         }
     }
 
@@ -437,15 +449,16 @@ public sealed class ImportPersistenceService : IImportPersistenceService
             .Max(candidate => ToInstant(candidate.CaughtOn));
     }
 
-    private async Task<CatchViewDto> RequireCatchAsync(Guid catchId, CancellationToken cancellationToken)
+    private async Task<CatchViewDto> RequireCatchAsync(
+        Guid catchId,
+        CancellationToken cancellationToken,
+        PersistenceContext context)
     {
         return await ExecuteAsync(
                 () => _catchClient.GetAsync(catchId, cancellationToken),
                 ImportPersistenceFailureEnum.Verification,
-                "The authoritative Catch could not be verified.")
-            ?? throw new ImportPersistenceException(
-                ImportPersistenceFailureEnum.Verification,
-                "The authoritative Catch could not be verified.");
+                "The authoritative Catch could not be verified.", context)
+            ?? throw new InvalidOperationException("The authoritative Catch could not be verified.");
     }
 
     private static CatchLocationDto? ToLocation(ImportLocationModel? location, DateTimeOffset caughtOn)
@@ -484,30 +497,18 @@ public sealed class ImportPersistenceService : IImportPersistenceService
     private static async Task<T> ExecuteAsync<T>(
         Func<Task<T>> action,
         ImportPersistenceFailureEnum failure,
-        string message)
+        string message,
+        PersistenceContext context)
     {
-        try
-        {
-            return await action();
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (ImportPersistenceException)
-        {
-            throw;
-        }
-        catch (Exception exception)
-        {
-            throw new ImportPersistenceException(failure, message, exception);
-        }
+        context.Failure = failure;
+        return await action();
     }
 
     private static async Task ExecuteAsync(
         Func<Task> action,
         ImportPersistenceFailureEnum failure,
-        string message)
+        string message,
+        PersistenceContext context)
     {
         await ExecuteAsync(
             async () =>
@@ -516,6 +517,12 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                 return true;
             },
             failure,
-            message);
+            message,
+            context);
+    }
+
+    private sealed class PersistenceContext
+    {
+        public ImportPersistenceFailureEnum Failure { get; set; } = ImportPersistenceFailureEnum.Verification;
     }
 }

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1433,6 +1433,10 @@
   <data name="Import_SummaryStandalone" xml:space="preserve"><value>Prises indépendantes : {0}</value></data>
   <data name="Import_ConfirmImport" xml:space="preserve"><value>Importer les prises</value></data>
   <data name="Import_Importing" xml:space="preserve"><value>Importation…</value></data>
+  <data name="Import_ProgressSavingTrip" xml:space="preserve"><value>Enregistrement de la sortie {0} sur {1}</value></data>
+  <data name="Import_ProgressSavingCatch" xml:space="preserve"><value>Enregistrement de la prise {0} sur {1}</value></data>
+  <data name="Import_ProgressUploadingPhotograph" xml:space="preserve"><value>Téléversement de la photo {0} sur {1}</value></data>
+  <data name="Import_ProgressVerifying" xml:space="preserve"><value>Vérification des données importées</value></data>
   <data name="Import_OnlineRequired" xml:space="preserve"><value>L’importation historique nécessite une connexion Internet.</value></data>
   <data name="Import_PersistenceFailed" xml:space="preserve"><value>L’importation n’a pas pu être terminée. Vos choix vérifiés restent disponibles pendant cette session.</value></data>
   <data name="Import_Success" xml:space="preserve"><value>{0} prises, {1} photographies et {2} sorties ont été importées.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1437,6 +1437,10 @@
   <data name="Import_ProgressSavingCatch" xml:space="preserve"><value>Enregistrement de la prise {0} sur {1}</value></data>
   <data name="Import_ProgressUploadingPhotograph" xml:space="preserve"><value>Téléversement de la photo {0} sur {1}</value></data>
   <data name="Import_ProgressVerifying" xml:space="preserve"><value>Vérification des données importées</value></data>
+  <data name="Import_TripPersistenceFailed" xml:space="preserve"><value>Une sortie n’a pas pu être enregistrée. Vérifiez votre connexion et réessayez.</value></data>
+  <data name="Import_CatchPersistenceFailed" xml:space="preserve"><value>Une prise n’a pas pu être enregistrée. Vérifiez votre connexion et réessayez.</value></data>
+  <data name="Import_PhotographPersistenceFailed" xml:space="preserve"><value>Le téléversement d’une photo a échoué. Vérifiez votre connexion et réessayez.</value></data>
+  <data name="Import_VerificationFailed" xml:space="preserve"><value>Les données importées n’ont pas pu être vérifiées. Réessayez pour les rapprocher du serveur.</value></data>
   <data name="Import_OnlineRequired" xml:space="preserve"><value>L’importation historique nécessite une connexion Internet.</value></data>
   <data name="Import_PersistenceFailed" xml:space="preserve"><value>L’importation n’a pas pu être terminée. Vos choix vérifiés restent disponibles pendant cette session.</value></data>
   <data name="Import_Success" xml:space="preserve"><value>{0} prises, {1} photographies et {2} sorties ont été importées.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1433,6 +1433,10 @@
   <data name="Import_SummaryStandalone" xml:space="preserve"><value>Standalone catches: {0}</value></data>
   <data name="Import_ConfirmImport" xml:space="preserve"><value>Import catches</value></data>
   <data name="Import_Importing" xml:space="preserve"><value>Importing…</value></data>
+  <data name="Import_ProgressSavingTrip" xml:space="preserve"><value>Saving Trip {0} of {1}</value></data>
+  <data name="Import_ProgressSavingCatch" xml:space="preserve"><value>Saving Catch {0} of {1}</value></data>
+  <data name="Import_ProgressUploadingPhotograph" xml:space="preserve"><value>Uploading photograph {0} of {1}</value></data>
+  <data name="Import_ProgressVerifying" xml:space="preserve"><value>Verifying imported records</value></data>
   <data name="Import_OnlineRequired" xml:space="preserve"><value>Historical Import requires an internet connection.</value></data>
   <data name="Import_PersistenceFailed" xml:space="preserve"><value>The import could not be completed. Your reviewed choices remain available in this session.</value></data>
   <data name="Import_Success" xml:space="preserve"><value>Imported {0} catches, {1} photographs and {2} Trips successfully.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1437,6 +1437,10 @@
   <data name="Import_ProgressSavingCatch" xml:space="preserve"><value>Saving Catch {0} of {1}</value></data>
   <data name="Import_ProgressUploadingPhotograph" xml:space="preserve"><value>Uploading photograph {0} of {1}</value></data>
   <data name="Import_ProgressVerifying" xml:space="preserve"><value>Verifying imported records</value></data>
+  <data name="Import_TripPersistenceFailed" xml:space="preserve"><value>A Trip could not be saved. Check your connection and retry.</value></data>
+  <data name="Import_CatchPersistenceFailed" xml:space="preserve"><value>A Catch could not be saved. Check your connection and retry.</value></data>
+  <data name="Import_PhotographPersistenceFailed" xml:space="preserve"><value>A photograph upload failed. Check your connection and retry.</value></data>
+  <data name="Import_VerificationFailed" xml:space="preserve"><value>The imported data could not be verified. Retry to reconcile it with the server.</value></data>
   <data name="Import_OnlineRequired" xml:space="preserve"><value>Historical Import requires an internet connection.</value></data>
   <data name="Import_PersistenceFailed" xml:space="preserve"><value>The import could not be completed. Your reviewed choices remain available in this session.</value></data>
   <data name="Import_Success" xml:space="preserve"><value>Imported {0} catches, {1} photographs and {2} Trips successfully.</value></data>

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportPhotographPickerTests/WhenTestingSelection.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportPhotographPickerTests/WhenTestingSelection.cs
@@ -69,6 +69,37 @@ public class WhenTestingSelection : BaseImportPhotographPickerTest
     }
 
     [Fact]
+    public async Task ItShouldAcceptExactlyTwentyFiles()
+    {
+        // Arrange
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        preparation.PrepareSelectionAsync(
+                Arg.Any<IReadOnlyList<IBrowserFile>>(),
+                Arg.Any<CancellationToken>())
+            .Returns([]);
+        await using var context = CreateContext(preparation);
+        var exceeded = false;
+        var cut = context.Render<ImportPhotographPicker>(parameters => parameters
+            .Add(component => component.Id, "import-picker")
+            .Add(component => component.SelectionLimitExceeded, () => exceeded = true));
+        var files = Enumerable.Range(0, ImportPhotoPreparationService.MaxPhotographs)
+            .Select(index => InputFileContent.CreateFromBinary(
+                [(byte)index],
+                $"{index}.jpg",
+                contentType: "image/jpeg"))
+            .ToArray();
+
+        // Act
+        cut.FindComponent<InputFile>().UploadFiles(files);
+
+        // Assert
+        exceeded.Should().BeFalse();
+        await preparation.Received(1).PrepareSelectionAsync(
+            Arg.Is<IReadOnlyList<IBrowserFile>>(selected => selected.Count == 20),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldReportThatSelectionProcessingStarted()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingBatch.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingBatch.cs
@@ -58,8 +58,8 @@ public class WhenTestingBatch : BaseImportModelTest
     {
         // Arrange
         var batch = Batch();
-        batch.AddPhoto(Photo());
-        batch.AddPhoto(Photo(SecondPhotoId, 1));
+        batch.AddPhoto(ReadyPersistencePhoto());
+        batch.AddPhoto(ReadyPersistencePhoto(SecondPhotoId, 1));
         batch.AddCatchProposal(Catch());
         var replacement = Catch(SecondCatchId, [PhotoId, SecondPhotoId]);
 
@@ -76,7 +76,7 @@ public class WhenTestingBatch : BaseImportModelTest
         // Arrange
         var batch = Batch();
         var current = Catch();
-        batch.AddPhoto(Photo());
+        batch.AddPhoto(ReadyPersistencePhoto());
         batch.AddCatchProposal(current);
         var invalid = Catch(SecondCatchId, [Guid.NewGuid()]);
         Action replace = () => batch.ReplaceCatchProposals([invalid]);
@@ -94,7 +94,7 @@ public class WhenTestingBatch : BaseImportModelTest
     {
         // Arrange
         var batch = Batch();
-        batch.AddPhoto(Photo());
+        batch.AddPhoto(ReadyPersistencePhoto());
         batch.AddCatchProposal(Catch());
         Action addTrip = () => batch.AddTripProposal(Trip());
 
@@ -175,7 +175,7 @@ public class WhenTestingBatch : BaseImportModelTest
         // Arrange
         var batch = Batch();
         var catchProposal = Catch(caughtOn: ImportTimestampModel.Missing());
-        batch.AddPhoto(Photo());
+        batch.AddPhoto(ReadyPersistencePhoto());
         batch.AddCatchProposal(catchProposal);
 
         // Act
@@ -187,6 +187,63 @@ public class WhenTestingBatch : BaseImportModelTest
         catchProposal.SetCaughtOn(ImportTimestampModel.UserConfirmed(CapturedOn));
         catchProposal.MarkReviewed();
         batch.IsReadyForConfirmation.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ItShouldRejectAnUnassignedActivePhotoAtThePersistenceBoundary()
+    {
+        // Arrange
+        var batch = Batch();
+        var catchProposal = Catch();
+        catchProposal.MarkReviewed();
+        batch.AddPhoto(ReadyPersistencePhoto());
+        batch.AddPhoto(ReadyPersistencePhoto(SecondPhotoId, 1));
+        batch.AddCatchProposal(catchProposal);
+        Action validate = () => batch.ValidateForPersistence(CapturedOn.AddDays(1));
+
+        // Act
+        var assertion = validate.Should();
+
+        // Assert
+        assertion.Throw<InvalidOperationException>()
+            .WithMessage("*exactly one active Catch*");
+    }
+
+    [Fact]
+    public void ItShouldRejectAFutureCatchAtThePersistenceBoundary()
+    {
+        // Arrange
+        var now = CapturedOn;
+        var batch = Batch();
+        var catchProposal = Catch(caughtOn: ImportTimestampModel.UserConfirmed(now.AddTicks(1)));
+        catchProposal.MarkReviewed();
+        batch.AddPhoto(ReadyPersistencePhoto());
+        batch.AddCatchProposal(catchProposal);
+        Action validate = () => batch.ValidateForPersistence(now);
+
+        // Act
+        var assertion = validate.Should();
+
+        // Assert
+        assertion.Throw<InvalidOperationException>()
+            .WithMessage("*valid historical timestamp*");
+    }
+
+    [Fact]
+    public void ItShouldAcceptACompleteBatchAtThePersistenceBoundary()
+    {
+        // Arrange
+        var batch = Batch();
+        var catchProposal = Catch();
+        catchProposal.MarkReviewed();
+        batch.AddPhoto(ReadyPersistencePhoto());
+        batch.AddCatchProposal(catchProposal);
+
+        // Act
+        var action = () => batch.ValidateForPersistence(CapturedOn.AddTicks(1));
+
+        // Assert
+        action.Should().NotThrow();
     }
 
     [Fact]
@@ -395,5 +452,15 @@ public class WhenTestingBatch : BaseImportModelTest
         batch.IsCancelled.Should().BeTrue();
         batch.IsProcessingPhotos.Should().BeFalse();
         batch.CanProcessPhotos.Should().BeFalse();
+    }
+
+    private static ImportSelectedPhotoModel ReadyPersistencePhoto(Guid? id = null, int index = 0)
+    {
+        var photo = Photo(id ?? PhotoId, index);
+        photo.SetPreparation(
+            ImportPhotoPreparationStatusEnum.Ready,
+            $"token-{index}",
+            $"blob:thumbnail-{index}");
+        return photo;
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
@@ -42,7 +42,10 @@ public class BaseImportCatchCatalogueTest
         var persistence = persistenceService ?? Substitute.For<IImportPersistenceService>();
         if (persistenceService is null)
         {
-            persistence.PersistAsync(Arg.Any<ImportBatchModel>(), Arg.Any<CancellationToken>())
+            persistence.PersistAsync(
+                    Arg.Any<ImportBatchModel>(),
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<IProgress<ImportPersistenceProgressModel>>())
                 .Returns(new ImportPersistenceResultModel([], [], 0, 0));
         }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
@@ -4,6 +4,7 @@ using FishingLogBook.Shared.Enums;
 using FishingLogBook.Web.Browser.Network;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Services;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
 using FishingLogBook.Web.Features.Import.Services;
@@ -29,7 +30,8 @@ public class BaseImportCatchCatalogueTest
         IModalService? modalService = null,
         IImportTripProposalService? tripProposalService = null,
         IImportPersistenceService? persistenceService = null,
-        INetworkService? networkService = null)
+        INetworkService? networkService = null,
+        ILoggingService? loggingService = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -57,6 +59,7 @@ public class BaseImportCatchCatalogueTest
         }
 
         context.Services.AddSingleton(network);
+        context.Services.AddSingleton(loggingService ?? Substitute.For<ILoggingService>());
         var existingTrips = Substitute.For<IImportExistingTripService>();
         existingTrips.GetCandidatesAsync(
                 Arg.Any<IReadOnlyList<ImportTripProposalModel>>(),

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
@@ -291,7 +291,10 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         var preparation = Substitute.For<IImportPhotoPreparationService>();
         var persistence = Substitute.For<IImportPersistenceService>();
         var persistenceCompletion = new TaskCompletionSource<ImportPersistenceResultModel>();
-        persistence.PersistAsync(Arg.Any<ImportBatchModel>(), Arg.Any<CancellationToken>())
+        persistence.PersistAsync(
+                Arg.Any<ImportBatchModel>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IProgress<ImportPersistenceProgressModel>>())
             .Returns(persistenceCompletion.Task);
         await using var context = CreateContext(
             proposal,
@@ -342,7 +345,8 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         cut.WaitForAssertion(() => cut.Find("#import-success").Should().NotBeNull());
         await persistence.Received(1).PersistAsync(
             Arg.Is<ImportBatchModel>(batch => batch.IsReadyForConfirmation),
-            Arg.Any<CancellationToken>());
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IProgress<ImportPersistenceProgressModel>>());
         await preparation.Received(1).ClearAsync(CancellationToken.None);
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
@@ -408,9 +408,8 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
                 Arg.Any<CancellationToken>(),
                 Arg.Any<IProgress<ImportPersistenceProgressModel>>())
             .Returns(
-                _ => throw new ImportPersistenceException(
+                _ => ImportPersistenceResultModel.Failed(
                     ImportPersistenceFailureEnum.Photograph,
-                    "upload failed",
                     new HttpRequestException("private endpoint detail")),
                 _ => new ImportPersistenceResultModel([], [Guid.NewGuid()], 1, 0));
         await using var context = CreateContext(
@@ -432,7 +431,7 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         await logging.Received(1).LogErrorAsync(
             "persisting a historical Import",
             Arg.Is<string>(message =>
-                message.Contains(nameof(ImportPersistenceException), StringComparison.Ordinal)
+                message.Contains(nameof(HttpRequestException), StringComparison.Ordinal)
                 && !message.Contains("private endpoint detail", StringComparison.Ordinal)),
             CancellationToken.None);
 

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Web.Common.Modals;
+using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Import.Components.ImportCatchReviewCard;
 using FishingLogBook.Web.Features.Import.Components.ImportPhotographPicker;
 using FishingLogBook.Web.Features.Import.Enums;
@@ -204,6 +205,43 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
     }
 
     [Fact]
+    public async Task ItShouldKeepAllTwentyPhotosThroughProposalAndReviewTransitions()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        await using var context = CreateContext(
+            proposal,
+            Substitute.For<IImportPhotoPreparationService>());
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var photos = System.Linq.Enumerable.Select(
+            Enumerable.Range(0, 20),
+            index => ReadyPhoto(index)).ToArray();
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync(photos));
+
+        // Act
+        cut.Find("#import-photos-continue").Click();
+
+        // Assert
+        cut.FindComponents<ImportCatchReviewCard>().Should().HaveCount(20);
+        proposal.Received(1).Propose(Arg.Is<ImportBatchModel>(batch =>
+            batch.Photos.Count == 20
+            && batch.Photos.All(photo => photo.IsReady)
+            && batch.Photos.Select(photo => photo.Id).Distinct().Count() == 20));
+
+        // Act
+        for (var catchNumber = 1; catchNumber <= 20; catchNumber++)
+        {
+            cut.Find($"#import-catch-{catchNumber}-confirm").Click();
+        }
+
+        // Assert
+        cut.Find("#import-review-continue").HasAttribute("disabled").Should().BeFalse();
+    }
+
+    [Fact]
     public async Task ItShouldShowGroupedPhotosTogetherAndExcludeFailedPhotosFromMembership()
     {
         // Arrange
@@ -295,7 +333,12 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
                 Arg.Any<ImportBatchModel>(),
                 Arg.Any<CancellationToken>(),
                 Arg.Any<IProgress<ImportPersistenceProgressModel>>())
-            .Returns(persistenceCompletion.Task);
+            .Returns(call =>
+            {
+                call.ArgAt<IProgress<ImportPersistenceProgressModel>>(2).Report(
+                    new ImportPersistenceProgressModel(ImportPersistenceStageEnum.SavingCatch, 1, 1));
+                return persistenceCompletion.Task;
+            });
         await using var context = CreateContext(
             proposal,
             preparation,
@@ -335,6 +378,7 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         {
             cut.Find("#import-confirm").HasAttribute("disabled").Should().BeTrue();
             cut.Find("#import-confirm-spinner").Should().NotBeNull();
+            cut.Find("#import-persistence-progress").TextContent.Should().Contain("Saving Catch 1 of 1");
         });
 
         // Act
@@ -348,6 +392,93 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
             Arg.Any<CancellationToken>(),
             Arg.Any<IProgress<ImportPersistenceProgressModel>>());
         await preparation.Received(1).ClearAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ItShouldRetainBlobsAndAllowRetryAfterPersistenceFailure()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        var persistence = Substitute.For<IImportPersistenceService>();
+        var logging = Substitute.For<ILoggingService>();
+        persistence.PersistAsync(
+                Arg.Any<ImportBatchModel>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IProgress<ImportPersistenceProgressModel>>())
+            .Returns(
+                _ => throw new ImportPersistenceException(
+                    ImportPersistenceFailureEnum.Photograph,
+                    "upload failed",
+                    new HttpRequestException("private endpoint detail")),
+                _ => new ImportPersistenceResultModel([], [Guid.NewGuid()], 1, 0));
+        await using var context = CreateContext(
+            proposal,
+            preparation,
+            persistenceService: persistence,
+            loggingService: logging);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await ReachConfirmationAsync(cut);
+
+        // Act
+        cut.Find("#import-confirm").Click();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#import-persistence-error").TextContent
+            .Should().Contain("photograph upload failed"));
+        cut.Find("#import-confirm").HasAttribute("disabled").Should().BeFalse();
+        await preparation.DidNotReceive().ClearAsync(Arg.Any<CancellationToken>());
+        await logging.Received(1).LogErrorAsync(
+            "persisting a historical Import",
+            Arg.Is<string>(message =>
+                message.Contains(nameof(ImportPersistenceException), StringComparison.Ordinal)
+                && !message.Contains("private endpoint detail", StringComparison.Ordinal)),
+            CancellationToken.None);
+
+        // Act
+        cut.Find("#import-confirm").Click();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#import-success").Should().NotBeNull());
+        await persistence.Received(2).PersistAsync(
+            Arg.Any<ImportBatchModel>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IProgress<ImportPersistenceProgressModel>>());
+        await preparation.Received(1).ClearAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ItShouldCancelPersistenceWithoutShowingFailureOrRemainingBusy()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        var persistence = Substitute.For<IImportPersistenceService>();
+        persistence.PersistAsync(
+                Arg.Any<ImportBatchModel>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IProgress<ImportPersistenceProgressModel>>())
+            .Returns(async call =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, call.ArgAt<CancellationToken>(1));
+                return new ImportPersistenceResultModel([], [], 0, 0);
+            });
+        await using var context = CreateContext(proposal, preparation, persistenceService: persistence);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await ReachConfirmationAsync(cut);
+        cut.Find("#import-confirm").Click();
+        cut.WaitForElement("#import-cancel-persistence");
+
+        // Act
+        cut.Find("#import-cancel-persistence").Click();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.Find("#import-confirm").HasAttribute("disabled").Should().BeFalse());
+        cut.FindAll("#import-persistence-error").Should().BeEmpty();
+        cut.FindAll("#import-cancel-persistence").Should().BeEmpty();
+        await preparation.DidNotReceive().ClearAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -577,5 +708,17 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         cut.Find("#import-species-BrownTrout").Click();
         cut.Find("#import-batch-continue").Click();
         return Task.CompletedTask;
+    }
+
+    private static async Task ReachConfirmationAsync(IRenderedComponent<ImportCatchCatalogue> cut)
+    {
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([ReadyPhoto(0)]));
+        cut.Find("#import-photos-continue").Click();
+        cut.Find("#import-catch-1-confirm").Click();
+        cut.Find("#import-review-continue").Click();
+        cut.Find("#import-trip-none").Click();
+        cut.Find("#import-trip-continue").Click();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/BaseImportPersistenceServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/BaseImportPersistenceServiceTest.cs
@@ -36,12 +36,18 @@ public class BaseImportPersistenceServiceTest
             return persistedTrip;
         });
         TripClient.GetDetailAsync(TripId, Arg.Any<CancellationToken>()).Returns(_ =>
-            new TripDetailDto(new TripViewDto(
-                TripId,
-                UserId,
-                persistedTrip!.Status,
-                persistedTrip.StartedOn,
-                persistedTrip.EndedOn)));
+            persistedTrip is null
+                ? null
+                : new TripDetailDto(new TripViewDto(
+                    TripId,
+                    UserId,
+                    persistedTrip.Status,
+                    persistedTrip.StartedOn,
+                    persistedTrip.EndedOn)
+                {
+                    Title = persistedTrip.Title,
+                    PlaceName = persistedTrip.PlaceName
+                }));
         var participantReads = 0;
         ParticipantClient.GetAsync(TripId, Arg.Any<CancellationToken>()).Returns(_ =>
         {
@@ -69,8 +75,13 @@ public class BaseImportPersistenceServiceTest
         var reads = 0;
         CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(_ =>
         {
+            if (persistedCatch is null)
+            {
+                return null;
+            }
+
             reads++;
-            return new CatchViewDto(CatchId, UserId, persistedCatch!.CaughtOn, new CatchLocationExposureDto
+            return new CatchViewDto(CatchId, UserId, persistedCatch.CaughtOn, new CatchLocationExposureDto
             {
                 Latitude = 53.1,
                 Longitude = -6.2,

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
@@ -93,7 +93,7 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             CatchId,
             Arg.Is<RecordPhotographDto>(photo => photo.PhotographId == PhotoId && photo.ObjectKey == "object"),
             Arg.Any<CancellationToken>());
-        await CatchClient.Received(2).GetAsync(CatchId, Arg.Any<CancellationToken>());
+        await CatchClient.Received(3).GetAsync(CatchId, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
@@ -149,11 +149,11 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             .Returns(Task.FromException<TripDto?>(new HttpRequestException("failed")));
 
         // Act
-        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<ImportPersistenceException>()
-            .Where(exception => exception.Failure == ImportPersistenceFailureEnum.Trip);
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().Be(ImportPersistenceFailureEnum.Trip);
         await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
         await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
             Arg.Any<Guid>(),
@@ -174,10 +174,10 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             .Returns((TripParticipantsDto?)null);
 
         // Act
-        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<InvalidOperationException>();
+        result.IsSuccess.Should().BeFalse();
         await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
     }
 
@@ -195,11 +195,11 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             .Returns(Task.FromException(new HttpRequestException("upload failed")));
 
         // Act
-        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<ImportPersistenceException>()
-            .Where(exception => exception.Failure == ImportPersistenceFailureEnum.Photograph);
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().Be(ImportPersistenceFailureEnum.Photograph);
         await CatchClient.DidNotReceive().RecordPhotographAsync(
             Arg.Any<Guid>(),
             Arg.Any<RecordPhotographDto>(),
@@ -234,11 +234,11 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             new TripDetailDto(new TripViewDto(TripId, UserId, "Completed", CaughtOn.AddHours(1))));
 
         // Act
-        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*conflicts*");
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().Be(ImportPersistenceFailureEnum.Verification);
         await TripClient.DidNotReceive().UpsertAsync(Arg.Any<TripDto>(), Arg.Any<CancellationToken>());
         await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
     }
@@ -275,11 +275,11 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             MatchingCatch(includePhotograph: false) with { SpeciesName = "Pike" });
 
         // Act
-        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*conflicts*");
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().Be(ImportPersistenceFailureEnum.Verification);
         await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
         await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
             Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>());
@@ -298,11 +298,11 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             });
 
         // Act
-        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<ImportPersistenceException>()
-            .Where(exception => exception.Failure == ImportPersistenceFailureEnum.Verification);
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().Be(ImportPersistenceFailureEnum.Verification);
         await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
             Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>());
     }
@@ -336,11 +336,11 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
         CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns((CatchViewDto?)null);
 
         // Act
-        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*could not be verified*");
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().Be(ImportPersistenceFailureEnum.Verification);
         await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
             Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>());
     }
@@ -379,9 +379,9 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             });
 
         // Act
-        var firstAttempt = () => sut.PersistAsync(batch, CancellationToken.None);
-        await firstAttempt.Should().ThrowAsync<ImportPersistenceException>()
-            .Where(exception => exception.Failure == ImportPersistenceFailureEnum.Photograph);
+        var firstAttempt = await sut.PersistAsync(batch, CancellationToken.None);
+        firstAttempt.IsSuccess.Should().BeFalse();
+        firstAttempt.Failure.Should().Be(ImportPersistenceFailureEnum.Photograph);
         var result = await sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Web.Features.Import.Enums;
 using FishingLogBook.Web.Features.Import.Models;
+using FishingLogBook.Web.Features.Import.Services;
 using NSubstitute;
 
 namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportPersistenceServiceTests;
@@ -151,7 +152,8 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
         var action = () => sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<HttpRequestException>();
+        await action.Should().ThrowAsync<ImportPersistenceException>()
+            .Where(exception => exception.Failure == ImportPersistenceFailureEnum.Trip);
         await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
         await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
             Arg.Any<Guid>(),
@@ -196,10 +198,262 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
         var action = () => sut.PersistAsync(batch, CancellationToken.None);
 
         // Assert
-        await action.Should().ThrowAsync<HttpRequestException>();
+        await action.Should().ThrowAsync<ImportPersistenceException>()
+            .Where(exception => exception.Failure == ImportPersistenceFailureEnum.Photograph);
         await CatchClient.DidNotReceive().RecordPhotographAsync(
             Arg.Any<Guid>(),
             Arg.Any<RecordPhotographDto>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReuseAMatchingAuthoritativeTripWithoutUpsertingIt()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.CreateNew);
+        var sut = CreateSut();
+        TripClient.GetDetailAsync(TripId, Arg.Any<CancellationToken>()).Returns(MatchingTrip());
+
+        // Act
+        await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await TripClient.DidNotReceive().UpsertAsync(Arg.Any<TripDto>(), Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(record => record.TripId == TripId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStopWithoutOverwritingAConflictingAuthoritativeTrip()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.CreateNew);
+        var sut = CreateSut();
+        TripClient.GetDetailAsync(TripId, Arg.Any<CancellationToken>()).Returns(
+            new TripDetailDto(new TripViewDto(TripId, UserId, "Completed", CaughtOn.AddHours(1))));
+
+        // Act
+        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*conflicts*");
+        await TripClient.DidNotReceive().UpsertAsync(Arg.Any<TripDto>(), Arg.Any<CancellationToken>());
+        await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReuseAMatchingCatchAndRegisteredPhotograph()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(MatchingCatch(includePhotograph: true));
+
+        // Act
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        result.CatchIds.Should().Equal(CatchId);
+        result.PhotographCount.Should().Be(1);
+        await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>());
+        await CatchClient.DidNotReceive().RecordPhotographAsync(
+            Arg.Any<Guid>(), Arg.Any<RecordPhotographDto>(), Arg.Any<CancellationToken>());
+        await BlobRegistry.DidNotReceive().GetBytesAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStopWithoutOverwritingAConflictingAuthoritativeCatch()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(
+            MatchingCatch(includePhotograph: false) with { SpeciesName = "Pike" });
+
+        // Act
+        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*conflicts*");
+        await CatchClient.DidNotReceive().UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>());
+        await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldStopWhenARegisteredPhotographIdentityHasDifferentContent()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(
+            MatchingCatch(includePhotograph: true) with
+            {
+                Photographs = [new CatchPhotographViewDto(PhotoId, "image/png", "https://photo.test")]
+            });
+
+        // Act
+        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await action.Should().ThrowAsync<ImportPersistenceException>()
+            .Where(exception => exception.Failure == ImportPersistenceFailureEnum.Verification);
+        await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotInviteAnExistingParticipantAgain()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.CreateNew, participant: true);
+        var sut = CreateSut();
+        ParticipantClient.GetAsync(TripId, Arg.Any<CancellationToken>()).Returns(
+            new TripParticipantsDto(TripId, "Owner")
+            {
+                Participants = [new TripParticipantDto(ParticipantId, "Accepted", "Angler", null, CaughtOn)]
+            });
+
+        // Act
+        await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await ParticipantClient.DidNotReceive().InviteAsync(
+            Arg.Any<Guid>(), Arg.Any<InviteTripParticipantDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotReportSuccessWhenTheAuthoritativeCatchCannotBeReread()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns((CatchViewDto?)null);
+
+        // Act
+        var action = () => sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*could not be verified*");
+        await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            Arg.Any<Guid>(), Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReconcilePartialPersistenceBeforeRetryingThePhotograph()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+        CatchDto? authoritativeCatch = null;
+        var photographRegistered = false;
+        var uploadAttempts = 0;
+        CatchClient.UpsertAsync(Arg.Any<CatchDto>(), Arg.Any<CancellationToken>()).Returns(call =>
+        {
+            authoritativeCatch = call.Arg<CatchDto>();
+            return authoritativeCatch;
+        });
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(_ =>
+            authoritativeCatch is null ? null : MatchingCatch(photographRegistered));
+        CatchClient.UploadPhotographAsync(
+                Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                uploadAttempts++;
+                return uploadAttempts == 1
+                    ? Task.FromException(new HttpRequestException("interrupted"))
+                    : Task.CompletedTask;
+            });
+        CatchClient.RecordPhotographAsync(
+                CatchId, Arg.Any<RecordPhotographDto>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                photographRegistered = true;
+                return Task.CompletedTask;
+            });
+
+        // Act
+        var firstAttempt = () => sut.PersistAsync(batch, CancellationToken.None);
+        await firstAttempt.Should().ThrowAsync<ImportPersistenceException>()
+            .Where(exception => exception.Failure == ImportPersistenceFailureEnum.Photograph);
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        result.CatchIds.Should().Equal(CatchId);
+        await CatchClient.Received(1).UpsertAsync(
+            Arg.Is<CatchDto>(record => record.Id == CatchId),
+            Arg.Any<CancellationToken>());
+        await CatchClient.Received(2).UploadPhotographAsync(
+            "https://upload.test",
+            Arg.Is<byte[]>(bytes => bytes.SequenceEqual(new byte[] { 1, 2, 3 })),
+            "image/jpeg",
+            Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).RecordPhotographAsync(
+            CatchId,
+            Arg.Is<RecordPhotographDto>(photo => photo.PhotographId == PhotoId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldReportMeaningfulPersistenceProgress()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.CreateNew);
+        var sut = CreateSut();
+        var progress = new RecordingProgress();
+
+        // Act
+        await sut.PersistAsync(batch, CancellationToken.None, progress);
+
+        // Assert
+        progress.Values.Select(value => value.Stage).Should().Equal(
+            ImportPersistenceStageEnum.SavingTrip,
+            ImportPersistenceStageEnum.SavingCatch,
+            ImportPersistenceStageEnum.UploadingPhotograph,
+            ImportPersistenceStageEnum.Verifying);
+        progress.Values.Should().OnlyContain(value => value.Current == 1 && value.Total == 1);
+    }
+
+    private static TripDetailDto MatchingTrip()
+    {
+        return new TripDetailDto(new TripViewDto(TripId, UserId, "Completed", CaughtOn, CaughtOn));
+    }
+
+    private static CatchViewDto MatchingCatch(bool includePhotograph)
+    {
+        return new CatchViewDto(CatchId, UserId, CaughtOn, new CatchLocationExposureDto
+        {
+            Latitude = 53.1,
+            Longitude = -6.2,
+            CapturedOn = CaughtOn,
+            Source = LocationDefaults.PhotoMetadata,
+            Visibility = LocationDefaults.Private
+        })
+        {
+            RecordedByUserId = UserId,
+            SpeciesName = "Brown Trout",
+            Method = "Fly",
+            Weight = 2.5m,
+            Length = 42m,
+            Photographs = includePhotograph
+                ? [new CatchPhotographViewDto(PhotoId, "image/jpeg", "https://photo.test")]
+                : []
+        };
+    }
+
+    private sealed class RecordingProgress : IProgress<ImportPersistenceProgressModel>
+    {
+        public List<ImportPersistenceProgressModel> Values { get; } = [];
+
+        public void Report(ImportPersistenceProgressModel value)
+        {
+            Values.Add(value);
+        }
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/WhenTestingPrepareSelectionAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/WhenTestingPrepareSelectionAsync.cs
@@ -13,6 +13,33 @@ namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportPhotoPreparati
 public class WhenTestingPrepareSelectionAsync : BaseImportPhotoPreparationServiceTest
 {
     [Fact]
+    public async Task ItShouldPrepareTheFullTwentyPhotoBatchSequentially()
+    {
+        // Arrange
+        var context = CreateContext();
+        var registry = new ConcurrencyTrackingBlobRegistry();
+        var sut = new ImportPhotoPreparationService(context.Metadata, registry, context.Logging);
+        var files = Enumerable.Range(0, ImportPhotoPreparationService.MaxPhotographs)
+            .Select(index => File([(byte)index], name: $"photo-{index}.jpg"))
+            .ToArray();
+
+        // Act
+        var result = await sut.PrepareSelectionAsync(files, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(20);
+        result.Should().OnlyContain(photo => photo.IsReady && photo.BlobToken != null);
+        result.Select(photo => photo.SelectionIndex).Should().Equal(Enumerable.Range(0, 20));
+        registry.RegistrationCount.Should().Be(20);
+        registry.MaximumConcurrency.Should().Be(1);
+        context.Metadata.Received(20).ReadHistorical(
+            Arg.Any<byte[]>(),
+            PhotographContentTypeConstants.Jpeg,
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<DateTimeOffset>());
+    }
+
+    [Fact]
     public async Task ItShouldRejectMoreThanTheConfiguredMaximum()
     {
         // Arrange
@@ -248,6 +275,45 @@ public class WhenTestingPrepareSelectionAsync : BaseImportPhotoPreparationServic
         {
             ClearCount++;
             _entries.Clear();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ConcurrencyTrackingBlobRegistry : IImportPhotoBlobRegistryService
+    {
+        private int _activeRegistrations;
+
+        public int RegistrationCount { get; private set; }
+
+        public int MaximumConcurrency { get; private set; }
+
+        public async Task<ImportPhotoBlobRegistrationModel> RegisterAsync(
+            byte[] bytes,
+            string contentType,
+            CancellationToken cancellationToken)
+        {
+            var active = Interlocked.Increment(ref _activeRegistrations);
+            MaximumConcurrency = Math.Max(MaximumConcurrency, active);
+            await Task.Yield();
+            RegistrationCount++;
+            Interlocked.Decrement(ref _activeRegistrations);
+            return new ImportPhotoBlobRegistrationModel(
+                $"token-{RegistrationCount}",
+                $"blob:thumbnail-{RegistrationCount}");
+        }
+
+        public Task<byte[]> GetBytesAsync(string token, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Array.Empty<byte>());
+        }
+
+        public Task RemoveAsync(string token, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(CancellationToken cancellationToken)
+        {
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
Contributes to #221

## Summary

- hardens authoritative online Import persistence with stable-ID reconciliation before Trip and Catch writes
- reuses matching authoritative records and stops on conflicting Trip, Catch, or photograph state
- avoids duplicate participant invitations, photograph uploads, and photograph registrations
- supports safe same-session retry after partial persistence without adding offline or durable Import state
- adds cancellable persistence, duplicate-submit protection, transient progress, categorised user-facing failures, and sanitised diagnostic logging
- centralises final Import invariants and uses the same validation for UI readiness and persistence
- proves the full 20-photo V1 cap through selection, sequential preparation, proposal/review, and Blob lifecycle coverage
- expands Chromium/WebKit coverage for 20 transient Blob registrations and complete cleanup
- documents the authenticated Import E2E harness gap and updates #157

## Retry and idempotency

- Trip and Catch stable IDs are reconciled through authoritative reads before any upsert
- matching records are reused
- conflicting records stop the Import and are not overwritten
- existing participant membership is not invited again
- existing photographs are not uploaded or registered again
- a retry after an interrupted upload rereads authoritative Catch/photo state before continuing
- no non-idempotent write is automatically retried without reconciliation

## Cancellation and Blob lifecycle

- photo preparation remains sequential
- deliberate persistence cancellation exits busy state without false success or a generic failure
- failed/cancelled persistence retains prepared Blobs for active-session retry
- removal, preparation cancellation, wizard disposal/abandon, and successful Import release transient Blob resources
- Import remains online-only and transient; it uses no IndexedDB Import session, offline queue, background sync, or synchroniser persistence path

## Validation

- formatting: passed
- focused Import tests: 164 passed
- Record Catch regression tests: 123 passed
- full Web tests: 1,870 passed
- JavaScript tests: 402 passed
- browser tests: 159 passed, 7 expected WebKit skips
- solution build: changed Web projects build; full solution command is blocked locally by the running API process locking its output DLLs
- remote CI: pending the follow-up commit/push

## Self Review

- Issue/AC: PASS for practical in-repository hardening and automated coverage; physical-device acceptance remains pending
- Architecture/CQRS: PASS — Import persists only through authoritative online clients
- Rules: PASS
- Security/privacy: PASS — logs contain an operation and exception type only; no bytes, EXIF, GPS, or participant details
- Database/migrations: N/A
- Tests/coverage: PASS — boundaries, failures, conflicts, cancellation, retry, deduplication, 20-photo scale, and Record Catch regression covered
- Browser: PASS for transient Blob lifecycle and ordinary post-import cache primitives; authenticated production Import remains outside the current harness
- Web/UI/localisation: PASS — progress, cancellation, and failure messages are localised in English and French
- Code smells: PASS
- CI/deployment: no migration, infrastructure, configuration, or manual deployment step

## Findings discovered during self-review

1. UI readiness used weaker checks than the final persistence boundary.
2. Deliberate cancellation could escape to the component error boundary.
3. Persistence failures were generic and were not logged through existing diagnostics.
4. Matching photograph IDs did not verify content type.

## Fixes made

1. Unified UI readiness and persistence around central batch invariant validation.
2. Added a linked per-operation cancellation source and a visible Cancel action.
3. Added categorised safe retry messages and sanitised logging.
4. Added photograph identity/content conflict validation.

## Remaining manual acceptance

These are not claimed as completed and #221 must remain open until they are performed:

- Android installed-PWA run with 20 representative photos
- iPhone Home Screen PWA run with 20 representative photos
- physical-device observations for preparation responsiveness, review scrolling/layout, persistence duration, and memory pressure
- authenticated production Import E2E journey tracked in #157

## Post-import cache/offline boundary

Import itself does not write IndexedDB. It creates ordinary authoritative Trip/Catch/photo records through the standard clients. Subsequent normal reads use the existing Catch/Trip cache and offline mechanisms, whose ownership, reload, photograph, and Trip-link browser suites remain green.
