### PR TITLE
FLB#219 | Fix Import upload and timestamp handling

### DIFF
--- a/.claude/rules/self-review.md
+++ b/.claude/rules/self-review.md
@@ -192,8 +192,9 @@ or RCL extraction to a product feature ticket in order to force Playwright cover
 
 If browser coverage is deliberately omitted, the self-review report must state:
 
-- what browser-specific risk remains
-- which lower-level tests cover the behaviour
+- the missing E2E scenario and exact risk it would have covered
+- the compensating test, its test level, and the real components/boundaries exercised
+- what browser-specific behaviour remains untested
 - why Playwright is not appropriate in the current architecture
 - whether a follow-up testing-infrastructure ticket is warranted
 
@@ -229,6 +230,25 @@ Ask what can pass all unit tests and still fail when layers combine (SQL mapping
 mismatch, DTO serialisation, presigned upload sequence, auth claims, service worker /
 offline, concurrency, constraints). Add the smallest integration test the risk warrants.
 Do not add broad end-to-end tests for behaviour already strongly covered below.
+
+### State transition review (mandatory where applicable)
+
+For changes involving persistence, retries, reconciliation, synchronisation, uploads,
+idempotency, partial failure, or authoritative rereads, follow the stateful and multi-stage
+rules in **`testing-csharp.md`** and explicitly:
+
+1. Trace the operation through the real implementations on both sides of changed
+   interfaces.
+2. Identify every meaningful intermediate state.
+3. Identify the authoritative completion predicate.
+4. Inspect the real persistence and read-back semantics.
+5. Compare those semantics with the test mocks.
+6. Confirm at least one appropriate test contains the real stateful boundary where
+   technically practical.
+7. Identify any remaining mocked boundary that could hide production behaviour.
+
+A green unit/component test suite is not sufficient evidence for a cross-layer state
+transition.
 
 ## Localisation / UI
 

--- a/.claude/rules/testing-blazor.md
+++ b/.claude/rules/testing-blazor.md
@@ -32,9 +32,20 @@ test-host complexity.
 Do **not** add test-only authentication, compile symbols, or dual-host hacks to
 `src/FishingLogBook.Web` to force authenticated Blazor Playwright onto a product ticket.
 
-If browser coverage is omitted, the **`self-review.md`** report must state remaining
-browser risk, compensating lower-level tests, why Playwright is not appropriate now,
-and whether a testing-infrastructure follow-up is warranted. Follow
+If browser/E2E coverage cannot be implemented, do not automatically accept mocked
+component or unit coverage as sufficient. First identify the exact risk the missing E2E
+scenario would have covered. If that risk exists below the browser, add the smallest
+integration, API, repository, or contract test that contains the real relevant boundary,
+following **`testing-csharp.md`**. For example, when a UI flow reaches an API, application
+service, repository, and object store, a persistence or reconciliation risk can be covered
+below the browser with those real stateful layers; only genuinely browser-specific
+behaviour may remain deferred.
+
+When browser coverage is omitted, the **`self-review.md`** report must state the missing
+E2E scenario, the exact risk it would have covered, the compensating test and its level,
+the real components/boundaries exercised, the residual untested browser behaviour, why
+Playwright is not appropriate now, and whether a testing-infrastructure follow-up is
+warranted. Follow
 **`self-review.md` → Browser / Playwright**.
 
 ## Tests mirror production (mandatory)

--- a/.claude/rules/testing-csharp.md
+++ b/.claude/rules/testing-csharp.md
@@ -32,6 +32,14 @@ For every GitHub issue:
 12. Existing tests must remain green.
 13. Run the appropriate test projects before considering implementation complete.
 
+For substantial cross-layer Acceptance Criteria, derive concrete acceptance scenarios
+before implementation. Wording such as "retries safely", "reconciles authoritative
+state", "does not duplicate", "completes interrupted upload", or "persists correctly"
+must be expanded into the authoritative starting state, operation, intermediate partial
+states, and expected authoritative result. Do not let the implementation silently define
+these terms. If the expected authoritative state cannot be determined from the issue or
+existing architecture, stop and report the ambiguity before implementing.
+
 ## Test projects (one per production project)
 
 Each production project has its **own** `FishingLogBook.<Project>.Tests` project; shared
@@ -105,6 +113,105 @@ For example, for an inclusive five-minute maximum group span, prove at least:
 Test names must describe the complete business invariant. Do not name or assert an
 implementation strategy such as adjacent chaining when that strategy is not itself the
 requirement.
+
+### Stateful and multi-stage behaviour (mandatory)
+
+Derive tests for stateful or multi-stage behaviour from the externally observable state
+transition:
+
+```text
+GIVEN authoritative starting state
+WHEN the operation occurs
+THEN authoritative resulting state
+```
+
+Prove the resulting persisted or external state is correct. A successful method return or
+an expected mocked call sequence is not sufficient when the Acceptance Criterion depends
+on database persistence, object upload, registration after upload, synchronisation,
+reconciliation, retry, idempotency, or partial-failure recovery.
+
+#### Choose the test level that contains the risk
+
+Use the smallest test level that contains the boundary capable of causing the failure:
+
+| Risk | Required test level |
+|------|---------------------|
+| Pure algorithm or invariant | Unit test |
+| Component rendering or interaction | bUnit/component test |
+| DTO or serialisation contract | Contract test |
+| Repository SQL or persistence lifecycle | Real repository/Testcontainers integration test |
+| API/application/repository lifecycle | API/integration test containing the real relevant layers |
+| Browser-specific JS or PWA behaviour | Playwright/browser test |
+| Persistence plus retry, reconciliation, synchronisation, or upload lifecycle | Integration or end-to-end test containing the real stateful boundary |
+
+Mocks remain valuable supporting evidence, but a mocked unit or component test must not be
+the sole acceptance/regression proof when correctness depends on the real semantics of the
+substituted dependency. If behaviour depends on both sides of an interface, include the
+real implementations on both sides in the smallest practical integration, API, repository,
+or contract test. This does not mean every feature needs browser E2E or every unit test
+needs a database.
+
+The repository's existing test-project boundaries still apply: `Api.Tests` substitutes
+repositories and does not start PostgreSQL. When database semantics determine correctness,
+put the real persistence proof in the Testcontainers-backed Infrastructure repository
+suite and use API tests for the real HTTP/application chain above the substituted
+repository. Together they must cover the risk without moving a live database into
+`Api.Tests`.
+
+#### Partial-state matrix
+
+Before declaring coverage complete for persistence, retries, reconciliation, idempotency,
+synchronisation, upload/registration, partial-failure recovery, authoritative rereads, or
+online/offline handoff, enumerate the meaningful intermediate states. Test the states that
+genuinely exist, including where applicable:
+
+1. Nothing persisted or completed.
+2. The primary record exists but the dependent operation has not started.
+3. Dependent metadata exists but the secondary/external operation is incomplete.
+4. The secondary operation completed but registration/finalisation is incomplete.
+5. A multi-item operation is partially complete.
+6. The operation is fully complete.
+7. Retry from every recoverable partial state.
+
+Tests must prove that an incomplete state is not mistaken for completion.
+
+#### Authoritative completion predicate
+
+For early-return or skip logic such as `existing != null`, `alreadyProcessed`, or an
+existing identifier, explicitly answer in the implementation and test design:
+
+> What authoritative fact proves this operation is complete?
+
+An identifier, metadata row, file, or primary record is not automatically proof that a
+multi-stage operation completed. Where possible, add a regression scenario in which the
+early/existence signal is present but the later operation remains incomplete, such as
+metadata without its object, a file without registration, or a server record without its
+dependent synchronised state.
+
+#### Mock lifecycle realism
+
+Mocks that represent a real lifecycle must match the documented or actual production
+dependency behaviour. Before modelling a sequence such as `Upsert -> Get -> retry`, inspect
+the real implementations or contracts for `Upsert` and `Get`; do not invent a convenient
+read-back state that differs materially from production. A mock may deliberately represent
+a synthetic or error state when the test makes that intent explicit. If correctness
+materially depends on the lifecycle, retain mocked unit coverage but add coverage across
+the real lifecycle boundary.
+
+#### Production bug regressions
+
+For a production bug fix:
+
+1. Reproduce the important production failure state in an automated test.
+2. Verify that test would fail against the broken behaviour.
+3. Implement or finalise the fix.
+4. Retain the regression test permanently.
+
+Do not simplify the lifecycle in a way that bypasses the cause. For example, if a primary
+upsert also creates dependent metadata while the secondary upload remains missing, the
+regression must begin from that real partial state and prove retry/reconciliation completes
+the secondary operation. A mock where the reread conveniently returns no dependent
+metadata does not reproduce the failure.
 
 ## Dependency verification (mandatory)
 

