### PR TITLE
FLB#219 | Complete Import workflow regression fixes

### DIFF
--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor
@@ -161,7 +161,7 @@
                         @Loc[Proposal.ReviewStatus == ImportCatchReviewStatusEnum.Reviewed ? "Import_Edit" : "Import_ReviewEdit"]
                     </MudButton>
                 }
-                @if (Proposal.ReviewStatus != ImportCatchReviewStatusEnum.Reviewed && Proposal.CanConfirmDisplayedValues)
+                @if (Proposal.ReviewStatus != ImportCatchReviewStatusEnum.Reviewed && Proposal.CanOfferDisplayedValueConfirmation)
                 {
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ConfirmAsync"
                                id="@($"import-catch-{Number}-confirm")">@Loc["Import_ConfirmCatch"]</MudButton>

--- a/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Components/ImportCatchReviewCard/ImportCatchReviewCard.razor.cs
@@ -262,6 +262,19 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
 
     private async Task ConfirmAsync()
     {
+        var displayedCaughtOn = Proposal.CaughtOn.Instant?.DateTime ?? Proposal.CaughtOn.LocalWallClock;
+        if (!displayedCaughtOn.HasValue)
+        {
+            return;
+        }
+
+        var confirmed = await ResolveCaughtOnAsync(displayedCaughtOn.Value, Proposal.CaughtOn);
+        if (confirmed is null)
+        {
+            return;
+        }
+
+        Batch.SetCatchCaughtOn(Proposal.Id, confirmed);
         Batch.ConfirmDisplayedCatch(Proposal.Id);
         await Changed.InvokeAsync();
     }
@@ -304,27 +317,30 @@ public partial class ImportCatchReviewCard : ComponentBase, IDisposable
         }
 
         var basis = _caughtOnBasis ?? Proposal.CaughtOn;
-        ImportTimestampModel confirmed;
-        if (basis.Instant.HasValue)
+        var confirmed = await ResolveCaughtOnAsync(caughtOn, basis);
+        if (confirmed is null)
         {
-            confirmed = basis.Confirm(caughtOn);
-        }
-        else
-        {
-            var resolved = await Time.FromDateTimeLocalValueAsync(
-                caughtOn.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture),
-                _cancellationTokenSource.Token);
-            if (!resolved.HasValue)
-            {
-                _caughtOnInvalid = true;
-                return false;
-            }
-
-            confirmed = ImportTimestampModel.UserConfirmed(resolved.Value);
+            _caughtOnInvalid = true;
+            return false;
         }
         Batch.SetCatchCaughtOn(Proposal.Id, confirmed);
         _caughtOnInvalid = false;
         return true;
+    }
+
+    private async Task<ImportTimestampModel?> ResolveCaughtOnAsync(
+        DateTime caughtOn,
+        ImportTimestampModel basis)
+    {
+        if (basis.Instant.HasValue)
+        {
+            return basis.Confirm(caughtOn);
+        }
+
+        var resolved = await Time.FromDateTimeLocalValueAsync(
+            caughtOn.ToString("yyyy-MM-ddTHH:mm", CultureInfo.InvariantCulture),
+            _cancellationTokenSource.Token);
+        return resolved.HasValue ? ImportTimestampModel.UserConfirmed(resolved.Value) : null;
     }
 
     private FishingMethodDto? FindMethod(Guid id) => Preferences.Catalogue.Methods.SingleOrDefault(method => method.Id == id);

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportCatchProposalModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportCatchProposalModel.cs
@@ -103,6 +103,13 @@ public sealed class ImportCatchProposalModel
         && _gpsConflictResolved
         && _photoIds.Count > 0;
 
+    public bool CanOfferDisplayedValueConfirmation => !IsRemoved
+        && (CaughtOn.Instant.HasValue || CaughtOn.LocalWallClock.HasValue)
+        && Method.IsValid
+        && Species.IsValid
+        && _gpsConflictResolved
+        && _photoIds.Count > 0;
+
     public bool IsLocationDecisionResolved => Location is null
         || !Location.HistoricalGpsPresent
         || Location.Decision != ImportLocationDecisionEnum.Undecided;

