### PR TITLE
FLB#219 | Warn about duplicate historical photo imports

### DIFF
--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportDuplicateDecisionEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportDuplicateDecisionEnum.cs
@@ -1,0 +1,7 @@
+namespace FishingLogBook.Web.Features.Import.Enums;
+
+public enum ImportDuplicateDecisionEnum
+{
+    Unresolved = 0,
+    KeepBoth = 1
+}

--- a/src/FishingLogBook.Web/Features/Import/Enums/ImportDuplicateReasonEnum.cs
+++ b/src/FishingLogBook.Web/Features/Import/Enums/ImportDuplicateReasonEnum.cs
@@ -1,0 +1,8 @@
+namespace FishingLogBook.Web.Features.Import.Enums;
+
+public enum ImportDuplicateReasonEnum
+{
+    None = 0,
+    IdenticalPreparedBytes = 1,
+    SameCaptureTimeAndSize = 2
+}

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportBatchModel.cs
@@ -44,6 +44,17 @@ public sealed class ImportBatchModel
 
     public bool CanProcessPhotos => FishingMethod.IsValid && Species.IsValid && !IsCancelled;
 
+    public bool HasUnresolvedExactDuplicates
+    {
+        get
+        {
+            var activePhotoIds = _photos.Where(photo => !photo.IsRemoved).Select(photo => photo.Id).ToHashSet();
+            return _photos.Any(photo => !photo.IsRemoved
+                && photo.RequiresDuplicateDecision
+                && photo.DuplicatePhotoIds.Any(activePhotoIds.Contains));
+        }
+    }
+
     public bool IsReadyForConfirmation
     {
         get
@@ -74,13 +85,18 @@ public sealed class ImportBatchModel
             ?? TripValidationError(activeCatches, now);
     }
 