--- a/src/FishingLogBook.Application/Catches/Services/CatchService.cs
+++ b/src/FishingLogBook.Application/Catches/Services/CatchService.cs
@@ -319,6 +319,11 @@ public sealed class CatchService : ICatchService
         }
 
         var objectKey = _objectKeyBuilder.Build(catchId, photographId);
+        if (!await _objectStorage.ExistsAsync(objectKey, cancellationToken))
+        {
+            return null;
+        }
+
         var url = await _objectStorage.CreateDownloadUrlAsync(objectKey, DownloadLifetime, cancellationToken);
         return url.ToString();
     }

--- a/src/FishingLogBook.Application/Common/Contracts/Services/IObjectStorage.cs
+++ b/src/FishingLogBook.Application/Common/Contracts/Services/IObjectStorage.cs
@@ -12,5 +12,7 @@ public interface IObjectStorage
 
     Task<Uri> CreateDownloadUrlAsync(string objectKey, TimeSpan lifetime, CancellationToken cancellationToken);
 
+    Task<bool> ExistsAsync(string objectKey, CancellationToken cancellationToken);
+
     Task DeleteObjectAsync(string objectKey, CancellationToken cancellationToken);
 }

--- a/src/FishingLogBook.Infrastructure/Storage/S3CompatibleObjectStorage.cs
+++ b/src/FishingLogBook.Infrastructure/Storage/S3CompatibleObjectStorage.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
@@ -72,6 +73,21 @@ public sealed class S3CompatibleObjectStorage : IObjectStorage, IDisposable
         };
 
         return Task.FromResult(new Uri(Client.GetPreSignedURL(request)));
+    }
+
+    public async Task<bool> ExistsAsync(string objectKey, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Client.GetObjectMetadataAsync(
+                new GetObjectMetadataRequest { BucketName = _config.BucketName, Key = objectKey },
+                cancellationToken);
+            return true;
+        }
+        catch (AmazonS3Exception exception) when (exception.StatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
+        }
     }
 
     public Task DeleteObjectAsync(string objectKey, CancellationToken cancellationToken)

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
@@ -42,25 +42,13 @@
                     <MudTooltip Text="@Loc["Import_ConfirmCaughtOn"]" ShowOnClick="true">
                         <MudButton StartIcon="@Icons.Material.Filled.Check" Size="Size.Small"
                                    Variant="Variant.Filled" Color="Color.Primary"
-                                   OnClick="ConfirmCaughtOn" Class="import-catch-confirm-caught-on"
+                                   OnClick="ConfirmCaughtOnAsync" Class="import-catch-confirm-caught-on"
                                    aria-label="@Loc["Import_ConfirmCaughtOn"]"
                                    id="@($"import-catch-{Number}-confirm-caught-on")">
                             <span class="import-catch-confirm-caught-on-label">@Loc["Import_ConfirmCaughtOn"]</span>
                         </MudButton>
                     </MudTooltip>
                 </div>
-                @if (RequiresUtcOffsetControl)
-                {
-                    <MudSelect T="TimeSpan?" Value="_utcOffset" ValueChanged="SetUtcOffset"
-                               Label="@Loc["Import_UtcOffset"]" Required="true"
-                               Error="_utcOffsetInvalid" ErrorText="@Loc["Import_UtcOffsetRequired"]"
-                               id="@($"import-catch-{Number}-utc-offset")">
-                        @foreach (var offset in UtcOffsetOptions)
-                        {
-                            <MudSelectItem T="TimeSpan?" Value="@((TimeSpan?)offset)">@UtcOffsetLabel(offset)</MudSelectItem>
-                        }
-                    </MudSelect>
-                }
                 @if (Proposal.RequiresCanonicalReview)
                 {
                     <MudAlert Severity="Severity.Warning">@Loc["Import_MergeValuesNeedReview"]</MudAlert>

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Import.Enums;
@@ -19,15 +20,11 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     private const int MaxChipOptions = 6;
     private readonly HashSet<Guid> _selectedPhotoIds = [];
     private readonly CancellationTokenSource _cancellationTokenSource = new();
-    private static readonly IReadOnlyList<TimeSpan> UtcOffsetOptions =
-        [.. Enumerable.Range(0, 53).Select(index => TimeSpan.FromMinutes(-720 + (index * 30)))];
     private string _caughtOnLocal = string.Empty;
     private ImportTimestampModel? _caughtOnBasis;
     private Guid? _activePhotoId;
     private bool _caughtOnInvalid;
     private bool _editing;
-    private TimeSpan? _utcOffset;
-    private bool _utcOffsetInvalid;
 
     [Parameter, EditorRequired] public ImportCatchProposalModel Proposal { get; set; } = default!;
     [Parameter, EditorRequired] public ImportBatchModel Batch { get; set; } = default!;
@@ -41,6 +38,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     [Inject] private IModalService ModalService { get; set; } = default!;
     [Inject] private IMeasurementService Measurement { get; set; } = default!;
     [Inject] private IStringLocalizer<UiStrings> Loc { get; set; } = default!;
+    [Inject] private ITimeService Time { get; set; } = default!;
 
     private IReadOnlyList<ImportSelectedPhotoModel> ProposalPhotos =>
         [.. Proposal.PhotoIds.Select(photoId => Batch.Photos.Single(photo => photo.Id == photoId))];
@@ -92,8 +90,6 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
             .Where(item => !item.Proposal.IsRemoved && item.Proposal.Id != Proposal.Id)];
 
     private bool CanSplit => _selectedPhotoIds.Count > 0 && _selectedPhotoIds.Count < Proposal.PhotoIds.Count;
-    private bool RequiresUtcOffsetControl => _caughtOnBasis is not null
-        && (_caughtOnBasis.LocalWallClock.HasValue || !_caughtOnBasis.Instant.HasValue);
     private bool ShowLocationDecision => Proposal.HasUnresolvedGpsConflict || Proposal.Location?.HasCanonicalCoordinates == true;
     private Color StatusColor => Proposal.ReviewStatus == ImportCatchReviewStatusEnum.Reviewed
         ? Color.Success : Proposal.CanBeReviewed ? Color.Info : Color.Warning;