--- a/src/FishingLogBook.Web/Features/Import/Models/ImportTripProposalModel.cs
+++ b/src/FishingLogBook.Web/Features/Import/Models/ImportTripProposalModel.cs
@@ -124,7 +124,7 @@ public sealed class ImportTripProposalModel
     public void RemoveCatch(Guid catchProposalId)
     {
         _catchProposalIds.Remove(catchProposalId);
-        if (_catchProposalIds.Count < 2)
+        if (_catchProposalIds.Count == 0)
         {
             IsRemoved = true;
         }

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor
@@ -193,7 +193,9 @@
                         <MudPaper Class="pa-3" Elevation="2" id="@($"import-trip-{proposalNumber}")">
                             <MudStack Spacing="1">
                                 <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="flex-wrap" Spacing="1">
-                                    <MudText Typo="Typo.h6">@Loc["Import_TripCatchCount", proposal.CatchProposalIds.Count]</MudText>
+                                    <MudText Typo="Typo.h6">
+                                        @Loc[proposal.CatchProposalIds.Count == 1 ? "Import_TripSingleCatch" : "Import_TripCatchCount", proposal.CatchProposalIds.Count]
+                                    </MudText>
                                     <MudText Align="Align.Right" id="@($"import-trip-date-time-{proposalNumber}")">
                                         @proposal.ProposedStartedOn.ToString("d", System.Globalization.CultureInfo.CurrentCulture)
                                         · @Loc["Import_TripTimeRange", proposal.ProposedStartedOn.ToString("t"), proposal.ProposedEndedOn.ToString("t")]
@@ -238,11 +240,11 @@
                                 }
                                 @for (var catchIndex = 0; catchIndex < proposal.CatchProposalIds.Count; catchIndex++)
                                 {
-                                    var catchNumber = catchIndex + 1;
                                     var catchId = proposal.CatchProposalIds[catchIndex];
                                     var catchProposal = CatchProposal(catchId);
+                                    var catchNumber = CatchNumber(catchProposal);
                                     var thumbnail = CatchThumbnail(catchProposal);
-                                    <div class="import-trip-catch-row" id="@($"import-trip-catch-{proposalNumber}-{catchNumber}")">
+                                    <div class="import-trip-catch-row" id="@($"import-trip-catch-{proposalNumber}-{catchIndex + 1}")">
                                         <img src="@thumbnail.ThumbnailUrl"
                                              alt="@Loc["Import_TripCatchPhotoAlt", catchNumber]"
                                              class="import-trip-catch-thumbnail" />
@@ -299,7 +301,7 @@
                             @if (_isPersisting)
                             {
                                 <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="CancelPersistence"
-                                           id="import-cancel-persistence">@Loc["Common_Cancel"]</MudButton>
+                                           id="import-cancel-persistence">@Loc["Modal_Cancel"]</MudButton>
                             }
                             <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_isPersisting"
                                        OnClick="PersistAsync" id="import-confirm">

--- a/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
+++ b/src/FishingLogBook.Web/Features/Import/Pages/ImportCatchCatalogue/ImportCatchCatalogue.razor.cs
@@ -61,6 +61,11 @@ public partial class ImportCatchCatalogue : ComponentBase, IAsyncDisposable
     private IReadOnlyList<ImportTripProposalModel> ActiveTripProposals =>
         [.. _batch?.TripProposals.Where(proposal => !proposal.IsRemoved) ?? []];
 
+    private int CatchNumber(ImportCatchProposalModel proposal)
+    {
+        return ActiveCatchProposals.ToList().IndexOf(proposal) + 1;
+    }
+
     private IReadOnlyList<CatalogueOptionModel> MethodOptions
     {
         get

--- a/src/FishingLogBook.Web/Features/Import/Services/ImportTripProposalService.cs
+++ b/src/FishingLogBook.Web/Features/Import/Services/ImportTripProposalService.cs
@@ -76,7 +76,7 @@ public sealed class ImportTripProposalService : IImportTripProposalService
 
     private static void AddCluster(IReadOnlyList<Candidate> cluster, ICollection<ImportTripProposalModel> proposals)
     {
-        if (cluster.Count < 2)
+        if (cluster.Count == 0)
         {
             return;
         }

--- a/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.fr.resx
@@ -1415,6 +1415,7 @@
   <data name="Import_ContinueToTrips" xml:space="preserve"><value>Continuer vers les suggestions de sorties</value></data>
   <data name="Import_TripSuggestionsTitle" xml:space="preserve"><value>Suggestions de sorties</value></data>
   <data name="Import_NoTripSuggestions" xml:space="preserve"><value>Aucune sortie probable n’a été trouvée. Ces prises resteront séparées.</value></data>
+  <data name="Import_TripSingleCatch" xml:space="preserve"><value>1 prise</value></data>
   <data name="Import_TripCatchCount" xml:space="preserve"><value>{0} prises</value></data>
   <data name="Import_TripTimeRange" xml:space="preserve"><value>{0} – {1}</value></data>
   <data name="Import_TripMissingGps" xml:space="preserve"><value>Les informations de localisation sont incomplètes pour cette suggestion.</value></data>

--- a/src/FishingLogBook.Web/Localization/UiStrings.resx
+++ b/src/FishingLogBook.Web/Localization/UiStrings.resx
@@ -1415,6 +1415,7 @@
   <data name="Import_ContinueToTrips" xml:space="preserve"><value>Continue to Trip suggestions</value></data>
   <data name="Import_TripSuggestionsTitle" xml:space="preserve"><value>Trip suggestions</value></data>
   <data name="Import_NoTripSuggestions" xml:space="preserve"><value>No likely Trips were found. These catches will remain separate.</value></data>
+  <data name="Import_TripSingleCatch" xml:space="preserve"><value>1 catch</value></data>
   <data name="Import_TripCatchCount" xml:space="preserve"><value>{0} catches</value></data>
   <data name="Import_TripTimeRange" xml:space="preserve"><value>{0} – {1}</value></data>
   <data name="Import_TripMissingGps" xml:space="preserve"><value>Location evidence is incomplete for this suggestion.</value></data>

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Components/ImportCatchReviewCardTests/WhenTestingRender.cs
@@ -100,6 +100,39 @@ public class WhenTestingRender
     }
 
     [Fact]
+    public async Task ItShouldQuickConfirmAnOffsetlessHistoricalWallClockUsingTheBrowserTimezone()
+    {
+        // Arrange
+        var resolved = new DateTimeOffset(2009, 2, 2, 15, 6, 0, TimeSpan.FromHours(4));
+        var time = BrowserTime(resolved);
+        await using var context = CreateContext(time);
+        var timestamp = ImportTimestampModel.FromLocalWallClock(
+            new DateTime(2009, 2, 2, 15, 6, 0),
+            ImportTimestampSourceEnum.ExifOriginal);
+        var photo = Photo(timestamp);
+        var proposal = Proposal(photo, timestamp, ImportCatchProposalReasonEnum.AmbiguousTimestamp);
+        var cut = context.Render<ImportCatchReviewCard>(parameters => parameters
+            .Add(component => component.Proposal, proposal)
+            .Add(component => component.Batch, Batch(photo, proposal))
+            .Add(component => component.Preferences, Preferences())
+            .Add(component => component.Number, 1)
+            .Add(component => component.Editable, true));
+
+        // Act
+        cut.Find("#import-catch-1-confirm").Click();
+
+        // Assert
+        proposal.CaughtOn.State.Should().Be(ImportTimestampStateEnum.UserConfirmed);
+        proposal.CaughtOn.Instant.Should().Be(resolved);
+        proposal.ReviewStatus.Should().Be(ImportCatchReviewStatusEnum.Reviewed);
+        cut.Find("#import-catch-1-status").TextContent.Should().Contain("Reviewed");
+        cut.FindAll("#import-catch-1-confirm").Should().BeEmpty();
+        await time.Received(1).FromDateTimeLocalValueAsync(
+            "2009-02-02T15:06",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ItShouldUseTheActiveCarouselPhotographTimestampForConfirmation()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingTripProposal.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Models/ImportModelTests/WhenTestingTripProposal.cs
@@ -7,6 +7,22 @@ namespace FishingLogBook.Web.Tests.Features.Import.Models.ImportModelTests;
 public class WhenTestingTripProposal : BaseImportModelTest
 {
     [Fact]
+    public void ItShouldRemainActiveWhenOneCatchRemains()
+    {
+        // Arrange
+        var remainingCatchId = Guid.NewGuid();
+        var removedCatchId = Guid.NewGuid();
+        var proposal = Trip(catchIds: [remainingCatchId, removedCatchId]);
+
+        // Act
+        proposal.RemoveCatch(removedCatchId);
+
+        // Assert
+        proposal.CatchProposalIds.Should().Equal(remainingCatchId);
+        proposal.IsRemoved.Should().BeFalse();
+    }
+
+    [Fact]
     public void ItShouldRequireAnIdentityWhenUsingAnExistingTrip()
     {
         // Arrange

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Pages/ImportCatchCatalogueTests/WhenTestingWizard.cs
@@ -361,7 +361,13 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
 
         // Assert
         cut.Find("#import-trip-review").Should().NotBeNull();
-        cut.Find("#import-trip-none").Should().NotBeNull();
+        cut.Find("#import-trip-1").TextContent.Should().Contain("1 catch");
+        cut.Find("#import-trip-catch-1-1").TextContent.Should().Contain("Catch 1");
+
+        // Act
+        cut.Find("#import-trip-separate-1").Click();
+
+        // Assert
         cut.Find("#import-trip-continue").HasAttribute("disabled").Should().BeFalse();
 
         // Act
@@ -470,6 +476,9 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         cut.Find("#import-confirm").Click();
         cut.WaitForElement("#import-cancel-persistence");
 
+        // Assert
+        cut.Find("#import-cancel-persistence").TextContent.Should().Be("Cancel");
+
         // Act
         cut.Find("#import-cancel-persistence").Click();
 
@@ -521,6 +530,42 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         {
             cut.Find($"#import-trip-catch-1-{catchNumber}").TextContent.Should().Contain($"Catch {catchNumber}");
         }
+    }
+
+    [Fact]
+    public async Task ItShouldKeepASingleCatchDayVisibleAsItsOwnTripSuggestion()
+    {
+        // Arrange
+        var proposal = Substitute.For<IImportCatchProposalService>();
+        proposal.Propose(Arg.Any<ImportBatchModel>()).Returns(call => ProposalsFor(call.Arg<ImportBatchModel>()));
+        await using var context = CreateContext(
+            proposal,
+            Substitute.For<IImportPhotoPreparationService>());
+        var cut = context.Render<ImportCatchCatalogue>();
+        await SelectDefaultsAndContinueAsync(cut);
+        await cut.InvokeAsync(() => cut.FindComponent<ImportPhotographPicker>().Instance.PhotosPrepared
+            .InvokeAsync([
+                ReadyPhoto(0, ImportTimestampModel.UserConfirmed(
+                    new DateTimeOffset(2009, 2, 2, 15, 6, 0, TimeSpan.FromHours(4)))),
+                ReadyPhoto(1, ImportTimestampModel.UserConfirmed(CapturedOn)),
+                ReadyPhoto(2, ImportTimestampModel.UserConfirmed(CapturedOn.AddMinutes(3)))
+            ]));
+        cut.Find("#import-photos-continue").Click();
+        for (var catchNumber = 1; catchNumber <= 3; catchNumber++)
+        {
+            cut.Find($"#import-catch-{catchNumber}-confirm").Click();
+        }
+
+        // Act
+        cut.Find("#import-review-continue").Click();
+
+        // Assert
+        cut.WaitForAssertion(() => cut.FindAll("[id^='import-trip-']").Should().NotBeEmpty());
+        cut.Find("#import-trip-1").TextContent.Should().Contain("1 catch");
+        cut.Find("#import-trip-catch-1-1").TextContent.Should().Contain("Catch 1");
+        cut.Find("#import-trip-2").TextContent.Should().Contain("2 catches");
+        cut.Find("#import-trip-catch-2-1").TextContent.Should().Contain("Catch 2");
+        cut.Find("#import-trip-catch-2-2").TextContent.Should().Contain("Catch 3");
     }
 
     [Fact]
@@ -812,7 +857,7 @@ public class WhenTestingWizard : BaseImportCatchCatalogueTest
         cut.Find("#import-photos-continue").Click();
         cut.Find("#import-catch-1-confirm").Click();
         cut.Find("#import-review-continue").Click();
-        cut.Find("#import-trip-none").Click();
+        cut.Find("#import-trip-separate-1").Click();
         cut.Find("#import-trip-continue").Click();
     }
 }

--- a/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportTripProposalServiceTests/WhenTestingPropose.cs
+++ b/tests/FishingLogBook.Web.Tests/Features/Import/Services/ImportTripProposalServiceTests/WhenTestingPropose.cs
@@ -9,7 +9,7 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
     private const double FiveKilometresLongitude = 0.0449660181862269d;
 
     [Fact]
-    public void ItShouldNotSuggestASingleton()
+    public void ItShouldSuggestASingleCatchTrip()
     {
         // Arrange
         var batch = Batch(new CatchSpec(TimeSpan.Zero));
@@ -18,7 +18,8 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
         var proposals = Sut.Propose(batch);
 
         // Assert
-        proposals.Should().BeEmpty();
+        proposals.Should().ContainSingle().Which.CatchProposalIds.Should()
+            .Equal(batch.CatchProposals[0].Id);
     }
 
     [Fact]
@@ -66,7 +67,8 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
         var proposals = Sut.Propose(batch);
 
         // Assert
-        proposals.Should().BeEmpty();
+        proposals.Should().HaveCount(2);
+        proposals.Should().OnlyContain(proposal => proposal.CatchProposalIds.Count == 1);
     }
 
     [Fact]
@@ -88,7 +90,7 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
 
     [Theory]
     [InlineData(4d, 1)]
-    [InlineData(4.01d, 0)]
+    [InlineData(4.01d, 2)]
     public void ItShouldApplyTheAdjacentGapBoundary(double hours, int expected)
     {
         // Arrange
@@ -118,7 +120,9 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
 
         // Assert
         boundaryProposals.Should().ContainSingle().Which.CatchProposalIds.Should().HaveCount(6);
-        beyondProposals.Should().ContainSingle().Which.CatchProposalIds.Should().HaveCount(5);
+        beyondProposals.Should().HaveCount(2);
+        beyondProposals[0].CatchProposalIds.Should().HaveCount(5);
+        beyondProposals[1].CatchProposalIds.Should().ContainSingle();
     }
 
     [Fact]
@@ -133,7 +137,8 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
         var proposals = Sut.Propose(batch);
 
         // Assert
-        proposals.Should().BeEmpty();
+        proposals.Should().HaveCount(2);
+        proposals.Should().OnlyContain(proposal => proposal.CatchProposalIds.Count == 1);
     }
 
     [Fact]
@@ -172,7 +177,8 @@ public class WhenTestingPropose : BaseImportTripProposalServiceTest
         batch.ReplaceTripProposals(Sut.Propose(batch));
 
         // Assert
-        batch.TripProposals.Should().BeEmpty();
+        batch.TripProposals.Should().ContainSingle().Which.CatchProposalIds.Should()
+            .Equal(batch.CatchProposals[0].Id);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- restore end-to-end Import photograph persistence, including interrupted and partial upload reconciliation
- resolve confirmed offset-less historical wall-clock timestamps through the browser timezone while preserving explicit EXIF offsets
- restore quick confirmation for displayed offset-less historical timestamps
- retain every reviewed Catch in Trip suggestions, including valid one-Catch Trips, with stable Catch numbering
- keep a one-Catch Trip proposal active when another Catch is removed
- fix the Import persistence Cancel button localisation
- strengthen testing and self-review rules for real stateful boundaries, partial states, completion predicates, and production-faithful mock lifecycles
- keep the approved five-minute complete-span Catch grouping rule unchanged

## Regression coverage

- photograph placeholder metadata versus completed object storage
- retries from interrupted and partial multi-photo states
- quick confirmation of offset-less historical wall-clock values
- mixed-date Import where a 2009 singleton Trip and a 2026 multi-Catch Trip remain visible
- singleton Trip proposals and removal down to one Catch
- stable Catch numbering across Trip proposals
- localized persistence Cancel action

## Validation

- `dotnet format FishingLogBook.sln --no-restore`
- `dotnet build FishingLogBook.sln --no-restore`
- `dotnet test FishingLogBook.sln --no-build` — 3,030 passed, 0 failed
- `npm test` — 405 passed
- `npm run test:browser` — 159 passed, 7 expected skipped
- `git diff --check`

The initial sandboxed Testcontainers run could not access Docker's named pipe. The complete suite was rerun with Docker access and all tests passed.

## Self review

- Issue/AC: PASS
- Architecture/CQRS: PASS
- Rules: PASS
- Security/privacy: PASS
- Database/migrations: N/A
- Tests/coverage: PASS
- Browser: PASS — existing browser suite passed; authenticated Import rendering is covered through bUnit because the Playwright harness is not an authenticated Blazor host
- Web/UI/localisation: PASS
- Code smells: PASS
- CI/deployment: PASS

Findings discovered and fixed during review:

1. Offset-less historical timestamps could not use quick confirmation.
2. Singleton Trip clusters were discarded and disappeared from Trip review.
3. Removing from a two-Catch proposal incorrectly removed the remaining singleton proposal.
4. Trip-stage Catch numbering reset within each proposal.
5. The persistence Cancel button referenced a missing localization key.
6. Existing wizard tests encoded the discarded-singleton assumption and were updated to make an explicit Trip decision.

Follow-up timestamp domain work remains tracked separately in #232. This PR does not add a database marker, migration, timezone selector, or broad Catch/Trip timestamp redesign.