-    private static string? ActiveRecordsValidationError(
+    private string? ActiveRecordsValidationError(
         ImportSelectedPhotoModel[] activePhotos,
         ImportCatchProposalModel[] activeCatches)
     {
         if (activePhotos.Length == 0 || activeCatches.Length == 0 || activePhotos.Any(photo => !photo.IsReady))
         {
             return "The Import batch requires active photographs and Catches.";
+        }
+
+        if (HasUnresolvedExactDuplicates)
+        {
+            return "Every exact duplicate photograph requires an explicit Import decision.";
         }
 
         if (activePhotos.Select(photo => photo.Id).Distinct().Count() != activePhotos.Length
@@ -292,6 +308,11 @@ public sealed class ImportBatchModel
 
         RemoveInactiveCatchMemberships();
         _tripProposals.Clear();
+    }
+
+    public void KeepDuplicatePhoto(Guid photoId)
+    {
+        _photos.Single(photo => photo.Id == photoId && !photo.IsRemoved).KeepDuplicate();
     }
 
     public void RemoveCatchProposal(Guid catchProposalId)

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportSelectedPhotoModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportSelectedPhotoModel.cs
@@ -58,6 +58,15 @@ public sealed class ImportSelectedPhotoModel
 
     public string? Fingerprint { get; private set; }
 
+    public IReadOnlyList<Guid> DuplicatePhotoIds { get; private set; } = [];
+
+    public ImportDuplicateReasonEnum DuplicateReason { get; private set; }
+
+    public ImportDuplicateDecisionEnum DuplicateDecision { get; private set; }
+
+    public bool RequiresDuplicateDecision => DuplicateStatus == ImportDuplicateStatusEnum.Duplicate
+        && DuplicateDecision == ImportDuplicateDecisionEnum.Unresolved;
+
     public bool IsRemoved { get; private set; }
 
     public ImportPhotoPreparationStatusEnum PreparationStatus { get; private set; }
@@ -94,10 +103,28 @@ public sealed class ImportSelectedPhotoModel
         MetadataError = error;
     }
 
-    public void SetDuplicateState(ImportDuplicateStatusEnum status, string? fingerprint)
+    public void SetFingerprint(string fingerprint)
+    {
+        Fingerprint = fingerprint;
+    }
+
+    public void SetDuplicateState(
+        ImportDuplicateStatusEnum status,
+        ImportDuplicateReasonEnum reason,
+        IReadOnlyList<Guid> counterpartIds)
     {
         DuplicateStatus = status;
-        Fingerprint = fingerprint;
+        DuplicateReason = reason;
+        DuplicatePhotoIds = counterpartIds;
+        DuplicateDecision = ImportDuplicateDecisionEnum.Unresolved;
+    }
+
+    public void KeepDuplicate()
+    {
+        if (DuplicateStatus == ImportDuplicateStatusEnum.Duplicate)
+        {
+            DuplicateDecision = ImportDuplicateDecisionEnum.KeepBoth;
+        }
     }
 
     public void SetThumbnail(string? thumbnailUrl)

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
@@ -115,6 +115,34 @@
                                                OnClick="@(() => RemovePhotoAsync(photo))"
                                                id="@($"import-remove-photo-{photo.SelectionIndex}")" />
                             </div>
+                            @if (RequiresDuplicateDecision(photo))
+                            {
+                                <MudAlert Severity="Severity.Warning" Dense="true"
+                                          id="@($"import-exact-duplicate-{photo.SelectionIndex}")">
+                                    <MudText Typo="Typo.body2">@Loc["Import_DuplicateExact"]</MudText>
+                                    <MudText Typo="Typo.caption">@DuplicateReasonLabel(photo)</MudText>
+                                    <MudStack Row="true" Spacing="1" Class="mt-2">
+                                        <MudButton Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small"
+                                                   OnClick="@(() => RemovePhotoAsync(photo))"
+                                                   id="@($"import-remove-duplicate-{photo.SelectionIndex}")">
+                                            @Loc["Import_DuplicateRemove"]
+                                        </MudButton>
+                                        <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                                                   OnClick="@(() => KeepDuplicatePhoto(photo))"
+                                                   id="@($"import-keep-duplicate-{photo.SelectionIndex}")">
+                                            @Loc["Import_DuplicateKeepBoth"]
+                                        </MudButton>
+                                    </MudStack>
+                                </MudAlert>
+                            }
+                            else if (photo.DuplicateStatus == ImportDuplicateStatusEnum.Warning)
+                            {
+                                <MudAlert Severity="Severity.Warning" Dense="true"
+                                          id="@($"import-possible-duplicate-{photo.SelectionIndex}")">
+                                    <MudText Typo="Typo.body2">@Loc["Import_DuplicatePossible"]</MudText>
+                                    <MudText Typo="Typo.caption">@DuplicateReasonLabel(photo)</MudText>
+                                </MudAlert>
+                            }
                         }
                         <MudStack Row="true" Justify="Justify.SpaceBetween">
                             <MudButton Variant="Variant.Text" OnClick="BackToBatch" id="import-photos-back">

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
@@ -50,7 +50,8 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
         get
         {
             return _batch?.IsProcessingPhotos == false
-                && _batch.Photos.Any(photo => !photo.IsRemoved && photo.IsReady);
+                && _batch.Photos.Any(photo => !photo.IsRemoved && photo.IsReady)
+                && !_batch.HasUnresolvedExactDuplicates;
         }
     }
 
@@ -536,6 +537,28 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
     {
         await Preparation.RemoveAsync(photo, _cancellationTokenSource.Token);
         _batch?.RemovePhoto(photo.Id);
+    }
+
+    private void KeepDuplicatePhoto(ImportSelectedPhotoModel photo)
+    {
+        _batch?.KeepDuplicatePhoto(photo.Id);
+    }
+
+    private bool RequiresDuplicateDecision(ImportSelectedPhotoModel photo)
+    {
+        return photo.RequiresDuplicateDecision
+            && _batch?.Photos.Any(candidate => !candidate.IsRemoved
+                && photo.DuplicatePhotoIds.Contains(candidate.Id)) == true;
+    }
+
+    private string DuplicateReasonLabel(ImportSelectedPhotoModel photo)
+    {
+        return photo.DuplicateReason switch
+        {
+            ImportDuplicateReasonEnum.IdenticalPreparedBytes => Loc["Import_DuplicateExactReason"],
+            ImportDuplicateReasonEnum.SameCaptureTimeAndSize => Loc["Import_DuplicateMetadataReason"],
+            _ => Loc["Import_DuplicatePossibleReason"]
+        };
     }
 
     private void ContinueToReview()

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPhotoPreparationService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPhotoPreparationService.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using FishingLogBook.Shared.Constants;
 using FishingLogBook.Web.Features.Diagnostics.Services;
 using FishingLogBook.Web.Features.Import.Enums;