@@ -119,11 +115,11 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
 
     private string TimestampLabel => DisplayedTimestamp.State switch
     {
-        ImportTimestampStateEnum.ExplicitInstant => DisplayedTimestamp.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz"),
-        ImportTimestampStateEnum.UserConfirmed when DisplayedTimestamp.Instant is { } instant => instant.ToString("dd MMM yyyy · HH:mm zzz"),
+        ImportTimestampStateEnum.ExplicitInstant => DisplayedTimestamp.Instant!.Value.ToString("dd MMM yyyy · HH:mm"),
+        ImportTimestampStateEnum.UserConfirmed when DisplayedTimestamp.Instant is { } instant => instant.ToString("dd MMM yyyy · HH:mm"),
         ImportTimestampStateEnum.UserConfirmed => DisplayedTimestamp.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm"),
         ImportTimestampStateEnum.LocalWallClock => Loc["Import_TimestampAmbiguous", DisplayedTimestamp.LocalWallClock!.Value.ToString("dd MMM yyyy · HH:mm")],
-        ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak", DisplayedTimestamp.Instant!.Value.ToString("dd MMM yyyy · HH:mm zzz")],
+        ImportTimestampStateEnum.WeakFallback => Loc["Import_TimestampWeak", DisplayedTimestamp.Instant!.Value.ToString("dd MMM yyyy · HH:mm")],
         ImportTimestampStateEnum.Unusable => Loc["Import_TimestampUnusable"],
         _ => Loc["Import_TimestampMissing"]
     };
@@ -151,8 +147,6 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         _editing = true;
         _caughtOnBasis = DisplayedTimestamp;
         _caughtOnLocal = EditorValue(DisplayedTimestamp);
-        _utcOffset = DisplayedTimestamp.LocalWallClock.HasValue ? DisplayedTimestamp.Instant?.Offset : null;
-        _utcOffsetInvalid = false;
     }
     private void CloseEditor()
     {
@@ -163,16 +157,9 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
     {
         _caughtOnLocal = value;
         _caughtOnInvalid = false;
-        _utcOffsetInvalid = false;
         var caughtOn = !TryParseCaughtOn(value, out var parsed)
             ? ImportTimestampModel.Missing()
-            : RequiresUtcOffsetControl
-                ? (_caughtOnBasis ?? Proposal.CaughtOn).EditLocalWallClock(parsed)
-                : ConfirmedCaughtOn(parsed);
-        if (RequiresUtcOffsetControl)
-        {
-            _utcOffset = null;
-        }
+            : ConfirmedCaughtOn(parsed);
         Batch.SetCatchCaughtOn(Proposal.Id, caughtOn);
     }
     private void SelectPhotos(IReadOnlySet<Guid> selectedPhotoIds)
@@ -193,23 +180,15 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         _caughtOnBasis = DisplayedTimestamp;
         _caughtOnLocal = EditorValue(DisplayedTimestamp);
         _caughtOnInvalid = false;
-        _utcOffset = DisplayedTimestamp.LocalWallClock.HasValue ? DisplayedTimestamp.Instant?.Offset : null;
-        _utcOffsetInvalid = false;
         return Task.CompletedTask;
     }
 
-    private void ConfirmCaughtOn()
+    private async Task ConfirmCaughtOnAsync()
     {
-        if (!TryConfirmCaughtOn())
+        if (!await TryConfirmCaughtOnAsync())
         {
             return;
         }
-    }
-
-    private void SetUtcOffset(TimeSpan? utcOffset)
-    {
-        _utcOffset = utcOffset;
-        _utcOffsetInvalid = false;
     }
 
     private static bool TryParseCaughtOn(string value, out DateTime caughtOn)
@@ -289,7 +268,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
 
     private async Task ContinueAsync()
     {
-        if (!TryConfirmCaughtOn())
+        if (!await TryConfirmCaughtOnAsync())
         {
             return;
         }
@@ -316,7 +295,7 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         return (_caughtOnBasis ?? Proposal.CaughtOn).Confirm(caughtOn);
     }
 
-    private bool TryConfirmCaughtOn()
+    private async Task<bool> TryConfirmCaughtOnAsync()
     {
         if (!TryParseCaughtOn(_caughtOnLocal, out var caughtOn))
         {
@@ -324,26 +303,28 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
             return false;
         }
 
-        if (RequiresUtcOffsetControl && !_utcOffset.HasValue)
+        var basis = _caughtOnBasis ?? Proposal.CaughtOn;
+        ImportTimestampModel confirmed;
+        if (basis.Instant.HasValue)
         {
-            _utcOffsetInvalid = true;
-            return false;
+            confirmed = basis.Confirm(caughtOn);
         }
+        else
+        {
+            var resolved = await Time.FromDateTimeLocalValueAsync(
+                caughtOn.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture),
+                _cancellationTokenSource.Token);
+            if (!resolved.HasValue)
+            {
+                _caughtOnInvalid = true;
+                return false;
+            }
 
-        var confirmed = RequiresUtcOffsetControl
-            ? (_caughtOnBasis ?? Proposal.CaughtOn).ConfirmLocalWallClock(caughtOn, _utcOffset!.Value)
-            : ConfirmedCaughtOn(caughtOn);
+            confirmed = ImportTimestampModel.UserConfirmed(resolved.Value);
+        }
         Batch.SetCatchCaughtOn(Proposal.Id, confirmed);
         _caughtOnInvalid = false;
-        _utcOffsetInvalid = false;
         return true;
-    }
-
-    private static string UtcOffsetLabel(TimeSpan offset)
-    {
-        var sign = offset < TimeSpan.Zero ? '-' : '+';
-        var absolute = offset.Duration();
-        return $"UTC{sign}{absolute.Hours:D2}:{absolute.Minutes:D2}";
     }
 
     private FishingMethodDto? FindMethod(Guid id) => Preferences.Catalogue.Methods.SingleOrDefault(method => method.Id == id);

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportTimestampModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportTimestampModel.cs
@@ -41,8 +41,6 @@ public sealed record ImportTimestampModel
         }
     }
 
-    public bool RequiresUtcOffset => LocalWallClock.HasValue && !Instant.HasValue;
-
     public static ImportTimestampModel Missing()
     {
         return new ImportTimestampModel(
@@ -97,24 +95,10 @@ public sealed record ImportTimestampModel
 
     public ImportTimestampModel Confirm(DateTime localValue)
     {
-        if (!Instant.HasValue)
-        {
-            throw new InvalidOperationException("An explicit UTC offset is required for a historical local date and time.");
-        }
-
         var unspecified = DateTime.SpecifyKind(localValue, DateTimeKind.Unspecified);
-        return UserConfirmed(new DateTimeOffset(unspecified, Instant.Value.Offset));
-    }
-
-    public ImportTimestampModel ConfirmLocalWallClock(DateTime localWallClock, TimeSpan utcOffset)
-    {
-        var unspecified = DateTime.SpecifyKind(localWallClock, DateTimeKind.Unspecified);
-        var instant = new DateTimeOffset(unspecified, utcOffset);
-        return new ImportTimestampModel(
-            ImportTimestampStateEnum.UserConfirmed,
-            ImportTimestampSourceEnum.User,
-            instant,
-            unspecified);
+        return Instant.HasValue
+            ? UserConfirmed(new DateTimeOffset(unspecified, Instant.Value.Offset))
+            : EditLocalWallClock(unspecified);
     }
 
     public ImportTimestampModel EditLocalWallClock(DateTime localWallClock)

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportPersistenceService.cs
@@ -301,7 +301,10 @@ public sealed class ImportPersistenceService : IImportPersistenceService
                     throw new InvalidOperationException("An authoritative photograph conflicts with the Import proposal.");
                 }
 
-                continue;
+                if (!string.IsNullOrWhiteSpace(existingPhotograph.Url))
+                {
+                    continue;
+                }
             }
 
             var photo = batch.Photos.Single(candidate => candidate.Id == photoId && !candidate.IsRemoved);
@@ -337,7 +340,8 @@ public sealed class ImportPersistenceService : IImportPersistenceService
         }
 
         if (!HasExpectedCatch(current, request)
-            || proposal.PhotoIds.Any(photoId => current.Photographs.All(photo => photo.Id != photoId)))
+            || proposal.PhotoIds.Any(photoId => current.Photographs.All(photo =>
+                photo.Id != photoId || string.IsNullOrWhiteSpace(photo.Url))))
         {
             throw new InvalidOperationException("The authoritative Catch state is incomplete.");
         }

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1381,7 +1381,7 @@
   <data name="Import_CatchNumber" xml:space="preserve"><value>Prise {0}</value></data>
   <data name="Import_NeedsReview" xml:space="preserve"><value>À vérifier</value></data>
   <data name="Import_Ready" xml:space="preserve"><value>Prête</value></data>
-  <data name="Import_TimestampAmbiguous" xml:space="preserve"><value>{0} · fuseau horaire à confirmer</value></data>
+  <data name="Import_TimestampAmbiguous" xml:space="preserve"><value>{0} · date et heure à confirmer</value></data>
   <data name="Import_TimestampWeak" xml:space="preserve"><value>{0} · date suggérée à confirmer</value></data>
   <data name="Import_TimestampUnusable" xml:space="preserve"><value>La date de la photo n’a pas pu être utilisée</value></data>
   <data name="Import_TimestampMissing" xml:space="preserve"><value>Date et heure requises</value></data>
@@ -1397,8 +1397,6 @@
   <data name="Import_CaughtOn" xml:space="preserve"><value>Date et heure de la prise</value></data>
   <data name="Import_CaughtOnRequired" xml:space="preserve"><value>Saisissez une date et une heure historiques valides.</value></data>
   <data name="Import_ConfirmCaughtOn" xml:space="preserve"><value>Confirmer la date et lâ€™heure</value></data>
-  <data name="Import_UtcOffset" xml:space="preserve"><value>Décalage UTC</value></data>
-  <data name="Import_UtcOffsetRequired" xml:space="preserve"><value>Choisissez le décalage UTC historique.</value></data>
   <data name="Import_SelectPhoto" xml:space="preserve"><value>SÃ©lectionner la photographie {0}</value></data>
   <data name="Import_UsePhotoLocation" xml:space="preserve"><value>Utiliser le lieu de la photo {0}</value></data>
   <data name="Import_RemoveLocation" xml:space="preserve"><value>Supprimer le lieu</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1381,7 +1381,7 @@
   <data name="Import_CatchNumber" xml:space="preserve"><value>Catch {0}</value></data>
   <data name="Import_NeedsReview" xml:space="preserve"><value>Needs review</value></data>
   <data name="Import_Ready" xml:space="preserve"><value>Ready</value></data>
-  <data name="Import_TimestampAmbiguous" xml:space="preserve"><value>{0} · timezone confirmation required</value></data>
+  <data name="Import_TimestampAmbiguous" xml:space="preserve"><value>{0} · date and time require confirmation</value></data>
   <data name="Import_TimestampWeak" xml:space="preserve"><value>{0} · suggested date requires confirmation</value></data>
   <data name="Import_TimestampUnusable" xml:space="preserve"><value>Photo date could not be used</value></data>
   <data name="Import_TimestampMissing" xml:space="preserve"><value>Date and time required</value></data>
@@ -1397,8 +1397,6 @@
   <data name="Import_CaughtOn" xml:space="preserve"><value>Caught on</value></data>
   <data name="Import_CaughtOnRequired" xml:space="preserve"><value>Enter a valid historical date and time.</value></data>
   <data name="Import_ConfirmCaughtOn" xml:space="preserve"><value>Confirm date and time</value></data>
-  <data name="Import_UtcOffset" xml:space="preserve"><value>UTC offset</value></data>
-  <data name="Import_UtcOffsetRequired" xml:space="preserve"><value>Choose the historical UTC offset.</value></data>
   <data name="Import_SelectPhoto" xml:space="preserve"><value>Select photograph {0}</value></data>
   <data name="Import_UsePhotoLocation" xml:space="preserve"><value>Use photo {0} location</value></data>
   <data name="Import_RemoveLocation" xml:space="preserve"><value>Remove location</value></data>

--- a/src/FishingLogBook.Web/wwwroot/js/browser/time.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/time.js
@@ -42,8 +42,12 @@ export function fromDateTimeLocalValue(localValue, timeZoneOffsetMinutes) {
     const hour = Number(match[4]);
     const minute = Number(match[5]);
     const second = match[6] ? Number(match[6]) : 0;
+    if (typeof timeZoneOffsetMinutes === 'string') {
+        return fromWallClockInTimeZone(year, monthIndex, day, hour, minute, second, timeZoneOffsetMinutes);
+    }
+
     const offsetMinutes = timeZoneOffsetMinutes
-        ?? new Date(year, monthIndex, day, hour, minute, second).getTimezoneOffset();
+        ?? historicalOffsetMinutes(year, monthIndex, day, hour, minute, second);
     const converted = new Date(
         Date.UTC(year, monthIndex, day, hour, minute, second) + (offsetMinutes * 60 * 1000));
     if (Number.isNaN(converted.getTime())) {
@@ -51,4 +55,34 @@ export function fromDateTimeLocalValue(localValue, timeZoneOffsetMinutes) {
     }
 
     return converted.toISOString();
+}
+
+function historicalOffsetMinutes(year, monthIndex, day, hour, minute, second) {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (!timeZone) {
+        return new Date(year, monthIndex, day, hour, minute, second).getTimezoneOffset();
+    }
+
+    const instant = fromWallClockInTimeZone(year, monthIndex, day, hour, minute, second, timeZone);
+    return (Date.parse(instant) - Date.UTC(year, monthIndex, day, hour, minute, second)) / 60000;
+}
+
+function fromWallClockInTimeZone(year, monthIndex, day, hour, minute, second, timeZone) {
+    const wallClockMillis = Date.UTC(year, monthIndex, day, hour, minute, second);
+    let candidate = wallClockMillis;
+    for (let attempt = 0; attempt < 2; attempt++) {
+        const parts = new Intl.DateTimeFormat('en-CA', {
+            timeZone,
+            year: 'numeric', month: '2-digit', day: '2-digit',
+            hour: '2-digit', minute: '2-digit', second: '2-digit',
+            hourCycle: 'h23'
+        }).formatToParts(new Date(candidate));
+        const values = Object.fromEntries(parts.map(part => [part.type, part.value]));
+        const representedWallClock = Date.UTC(
+            Number(values.year), Number(values.month) - 1, Number(values.day),
+            Number(values.hour), Number(values.minute), Number(values.second));
+        candidate = wallClockMillis - (representedWallClock - candidate);
+    }
+
+    return new Date(candidate).toISOString();
 }

--- a/src/FishingLogBook.Web/wwwroot/js/browser/time.test.js
+++ b/src/FishingLogBook.Web/wwwroot/js/browser/time.test.js
@@ -44,4 +44,19 @@ describe('time', () => {
         expect(fromDateTimeLocalValue('2026-08-18T02:00', utcPlusFourOffsetMinutes))
             .toBe('2026-08-17T22:00:00.000Z');
     });
+
+    it('resolves an unknown historical offset using Asia/Dubai timezone rules', () => {
+        expect(fromDateTimeLocalValue('2009-02-02T15:06', 'Asia/Dubai'))
+            .toBe('2009-02-02T11:06:00.000Z');
+    });
+
+    it('uses the historical summer offset for Europe/Dublin', () => {
+        expect(fromDateTimeLocalValue('2026-08-27T14:38', 'Europe/Dublin'))
+            .toBe('2026-08-27T13:38:00.000Z');
+    });
+
+    it('uses the historical winter offset for Europe/Dublin', () => {
+        expect(fromDateTimeLocalValue('2026-02-02T15:06', 'Europe/Dublin'))
+            .toBe('2026-02-02T15:06:00.000Z');
+    });
 });