@@ -46,6 +47,8 @@ public sealed class ImportPhotoPreparationService : IImportPhotoPreparationServi
                 cancellationToken.ThrowIfCancellationRequested();
                 prepared.Add(await PrepareAsync(files[index], index, cancellationToken));
             }
+
+            DetectDuplicates(prepared);
 
             return prepared;
         }
@@ -123,6 +126,8 @@ public sealed class ImportPhotoPreparationService : IImportPhotoPreparationServi
                 return photo;
             }
 
+            photo.SetFingerprint(Convert.ToHexString(SHA256.HashData(sanitised)));
+
             var registration = await _registry.RegisterAsync(sanitised, file.ContentType, cancellationToken);
             photo.SetPreparation(
                 ImportPhotoPreparationStatusEnum.Ready,
@@ -141,6 +146,57 @@ public sealed class ImportPhotoPreparationService : IImportPhotoPreparationServi
             photo.SetPreparation(ImportPhotoPreparationStatusEnum.PreparationFailed);
             return photo;
         }
+    }
+
+    private static void DetectDuplicates(IReadOnlyList<ImportSelectedPhotoModel> photos)
+    {
+        var ready = photos.Where(photo => photo.IsReady).OrderBy(photo => photo.SelectionIndex).ToArray();
+        foreach (var group in ready
+                     .Where(photo => !string.IsNullOrWhiteSpace(photo.Fingerprint))
+                     .GroupBy(photo => photo.Fingerprint, StringComparer.Ordinal)
+                     .Where(group => group.Count() > 1))
+        {
+            var members = group.ToArray();
+            foreach (var duplicate in members.Skip(1))
+            {
+                duplicate.SetDuplicateState(
+                    ImportDuplicateStatusEnum.Duplicate,
+                    ImportDuplicateReasonEnum.IdenticalPreparedBytes,
+                    members.Where(photo => photo.Id != duplicate.Id).Select(photo => photo.Id).ToArray());
+            }
+        }
+
+        foreach (var photo in ready.Where(photo => photo.DuplicateStatus != ImportDuplicateStatusEnum.Duplicate))
+        {
+            var counterpart = ready.FirstOrDefault(candidate =>
+                candidate.SelectionIndex < photo.SelectionIndex
+                && candidate.Fingerprint != photo.Fingerprint
+                && HasSameCaptureTime(photo, candidate)
+                && candidate.ByteSize == photo.ByteSize);
+            if (counterpart is not null)
+            {
+                photo.SetDuplicateState(
+                    ImportDuplicateStatusEnum.Warning,
+                    ImportDuplicateReasonEnum.SameCaptureTimeAndSize,
+                    [counterpart.Id]);
+            }
+            else
+            {
+                photo.SetDuplicateState(ImportDuplicateStatusEnum.None, ImportDuplicateReasonEnum.None, []);
+            }
+        }
+    }
+
+    private static bool HasSameCaptureTime(ImportSelectedPhotoModel first, ImportSelectedPhotoModel second)
+    {
+        if (first.Timestamp.State == ImportTimestampStateEnum.ExplicitInstant
+            && second.Timestamp.State == ImportTimestampStateEnum.ExplicitInstant)
+        {
+            return first.Timestamp.Instant == second.Timestamp.Instant;
+        }
+
+        return first.Timestamp.LocalWallClock.HasValue
+            && first.Timestamp.LocalWallClock == second.Timestamp.LocalWallClock;
     }
 
     private static ImportSelectedPhotoModel NewPhoto(IBrowserFile file, int selectionIndex)

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1368,6 +1368,13 @@
   <data name="Import_PhotoFailed" xml:space="preserve"><value>Cette photographie n’a pas pu être préparée.</value></data>
   <data name="Import_MetadataUnavailable" xml:space="preserve"><value>Photo prête · détails historiques à vérifier</value></data>
   <data name="Import_PhotoReady" xml:space="preserve"><value>Photo prête</value></data>