--- a/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingGetView.cs
+++ b/tests/FishingLogBook.Application.Tests/Catches/Services/CatchServiceTests/WhenTestingGetView.cs
@@ -155,6 +155,10 @@ public class WhenTestingGetView : BaseCatchServiceTest
             .GetDetailForUserAsync(catchRecord.Id, CurrentUserId, Arg.Any<CancellationToken>())
             .Returns(Result.Ok<CatchDetail?>(new CatchDetail { Catch = catchRecord }));
         MockObjectStorage.IsConfigured.Returns(true);
+        MockObjectStorage.ExistsAsync(
+                $"catch-photographs/{catchRecord.Id:D}/{photographId:D}",
+                Arg.Any<CancellationToken>())
+            .Returns(true);
         MockObjectStorage
             .CreateDownloadUrlAsync(
                 $"catch-photographs/{catchRecord.Id:D}/{photographId:D}",
@@ -173,6 +177,35 @@ public class WhenTestingGetView : BaseCatchServiceTest
             photograph.Id == photographId
             && photograph.ContentType == "image/jpeg"
             && photograph.Url == "https://r2.test/signed-download");
+    }
+
+    [Fact]
+    public async Task ItShouldExposePlaceholderMetadataWithoutAUsableUrlWhenTheObjectIsMissing()
+    {
+        // Arrange
+        var photographId = Guid.NewGuid();
+        var catchRecord = new Catch
+        {
+            Id = Guid.NewGuid(),
+            CaughtByUserId = CurrentUserId,
+            RecordedByUserId = CurrentUserId,
+            CaughtOn = DateTimeOffset.Parse("2026-08-17T08:00:00Z"),
+            Photographs = [new CatchPhotograph { Id = photographId, ContentType = "image/jpeg" }]
+        };
+        MockCatchRepository
+            .GetDetailForUserAsync(catchRecord.Id, CurrentUserId, Arg.Any<CancellationToken>())
+            .Returns(Result.Ok<CatchDetail?>(new CatchDetail { Catch = catchRecord }));
+        MockObjectStorage.IsConfigured.Returns(true);
+        MockObjectStorage.ExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        // Act
+        var result = await Sut.GetViewAsync(new GetCatchArgs { CatchId = catchRecord.Id }, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Photographs.Should().ContainSingle(photograph => photograph.Id == photographId && photograph.Url == null);
+        await MockObjectStorage.DidNotReceive().CreateDownloadUrlAsync(
+            Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/FishingLogBook.Infrastructure.Tests/Storage/S3CompatibleObjectStorageTests/WhenTestingExists.cs
+++ b/tests/FishingLogBook.Infrastructure.Tests/Storage/S3CompatibleObjectStorageTests/WhenTestingExists.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using Amazon.S3;
+using Amazon.S3.Model;
+using AwesomeAssertions;
+using FishingLogBook.Domain.Config;
+using FishingLogBook.Infrastructure.Storage;
+using NSubstitute;
+
+namespace FishingLogBook.Infrastructure.Tests.Storage.S3CompatibleObjectStorageTests;
+
+public class WhenTestingExists
+{
+    [Fact]
+    public async Task ItShouldReturnTrueWhenObjectMetadataExists()
+    {
+        var (sut, client) = CreateSut();
+        using (sut)
+        {
+            client.GetObjectMetadataAsync(Arg.Any<GetObjectMetadataRequest>(), Arg.Any<CancellationToken>())
+                .Returns(new GetObjectMetadataResponse());
+
+            var exists = await sut.ExistsAsync("catches/catch/photo", CancellationToken.None);
+
+            exists.Should().BeTrue();
+            await client.Received(1).GetObjectMetadataAsync(
+                Arg.Is<GetObjectMetadataRequest>(request =>
+                    request.BucketName == "catch-photographs" && request.Key == "catches/catch/photo"),
+                Arg.Any<CancellationToken>());
+        }
+    }
+
+    [Fact]
+    public async Task ItShouldReturnFalseWhenTheObjectDoesNotExist()
+    {
+        var (sut, client) = CreateSut();
+        using (sut)
+        {
+            client.GetObjectMetadataAsync(Arg.Any<GetObjectMetadataRequest>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<GetObjectMetadataResponse>(
+                    new AmazonS3Exception("missing") { StatusCode = HttpStatusCode.NotFound }));
+
+            var exists = await sut.ExistsAsync("catches/catch/photo", CancellationToken.None);
+
+            exists.Should().BeFalse();
+        }
+    }
+
+    private static (S3CompatibleObjectStorage Sut, IAmazonS3 Client) CreateSut()
+    {
+        var client = Substitute.For<IAmazonS3>();
+        var config = new ObjectStorageConfig
+        {
+            ServiceUrl = "https://storage.test",
+            AccessKeyId = "access-key",
+            SecretAccessKey = "secret-key",
+            BucketName = "catch-photographs"
+        };
+        return (new S3CompatibleObjectStorage(config, client), client);
+    }
+}

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Bunit;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
+using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Components.MeasurementEditor;
 using FishingLogBook.Web.Features.Catch.Services;
@@ -65,7 +66,7 @@ public class WhenTestingRender
             .Add(component => component.Number, 1));
 
         // Assert
-        cut.Find("#import-catch-1-timestamp").TextContent.Should().Contain("+01:00");
+        cut.Find("#import-catch-1-timestamp").TextContent.Should().NotContain("+01:00");
         cut.Find("#import-catch-1-status").TextContent.Should().Contain("Ready");
         cut.FindAll("#import-catch-1-utc-offset").Should().BeEmpty();
     }
@@ -207,10 +208,11 @@ public class WhenTestingRender
     }
 
     [Fact]
-    public async Task ItShouldConfirmAMissingHistoricalWallClockWithoutAddingAnOffset()
+    public async Task ItShouldConfirmAMissingHistoricalWallClockUsingTheBrowserTimezone()
     {
         // Arrange
-        await using var context = CreateContext();
+        var time = BrowserTime(new DateTimeOffset(2024, 6, 14, 9, 20, 0, TimeSpan.FromHours(4)));
+        await using var context = CreateContext(time);
         var timestamp = ImportTimestampModel.Missing();
         var photo = Photo(timestamp);
         var proposal = new ImportCatchProposalModel(
@@ -246,34 +248,12 @@ public class WhenTestingRender
         cut.Find("#import-catch-1-continue").Click();
 
         // Assert
-        proposal.IsReadyForConfirmation.Should().BeFalse();
-        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Draft);
-        cut.Find("#import-catch-1-editor").Should().NotBeNull();
-        cut.Find("#import-catch-1-utc-offset").Should().NotBeNull();
-        var offsets = cut.FindComponents<MudSelectItem<TimeSpan?>>()
-            .Select(item => item.Instance.GetState(component => component.Value))
-            .ToArray();
-        offsets.Should().HaveCount(53);
-        offsets.Should().Contain(TimeSpan.FromHours(-12));
-        offsets.Should().Contain(TimeSpan.FromHours(5.5));
-        offsets.Should().Contain(TimeSpan.FromHours(14));
-
-        // Act
-        await SelectUtcOffsetAsync(cut, TimeSpan.FromHours(5.5));
-        cut.Find("#import-catch-1-confirm-caught-on").Click();
-        cut.Find("#import-catch-1-close-editor").Click();
-
-        // Assert
         proposal.CaughtOn.Instant.Should().Be(
-            new DateTimeOffset(2024, 6, 14, 9, 20, 0, TimeSpan.FromHours(5.5)));
-        proposal.CaughtOn.LocalWallClock.Should().Be(new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Unspecified));
-        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Ready");
-
-        // Act
-        cut.Find("#import-catch-1-edit").Click();
-
-        // Assert
-        cut.FindComponent<MudSelect<TimeSpan?>>().Instance.GetState(x => x.Value).Should().Be(TimeSpan.FromHours(5.5));
+            new DateTimeOffset(2024, 6, 14, 9, 20, 0, TimeSpan.FromHours(4)));
+        proposal.CaughtOn.LocalWallClock.Should().BeNull();
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        cut.FindAll("#import-catch-1-utc-offset").Should().BeEmpty();
+        await time.Received().FromDateTimeLocalValueAsync("2024-06-14T09:20", Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -281,7 +261,8 @@ public class WhenTestingRender
     {
         // Arrange
         using var culture = TestCulture.Use("en-GB");
-        await using var context = CreateContext();
+        var time = BrowserTime(new DateTimeOffset(2026, 4, 9, 15, 6, 0, TimeSpan.FromHours(-5)));
+        await using var context = CreateContext(time);
         var timestamp = ImportTimestampModel.FromLocalWallClock(
             new DateTime(2009, 2, 2, 15, 6, 0),
             ImportTimestampSourceEnum.ExifOriginal);
@@ -297,11 +278,10 @@ public class WhenTestingRender
 
         // Act
         cut.Find("#import-catch-1-caught-on").Input("09/04/2026 03:06 PM");
-        await SelectUtcOffsetAsync(cut, TimeSpan.FromHours(-5));
         cut.Find("#import-catch-1-confirm-caught-on").Click();
 
         // Assert
-        proposal.CaughtOn.LocalWallClock.Should().Be(new DateTime(2026, 4, 9, 15, 6, 0));
+        proposal.CaughtOn.LocalWallClock.Should().BeNull();
         proposal.CaughtOn.Instant.Should().Be(
             new DateTimeOffset(2026, 4, 9, 15, 6, 0, TimeSpan.FromHours(-5)));
         cut.FindAll(".mud-input-error").Should().BeEmpty();
@@ -311,7 +291,8 @@ public class WhenTestingRender
     public async Task ItShouldContinueFromTheEditorWithoutRequiringBack()
     {
         // Arrange
-        await using var context = CreateContext();
+        var time = BrowserTime(new DateTimeOffset(2026, 4, 9, 15, 6, 0, TimeSpan.FromHours(1)));
+        await using var context = CreateContext(time);
         var timestamp = ImportTimestampModel.FromLocalWallClock(
             new DateTime(2009, 2, 2, 15, 6, 0),
             ImportTimestampSourceEnum.ExifOriginal);
@@ -327,7 +308,6 @@ public class WhenTestingRender
 
         // Act
         cut.Find("#import-catch-1-caught-on").Input("09/04/2026 03:06 PM");
-        await SelectUtcOffsetAsync(cut, TimeSpan.FromHours(1));
         cut.Find("#import-catch-1-continue").Click();
 
         // Assert
@@ -451,11 +431,11 @@ public class WhenTestingRender
                 new DateTime(2025, 6, 14, 9, 30, 0),
                 ImportTimestampSourceEnum.ExifOriginal),
             ImportCatchProposalReasonEnum.AmbiguousTimestamp,
-            "timezone confirmation required"
+            "date and time require confirmation"
         }
     };
 
-    private static BunitContext CreateContext()
+    private static BunitContext CreateContext(ITimeService? time = null)
     {
         var context = new BunitContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
@@ -463,7 +443,16 @@ public class WhenTestingRender
         context.Services.AddLocalization();
         context.Services.AddSingleton<IMeasurementService, MeasurementService>();
         context.Services.AddSingleton(Substitute.For<IModalService>());
+        context.Services.AddSingleton(time ?? BrowserTime(CapturedOn));
         return context;
+    }
+
+    private static ITimeService BrowserTime(DateTimeOffset resolved)
+    {
+        var time = Substitute.For<ITimeService>();
+        time.FromDateTimeLocalValueAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(resolved);
+        return time;
     }
 
     private static ImportSelectedPhotoModel Photo(ImportTimestampModel timestamp, int index = 0)
@@ -516,10 +505,4 @@ public class WhenTestingRender
             LengthUnitEnum.Cm);
     }
 
-    private static Task SelectUtcOffsetAsync(
-        IRenderedComponent<ImportCatchReviewCard> cut,
-        TimeSpan offset)
-    {
-        return cut.InvokeAsync(() => cut.FindComponent<MudSelect<TimeSpan?>>().Instance.ValueChanged.InvokeAsync(offset));
-    }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingTimestamp.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingTimestamp.cs
@@ -90,7 +90,7 @@ public class WhenTestingTimestamp : BaseImportModelTest
     }
 
     [Fact]
-    public void ItShouldRequireAnExplicitOffsetToConfirmALocalWallClock()
+    public void ItShouldKeepALocalWallClockUnresolvedUntilTheBrowserResolvesIt()
     {
         // Arrange
         var wallClock = new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Local);
@@ -99,39 +99,27 @@ public class WhenTestingTimestamp : BaseImportModelTest
             ImportTimestampSourceEnum.ExifOriginal);
 
         // Act
-        Action confirm = () => proposed.Confirm(wallClock);
+        var edited = proposed.Confirm(wallClock);
 
         // Assert
-        confirm.Should().Throw<InvalidOperationException>()
-            .WithMessage("*explicit UTC offset*");
-        proposed.RequiresUtcOffset.Should().BeTrue();
-        proposed.IsResolved.Should().BeFalse();
+        edited.Instant.Should().BeNull();
+        edited.LocalWallClock.Should().Be(DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified));
+        edited.IsResolved.Should().BeFalse();
     }
 
-    [Theory]
-    [InlineData(4, 0)]
-    [InlineData(-5, 0)]
-    [InlineData(5, 30)]
-    public void ItShouldCreateAnExactUserConfirmedInstantFromALocalWallClockAndOffset(
-        int offsetHours,
-        int offsetMinutes)
+    [Fact]
+    public void ItShouldRepresentTheInstantResolvedByTheBrowser()
     {
         // Arrange
-        var wallClock = new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Local);
-        var proposed = ImportTimestampModel.FromLocalWallClock(
-            wallClock,
-            ImportTimestampSourceEnum.ExifOriginal);
-        var sign = offsetHours < 0 ? -1 : 1;
-        var offset = new TimeSpan(offsetHours, sign * offsetMinutes, 0);
+        var resolved = new DateTimeOffset(2024, 6, 14, 9, 20, 0, TimeSpan.FromHours(4));
 
         // Act
-        var confirmed = proposed.ConfirmLocalWallClock(wallClock, offset);
+        var confirmed = ImportTimestampModel.UserConfirmed(resolved);
 
         // Assert
         confirmed.State.Should().Be(ImportTimestampStateEnum.UserConfirmed);