+  <data name="Import_DuplicateExact" xml:space="preserve"><value>Photographie probablement dupliquée à l’identique</value></data>
+  <data name="Import_DuplicateExactReason" xml:space="preserve"><value>Cette photographie a le même contenu préparé qu’une sélection précédente.</value></data>
+  <data name="Import_DuplicateMetadataReason" xml:space="preserve"><value>Même heure de capture et même taille de fichier.</value></data>
+  <data name="Import_DuplicatePossibleReason" xml:space="preserve"><value>Métadonnées de photographie historique similaires.</value></data>
+  <data name="Import_DuplicatePossible" xml:space="preserve"><value>Photographie potentiellement dupliquée</value></data>
+  <data name="Import_DuplicateRemove" xml:space="preserve"><value>Supprimer le doublon</value></data>
+  <data name="Import_DuplicateKeepBoth" xml:space="preserve"><value>Conserver les deux</value></data>
   <data name="Import_ReviewCatches" xml:space="preserve"><value>Vérifier les prises</value></data>
   <data name="Import_ReviewTitle" xml:space="preserve"><value>Prises proposées</value></data>
   <data name="Import_CorrectionLater" xml:space="preserve"><value>Les outils de vérification et de correction seront ajoutés à la prochaine étape de cette fonctionnalité.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1368,6 +1368,13 @@
   <data name="Import_PhotoFailed" xml:space="preserve"><value>This photograph could not be prepared.</value></data>
   <data name="Import_MetadataUnavailable" xml:space="preserve"><value>Photo ready · historical details need review</value></data>
   <data name="Import_PhotoReady" xml:space="preserve"><value>Photo ready</value></data>
+  <data name="Import_DuplicateExact" xml:space="preserve"><value>Likely exact duplicate photo</value></data>
+  <data name="Import_DuplicateExactReason" xml:space="preserve"><value>This photograph has the same prepared image content as an earlier selection.</value></data>
+  <data name="Import_DuplicateMetadataReason" xml:space="preserve"><value>Same capture time and file size.</value></data>
+  <data name="Import_DuplicatePossibleReason" xml:space="preserve"><value>Similar historical photograph metadata.</value></data>
+  <data name="Import_DuplicatePossible" xml:space="preserve"><value>Possible duplicate photo</value></data>
+  <data name="Import_DuplicateRemove" xml:space="preserve"><value>Remove duplicate</value></data>
+  <data name="Import_DuplicateKeepBoth" xml:space="preserve"><value>Keep both</value></data>
   <data name="Import_ReviewCatches" xml:space="preserve"><value>Review catches</value></data>
   <data name="Import_ReviewTitle" xml:space="preserve"><value>Proposed catches</value></data>
   <data name="Import_CorrectionLater" xml:space="preserve"><value>Review and correction controls are added in the next step of this feature.</value></data>

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingBatch.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingBatch.cs
@@ -247,6 +247,86 @@ public class WhenTestingBatch : BaseImportModelTest
     }
 
     [Fact]