-        confirmed.Instant.Should().Be(new DateTimeOffset(2024, 6, 14, 9, 20, 0, offset));
-        confirmed.LocalWallClock.Should().Be(new DateTime(2024, 6, 14, 9, 20, 0, DateTimeKind.Unspecified));
-        confirmed.RequiresUtcOffset.Should().BeFalse();
+        confirmed.Instant.Should().Be(resolved);
+        confirmed.LocalWallClock.Should().BeNull();
         confirmed.IsResolved.Should().BeTrue();
     }
 
@@ -143,7 +131,7 @@ public class WhenTestingTimestamp : BaseImportModelTest
         var confirmed = ImportTimestampModel.FromLocalWallClock(
                 original,
                 ImportTimestampSourceEnum.ExifOriginal)
-            .ConfirmLocalWallClock(original, TimeSpan.FromHours(1));
+            .Confirm(original);
 
         // Act
         var edited = confirmed.EditLocalWallClock(original.AddMinutes(10));
@@ -152,7 +140,6 @@ public class WhenTestingTimestamp : BaseImportModelTest
         edited.State.Should().Be(ImportTimestampStateEnum.LocalWallClock);
         edited.Instant.Should().BeNull();
         edited.LocalWallClock.Should().Be(original.AddMinutes(10));
-        edited.RequiresUtcOffset.Should().BeTrue();
         edited.IsResolved.Should().BeFalse();
     }
 

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/BaseImportCatchCatalogueTest.cs
@@ -2,6 +2,7 @@ using Bunit;
 using FishingLogBook.Shared.Dtos;
 using FishingLogBook.Shared.Enums;
 using FishingLogBook.Web.Browser.Network;
+using FishingLogBook.Web.Browser.Time;
 using FishingLogBook.Web.Common.Modals;
 using FishingLogBook.Web.Features.Catch.Services;
 using FishingLogBook.Web.Features.Diagnostics.Services;
@@ -38,6 +39,9 @@ public class BaseImportCatchCatalogueTest
         context.Services.AddMudServices();
         context.Services.AddLocalization();
         context.Services.AddSingleton<IMeasurementService, MeasurementService>();
+        var time = Substitute.For<ITimeService>();
+        time.FromDateTimeLocalValueAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(CapturedOn);
+        context.Services.AddSingleton(time);
         context.Services.AddSingleton(proposal);
         context.Services.AddSingleton(preparation);
         context.Services.AddSingleton(tripProposalService ?? new ImportTripProposalService());

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/BaseImportPersistenceServiceTest.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/BaseImportPersistenceServiceTest.cs
@@ -14,6 +14,7 @@ public class BaseImportPersistenceServiceTest
     protected static readonly Guid UserId = Guid.Parse("10000000-0000-0000-0000-000000000001");
     protected static readonly Guid CatchId = Guid.Parse("20000000-0000-0000-0000-000000000001");
     protected static readonly Guid PhotoId = Guid.Parse("30000000-0000-0000-0000-000000000001");
+    protected static readonly Guid SecondPhotoId = Guid.Parse("30000000-0000-0000-0000-000000000002");
     protected static readonly Guid TripId = Guid.Parse("40000000-0000-0000-0000-000000000001");
     protected static readonly Guid ParticipantId = Guid.Parse("50000000-0000-0000-0000-000000000001");
     protected static readonly DateTimeOffset CaughtOn = DateTimeOffset.Parse("2009-02-02T15:06:00+01:00");
@@ -72,7 +73,13 @@ public class BaseImportPersistenceServiceTest
         });
         CatchClient.CreatePhotographUploadAsync(CatchId, Arg.Any<PhotographUploadRequestDto>(), Arg.Any<CancellationToken>())
             .Returns(new PhotographUploadDto("object", "https://upload.test"));
-        var reads = 0;
+        var photographRecorded = false;
+        CatchClient.RecordPhotographAsync(CatchId, Arg.Any<RecordPhotographDto>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                photographRecorded = true;
+                return Task.CompletedTask;
+            });
         CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(_ =>
         {
             if (persistedCatch is null)
@@ -80,7 +87,6 @@ public class BaseImportPersistenceServiceTest
                 return null;
             }
 
-            reads++;
             return new CatchViewDto(CatchId, UserId, persistedCatch.CaughtOn, new CatchLocationExposureDto
             {
                 Latitude = 53.1,
@@ -96,7 +102,13 @@ public class BaseImportPersistenceServiceTest
                 Method = persistedCatch?.Method,
                 Weight = persistedCatch?.Weight,
                 Length = persistedCatch?.Length,
-                Photographs = reads > 1 ? [new CatchPhotographViewDto(PhotoId, "image/jpeg", "https://photo.test")] : []
+                Photographs =
+                [
+                    new CatchPhotographViewDto(
+                        PhotoId,
+                        "image/jpeg",
+                        photographRecorded ? "https://photo.test" : null)
+                ]
             };
         });
         return new ImportPersistenceService(TripClient, ParticipantClient, CatchClient, CurrentUserClient, BlobRegistry);