+    public void ItShouldBlockPersistenceUntilAnExactDuplicateIsExplicitlyKept()
+    {
+        // Arrange
+        var batch = Batch();
+        var first = ReadyPersistencePhoto();
+        var duplicate = ReadyPersistencePhoto(SecondPhotoId, 1);
+        duplicate.SetDuplicateState(
+            ImportDuplicateStatusEnum.Duplicate,
+            ImportDuplicateReasonEnum.IdenticalPreparedBytes,
+            [first.Id]);
+        var catchProposal = Catch(photoIds: [first.Id, duplicate.Id]);
+        catchProposal.MarkReviewed();
+        batch.AddPhoto(first);
+        batch.AddPhoto(duplicate);
+        batch.AddCatchProposal(catchProposal);
+
+        // Act
+        var beforeDecision = batch.IsReadyForConfirmation;
+        batch.KeepDuplicatePhoto(duplicate.Id);
+
+        // Assert
+        beforeDecision.Should().BeFalse();
+        duplicate.DuplicateDecision.Should().Be(ImportDuplicateDecisionEnum.KeepBoth);
+        batch.IsReadyForConfirmation.Should().BeTrue();
+        batch.Photos.Should().OnlyContain(photo => !photo.IsRemoved);
+    }
+
+    [Fact]
+    public void ItShouldResolveAnExactDuplicateThroughTheNormalRemovalFlow()
+    {
+        // Arrange
+        var batch = Batch();
+        var first = ReadyPersistencePhoto();
+        var duplicate = ReadyPersistencePhoto(SecondPhotoId, 1);
+        duplicate.SetDuplicateState(
+            ImportDuplicateStatusEnum.Duplicate,
+            ImportDuplicateReasonEnum.IdenticalPreparedBytes,
+            [first.Id]);
+        var catchProposal = Catch(photoIds: [first.Id, duplicate.Id]);
+        catchProposal.MarkReviewed();
+        batch.AddPhoto(first);
+        batch.AddPhoto(duplicate);
+        batch.AddCatchProposal(catchProposal);
+        var trip = Trip();
+        batch.AddTripProposal(trip);
+
+        // Act
+        batch.RemovePhoto(duplicate.Id);
+
+        // Assert
+        duplicate.IsRemoved.Should().BeTrue();
+        catchProposal.PhotoIds.Should().Equal(first.Id);
+        catchProposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
+        batch.TripProposals.Should().BeEmpty();
+        batch.IsReadyForConfirmation.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItShouldNotRequireAResolutionWhenTheDuplicateCounterpartWasRemoved()
+    {
+        // Arrange
+        var batch = Batch();
+        var first = ReadyPersistencePhoto();
+        var duplicate = ReadyPersistencePhoto(SecondPhotoId, 1);
+        duplicate.SetDuplicateState(
+            ImportDuplicateStatusEnum.Duplicate,
+            ImportDuplicateReasonEnum.IdenticalPreparedBytes,
+            [first.Id]);
+        batch.AddPhoto(first);
+        batch.AddPhoto(duplicate);
+
+        // Act
+        batch.RemovePhoto(first.Id);
+
+        // Assert
+        duplicate.RequiresDuplicateDecision.Should().BeTrue();
+        batch.HasUnresolvedExactDuplicates.Should().BeFalse();
+    }
+
+    [Fact]
     public void ItShouldRepresentMultipleIndependentTripProposals()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingSelectedPhoto.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingSelectedPhoto.cs
@@ -19,7 +19,11 @@ public class WhenTestingSelectedPhoto : BaseImportModelTest
 
         // Act
         photo.SetMetadata(ImportMetadataStatusEnum.Available, timestamp, location);
-        photo.SetDuplicateState(ImportDuplicateStatusEnum.Warning, "fingerprint-placeholder");
+        photo.SetFingerprint("fingerprint-placeholder");
+        photo.SetDuplicateState(
+            ImportDuplicateStatusEnum.Warning,
+            ImportDuplicateReasonEnum.SameCaptureTimeAndSize,
+            [SecondPhotoId]);
 
         // Assert
         photo.MetadataStatus.Should().Be(ImportMetadataStatusEnum.Available);
@@ -27,6 +31,7 @@ public class WhenTestingSelectedPhoto : BaseImportModelTest
         photo.Location.Should().Be(location);
         photo.DuplicateStatus.Should().Be(ImportDuplicateStatusEnum.Warning);
         photo.Fingerprint.Should().Be("fingerprint-placeholder");
+        photo.DuplicatePhotoIds.Should().Equal(SecondPhotoId);
         photo.GetType().GetProperties().Select(property => property.PropertyType)
             .Should().NotContain(typeof(byte[]));
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
@@ -683,6 +683,101 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
     }
 
     [Fact]