@@ -105,7 +117,8 @@ public class BaseImportPersistenceServiceTest
     protected static ImportBatchModel Batch(
         ImportTripDecisionEnum decision,
         bool participant = false,
-        ImportTimestampModel? timestamp = null)
+        ImportTimestampModel? timestamp = null,
+        bool includeSecondPhoto = false)
     {
         var method = new ImportCatalogueSelectionModel(Guid.NewGuid(), "Fly", "Fly");
         var species = new ImportCatalogueSelectionModel(Guid.NewGuid(), "BrownTrout", "Brown Trout");
@@ -113,10 +126,17 @@ public class BaseImportPersistenceServiceTest
         var photo = new ImportSelectedPhotoModel(PhotoId, 0, "image/jpeg", 3, "token", "fish.jpg", "blob:thumb");
         photo.SetPreparation(ImportPhotoPreparationStatusEnum.Ready, "token", "blob:thumb");
         batch.AddPhoto(photo);
+        if (includeSecondPhoto)
+        {
+            var second = new ImportSelectedPhotoModel(
+                SecondPhotoId, 1, "image/png", 3, "token", "fish-2.png", "blob:thumb-2");
+            second.SetPreparation(ImportPhotoPreparationStatusEnum.Ready, "token", "blob:thumb-2");
+            batch.AddPhoto(second);
+        }
         var location = new ImportLocationModel(53.1, -6.2, true).Accept();
         var proposal = new ImportCatchProposalModel(
             CatchId,
-            [PhotoId],
+            includeSecondPhoto ? [PhotoId, SecondPhotoId] : [PhotoId],
             timestamp ?? ImportTimestampModel.UserConfirmed(CaughtOn),
             method,
             species,

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportPersistenceServiceTests/WhenTestingPersistAsync.cs
@@ -14,10 +14,8 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
     {
         // Arrange
         var wallClock = new DateTime(2009, 2, 2, 15, 6, 0, DateTimeKind.Local);
-        var confirmed = ImportTimestampModel.FromLocalWallClock(
-                wallClock,
-                ImportTimestampSourceEnum.ExifOriginal)
-            .ConfirmLocalWallClock(wallClock, TimeSpan.FromHours(5.5));
+        var confirmed = ImportTimestampModel.UserConfirmed(
+            new DateTimeOffset(DateTime.SpecifyKind(wallClock, DateTimeKind.Unspecified), TimeSpan.FromHours(5.5)));
         var batch = Batch(ImportTripDecisionEnum.NoTrip, timestamp: confirmed);
         var sut = CreateSut();
 
@@ -266,6 +264,102 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
     }
 
     [Fact]
+    public async Task ItShouldCompleteAPlaceholderPhotographOnRetry()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+        var completed = false;
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(_ =>
+            MatchingCatch(includePhotograph: true, photographCompleted: completed));
+        CatchClient.RecordPhotographAsync(CatchId, Arg.Any<RecordPhotographDto>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                completed = true;
+                return Task.CompletedTask;
+            });
+
+        // Act
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await BlobRegistry.Received(1).GetBytesAsync("token", Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).CreatePhotographUploadAsync(
+            CatchId,
+            Arg.Is<PhotographUploadRequestDto>(request => request.PhotographId == PhotoId),
+            Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).UploadPhotographAsync(
+            "https://upload.test", Arg.Any<byte[]>(), "image/jpeg", Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).RecordPhotographAsync(
+            CatchId, Arg.Is<RecordPhotographDto>(photo => photo.PhotographId == PhotoId), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldNotTreatPlaceholderMetadataAsFinalSuccess()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip);
+        var sut = CreateSut();
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(
+            MatchingCatch(includePhotograph: true, photographCompleted: false));
+
+        // Act
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Failure.Should().Be(ImportPersistenceFailureEnum.Verification);
+        await CatchClient.Received(1).UploadPhotographAsync(
+            "https://upload.test", Arg.Any<byte[]>(), "image/jpeg", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ItShouldSkipOnlyCompletedPhotographsDuringAPartialMultiPhotoRetry()
+    {
+        // Arrange
+        var batch = Batch(ImportTripDecisionEnum.NoTrip, includeSecondPhoto: true);
+        var sut = CreateSut();
+        var secondCompleted = false;
+        CatchClient.GetAsync(CatchId, Arg.Any<CancellationToken>()).Returns(_ =>
+            MatchingCatch(includePhotograph: false) with
+            {
+                Photographs =
+                [
+                    new CatchPhotographViewDto(PhotoId, "image/jpeg", "https://photo.test/one"),
+                    new CatchPhotographViewDto(
+                        SecondPhotoId,
+                        "image/png",
+                        secondCompleted ? "https://photo.test/two" : null)
+                ]
+            });
+        CatchClient.RecordPhotographAsync(CatchId, Arg.Any<RecordPhotographDto>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                secondCompleted = call.Arg<RecordPhotographDto>().PhotographId == SecondPhotoId;
+                return Task.CompletedTask;
+            });
+
+        // Act
+        var result = await sut.PersistAsync(batch, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await CatchClient.Received(1).CreatePhotographUploadAsync(
+            CatchId,
+            Arg.Is<PhotographUploadRequestDto>(request => request.PhotographId == SecondPhotoId),
+            Arg.Any<CancellationToken>());
+        await CatchClient.DidNotReceive().CreatePhotographUploadAsync(
+            CatchId,
+            Arg.Is<PhotographUploadRequestDto>(request => request.PhotographId == PhotoId),
+            Arg.Any<CancellationToken>());
+        await CatchClient.Received(1).RecordPhotographAsync(
+            CatchId,
+            Arg.Is<RecordPhotographDto>(photo => photo.PhotographId == SecondPhotoId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldStopWithoutOverwritingAConflictingAuthoritativeCatch()
     {
         // Arrange
@@ -425,7 +519,7 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
         return new TripDetailDto(new TripViewDto(TripId, UserId, "Completed", CaughtOn, CaughtOn));
     }
 
-    private static CatchViewDto MatchingCatch(bool includePhotograph)
+    private static CatchViewDto MatchingCatch(bool includePhotograph, bool photographCompleted = true)
     {
         return new CatchViewDto(CatchId, UserId, CaughtOn, new CatchLocationExposureDto
         {
@@ -442,7 +536,10 @@ public class WhenTestingPersistAsync : BaseImportPersistenceServiceTest
             Weight = 2.5m,
             Length = 42m,
             Photographs = includePhotograph
-                ? [new CatchPhotographViewDto(PhotoId, "image/jpeg", "https://photo.test")]
+                ? [new CatchPhotographViewDto(
+                    PhotoId,
+                    "image/jpeg",
+                    photographCompleted ? "https://photo.test" : null)]
                 : []
         };
     }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportTripProposalServiceTests/WhenTestingPropose.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportTripProposalServiceTests/WhenTestingPropose.cs
@@ -210,15 +210,13 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
     }
 
     [Fact]
-    public void ItShouldUseAConfirmedOffsetlessWallClockWithoutInventingAnOffset()
+    public void ItShouldUseBrowserResolvedHistoricalInstantsWithoutChangingTripGrouping()
     {
         // Arrange
         var firstLocal = new DateTime(2024, 6, 14, 9, 0, 0);
         var secondLocal = new DateTime(2024, 6, 14, 10, 0, 0);
-        var first = ImportTimestampModel.FromLocalWallClock(firstLocal, ImportTimestampSourceEnum.ExifOriginal)
-            .ConfirmLocalWallClock(firstLocal, TimeSpan.FromHours(1));
-        var second = ImportTimestampModel.FromLocalWallClock(secondLocal, ImportTimestampSourceEnum.ExifOriginal)
-            .ConfirmLocalWallClock(secondLocal, TimeSpan.FromHours(1));
+        var first = ImportTimestampModel.UserConfirmed(new DateTimeOffset(firstLocal, TimeSpan.FromHours(1)));
+        var second = ImportTimestampModel.UserConfirmed(new DateTimeOffset(secondLocal, TimeSpan.FromHours(1)));
         var batch = Batch(
             new CatchSpec(TimeSpan.Zero, Timestamp: first),
             new CatchSpec(TimeSpan.Zero, Timestamp: second));
@@ -227,7 +225,7 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
         var proposal = Sut.Propose(batch).Single();
 
         // Assert
-        proposal.ProposedStartedOn.Should().Be(first.LocalWallClock!.Value);
+        proposal.ProposedStartedOn.Should().Be(first.Instant!.Value.DateTime);
         proposal.ProposedStartedOn.Kind.Should().Be(DateTimeKind.Unspecified);
     }
 


### PR DESCRIPTION
## Summary

- restore end-to-end Import photograph persistence by distinguishing placeholder metadata from completed object uploads
- verify stored objects before returning photograph download URLs and complete interrupted/partial imports safely on retry
- resolve confirmed offset-less historical wall-clock values using the browser timezone for that historical date while preserving genuine explicit EXIF offsets exactly
- keep the approved five-minute complete-span Catch grouping behaviour unchanged
- remove the abandoned UTC-offset selector and database provenance-marker approach

## Validation

- `dotnet format FishingLogBook.sln --no-restore`
- `dotnet build FishingLogBook.sln --no-restore`
- `dotnet test FishingLogBook.sln --no-build` — 3,027 passed, 0 failed
- `npm test` — 405 passed
- `npm run test:browser` — 159 passed, 7 expected skipped
- `git diff --check`

## Regression coverage

- new, completed, interrupted, conflicting, and partial multi-photo Import persistence paths
- object-storage existence checks and placeholder URL behaviour
- deterministic historical timezone conversion for Asia/Dubai and Europe/Dublin, including seasonal offsets
- preservation of explicit-offset timestamps
- Import review workflow and five-minute grouping invariants

## Self-review

Completed after the final changes. The full Web suite exposed a missing `ITimeService` registration in the wizard test fixture; this was fixed and the complete validation suite was rerun successfully.

Follow-up timestamp domain work remains tracked separately in #232. This PR does not add a database marker, migration, timezone selector, or broad Catch/Trip timestamp redesign.