+    public async Task ItShouldRequireAnExplicitDecisionForAnExactDuplicateAndKeepBothInSession()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var first = ReadyPhoto(0);
+        var duplicate = ReadyPhoto(1);
+        duplicate.SetDuplicateState(
+            ImportDuplicateStatusEnum.Duplicate,
+            ImportDuplicateReasonEnum.IdenticalPreparedBytes,
+            [first.Id]);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([first, duplicate]));
+
+        // Act
+        cut.Find("#import-photos-continue").HasAttribute("disabled").Should().BeTrue();
+        cut.Find("#import-keep-duplicate-1").Click();
+        cut.Find("#import-photos-continue").Click();
+        cut.Find("#import-review-back").Click();
+
+        // Assert
+        cut.FindAll("#import-exact-duplicate-1").Should().BeEmpty();
+        cut.Find("#import-photos-continue").HasAttribute("disabled").Should().BeFalse();
+        duplicate.DuplicateDecision.Should().Be(ImportDuplicateDecisionEnum.KeepBoth);
+        await preparation.DidNotReceive().RemoveAsync(Arg.Any<ImportSelectedPhotoModel>(), Arg.Any<CancellationToken>());
+        proposal.Received(1).Propose(Arg.Is<ImportBatchModel>(batch =>
+            batch.Photos.Count(photo => !photo.IsRemoved) == 2));
+    }
+
+    [Fact]
+    public async Task ItShouldRemoveAnExactDuplicateThroughTheNormalPhotoLifecycle()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var first = ReadyPhoto(0);
+        var duplicate = ReadyPhoto(1);
+        duplicate.SetDuplicateState(
+            ImportDuplicateStatusEnum.Duplicate,
+            ImportDuplicateReasonEnum.IdenticalPreparedBytes,
+            [first.Id]);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([first, duplicate]));
+
+        // Act
+        cut.Find("#import-remove-duplicate-1").Click();
+
+        // Assert
+        await preparation.Received(1).RemoveAsync(
+            Arg.Is<ImportSelectedPhotoModel>(photo => photo.Id == duplicate.Id),
+            Arg.Any<CancellationToken>());
+        cut.FindAll("#import-photo-1").Should().BeEmpty();
+        cut.Find("#import-photos-continue").HasAttribute("disabled").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ItShouldShowMetadataDuplicateEvidenceWithoutBlockingReview()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        var preparation = Substitute.For<IImportPhotoPreparationService>();
+        await using var context = CreateContext(proposal, preparation);
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        var first = ReadyPhoto(0);
+        var possibleDuplicate = ReadyPhoto(1);
+        possibleDuplicate.SetDuplicateState(
+            ImportDuplicateStatusEnum.Warning,
+            ImportDuplicateReasonEnum.SameCaptureTimeAndSize,
+            [first.Id]);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([first, possibleDuplicate]));
+
+        // Act
+        var warning = cut.Find("#import-possible-duplicate-1").TextContent;
+        cut.Find("#import-photos-continue").Click();
+
+        // Assert
+        warning.Should().Contain("Possible duplicate photo");
+        cut.Find("#import-catch-review").Should().NotBeNull();
+        possibleDuplicate.IsRemoved.Should().BeFalse();
+        await preparation.DidNotReceive().RemoveAsync(Arg.Any<ImportSelectedPhotoModel>(), Arg.Any<CancellationToken>());
+        proposal.Received(1).Propose(Arg.Is<ImportBatchModel>(batch =>
+            batch.Photos.Count(photo => !photo.IsRemoved) == 2));
+    }
+
+    [Fact]
     public async Task ItShouldClearTransientPhotoResourcesWhenDisposed()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/WhenTestingPrepareSelectionAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPhotoPreparationServiceTests/WhenTestingPrepareSelectionAsync.cs
@@ -13,6 +13,94 @@ namespace FishingLogBook.Web.Tests.Features.Import.Services.ImportPhotoPreparati
 public class WhenTestingPrepareSelectionAsync : BaseImportPhotoPreparationServiceTest
 {
     [Fact]
+    public async Task ItShouldRequireResolutionForIdenticalPreparedBytesRegardlessOfFileName()
+    {
+        // Arrange
+        var context = CreateContext();
+        var files = new[] { File([1, 2, 3], name: "first.jpg"), File([9, 8, 7], name: "copy.jpg") };
+
+        // Act
+        var result = await context.Sut.PrepareSelectionAsync(files, CancellationToken.None);
+
+        // Assert
+        result[0].Fingerprint.Should().Be(result[1].Fingerprint);
+        result[0].Fingerprint.Should().Be(Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(SanitisedBytes)));
+        result[0].RequiresDuplicateDecision.Should().BeFalse();
+        result[1].DuplicateStatus.Should().Be(ImportDuplicateStatusEnum.Duplicate);
+        result[1].DuplicateReason.Should().Be(ImportDuplicateReasonEnum.IdenticalPreparedBytes);
+        result[1].DuplicatePhotoIds.Should().ContainSingle().Which.Should().Be(result[0].Id);
+        result[1].RequiresDuplicateDecision.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ItShouldNotTreatMatchingMetadataOrThumbnailAsAnExactDuplicateWhenPreparedBytesDiffer()
+    {
+        // Arrange
+        var capturedOn = DateTimeOffset.Parse("2025-06-14T09:30:00+01:00");
+        var historical = new PhotographHistoricalMetadataModel(
+            capturedOn, null, PhotographCapturedOnSourceEnum.ExifOriginal, true, false, null, null);
+        var context = CreateContext(historical);
+        context.Metadata.Sanitise(Arg.Any<byte[]>(), Arg.Any<string>())
+            .Returns(call => call.ArgAt<byte[]>(0));
+        context.Registry.RegisterAsync(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(call => new ImportPhotoBlobRegistrationModel(
+                $"token-{call.ArgAt<byte[]>(0)[0]}",
+                "blob:same-thumbnail"));
+        var files = new[] { File([1, 2, 3], name: "photo.jpg"), File([4, 5, 6], name: "photo.jpg") };
+
+        // Act
+        var result = await context.Sut.PrepareSelectionAsync(files, CancellationToken.None);
+
+        // Assert
+        result.Select(photo => photo.Fingerprint).Distinct().Should().HaveCount(2);
+        result.Select(photo => photo.ThumbnailUrl).Distinct().Should().ContainSingle();
+        result.Should().NotContain(photo => photo.DuplicateStatus == ImportDuplicateStatusEnum.Duplicate);
+        result[1].DuplicateStatus.Should().Be(ImportDuplicateStatusEnum.Warning);
+        result[1].DuplicateReason.Should().Be(ImportDuplicateReasonEnum.SameCaptureTimeAndSize);
+    }
+
+    [Fact]
+    public async Task ItShouldNotWarnForFileNameAlone()
+    {
+        // Arrange
+        var context = CreateContext();
+        context.Metadata.Sanitise(Arg.Any<byte[]>(), Arg.Any<string>())
+            .Returns(call => call.ArgAt<byte[]>(0));
+        var files = new[] { File([1], name: "photo.jpg"), File([2, 3], name: "photo.jpg") };
+
+        // Act
+        var result = await context.Sut.PrepareSelectionAsync(files, CancellationToken.None);
+
+        // Assert
+        result.Should().OnlyContain(photo => photo.DuplicateStatus == ImportDuplicateStatusEnum.None);
+        result.Should().OnlyContain(photo => !photo.RequiresDuplicateDecision);
+    }
+
+    [Fact]
+    public async Task ItShouldNeverTreatGpsAloneAsDuplicateEvidence()
+    {
+        // Arrange
+        var context = CreateContext();
+        var metadataIndex = 0;
+        context.Metadata.ReadHistorical(
+                Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset>())
+            .Returns(_ => new PhotographHistoricalMetadataModel(
+                FileModifiedOn.AddMinutes(metadataIndex++), null,
+                PhotographCapturedOnSourceEnum.ExifOriginal, true, false, 53.3498, -6.2603));
+        context.Metadata.Sanitise(Arg.Any<byte[]>(), Arg.Any<string>())
+            .Returns(call => call.ArgAt<byte[]>(0));
+
+        // Act
+        var result = await context.Sut.PrepareSelectionAsync(
+            [File([1]), File([2, 3])], CancellationToken.None);
+
+        // Assert
+        result.Should().OnlyContain(photo => photo.DuplicateStatus == ImportDuplicateStatusEnum.None);
+        result.Should().OnlyContain(photo => !photo.RequiresDuplicateDecision);
+    }
+
+    [Fact]
     public async Task ItShouldPrepareTheFullTwentyPhotoBatchSequentially()
     {
         // Arrange
@@ -30,6 +118,7 @@ public class WhenTestingPrepareSelectionAsync : BaseImportPhotoPreparationServic
         result.Should().HaveCount(20);
         result.Should().OnlyContain(photo => photo.IsReady && photo.BlobToken != null);
         result.Select(photo => photo.SelectionIndex).Should().Equal(Enumerable.Range(0, 20));
+        result.Count(photo => photo.RequiresDuplicateDecision).Should().Be(19);
         registry.RegistrationCount.Should().Be(20);
         registry.MaximumConcurrency.Should().Be(1);
         context.Metadata.Received(20).ReadHistorical(


### PR DESCRIPTION
## Summary

Contributes to #219.

- hashes each prepared/sanitised photograph with SHA-256 during the existing sequential preparation flow
- detects exact duplicates within the active Import batch independently of filenames and thumbnails
- requires an explicit Remove duplicate or Keep both decision before the Import can advance or persist
- routes removal through the existing photograph/Blob cleanup and Catch/Trip invalidation flow
- shows metadata-only matches as non-blocking possible-duplicate warnings
- keeps fingerprints and decisions transient to the active online Import session
- preserves the approved inclusive five-minute complete-span Catch grouping rule
- adds English and French duplicate-warning copy

## Scope boundary

Persisted Catch photograph contracts currently expose only photograph identity, content type and URL/object-storage data. They do not retain a reusable fingerprint or sufficient historical metadata for authoritative cross-import exact matching.

This PR therefore does not invent a client-only cross-import check or broaden the photograph schema/API/domain contract. Cross-import exact duplicate detection remains the explicit follow-up gap, so this PR intentionally uses `Contributes to #219` rather than closing the issue.

The authenticated end-to-end duplicate journey is also not representable in the current JS/PWA-only Playwright harness. Issue #157 has been updated with the required remove-duplicate and keep-both journeys.

## Validation

- `dotnet format FishingLogBook.sln --no-restore`
- `git diff --check`
- `dotnet build FishingLogBook.sln --no-restore`
- focused Import tests: passed
- full Web tests: 1,880 passed
- `npm test`: 402 passed
- `npm run test:browser`: 159 passed, 7 expected WebKit skips

Existing analyzer/nullability warnings remain unchanged.

## Self Review

- Issue/AC: PASS for within-batch strong detection, warning-only metadata evidence, explicit decisions, Blob lifecycle, structural invalidation and 20-photo behavior; cross-import fingerprint persistence remains deliberately incomplete and is documented above
- Architecture/CQRS: PASS — Web-only transient Import state; no API, domain, repository or CQRS changes
- Rules: PASS
- Security/privacy: PASS — hashes, bytes, filenames, EXIF and GPS are not logged; hashes are not displayed or transmitted
- Database/migrations: N/A
- Tests/coverage: PASS — exact bytes, different filenames, deterministic SHA-256, different full bytes with identical thumbnail, metadata-only warning, filename-only, GPS-only, unresolved blocking, removal, keep-both, navigation retention, structural invalidation and 20-photo sequential preparation
- Browser: PASS for existing browser/PWA suites; authenticated Import journey remains a documented #157 infrastructure gap
- Web/UI/localisation: PASS — compact warnings/actions with English and French resources
- Code smells: PASS
- CI/deployment: PASS locally; remote CI pending

### Findings discovered during self-review

1. Removing a duplicate changes Catch membership and must reset that Catch to Draft and invalidate Trip proposals.
2. Removing the earlier counterpart must not leave the remaining photograph blocked as a duplicate of an inactive photo.
3. Normal solution output was initially locked by a running local API process.

### Fixes made

1. Added regression coverage proving structural removal resets review state and invalidates Trip proposals.
2. Made unresolved duplicate validation consider active counterparts only.
3. Re-ran the normal solution build successfully after the local API process stopped.

### Remaining deliberate gaps

- Authoritative cross-import exact matching requires a deliberate persisted fingerprint contract/schema extension.
- Full authenticated browser coverage requires the testing-host work tracked in #157.
